### PR TITLE
feat(interactions): surface stuck-on-prompt states from claude tmux sessions

### DIFF
--- a/src/bun/approvals-endpoint.test.ts
+++ b/src/bun/approvals-endpoint.test.ts
@@ -137,3 +137,131 @@ test("/approvals/:id/answer rejects invalid decision values", async () => {
   });
   expect(res.status).toBe(400);
 });
+
+/** Build a task with a saved Edit allow-rule + install a fake claude-tmux
+ *  SessionState so getCurrentPermissionMode returns whatever the test
+ *  sets. Returns the cwd + the state handle so the test can flip
+ *  permissionMode mid-run. */
+async function seedTaskWithSavedRule(args: {
+  taskId: string;
+  ruleEntry: string;
+}): Promise<{ cwd: string; state: { permissionMode: string | null } }> {
+  const cwd = mkdtempSync(path.join(tmpdir(), `agetor-plan-mode-${args.taskId}-`));
+  const { tasks } = await import("./db.ts");
+  tasks.insert({
+    id: args.taskId,
+    title: args.taskId,
+    prompt: "",
+    column: "running",
+    agent: "claude-code",
+    workdir: cwd,
+    isolation: "none",
+    branch: null,
+    worktreePath: null,
+    baseRef: null,
+    mode: "plan",
+    model: "opus-4.7",
+    effort: null,
+    references: [],
+    runId: "run-plan",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    hasOpenableRun: false,
+  });
+  // Pre-write the allow-rule directly to the task's settings file so the
+  // route's lookupAllowRule call hits "allow" — same shape we'd get if the
+  // user had previously clicked "Allow always" on an Edit card.
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  mkdirSync(path.join(cwd, ".claude"), { recursive: true });
+  writeFileSync(
+    path.join(cwd, ".claude", "settings.local.json"),
+    JSON.stringify({ permissions: { allow: [args.ruleEntry] } }),
+  );
+  // Stand up a fake claude-tmux session so getCurrentPermissionMode has
+  // something to read. The test mutates `state.permissionMode` between
+  // sub-cases.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const jsonl = path.join(cwd, "session.jsonl");
+  writeFileSync(jsonl, "");
+  const state = __forTest.installSession(args.taskId, jsonl);
+  return { cwd, state };
+}
+
+test("POST /approvals — saved Edit rule still auto-allows in non-plan mode (regression guard)", async () => {
+  // Reset before this test — prior sibling tests in the same process may
+  // have left pending approvals that would skew the assertion below.
+  const { __testing: pre } = await import("./interactions.ts");
+  pre.reset();
+  const { state } = await seedTaskWithSavedRule({
+    taskId: "t-saved-rule-auto",
+    ruleEntry: "Edit(/tmp/**)",
+  });
+  state.permissionMode = "auto"; // not plan
+  const res = await fetch(url(`/approvals?taskId=t-saved-rule-auto`), {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: "/tmp/x", old_string: "a", new_string: "b" },
+    }),
+  });
+  // Fast path → instant 200 with "allow" decision; no pending interaction.
+  expect(res.status).toBe(200);
+  const body = await res.json() as { hookSpecificOutput?: { permissionDecision?: string } };
+  expect(body.hookSpecificOutput?.permissionDecision).toBe("allow");
+  const { __testing } = await import("./interactions.ts");
+  expect(__testing.approvalsSize()).toBe(0);
+});
+
+test("POST /approvals — plan mode skips the saved-rule fast-path and registers an approval", async () => {
+  const { state } = await seedTaskWithSavedRule({
+    taskId: "t-saved-rule-plan",
+    ruleEntry: "Edit(/tmp/**)",
+  });
+  state.permissionMode = "plan";
+  const { __testing } = await import("./interactions.ts");
+  __testing.reset();
+  // Don't await — the route blocks until the interaction answers, which
+  // is the *point*: in plan mode we want to surface to the UI, not
+  // short-circuit. Race the fetch against a short delay; the registry
+  // size assertion proves the interaction landed.
+  const pending = fetch(url(`/approvals?taskId=t-saved-rule-plan`), {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: "/tmp/y", old_string: "c", new_string: "d" },
+    }),
+  });
+  // Give the server a tick to register before we assert.
+  await new Promise((r) => setTimeout(r, 50));
+  expect(__testing.approvalsSize()).toBe(1);
+  // Resolve via the answer endpoint so the awaiting fetch settles and
+  // doesn't leak across tests.
+  const { listPendingForTask, answerApproval } = await import("./interactions.ts");
+  const list = listPendingForTask("t-saved-rule-plan");
+  expect(list[0]?.kind).toBe("approval");
+  if (list[0]?.kind === "approval") {
+    answerApproval(list[0].id, { decision: "allow" });
+  }
+  const res = await pending;
+  expect(res.status).toBe(200);
+});
+
+test("POST /approvals — plan mode still fast-paths read-only tools (Read)", async () => {
+  const { state } = await seedTaskWithSavedRule({
+    taskId: "t-saved-rule-plan-read",
+    ruleEntry: "Edit(/tmp/**)",
+  });
+  state.permissionMode = "plan";
+  const res = await fetch(url(`/approvals?taskId=t-saved-rule-plan-read`), {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ tool_name: "Read", tool_input: { file_path: "/etc/hosts" } }),
+  });
+  // SAFE_TOOLS short-circuit still applies — Read is read-only, plan mode
+  // doesn't care.
+  expect(res.status).toBe(200);
+  const body = await res.json() as { hookSpecificOutput?: { permissionDecision?: string } };
+  expect(body.hookSpecificOutput?.permissionDecision).toBe("allow");
+});

--- a/src/bun/claude-tmux-scraper.test.ts
+++ b/src/bun/claude-tmux-scraper.test.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Set data dir before db.ts is loaded transitively (claude-tmux.ts imports
+// it now that the scraper looks up the task's runId).
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-scraper-"));
+
+import { __forTest } from "./claude-tmux.ts";
+
+const { matchNumberedModal, matchYesNoModal } = __forTest;
+
+test("matchNumberedModal — claude plan-mode dialog (cursor on choice 1)", () => {
+  const pane = `
+  Edit file
+    src/foo.ts
+    1 line changed
+  Do you want to make this edit to foo.ts?
+  ❯ 1. Yes
+    2. Yes, allow all
+    3. No
+`;
+  const m = matchNumberedModal(pane);
+  expect(m).not.toBeNull();
+  expect(m!.choices.map((c) => c.key)).toEqual(["1", "2", "3"]);
+  expect(m!.choices[0]!.label).toBe("Yes");
+  expect(m!.choices[1]!.label).toBe("Yes, allow all");
+  expect(m!.choices[2]!.label).toBe("No");
+});
+
+test("matchNumberedModal — alt cursor glyph (›)", () => {
+  const pane = `Question?
+› 1. Pick A
+  2. Pick B`;
+  const m = matchNumberedModal(pane);
+  expect(m?.choices.length).toBe(2);
+});
+
+test("matchNumberedModal — no cursor anywhere means it's a printed list, not a modal", () => {
+  const pane = `Here are the next steps:
+  1. Install
+  2. Configure
+  3. Run`;
+  expect(matchNumberedModal(pane)).toBeNull();
+});
+
+test("matchNumberedModal — only one numbered line → not a choice set", () => {
+  const pane = `Foo
+❯ 1. Just one`;
+  expect(matchNumberedModal(pane)).toBeNull();
+});
+
+test("matchNumberedModal — same content yields a stable fingerprint", () => {
+  const pane = `Q?
+❯ 1. A
+  2. B`;
+  const a = matchNumberedModal(pane)!;
+  const b = matchNumberedModal(pane + "\n   "); // trailing whitespace shouldn't change fp
+  expect(a.fingerprint).toBe(b!.fingerprint);
+});
+
+test("matchNumberedModal — changing labels changes the fingerprint", () => {
+  const a = matchNumberedModal(`❯ 1. A\n  2. B`)!;
+  const b = matchNumberedModal(`❯ 1. A\n  2. C`)!;
+  expect(a.fingerprint).not.toBe(b.fingerprint);
+});
+
+test("matchYesNoModal — (y/N) prompt on last line", () => {
+  const pane = `Continue with the operation? (y/N)`;
+  const m = matchYesNoModal(pane);
+  expect(m).not.toBeNull();
+  expect(m!.choices.map((c) => c.key)).toEqual(["y", "n"]);
+});
+
+test("matchYesNoModal — bracket variant [Y/n] with trailing colon", () => {
+  const pane = `Proceed [Y/n]:`;
+  const m = matchYesNoModal(pane);
+  expect(m).not.toBeNull();
+});
+
+test("matchYesNoModal — ignores numbered modal pane (different signature)", () => {
+  const pane = `❯ 1. Yes
+  2. No`;
+  expect(matchYesNoModal(pane)).toBeNull();
+});
+
+test("dispatchLine updates permissionMode BEFORE the dedup guard (reattach safety)", async () => {
+  const { __forTest } = await import("./claude-tmux.ts");
+  const { mkdtempSync, writeFileSync } = await import("node:fs");
+  const { tmpdir: t } = await import("node:os");
+  const path2 = await import("node:path");
+  const dir = mkdtempSync(path2.default.join(t(), "agetor-pm-"));
+  const jsonl = path2.default.join(dir, "session.jsonl");
+  writeFileSync(jsonl, "");
+  const state = __forTest.installSession("t-pm-reattach", jsonl);
+  // Simulate the reattach situation: the uuid is already in the dedup
+  // set (the previous process persisted it to run_events), so any
+  // SSE-emitting work would be skipped. The permission-mode update
+  // must still apply because it lives ABOVE the dedup return.
+  const uuid = "11111111-1111-1111-1111-111111111111";
+  state.seenLineUuids.add(uuid);
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "permission-mode", uuid, permissionMode: "plan",
+  }));
+  expect(state.permissionMode).toBe("plan");
+  __forTest.uninstallSession("t-pm-reattach");
+});

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -10,12 +10,19 @@ import {
 import { open } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { API_TOKEN, getApiPort } from "./api-config.ts";
+import { tasks } from "./db.ts";
 import { ensureInstalledForCwd } from "./hook-installer.ts";
 import {
   ASK_QUESTIONS_REPLY_PREFIX,
   PLAN_APPROVED_REPLY_PREFIX,
   PLAN_REJECTED_REPLY_PREFIX,
+  activeTmuxPromptsForTask,
+  answerTmuxPrompt,
+  findTmuxPromptByFingerprint,
+  registerTmuxPrompt,
+  type TmuxPromptChoice,
 } from "./interactions.ts";
 import { resolveTmuxBin } from "./tmux-resolution.ts";
 
@@ -417,6 +424,42 @@ export function killSessionByName(name: string): void {
   tmux(["kill-session", "-t", name]);
 }
 
+/**
+ * Current permission-mode for this task's claude session, as last reported
+ * by a JSONL `permission-mode` event (or, on first launch, the value the
+ * orchestrator passed to `spawnClaudeViaTmux`). Returns null when no
+ * session is registered for this task (idle, between runs, or unknown
+ * task). Read by the `/approvals` route so plan mode can never silently
+ * short-circuit a tool call via the saved-rule fast-path.
+ */
+export function getCurrentPermissionMode(taskId: string): string | null {
+  return sessions.get(taskId)?.permissionMode ?? null;
+}
+
+/**
+ * Send a literal keystroke (or short sequence) to a task's tmux session
+ * followed by Enter. Used by the `/tmux-prompts/:id/answer` route to
+ * dismiss a Claude REPL modal the scraper detected — typing `"1"` then
+ * Enter into the pane is how the user would manually pick choice 1.
+ *
+ * NOT a chat message: we deliberately bypass the `load-buffer +
+ * paste-buffer` flow `pastePrompt` uses, because that path delivers the
+ * text into claude's input buffer to become the next prompt. The modal
+ * wants a direct keypress, not a queued message.
+ *
+ * Returns true on apparent success (tmux command exited 0). Silently
+ * returns false when no session is registered.
+ */
+export function dismissTmuxPrompt(taskId: string, key: string): boolean {
+  const state = sessions.get(taskId);
+  if (!state) return false;
+  // send-keys interprets every positional arg as a tmux key spec — pass
+  // the literal first, then "Enter" as a separate token so claude sees
+  // an actual carriage return.
+  const res = tmux(["send-keys", "-t", state.sessionName, key, "Enter"]);
+  return res.ok;
+}
+
 /* ────────────────────────────────────────────────────────────────────────── *
  * Per-task session state.
  * ────────────────────────────────────────────────────────────────────────── */
@@ -459,6 +502,41 @@ interface SessionState {
    *  waiting on `done`. Cleared after the first fire. Untouched on freshly-
    *  spawned sessions (those resolve via the turn slot's promise instead). */
   onEndOfTurn: (() => void) | null;
+  /** Most recently observed permission-mode for this claude session.
+   *  Initialized from the launch `mode`; updated when the JSONL emits a
+   *  `permission-mode` event (the user typed `/permission-mode <id>`
+   *  inside the REPL). Read by the `/approvals` route at the moment a
+   *  PreToolUse hook fires so plan mode can never silently fast-path
+   *  through a saved allow-rule. */
+  permissionMode: string | null;
+  /** Periodic scrape of the visible tmux pane — looks for `Do you want
+   *  to … 1.Yes 2.Yes,allow 3.No` style modals that bypass the hook
+   *  system (plan-mode dialogs, `acceptEdits` + Bash, `/login`, etc.).
+   *  Lazily armed when a turn enters the queue; torn down with the
+   *  pollTimer. */
+  scrapeTimer: ReturnType<typeof setInterval> | null;
+  /** Last fingerprint the scraper saw; an entry must match the previous
+   *  scrape (i.e. two consecutive ticks) before we register a real
+   *  TmuxPromptRequest. Suppresses false positives where a numbered list
+   *  flickers past during normal output. Reset whenever the pane no
+   *  longer matches any signature. */
+  scrapeLastFingerprint: string | null;
+  /** `Date.now()` stamp of the most recent successful JSONL append the
+   *  flusher dispatched. The scraper consults it to (a) suppress
+   *  matches that happened while claude was actively writing (the
+   *  "prompt" is probably transient list output, not a stable modal)
+   *  and (b) cheaply detect a truly idle session so the 1s scrape
+   *  tick can self-throttle. 0 means "no append observed yet". */
+  lastJsonlAppendAt: number;
+  /** Fingerprint → `Date.now()` of when it was answered. The route
+   *  handler stamps an entry here right after `dismissTmuxPrompt`; the
+   *  scraper skips re-registering a fingerprint that's still inside
+   *  the TTL window. Without this, the next tick's two-tick-stability
+   *  fires *after* the user clicked (the same fingerprint was on the
+   *  pane the previous tick AND now), the entry is gone from the
+   *  pending map, and we'd register a ghost duplicate before
+   *  tmux/claude actually repainted. */
+  recentlyAnsweredFingerprints: Map<string, number>;
 }
 
 interface TurnSlot {
@@ -555,6 +633,23 @@ function dispatchLine(state: SessionState, line: string): void {
     return;
   }
   const uuid = typeof evt.uuid === "string" ? evt.uuid : undefined;
+
+  // Track the latest permission-mode the JSONL reports. The user can
+  // change it mid-session via `/permission-mode <id>`, so we can't rely
+  // on the launch `mode` alone. Read by `/approvals` to know whether
+  // the saved-rule fast-path is safe (it isn't in plan mode).
+  //
+  // IMPORTANT: this update MUST stay above the seenLineUuids early-
+  // return below. On reattach the dedup set is pre-seeded from
+  // run_events, so every replayed line — including the permission-mode
+  // event the prior process recorded — would be skipped. Re-applying
+  // the in-memory update is cheap and idempotent; skipping it leaves
+  // state.permissionMode at null and silently disables the plan-mode
+  // saved-rule safety net for any session that survives a restart.
+  if (evt.type === "permission-mode" && typeof evt.permissionMode === "string") {
+    state.permissionMode = evt.permissionMode;
+  }
+
   if (uuid && state.seenLineUuids.has(uuid)) return;
 
   const slot = state.turnQueue[0];
@@ -667,10 +762,273 @@ async function flush(state: SessionState): Promise<void> {
   // Advance the cursor to *just before* the partial tail so we re-read it
   // once it's complete.
   state.offset = chunk.next - Buffer.byteLength(tail, "utf8");
+  // Mark claude as actively writing — the scraper consults this to
+  // suppress false positives from numbered output that streams in mid-
+  // turn (and that one-tick-stable list-printing wouldn't normally
+  // beat the two-tick stability requirement).
+  state.lastJsonlAppendAt = Date.now();
   for (const line of lines) {
     if (!line) continue;
     dispatchLine(state, line);
   }
+}
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Tmux pane scraper — catches REPL modals the PreToolUse hook never sees.
+ *
+ * The hook system is a closed loop with claude's permission engine: only
+ * tool calls fire PreToolUse, and within that, only paths claude routes to
+ * the hook. Plan-mode safety dialogs, `/login`, the model picker, auth
+ * re-prompts, and `acceptEdits` + Bash all paint a modal in the TUI that
+ * the hook never sees. Without this scraper, the kanban shows
+ * "Agent is working…" while claude is actually paused on a 3-choice
+ * dialog inside tmux, invisible to anyone who hasn't `tmux attach`-ed.
+ *
+ * The scraper runs every ~1s, capture-panes the visible window, and tries
+ * a small set of regex matchers against the tail. On a match it hashes
+ * the matched block and waits one more tick before registering — a
+ * single-tick blip never wins, which suppresses false positives from
+ * normal numbered-list output. Once registered, the prompt rides the
+ * standard interaction broadcast → SSE → run-panel path; answering ships
+ * the choice's `key` back via `tmux send-keys` (see `dismissTmuxPrompt`).
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** How often the scraper polls the tmux pane. Aligned with the SSE poll
+ *  budget — slower than this lets dialogs sit unannounced for too long;
+ *  faster wastes CPU on `tmux capture-pane` syscalls during normal work. */
+const SCRAPE_INTERVAL_MS = 1000;
+
+/** Number of trailing pane lines we look at. Modal dialogs always anchor
+ *  to the bottom of the pane; ignoring the rest avoids matching old
+ *  output that scrolled past. */
+const SCRAPE_TAIL_LINES = 40;
+
+interface ScrapeMatch {
+  /** Verbatim text the user will see in the UI card. */
+  paneText: string;
+  /** Buttons to render — `key` is what we send to tmux on click. */
+  choices: TmuxPromptChoice[];
+  /** Stable hash that survives across consecutive scrapes as long as the
+   *  modal stays on screen unchanged. */
+  fingerprint: string;
+}
+
+/** Recognise claude's standard numbered-choice modal:
+ *
+ *   Do you want to proceed?
+ *   ❯ 1. Yes
+ *     2. Yes, allow always
+ *     3. No
+ *
+ * Different claude versions use `❯` or `›` as the cursor on the
+ * selected line. We deliberately do NOT accept `>` — markdown
+ * blockquotes (`> 1. some text`), CLI usage examples, and shell-prompt
+ * captures all start with `>` and would otherwise misfire the matcher.
+ * Choices are captured verbatim from the pane so the UI label matches
+ * what was on screen. The `key` is the literal digit — typing it +
+ * Enter dismisses the modal exactly the way the user would. */
+function matchNumberedModal(tail: string): ScrapeMatch | null {
+  const lines = tail.split("\n");
+  const numbered: Array<{ key: string; label: string; cursorHere: boolean }> = [];
+  for (const raw of lines) {
+    const m = raw.match(/^\s*([›❯])?\s*(\d+)\.\s+(.+?)\s*$/);
+    if (!m) continue;
+    numbered.push({
+      cursorHere: !!m[1],
+      key: m[2]!,
+      label: m[3]!.trim(),
+    });
+  }
+  if (numbered.length < 2) return null;
+  // Need at least one cursor marker on the numbered block — otherwise
+  // we're probably looking at a printed list, not an interactive modal.
+  if (!numbered.some((n) => n.cursorHere)) return null;
+  // Take the contiguous trailing run of numbered lines (a list further
+  // up the pane shouldn't poison the choice set).
+  const tailRun: typeof numbered = [];
+  for (let i = numbered.length - 1; i >= 0; i--) {
+    tailRun.unshift(numbered[i]!);
+    if (i > 0 && Number(numbered[i - 1]!.key) + 1 !== Number(numbered[i]!.key)) break;
+  }
+  if (tailRun.length < 2) return null;
+  const choices: TmuxPromptChoice[] = tailRun.map((n) => ({ key: n.key, label: n.label }));
+  // Use the last ~12 lines for the displayed pane snippet so the user
+  // sees the question text + the choices, not 40 lines of unrelated
+  // context above.
+  const paneText = lines.slice(-12).join("\n").trimEnd();
+  const fingerprint = sha1(`numbered:${choices.map((c) => `${c.key}|${c.label}`).join("/")}`);
+  return { paneText, choices, fingerprint };
+}
+
+/** Recognise `(y/N)` / `(Y/n)` / `[y/n]` confirmation prompts on the
+ *  last non-empty line. Lower priority than the numbered matcher — only
+ *  fires when no numbered choices were found. */
+function matchYesNoModal(tail: string): ScrapeMatch | null {
+  const lines = tail.split("\n").filter((l) => l.trim().length > 0);
+  const last = lines[lines.length - 1] ?? "";
+  // Match patterns like `… (y/N)`, `… [Y/n]`, with optional trailing
+  // whitespace or a `?`. Case-insensitive to forgive minor variants.
+  if (!/[(\[][yYnN]\/[yYnN][)\]]\s*[?:]?\s*$/.test(last)) return null;
+  // Default capital indicates the default answer if the user just hits
+  // Enter — we surface both as explicit buttons regardless so the user
+  // always picks consciously.
+  const choices: TmuxPromptChoice[] = [
+    { key: "y", label: "Yes" },
+    { key: "n", label: "No" },
+  ];
+  const paneText = lines.slice(-6).join("\n").trimEnd();
+  const fingerprint = sha1(`y-n:${last}`);
+  return { paneText, choices, fingerprint };
+}
+
+function sha1(s: string): string {
+  return createHash("sha1").update(s).digest("hex").slice(0, 16);
+}
+
+/** TTL on the "just answered this fingerprint" suppression. Has to
+ *  comfortably exceed the worst-case lag between sending Enter into
+ *  tmux and claude repainting the pane without the modal. 3s is
+ *  generous on a busy machine but cheap to wait through.  */
+const RECENTLY_ANSWERED_TTL_MS = 3_000;
+
+/** A scrape tick is skipped when the JSONL has been written to this
+ *  recently — claude is mid-stream, so whatever's on the pane is
+ *  likely transient output (a numbered list being printed) and not a
+ *  stable modal awaiting input. */
+const JSONL_RECENT_WRITE_MS = 500;
+
+/** Beyond this idle window with no active turn, the scraper stops
+ *  tick'ing entirely — there's no plausible scenario where a brand-
+ *  new modal appears on a session that hasn't seen output in a long
+ *  time. Idle sessions cost nothing this way. */
+const SCRAPE_IDLE_AFTER_MS = 5_000;
+
+/** Run a single scrape tick. Idempotent: registers at most one new
+ *  TmuxPromptRequest per call, auto-cancels any pending one whose
+ *  fingerprint no longer matches the pane. */
+function scrapeOnce(state: SessionState): void {
+  const now = Date.now();
+  // Idle gate: skip the syscall entirely when nothing is plausibly
+  // happening. A session with no turn in flight that hasn't appended
+  // to its JSONL in 5s is at the REPL prompt; the user isn't waiting
+  // on a modal we missed.
+  if (state.turnQueue.length === 0
+      && state.lastJsonlAppendAt !== 0
+      && now - state.lastJsonlAppendAt > SCRAPE_IDLE_AFTER_MS
+      && activeTmuxPromptsForTask(state.taskId).length === 0) {
+    return;
+  }
+
+  const cap = tmux(["capture-pane", "-p", "-t", state.sessionName]);
+  if (!cap.ok) {
+    // Session vanished — let `disposeSessionState` clean us up the next
+    // time the orchestrator notices. Don't churn here.
+    return;
+  }
+  const lines = cap.stdout.split("\n");
+  const tail = lines.slice(Math.max(0, lines.length - SCRAPE_TAIL_LINES)).join("\n");
+
+  // JSONL-recency gate: claude is actively writing. The pane content
+  // is mid-render, not a stable modal — defer matching until things
+  // settle. We still run the auto-cancel sweep below so a previously
+  // registered prompt that just disappeared can clear out.
+  const claudeIsWriting = state.lastJsonlAppendAt !== 0
+    && now - state.lastJsonlAppendAt < JSONL_RECENT_WRITE_MS;
+
+  const match = claudeIsWriting
+    ? null
+    : (matchNumberedModal(tail) ?? matchYesNoModal(tail));
+
+  // Auto-cancel: any registered prompt for this task whose fingerprint
+  // is NOT what we see now has been dismissed (either externally via
+  // `tmux attach`, or the dialog was transient). Resolve those entries
+  // so the UI stops showing them.
+  const stillPresent = new Set<string>(match ? [match.fingerprint] : []);
+  for (const pending of activeTmuxPromptsForTask(state.taskId)) {
+    if (!stillPresent.has(pending.fingerprint)) {
+      answerTmuxPrompt(pending.id, { key: "__external__" });
+    }
+  }
+
+  // Garbage-collect the recently-answered map. Cheap (typically 0–1
+  // entries) and keeps stale fingerprints from leaking memory if a
+  // session lives long enough to churn through hundreds of prompts.
+  for (const [fp, ts] of state.recentlyAnsweredFingerprints) {
+    if (now - ts > RECENTLY_ANSWERED_TTL_MS) {
+      state.recentlyAnsweredFingerprints.delete(fp);
+    }
+  }
+
+  if (!match) {
+    state.scrapeLastFingerprint = null;
+    return;
+  }
+
+  // Re-registration suppression: if the user *just* answered this
+  // exact fingerprint, the modal may still be on the pane for one
+  // more tick while tmux/claude finish repainting. Skip — without
+  // this, the two-tick stability requirement (the previous tick
+  // saw the same fingerprint) would register a ghost duplicate.
+  if (state.recentlyAnsweredFingerprints.has(match.fingerprint)) {
+    return;
+  }
+
+  // Two-tick stability — require the same match on two consecutive
+  // scrapes before registering. Single-tick blips (a numbered list the
+  // agent is printing) never make it through.
+  if (state.scrapeLastFingerprint !== match.fingerprint) {
+    state.scrapeLastFingerprint = match.fingerprint;
+    return;
+  }
+
+  // Already registered? Nothing to do — the previous tick's broadcast
+  // is what the UI is showing.
+  if (findTmuxPromptByFingerprint(state.taskId, match.fingerprint)) return;
+
+  // Look up the active run id for this task. We need it on the
+  // interaction so the run panel can scope correctly; without one the
+  // prompt would float unattached. Idle tasks (no run) skip — there's
+  // nothing for the user to react to without an active session anyway.
+  const runId = tasks.get(state.taskId)?.runId;
+  if (!runId) return;
+
+  registerTmuxPrompt({
+    taskId: state.taskId,
+    runId,
+    paneText: match.paneText,
+    choices: match.choices,
+    fingerprint: match.fingerprint,
+  });
+}
+
+/**
+ * Stamp a fingerprint as "just answered" so the next scrape tick
+ * doesn't immediately re-register a ghost copy while tmux/claude
+ * finish repainting. Called by the `/tmux-prompts/:id/answer` route
+ * right after `dismissTmuxPrompt`.
+ *
+ * No-op when there's no session for the task — same idempotent
+ * behaviour as `dismissTmuxPrompt` on a torn-down session.
+ */
+export function markTmuxPromptAnswered(taskId: string, fingerprint: string): void {
+  const state = sessions.get(taskId);
+  if (!state) return;
+  state.recentlyAnsweredFingerprints.set(fingerprint, Date.now());
+  // Clear the stability cursor so the next match has to re-stabilise
+  // before it can register again — this defends against the case where
+  // the same fingerprint genuinely re-appears later (the user answered,
+  // claude immediately printed an identical-looking dialog), without
+  // racing the registration.
+  state.scrapeLastFingerprint = null;
+}
+
+/** Install or refresh the scraper interval for a session. Called from
+ *  `attachTailer`; torn down by `disposeSessionState`. */
+function startScraper(state: SessionState): void {
+  if (state.scrapeTimer) return;
+  state.scrapeTimer = setInterval(() => {
+    try { scrapeOnce(state); } catch { /* swallow — never crash the timer */ }
+  }, SCRAPE_INTERVAL_MS);
 }
 
 function attachTailer(state: SessionState): void {
@@ -686,6 +1044,7 @@ function attachTailer(state: SessionState): void {
   // accumulated in the JSONL without firing the watcher. A 400ms tick is
   // cheap (one stat + read-if-grew) and bulletproof.
   state.pollTimer = setInterval(() => { void flush(state); }, 400);
+  startScraper(state);
 }
 
 /* ────────────────────────────────────────────────────────────────────────── *
@@ -769,6 +1128,11 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
     lastChunk: null,
     seenLineUuids: new Set(),
     onEndOfTurn: null,
+    permissionMode: opts.mode,
+    scrapeTimer: null,
+    scrapeLastFingerprint: null,
+    lastJsonlAppendAt: 0,
+    recentlyAnsweredFingerprints: new Map(),
   };
   sessions.set(opts.taskId, state);
 
@@ -871,6 +1235,16 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
     lastChunk: opts.onChunk,
     seenLineUuids: opts.seenLineUuids,
     onEndOfTurn: () => resolveDone?.(0),
+    // Seed from the persisted task mode so plan-mode safety is in
+    // force the instant the session is registered (the JSONL replay
+    // still re-applies any in-session `/permission-mode <id>` change
+    // because dispatchLine updates this field *above* the dedup
+    // guard, which is the only reason that replay path works).
+    permissionMode: tasks.get(opts.taskId)?.mode ?? null,
+    scrapeTimer: null,
+    scrapeLastFingerprint: null,
+    lastJsonlAppendAt: 0,
+    recentlyAnsweredFingerprints: new Map(),
   };
   // Belt to reconcileOrphans's sort-and-dedup suspender: if some prior
   // reattach (or other code path) already left a SessionState in the map
@@ -977,6 +1351,9 @@ function disposeSessionState(state: SessionState | undefined): void {
   state.watcher = null;
   if (state.pollTimer) clearInterval(state.pollTimer);
   state.pollTimer = null;
+  if (state.scrapeTimer) clearInterval(state.scrapeTimer);
+  state.scrapeTimer = null;
+  state.scrapeLastFingerprint = null;
   state.onEndOfTurn = null;
   const err = new Error("session killed");
   for (const slot of state.turnQueue.splice(0)) slot.reject?.(err);
@@ -1032,6 +1409,11 @@ export const __forTest = {
       lastChunk: null,
       seenLineUuids: new Set(),
       onEndOfTurn: null,
+      permissionMode: null,
+      scrapeTimer: null,
+      scrapeLastFingerprint: null,
+      lastJsonlAppendAt: 0,
+      recentlyAnsweredFingerprints: new Map(),
     };
     sessions.set(taskId, state);
     return state;
@@ -1045,6 +1427,8 @@ export const __forTest = {
   flushSync,
   flush,
   dispatchLine,
+  matchNumberedModal,
+  matchYesNoModal,
 };
 
 /**

--- a/src/bun/interactions.test.ts
+++ b/src/bun/interactions.test.ts
@@ -322,3 +322,98 @@ test("cancelPendingForTask resolves ask_questions + plan_approval entries", asyn
   expect(pa.choice).toBe("reject");
   expect(pa.revision).toBe("cancelled by user");
 });
+
+test("registerTmuxPrompt + answerTmuxPrompt round-trips a key", async () => {
+  const { registerTmuxPrompt, answerTmuxPrompt, __testing } = await import("./interactions.ts");
+  expect(__testing.tmuxPromptsSize()).toBe(0);
+  const { id, answer } = registerTmuxPrompt({
+    taskId: "tT", runId: "rT",
+    paneText: "Do you want to proceed?",
+    choices: [{ key: "1", label: "Yes" }, { key: "2", label: "No" }],
+    fingerprint: "abc123",
+  });
+  expect(__testing.tmuxPromptsSize()).toBe(1);
+  expect(answerTmuxPrompt(id, { key: "1" })).toBe(true);
+  await expect(answer).resolves.toEqual({ key: "1" });
+  expect(__testing.tmuxPromptsSize()).toBe(0);
+});
+
+test("findTmuxPromptByFingerprint hits only the same task + fingerprint", async () => {
+  const { registerTmuxPrompt, findTmuxPromptByFingerprint } = await import("./interactions.ts");
+  registerTmuxPrompt({
+    taskId: "tA", runId: "r1",
+    paneText: "x", choices: [{ key: "1", label: "Y" }], fingerprint: "fp-A",
+  });
+  registerTmuxPrompt({
+    taskId: "tB", runId: "r1",
+    paneText: "x", choices: [{ key: "1", label: "Y" }], fingerprint: "fp-B",
+  });
+  expect(findTmuxPromptByFingerprint("tA", "fp-A")?.fingerprint).toBe("fp-A");
+  expect(findTmuxPromptByFingerprint("tA", "fp-B")).toBeNull();   // wrong task
+  expect(findTmuxPromptByFingerprint("tB", "fp-A")).toBeNull();   // wrong fp
+});
+
+test("listPendingForTask returns tmux_prompt entries alongside other kinds", async () => {
+  const { registerApproval, registerTmuxPrompt, listPendingForTask } = await import("./interactions.ts");
+  registerApproval({ taskId: "tM", runId: "rM", toolName: "Edit", toolInput: {} });
+  registerTmuxPrompt({
+    taskId: "tM", runId: "rM",
+    paneText: "?", choices: [{ key: "1", label: "Y" }], fingerprint: "fp",
+  });
+  const kinds = listPendingForTask("tM").map((r) => r.kind).sort();
+  expect(kinds).toEqual(["approval", "tmux_prompt"]);
+});
+
+test("cancelPendingForTask resolves tmux_prompt entries with the sentinel", async () => {
+  const { registerTmuxPrompt, cancelPendingForTask } = await import("./interactions.ts");
+  const { answer } = registerTmuxPrompt({
+    taskId: "tX", runId: "rX",
+    paneText: "x", choices: [{ key: "1", label: "Y" }], fingerprint: "fp-X",
+  });
+  cancelPendingForTask("tX", "task deleted");
+  await expect(answer).resolves.toEqual({ key: "__cancelled__" });
+});
+
+test("registerTmuxPrompt rejects reserved sentinel keys", async () => {
+  const { registerTmuxPrompt } = await import("./interactions.ts");
+  expect(() => registerTmuxPrompt({
+    taskId: "t-sentinel", runId: "r1",
+    paneText: "?",
+    choices: [{ key: "__external__", label: "External" }],
+    fingerprint: "fp-sentinel",
+  })).toThrow(/reserved/);
+});
+
+test("answer* paths emit on the resolved broadcaster", async () => {
+  const {
+    setResolvedBroadcaster,
+    registerApproval, answerApproval,
+    registerTmuxPrompt, answerTmuxPrompt,
+    cancelPendingForTask,
+  } = await import("./interactions.ts");
+  const seen: Array<{ id: string; kind: string }> = [];
+  setResolvedBroadcaster((r) => { seen.push({ id: r.id, kind: r.kind }); });
+
+  const a = registerApproval({ taskId: "tR", runId: "rR", toolName: "Bash", toolInput: {} });
+  answerApproval(a.id, { decision: "allow" });
+  await a.answer;
+
+  const t = registerTmuxPrompt({
+    taskId: "tR", runId: "rR",
+    paneText: "x", choices: [{ key: "1", label: "Y" }], fingerprint: "fp-r",
+  });
+  answerTmuxPrompt(t.id, { key: "1" });
+  await t.answer;
+
+  // cancellation path should fan out too
+  const t2 = registerTmuxPrompt({
+    taskId: "tR", runId: "rR",
+    paneText: "x", choices: [{ key: "1", label: "Y" }], fingerprint: "fp-r2",
+  });
+  cancelPendingForTask("tR", "test");
+  await t2.answer;
+
+  // Expect three resolution emissions in order.
+  expect(seen.map((s) => s.kind)).toEqual(["approval", "tmux_prompt", "tmux_prompt"]);
+  expect(seen.map((s) => s.id)).toEqual([a.id, t.id, t2.id]);
+});

--- a/src/bun/interactions.ts
+++ b/src/bun/interactions.ts
@@ -26,7 +26,8 @@ export type InteractionKind =
   | "approval"
   | "question"
   | "ask_questions"   // claude built-in AskUserQuestion intercepted via PreToolUse hook
-  | "plan_approval";  // claude built-in ExitPlanMode intercepted via PreToolUse hook
+  | "plan_approval"   // claude built-in ExitPlanMode intercepted via PreToolUse hook
+  | "tmux_prompt";    // unstructured in-REPL prompt detected by scraping the tmux pane
 
 export interface ApprovalRequest {
   kind: "approval";
@@ -134,11 +135,63 @@ export interface PlanApprovalAnswer {
   revision?: string;
 }
 
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Tmux pane scraper (catch-all for prompts the hook never sees).
+ *
+ * Some Claude REPL prompts — plan-mode safety dialogs that bypass hooks,
+ * `acceptEdits` + Bash, `/login`, model picker, auth re-prompts — never
+ * surface through PreToolUse. The scraper in `claude-tmux.ts` regex-matches
+ * the visible pane and registers one of these for each detected prompt.
+ * Answering ships the choice's `key` (typically `"1"`/`"2"`/`"3"` for
+ * numbered modals or `"y"`/`"n"` for y/N prompts) back to claude via
+ * `tmux send-keys` so the modal dismisses without the user touching tmux.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export interface TmuxPromptChoice {
+  /** The literal keystroke(s) to send. Numbered modals expect a single
+   *  digit; y/N prompts expect a single letter.
+   *
+   *  RESERVED: keys starting with `__` are sentinels for the resolver
+   *  (`__external__` for scraper-detected dismissals, `__cancelled__`
+   *  for run-teardown). `registerTmuxPrompt` rejects choices using a
+   *  reserved key so a future matcher can't accidentally collide. */
+  key: string;
+  /** Display label shown on the UI button. */
+  label: string;
+}
+
+export interface TmuxPromptRequest {
+  kind: "tmux_prompt";
+  id: string;
+  taskId: string;
+  runId: string;
+  /** Verbatim trailing slice of the tmux pane that matched a known prompt
+   *  signature. Rendered as monospace in the UI so the user sees exactly
+   *  what claude is asking. */
+  paneText: string;
+  choices: TmuxPromptChoice[];
+  /** Stable hash of the matched block — used to debounce duplicate
+   *  registrations across consecutive scrapes and to detect external
+   *  dismissal (the prompt disappeared from the pane). */
+  fingerprint: string;
+  createdAt: number;
+}
+
+export interface TmuxPromptAnswer {
+  /** Must equal one of the keys advertised on the request. The route
+   *  validates this before sending keystrokes to tmux. The sentinel
+   *  `"__external__"` is reserved for the scraper's auto-cancel path
+   *  (the prompt vanished from the pane on its own — e.g. user
+   *  attached to tmux and answered directly). */
+  key: string;
+}
+
 export type AnyRequest =
   | ApprovalRequest
   | QuestionRequest
   | AskQuestionsRequest
-  | PlanApprovalRequest;
+  | PlanApprovalRequest
+  | TmuxPromptRequest;
 
 /**
  * Tools we never bother the user about. Same list lives in the hook script
@@ -166,14 +219,33 @@ interface PlanApprovalEntry {
   req: PlanApprovalRequest;
   resolve: (answer: PlanApprovalAnswer) => void;
 }
+interface TmuxPromptEntry {
+  req: TmuxPromptRequest;
+  resolve: (answer: TmuxPromptAnswer) => void;
+}
 
 const approvals = new Map<string, ApprovalEntry>();
 const questions = new Map<string, QuestionEntry>();
 const askQuestions = new Map<string, AskQuestionsEntry>();
 const planApprovals = new Map<string, PlanApprovalEntry>();
+const tmuxPrompts = new Map<string, TmuxPromptEntry>();
 
 type BroadcastFn = (req: AnyRequest) => void;
 let broadcast: BroadcastFn = () => { /* installed by the orchestrator */ };
+
+/** Carries the bare minimum the UI needs to drop a card whose interaction
+ *  has been resolved server-side (auto-cancel from the scraper, tear-down
+ *  from `cancelPendingForTask`, route-driven answer, …). The UI filters
+ *  its local interactions array on `id`. */
+export interface InteractionResolved {
+  id: string;
+  taskId: string;
+  runId: string;
+  kind: InteractionKind;
+}
+
+type ResolveBroadcastFn = (res: InteractionResolved) => void;
+let broadcastResolved: ResolveBroadcastFn = () => { /* installed by the orchestrator */ };
 
 /**
  * The orchestrator hands us its event emitter so we can fan out new
@@ -183,6 +255,24 @@ let broadcast: BroadcastFn = () => { /* installed by the orchestrator */ };
  */
 export function setBroadcaster(fn: BroadcastFn): void {
   broadcast = fn;
+}
+
+/**
+ * Companion to `setBroadcaster` for the *removal* side: every `answer*`
+ * call and `cancelPendingForTask` path emits one of these so the UI can
+ * drop the resolved card without waiting for a polling refresh. Without
+ * this, scraper auto-cancel and run-cancellation leave stale cards in
+ * the run panel until the user closes and reopens it.
+ */
+export function setResolvedBroadcaster(fn: ResolveBroadcastFn): void {
+  broadcastResolved = fn;
+}
+
+/** Internal helper — every answer* / cancel* path that deletes from one
+ *  of the maps should call this with the request it removed so the UI
+ *  hears about it. */
+function fanoutResolved(req: AnyRequest): void {
+  broadcastResolved({ id: req.id, taskId: req.taskId, runId: req.runId, kind: req.kind });
 }
 
 /* ────────────────────────────────────────────────────────────────────────── *
@@ -230,6 +320,7 @@ export function answerApproval(id: string, answer: ApprovalAnswer): boolean {
     });
   }
   pending.resolve(answer);
+  fanoutResolved(pending.req);
   return true;
 }
 
@@ -272,6 +363,7 @@ export function answerQuestion(id: string, answer: QuestionAnswer): boolean {
   if (!entry) return false;
   questions.delete(id);
   entry.resolve(answer);
+  fanoutResolved(entry.req);
   return true;
 }
 
@@ -305,6 +397,7 @@ export function answerAskQuestions(id: string, answer: AskQuestionsAnswer): bool
   if (!entry) return false;
   askQuestions.delete(id);
   entry.resolve(answer);
+  fanoutResolved(entry.req);
   return true;
 }
 
@@ -376,6 +469,7 @@ export function answerPlanApproval(id: string, answer: PlanApprovalAnswer): bool
   if (!entry) return false;
   planApprovals.delete(id);
   entry.resolve(answer);
+  fanoutResolved(entry.req);
   return true;
 }
 
@@ -398,6 +492,85 @@ export function formatPlanApprovalReason(ans: PlanApprovalAnswer): string {
 }
 
 /* ────────────────────────────────────────────────────────────────────────── *
+ * Tmux pane scraper interactions
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export function registerTmuxPrompt(args: {
+  taskId: string;
+  runId: string;
+  paneText: string;
+  choices: TmuxPromptChoice[];
+  fingerprint: string;
+}): { id: string; req: TmuxPromptRequest; answer: Promise<TmuxPromptAnswer> } {
+  // Defend the reserved-key namespace — `__external__` / `__cancelled__`
+  // must be unambiguously sentinels, not legitimate user keystrokes.
+  for (const c of args.choices) {
+    if (c.key.startsWith("__")) {
+      throw new Error(
+        `registerTmuxPrompt: choice key '${c.key}' is reserved (keys starting with '__' are sentinels)`,
+      );
+    }
+  }
+  const id = randomUUID();
+  const req: TmuxPromptRequest = {
+    kind: "tmux_prompt",
+    id,
+    taskId: args.taskId,
+    runId: args.runId,
+    paneText: args.paneText,
+    choices: args.choices,
+    fingerprint: args.fingerprint,
+    createdAt: Date.now(),
+  };
+  const answer = new Promise<TmuxPromptAnswer>((resolve) => {
+    tmuxPrompts.set(id, { req, resolve });
+  });
+  broadcast(req);
+  return { id, req, answer };
+}
+
+export function answerTmuxPrompt(id: string, answer: TmuxPromptAnswer): boolean {
+  const entry = tmuxPrompts.get(id);
+  if (!entry) return false;
+  tmuxPrompts.delete(id);
+  entry.resolve(answer);
+  fanoutResolved(entry.req);
+  return true;
+}
+
+/** Look up a pending tmux_prompt by id — used by the route handler to
+ *  validate the key against the recorded choices before sending
+ *  keystrokes to tmux. */
+export function findTmuxPromptById(id: string): TmuxPromptRequest | null {
+  return tmuxPrompts.get(id)?.req ?? null;
+}
+
+/** Find a pending tmux_prompt for the task by its content fingerprint —
+ *  used by the scraper to skip re-registering an already-pending prompt. */
+export function findTmuxPromptByFingerprint(
+  taskId: string,
+  fingerprint: string,
+): TmuxPromptRequest | null {
+  for (const entry of tmuxPrompts.values()) {
+    if (entry.req.taskId === taskId && entry.req.fingerprint === fingerprint) {
+      return entry.req;
+    }
+  }
+  return null;
+}
+
+/** List the ids of every active tmux_prompt for this task. The scraper
+ *  uses this to auto-cancel prompts whose fingerprints disappeared from
+ *  the pane (the user dismissed them from a real tmux attach). */
+export function activeTmuxPromptsForTask(taskId: string): TmuxPromptRequest[] {
+  const out: TmuxPromptRequest[] = [];
+  for (const entry of tmuxPrompts.values()) {
+    if (entry.req.taskId === taskId) out.push(entry.req);
+  }
+  return out;
+}
+
+/* ────────────────────────────────────────────────────────────────────────── *
  * Shared helpers
  * ────────────────────────────────────────────────────────────────────────── */
 
@@ -413,11 +586,13 @@ export function cancelPendingForTask(taskId: string, reason: string): void {
     if (entry.req.taskId !== taskId) continue;
     approvals.delete(id);
     entry.resolve({ decision: "deny", reason });
+    fanoutResolved(entry.req);
   }
   for (const [id, entry] of questions) {
     if (entry.req.taskId !== taskId) continue;
     questions.delete(id);
     entry.resolve({ selected: [], custom: reason });
+    fanoutResolved(entry.req);
   }
   for (const [id, entry] of askQuestions) {
     if (entry.req.taskId !== taskId) continue;
@@ -425,11 +600,22 @@ export function cancelPendingForTask(taskId: string, reason: string): void {
     entry.resolve({
       answers: entry.req.questions.map(() => ({ selected: [], custom: reason })),
     });
+    fanoutResolved(entry.req);
   }
   for (const [id, entry] of planApprovals) {
     if (entry.req.taskId !== taskId) continue;
     planApprovals.delete(id);
     entry.resolve({ choice: "reject", revision: reason });
+    fanoutResolved(entry.req);
+  }
+  for (const [id, entry] of tmuxPrompts) {
+    if (entry.req.taskId !== taskId) continue;
+    tmuxPrompts.delete(id);
+    // Sentinel — the route handler reads this and skips the send-keys
+    // step so we don't inject random keystrokes into a session that's
+    // already being torn down.
+    entry.resolve({ key: "__cancelled__" });
+    fanoutResolved(entry.req);
   }
 }
 
@@ -439,6 +625,7 @@ export function listPendingForTask(taskId: string): AnyRequest[] {
   for (const e of questions.values()) if (e.req.taskId === taskId) out.push(e.req);
   for (const e of askQuestions.values()) if (e.req.taskId === taskId) out.push(e.req);
   for (const e of planApprovals.values()) if (e.req.taskId === taskId) out.push(e.req);
+  for (const e of tmuxPrompts.values()) if (e.req.taskId === taskId) out.push(e.req);
   return out.sort((a, b) => a.createdAt - b.createdAt);
 }
 
@@ -649,11 +836,14 @@ export const __testing = {
   questionsSize: () => questions.size,
   askQuestionsSize: () => askQuestions.size,
   planApprovalsSize: () => planApprovals.size,
+  tmuxPromptsSize: () => tmuxPrompts.size,
   reset() {
     approvals.clear();
     questions.clear();
     askQuestions.clear();
     planApprovals.clear();
+    tmuxPrompts.clear();
     broadcast = () => { /* reset */ };
+    broadcastResolved = () => { /* reset */ };
   },
 };

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -21,7 +21,13 @@ import {
 function resolveHarness(harnessId: string): Harness | null {
   return harnesses.getByIdOrKind(harnessId);
 }
-import { cancelPendingForTask, setBroadcaster, type AnyRequest } from "./interactions.ts";
+import {
+  cancelPendingForTask,
+  setBroadcaster,
+  setResolvedBroadcaster,
+  type AnyRequest,
+  type InteractionResolved,
+} from "./interactions.ts";
 import {
   dropSession,
   listAgetorSessions,
@@ -141,6 +147,22 @@ setBroadcaster((req: AnyRequest) => {
     stream: "interaction",
     data: JSON.stringify(req),
     ts: req.createdAt,
+  });
+});
+
+// Companion bridge for the *removal* side. Every answer*/cancel* path
+// in interactions.ts calls into this, so the run panel can drop the
+// card immediately instead of waiting for a refresh poll. Without
+// this, scraper auto-cancel and run-cancellation leave stale cards in
+// the panel (the existing additions-only SSE plumbing has no way to
+// signal "this is gone").
+setResolvedBroadcaster((res: InteractionResolved) => {
+  emit({
+    runId: res.runId,
+    taskId: res.taskId,
+    stream: "interaction_resolved",
+    data: JSON.stringify({ id: res.id, kind: res.kind }),
+    ts: Date.now(),
   });
 });
 

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -25,7 +25,14 @@ import {
   setTmuxSource,
   type TmuxSource,
 } from "./tmux-resolution.ts";
-import { jsonlPathFor, mapJsonlEventToChunks } from "./claude-tmux.ts";
+import {
+  dismissTmuxPrompt,
+  getCurrentPermissionMode,
+  jsonlPathFor,
+  mapJsonlEventToChunks,
+  markTmuxPromptAnswered,
+  sessionExists,
+} from "./claude-tmux.ts";
 import { listBranches } from "./worktree.ts";
 import { listAvailableCommands } from "./commands.ts";
 import { getDiscoveredModels, refreshDiscoveredModels } from "./agent-discovery.ts";
@@ -36,6 +43,8 @@ import {
   answerAskQuestions,
   answerPlanApproval,
   answerQuestion,
+  answerTmuxPrompt,
+  findTmuxPromptById,
   formatAskQuestionsReason,
   formatPlanApprovalReason,
   listPendingForTask,
@@ -834,11 +843,24 @@ export function startApiServer() {
           // accidental "Allow always" path that used to route through the
           // generic ApprovalCard) shouldn't be able to disable the safety.
           const ALWAYS_INTERCEPT = new Set(["AskUserQuestion", "ExitPlanMode"]);
+          // Plan mode is the user explicitly opting into "stop and ask
+          // before any write". A saved allow-rule from a prior non-plan
+          // run must not silently bypass that — otherwise the kanban
+          // shows "Agent is working…" while claude is actually paused on
+          // its plan-mode confirmation dialog inside tmux (see
+          // docs/can-we-apply-both-* plan). Read-only tools keep their
+          // fast-path even here: they can't mutate the workspace, so
+          // the plan-mode safety doesn't apply.
+          const PLAN_MODE_INTERCEPT = new Set([
+            "Edit", "Write", "MultiEdit", "NotebookEdit", "Bash",
+          ]);
+          const currentMode = getCurrentPermissionMode(taskId);
+          const planModeForce = currentMode === "plan" && PLAN_MODE_INTERCEPT.has(toolName);
           // Fast paths: safe tools and previously-saved rules auto-allow,
           // except for the always-intercept set above. The allow-rule lookup
           // now reads `.claude/settings.local.json` `permissions.allow` and
           // matches per the claude pattern syntax (see claude-permissions.ts).
-          if (!ALWAYS_INTERCEPT.has(toolName) &&
+          if (!ALWAYS_INTERCEPT.has(toolName) && !planModeForce &&
               (SAFE_TOOLS.has(toolName) ||
                lookupAllowRule({ taskId, toolName, toolInput: payload.tool_input }) === "allow")) {
             return json(makeHookResponse({ decision: "allow" }), { headers: corsHeaders(req) });
@@ -992,6 +1014,67 @@ export function startApiServer() {
           }
           const revision = typeof body.revision === "string" ? body.revision : undefined;
           const ok = answerPlanApproval(req.params.id, { choice: body.choice, revision });
+          return json({ ok }, { headers: corsHeaders(req) });
+        }),
+      },
+
+      // ─── Interactions: tmux pane scraper (catch-all REPL prompts) ────
+      // The scraper detects modals the PreToolUse hook never sees
+      // (plan-mode safety dialogs that bypass hooks, `/login`, model
+      // picker, …). Answering ships the chosen key — typically a single
+      // digit — back into the tmux pane via send-keys so claude reads
+      // it as the user's keypress and dismisses the modal.
+      "/tmux-prompts/:id/answer": {
+        POST: authed(async (req) => {
+          const body = (await req.json().catch(() => ({}))) as { key?: unknown };
+          const key = typeof body.key === "string" ? body.key : "";
+          if (!key) {
+            return json({ error: "key required" }, { status: 400, headers: corsHeaders(req) });
+          }
+          const pending = findTmuxPromptById(req.params.id);
+          if (!pending) {
+            // Either the prompt was auto-cancelled (scraper saw the pane
+            // change) or the id is unknown. Either way return ok:false so
+            // the UI can drop the card on its next poll.
+            return json({ ok: false }, { headers: corsHeaders(req) });
+          }
+          // Reject anything not in the recorded choice set — the request
+          // ships the exact keys we want the user to be able to send, and
+          // the UI is the only legitimate caller, so an unknown key here
+          // is an attempt to inject arbitrary keystrokes. Letting it
+          // through would let any code that reaches this endpoint type
+          // into the user's REPL.
+          if (!pending.choices.some((c) => c.key === key)) {
+            return json(
+              { error: `key '${key}' is not one of the registered choices` },
+              { status: 400, headers: corsHeaders(req) },
+            );
+          }
+          // Drive tmux FIRST. If the session is gone or send-keys
+          // fails, we must not resolve the interaction — doing so would
+          // remove the card from the UI while leaving claude paused on
+          // the modal. The user clicks "Yes", the card vanishes, and
+          // nothing actually happens. Surface the failure so the UI
+          // can leave the card up for retry.
+          if (!sessionExists(pending.taskId)) {
+            return json(
+              { ok: false, error: "tmux session is gone — cancel the run and start a new one" },
+              { status: 410, headers: corsHeaders(req) },
+            );
+          }
+          const delivered = dismissTmuxPrompt(pending.taskId, key);
+          if (!delivered) {
+            return json(
+              { ok: false, error: "failed to deliver keystroke to tmux" },
+              { status: 500, headers: corsHeaders(req) },
+            );
+          }
+          // Stamp the fingerprint as just-answered before resolving so
+          // the next scrape tick (which may catch the modal still on
+          // screen mid-repaint) doesn't register a ghost duplicate. See
+          // `markTmuxPromptAnswered` for why this is two-step.
+          markTmuxPromptAnswered(pending.taskId, pending.fingerprint);
+          const ok = answerTmuxPrompt(req.params.id, { key });
           return json({ ok }, { headers: corsHeaders(req) });
         }),
       },

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -292,6 +292,18 @@ function RunPanelBody({
         } catch { /* ignore malformed */ }
         return;
       }
+      if (e.stream === "interaction_resolved") {
+        // Server-side resolution (scraper auto-cancel, run cancellation,
+        // delete) — drop the matching card so the UI doesn't keep
+        // showing a stale prompt. The card's own submit handler also
+        // calls `dismissInteraction(id)` directly; both paths are
+        // idempotent under `id`-based filtering.
+        try {
+          const { id } = JSON.parse(e.data) as { id: string };
+          setInteractions((cur) => cur.filter((x) => x.id !== id));
+        } catch { /* ignore malformed */ }
+        return;
+      }
       setEvents((cur) => [...cur, e]);
     });
     return unsub;
@@ -926,6 +938,8 @@ function RunEventList({
         return <AskQuestionsCard key={`int-${it.id}`} req={it} onResolved={onResolved} />;
       case "plan_approval":
         return <PlanApprovalCard key={`int-${it.id}`} req={it} onResolved={onResolved} />;
+      case "tmux_prompt":
+        return <TmuxPromptCard key={`int-${it.id}`} req={it} onResolved={onResolved} />;
     }
   };
 
@@ -2630,6 +2644,70 @@ function PlanApprovalCard({
             </Button>
           </>
         )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Card for a REPL modal the tmux pane scraper caught — typically a
+ * plan-mode safety dialog, `/login`, model picker, or any prompt the
+ * PreToolUse hook system never sees. Clicking a choice ships the
+ * literal key (e.g. `"1"`) back to the server, which `tmux send-keys`-es
+ * it into the pane so claude reads it as the user's keypress.
+ *
+ * The card's appearance is intentionally pane-like (monospace, dark
+ * background) so the user recognises that they're looking at what's
+ * actually on the tmux screen, not an agetor-synthesised question.
+ */
+function TmuxPromptCard({
+  req,
+  onResolved,
+}: {
+  req: Extract<PendingInteraction, { kind: "tmux_prompt" }>;
+  onResolved: (id: string) => void;
+}) {
+  const [submitting, setSubmitting] = useState<string | null>(null);
+  const send = async (key: string) => {
+    if (submitting) return;
+    setSubmitting(key);
+    try {
+      await api.answerTmuxPrompt(req.id, { key });
+      onResolved(req.id);
+    } finally {
+      setSubmitting(null);
+    }
+  };
+  return (
+    <div className="rounded-md border border-amber-500/60 bg-card p-3 ring-1 ring-amber-500/40">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-amber-500">
+          <Terminal className="size-3.5" aria-hidden /> Claude is paused on a prompt
+        </span>
+      </div>
+      <pre className="max-h-96 overflow-auto whitespace-pre rounded-md border border-border/40 bg-muted/40 p-2 font-mono text-[11px] leading-snug">
+        {req.paneText}
+      </pre>
+      <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
+        {req.choices.map((c) => {
+          // Visual hint only: dim out the "negative" choice so it doesn't
+          // sit at equal weight with the primary one. Anchor the regex
+          // so labels like "Notify me" or "Nominate" don't accidentally
+          // get styled as a destructive action.
+          const isNegative = c.key.toLowerCase() === "n"
+            || /^(no|reject|cancel|deny|abort|quit)\b/i.test(c.label.trim());
+          return (
+            <Button
+              key={c.key}
+              onClick={() => void send(c.key)}
+              size="sm"
+              variant={isNegative ? "outline" : "secondary"}
+              disabled={submitting !== null}
+            >
+              {submitting === c.key ? "Sending…" : `${c.key}. ${c.label}`}
+            </Button>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -88,11 +88,27 @@ export interface PendingPlanApproval {
   createdAt: number;
 }
 
+/** Modal the tmux pane scraper detected — typically a plan-mode safety
+ *  dialog or another REPL prompt the PreToolUse hook system never sees.
+ *  Each `choices[i].key` is the literal keystroke the server will
+ *  `tmux send-keys` on click. */
+export interface PendingTmuxPrompt {
+  kind: "tmux_prompt";
+  id: string;
+  taskId: string;
+  runId: string;
+  paneText: string;
+  choices: Array<{ key: string; label: string }>;
+  fingerprint: string;
+  createdAt: number;
+}
+
 export type PendingInteraction =
   | PendingApproval
   | PendingQuestion
   | PendingAskQuestions
-  | PendingPlanApproval;
+  | PendingPlanApproval
+  | PendingTmuxPrompt;
 
 // Read api port + token, preferring globals injected by the Bun side via
 // BrowserWindow's `preload` option — that path works under the native
@@ -294,6 +310,14 @@ export const api = {
     body: { choice: "approve_implement" | "approve_ask" | "reject"; revision?: string },
   ) =>
     j<{ ok: boolean }>(`/plan-approvals/${id}/answer`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  /** Answer a tmux-pane-scraped REPL prompt. `key` must be one of the
+   *  keys advertised on the request — the server validates against the
+   *  recorded set before injecting keystrokes via `tmux send-keys`. */
+  answerTmuxPrompt: (id: string, body: { key: string }) =>
+    j<{ ok: boolean }>(`/tmux-prompts/${id}/answer`, {
       method: "POST",
       body: JSON.stringify(body),
     }),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -496,6 +496,7 @@ export type RunEventStream =
   | "stderr"
   | "status"
   | "interaction"
+  | "interaction_resolved"
   | "user"
   | "assistant"
   | "thinking"


### PR DESCRIPTION
Adds two layers that catch REPL modals the PreToolUse hook never sees (plan-mode safety dialogs, /login, model picker, acceptEdits + Bash, hook fail-open bypass):

- Plan-mode hole: track per-session permission mode on SessionState and skip the SAFE_TOOLS / saved-rule fast-path for mutating tools (Edit/Write/MultiEdit/NotebookEdit/Bash) when the task is in plan mode. permissionMode is seeded from task.mode at spawn + reattach and updated above the seenLineUuids dedup guard so JSONL replay rehydrates it.

- Tmux pane scraper: new "tmux_prompt" InteractionKind. A 1s scrape capture-panes the visible tmux window, matches numbered (❯/›) and y/N signatures, and registers a structured interaction after two-tick stability + JSONL-recency suppression. Answering a card POSTs to /tmux-prompts/:id/answer, which sessionExists-checks, send-keys'es the literal choice into the pane, then resolves the interaction (errors surface 410/500 so the UI keeps the card up for retry). Recently- answered fingerprints are blacklisted for 3s so the next tick can't ghost-duplicate before tmux repaints.

- New interaction_resolved SSE stream so scraper auto-cancel and cancelPendingForTask immediately drop cards from the run panel instead of leaving stale prompts visible until a panel reopen.

- Reserved __external__ / __cancelled__ sentinel keys are enforced in registerTmuxPrompt to keep the namespace clean for future matchers.