### PR TITLE
feat(ui): attach to a claude-code task's tmux session from Task details

### DIFF
--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -25,7 +25,7 @@ import {
   setTmuxSource,
   type TmuxSource,
 } from "./tmux-resolution.ts";
-import { jsonlPathFor, mapJsonlEventToChunks } from "./claude-tmux.ts";
+import { jsonlPathFor, mapJsonlEventToChunks, sessionExists, sessionNameFor } from "./claude-tmux.ts";
 import { listBranches } from "./worktree.ts";
 import { listAvailableCommands } from "./commands.ts";
 import { getDiscoveredModels, refreshDiscoveredModels } from "./agent-discovery.ts";
@@ -751,6 +751,84 @@ export function startApiServer() {
 
       "/tasks/:id/runs": {
         GET: authed((req) => json(runs.listForTask(req.params.id), { headers: corsHeaders(req) })),
+      },
+
+      // Open the task's claude-code tmux session in a new Terminal.app window.
+      // The session name is deterministic (`agetor-<taskId-prefix>`) so we can
+      // look it up without consulting the run row. We probe tmux availability
+      // and session liveness up-front so the UI gets a clear, distinct error
+      // for each failure mode instead of an empty Terminal that immediately
+      // errors with "can't find session".
+      "/tasks/:id/open-tmux": {
+        POST: authed((req) => {
+          const task = tasks.get(req.params.id);
+          if (!task) {
+            return json({ error: "task not found" }, { status: 404, headers: corsHeaders(req) });
+          }
+          const harness = harnesses.getByIdOrKind(task.agent);
+          if (harness?.kind !== "claude-code") {
+            return json(
+              { error: "tmux attach is only available for claude-code tasks" },
+              { status: 400, headers: corsHeaders(req) },
+            );
+          }
+          const sessionName = sessionNameFor(task.id);
+          // Distinguish "tmux missing" from "session missing" — both would
+          // otherwise look like sessionExists() === false and tell the user
+          // to restart the task, which doesn't help when the real problem
+          // is the tmux binary itself. Mirror the resolution path used by
+          // checkHarness so the same install hint applies.
+          const tmuxBin = resolveTmuxBin();
+          const tmuxPath = path.isAbsolute(tmuxBin)
+            ? (existsSync(tmuxBin) ? tmuxBin : null)
+            : Bun.which(tmuxBin, { PATH: process.env.PATH });
+          if (!tmuxPath) {
+            return json(
+              {
+                error: "tmux binary not found — install tmux (brew install tmux) or enable the bundled tmux in Settings",
+                sessionName,
+                reason: "tmux-missing",
+              },
+              { status: 503, headers: corsHeaders(req) },
+            );
+          }
+          if (!sessionExists(task.id)) {
+            return json(
+              {
+                error: `no live tmux session "${sessionName}" — start (or send a message to) the task first`,
+                sessionName,
+                reason: "session-missing",
+              },
+              { status: 404, headers: corsHeaders(req) },
+            );
+          }
+          // AppleScript `do script` runs the string through `/bin/bash`, so
+          // we escape anything bash would interpret inside double-quotes:
+          // backslash, dollar, backtick, and the double-quote itself. Without
+          // this, a tmux bin path containing `$` (legal but unusual) would
+          // silently misbehave. Session names are server-generated and only
+          // contain `agetor-<hex>` so they don't strictly need escaping, but
+          // we apply the same helper for symmetry.
+          const shellEscape = (s: string) => s.replace(/(["\\$`])/g, "\\$1");
+          const script =
+            `tell application "Terminal" to do script "exec \\"${shellEscape(tmuxPath)}\\" attach -t \\"${shellEscape(sessionName)}\\""\n` +
+            `activate application "Terminal"`;
+          const proc = Bun.spawn(["osascript", "-e", script], {
+            stdout: "ignore",
+            stderr: "ignore",
+          });
+          // Don't block on the AppleScript — Terminal.app opening shouldn't
+          // hold the HTTP response open. Log non-zero exits so users with
+          // Automation permissions revoked have a breadcrumb in the console.
+          void proc.exited.then((code) => {
+            if (code !== 0) {
+              console.warn(
+                `[agetor] osascript exited ${code} while attaching to tmux session "${sessionName}" — check System Settings → Privacy & Security → Automation`,
+              );
+            }
+          });
+          return json({ ok: true, sessionName }, { headers: corsHeaders(req) });
+        }),
       },
 
       "/runs/:id/cancel": {

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ComponentType } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { toast } from "sonner";
 import {
   Bot, ClipboardList, FolderOpen, FileText, FilePenLine, FilePlus, Folder,
   Globe, HelpCircle, ListTodo, MessageSquareQuote, Plug, Search, Send, Slash,
@@ -12,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { abbreviateHome, cn } from "@/lib/utils";
+import { iconForRef, refBasename } from "@/lib/file-icons";
 import {
   AGENT_OPTIONS,
   DEFAULT_EFFORT,
@@ -26,6 +28,11 @@ import {
   type Task,
   type TaskReference,
 } from "../../../shared/types.ts";
+import { appendReferences } from "../../../shared/refs.ts";
+import { proposeAllowRules, type AllowRuleProposal } from "../../../shared/claude-permissions.ts";
+import { AgentIcon } from "./AgentIcon";
+import { ReferencesPicker } from "./ReferencesPicker";
+import { SlashAutocomplete } from "./SlashAutocomplete";
 
 /**
  * Resolve a task's harness id to its underlying kind. Falls back to
@@ -36,12 +43,6 @@ import {
 function harnessKindOf(harnessId: string, harnesses: Harness[]): AgentKind {
   return harnesses.find((h) => h.id === harnessId)?.kind ?? "claude-code";
 }
-import { iconForRef, refBasename } from "@/lib/file-icons";
-import { appendReferences } from "../../../shared/refs.ts";
-import { proposeAllowRules, type AllowRuleProposal } from "../../../shared/claude-permissions.ts";
-import { AgentIcon } from "./AgentIcon";
-import { ReferencesPicker } from "./ReferencesPicker";
-import { SlashAutocomplete } from "./SlashAutocomplete";
 
 interface Props {
   /** When null, the panel slides off-screen and unmounts after the exit animation. */
@@ -513,7 +514,14 @@ function RunPanelBody({
           model / effort each PATCH the task on change, and if a live claude
           tmux session exists the backend mirrors the change via slash commands
           so the conversation context survives the edit. */}
-      <TaskDetails task={task} agents={agents} harnesses={harnesses} agentModels={agentModels} homeDir={homeDir} />
+      <TaskDetails
+        task={task}
+        agents={agents}
+        harnesses={harnesses}
+        agentModels={agentModels}
+        homeDir={homeDir}
+        tmuxSession={latestRun?.tmuxSession ?? null}
+      />
 
       <RunsList runs={runs} />
 
@@ -1838,12 +1846,17 @@ function TaskDetails({
   harnesses,
   agentModels,
   homeDir,
+  tmuxSession,
 }: {
   task: Task;
   agents: AgentStatus[];
   harnesses: Harness[];
   agentModels: AgentModelMap;
   homeDir: string;
+  /** Tmux session name from the latest run (claude-code only). `null` when
+   *  no run has spawned a session yet — the Tmux row hides itself in that
+   *  case rather than presenting an Attach button that's guaranteed to 404. */
+  tmuxSession: string | null;
 }) {
   const editable = task.column !== "running" && task.column !== "blocked";
   const kind = harnessKindOf(task.agent, harnesses);
@@ -1995,6 +2008,30 @@ function TaskDetails({
             <>
               <dt className="text-muted-foreground">Base</dt>
               <dd className="min-w-0 truncate font-mono">{task.baseRef.slice(0, 12)}</dd>
+            </>
+          )}
+          {kind === "claude-code" && tmuxSession && (
+            <>
+              <dt className="text-muted-foreground">Tmux</dt>
+              <dd className="flex min-w-0 items-center justify-between gap-2">
+                <span className="min-w-0 truncate font-mono" title={tmuxSession}>
+                  {tmuxSession}
+                </span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-6 shrink-0 px-2 text-[11px]"
+                  onClick={() => {
+                    void api.openTmux(task.id).catch((err: unknown) => {
+                      const msg = err instanceof Error ? err.message : "Could not attach to tmux session";
+                      toast.error(msg);
+                    });
+                  }}
+                  title={`Attach to the tmux session in a new Terminal window (tmux attach -t ${tmuxSession})`}
+                >
+                  <Terminal className="mr-1 size-3" /> Attach
+                </Button>
+              </dd>
             </>
           )}
           {task.references.length > 0 && (

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -260,6 +260,16 @@ export const api = {
       body: JSON.stringify(input),
     }),
 
+  /**
+   * Open the claude-code task's tmux session in a new Terminal.app window.
+   * Returns the session name on success. Server-side checks the session is
+   * actually live and that the task uses a claude-code harness.
+   */
+  openTmux: (taskId: string) =>
+    j<{ ok: true; sessionName: string }>(`/tasks/${taskId}/open-tmux`, {
+      method: "POST",
+    }),
+
   /** Interactions: tool-call approvals and clarifying questions. */
   answerApproval: (
     id: string,


### PR DESCRIPTION
Adds a Tmux row to the Task details panel for claude-code tasks that shows the latest run's session name and a Terminal-icon Attach button. Clicking it asks the Bun side to open Terminal.app via osascript and exec `tmux attach -t <session>` against the resolved tmux binary.

The row is gated on `latestRun.tmuxSession` so backlog / never-started tasks don't surface an Attach button that's guaranteed to 404. The server distinguishes tmux-missing from session-missing so the UI toast tells the user which of those they're hitting.