### PR TITLE
feat(env): Settings → Environment panel + first-run banner for PATH overrides

### DIFF
--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -1,8 +1,12 @@
 import { writeFileSync } from "node:fs";
 import Electrobun, { ApplicationMenu, BrowserWindow, Updater } from "electrobun/bun";
-import { rehydratePath } from "./login-path.ts";
+import {
+  EXTRA_PATH_DIRS_PREF_KEY,
+  parseExtraPathDirs,
+  rehydratePath,
+} from "./login-path.ts";
 import { startApiServer, API_PORT, API_TOKEN } from "./server.ts";
-import { db, harnesses, pidFilePath, tasks } from "./db.ts";
+import { db, harnesses, pidFilePath, preferences, tasks } from "./db.ts";
 import { reconcileOrphans } from "./orchestrator.ts";
 import { broadcastAppEvent, consumeForceQuit } from "./quit-guard.ts";
 import { prewarmSharedFiles } from "./hook-installer.ts";
@@ -108,7 +112,14 @@ async function getMainViewUrl(): Promise<string> {
 // before prewarmSharedFiles (which resolves `bun`) and before the API server
 // starts handling /agents probes. Idempotent and safe in dev runs — the
 // merge dedupes.
-rehydratePath();
+//
+// User-supplied extra dirs (Settings → Environment) take precedence over
+// everything else in `extras` so a manual override always wins. Read here
+// instead of inside login-path.ts to keep that module free of a hard DB
+// dependency (the tests import it without booting the DB).
+rehydratePath({
+  extraDirs: parseExtraPathDirs(preferences.get(EXTRA_PATH_DIRS_PREF_KEY)),
+});
 
 // Eagerly refresh the materialised hook + MCP launcher scripts on disk
 // (~/.agetor/bin/*) so a `claude` invocation made directly in a previously-

--- a/src/bun/login-path.test.ts
+++ b/src/bun/login-path.test.ts
@@ -3,7 +3,12 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-import { defaultDevPaths, rehydratePath } from "./login-path.ts";
+import {
+  defaultDevPaths,
+  getLastRehydration,
+  parseExtraPathDirs,
+  rehydratePath,
+} from "./login-path.ts";
 
 // rehydratePath() and defaultDevPaths() both read process.env at call time and
 // rehydratePath mutates process.env.PATH. Snapshot the relevant vars and
@@ -133,5 +138,46 @@ describe("rehydratePath", () => {
     process.env.PATH = `/my/custom/bin:/usr/bin`;
     const result = rehydratePath();
     expect(result.split(":")).toContain("/my/custom/bin");
+  });
+
+  test("prepends extraDirs ahead of defaults and the existing PATH", () => {
+    process.env.PATH = "/usr/bin";
+    const result = rehydratePath({ extraDirs: ["/zzz/first", "/zzz/second"] });
+    const segs = result.split(":");
+    // Both extras land before any default-dev path. Using /opt/homebrew/bin
+    // as the marker since defaultDevPaths() always emits it.
+    const homebrewIdx = segs.indexOf("/opt/homebrew/bin");
+    expect(segs.indexOf("/zzz/first")).toBeLessThan(homebrewIdx);
+    expect(segs.indexOf("/zzz/second")).toBeLessThan(homebrewIdx);
+    // And extraDirs preserve the order they were given.
+    expect(segs.indexOf("/zzz/first")).toBeLessThan(segs.indexOf("/zzz/second"));
+  });
+
+  test("snapshot captures extras + login-probe outcome", () => {
+    process.env.PATH = "/usr/bin";
+    rehydratePath({ extraDirs: ["/zzz/mine"] });
+    const snap = getLastRehydration();
+    expect(snap).not.toBeNull();
+    expect(snap!.extraDirs).toEqual(["/zzz/mine"]);
+    // SHELL was deleted in beforeEach — the login-shell probe should miss.
+    expect(snap!.loginProbeOk).toBe(false);
+    expect(snap!.path).toBe(process.env.PATH);
+  });
+});
+
+describe("parseExtraPathDirs", () => {
+  test("returns [] for null / empty / whitespace-only inputs", () => {
+    expect(parseExtraPathDirs(null)).toEqual([]);
+    expect(parseExtraPathDirs(undefined)).toEqual([]);
+    expect(parseExtraPathDirs("")).toEqual([]);
+    expect(parseExtraPathDirs("\n\n  \n")).toEqual([]);
+  });
+
+  test("splits on newlines, trims, drops blanks", () => {
+    expect(parseExtraPathDirs("/a/b\n  /c/d  \n\n/e/f")).toEqual([
+      "/a/b",
+      "/c/d",
+      "/e/f",
+    ]);
   });
 });

--- a/src/bun/login-path.ts
+++ b/src/bun/login-path.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
+import type { EnvSnapshot } from "../shared/types.ts";
 
 /**
  * When agetor is launched as a packaged .app (Finder, Spotlight, Dock,
@@ -23,6 +24,23 @@ import path from "node:path";
 
 const MARKER_START = "__AGETOR_PATH_START__";
 const MARKER_END = "__AGETOR_PATH_END__";
+
+/** Preference key for the user-supplied extra-PATH list. Value is one
+ *  directory per line; blank lines and surrounding whitespace are
+ *  ignored at parse time. Defined here so the boot path
+ *  (`index.ts:rehydratePath`) and the API setter (`server.ts:/env/extra-paths`)
+ *  share the same key. */
+export const EXTRA_PATH_DIRS_PREF_KEY = "extra_path_dirs";
+
+/** Parse the textarea-style preference value (one dir per line) into a
+ *  clean list. Empty result for null/empty strings. */
+export function parseExtraPathDirs(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
 
 function readLoginShellPath(): string | null {
   const shell = process.env.SHELL;
@@ -178,22 +196,48 @@ export function defaultDevPaths(): string[] {
   return candidates;
 }
 
+let lastSnapshot: EnvSnapshot | null = null;
+
+/** Return the most recent rehydratePath() result, or null if it hasn't run
+ *  yet (only relevant in tests — boot always calls rehydratePath first).
+ *  Shape lives in `shared/types.ts:EnvSnapshot` so the webview can import
+ *  it without duplicating the structure. */
+export function getLastRehydration(): EnvSnapshot | null {
+  return lastSnapshot;
+}
+
 /**
  * Rehydrate `process.env.PATH` with the user's login-shell PATH plus common
  * dev locations. Idempotent — safe to call multiple times. Returns the new
  * PATH so callers can log it during debugging.
+ *
+ * `extraDirs` is the user's escape hatch (Settings → Environment): every
+ * non-empty entry is prepended ahead of the login-shell PATH and the
+ * default candidates, so it wins over both. Re-runnable at runtime — when
+ * the user saves a new list, the server calls this again and the next
+ * `Bun.which({ PATH: process.env.PATH })` lookup in `agent-status.ts` picks
+ * up the fresh value on the next `/agents` poll.
  */
-export function rehydratePath(): string {
+export function rehydratePath(opts: { extraDirs?: string[] } = {}): string {
   const current = (process.env.PATH ?? "").split(":").filter(Boolean);
   const loginPath = readLoginShellPath();
+  // De-dupe + trim the user's extras up front so the snapshot reports
+  // exactly what we used (textarea input often has trailing whitespace
+  // or blank lines).
+  const extraDirs = (opts.extraDirs ?? [])
+    .map((d) => d.trim())
+    .filter((d) => d.length > 0);
+  const defaultDirs = defaultDevPaths();
   const extras = [
+    ...extraDirs,
     ...(loginPath ? loginPath.split(":").filter(Boolean) : []),
-    ...defaultDevPaths(),
+    ...defaultDirs,
   ];
 
   // Login-shell PATH wins (it includes the user's intentional additions in
   // the order they want them). Current PATH appended after dedupe so we never
-  // *drop* something that was already there.
+  // *drop* something that was already there. User-supplied extraDirs are
+  // first in `extras`, so they win over both.
   const seen = new Set<string>();
   const merged: string[] = [];
   for (const p of [...extras, ...current]) {
@@ -234,13 +278,16 @@ export function rehydratePath(): string {
   // line, no PII beyond the absolute path the user installed `claude` at —
   // which is what the bug report needs.
   const resolved = {
-    claude: Bun.which("claude", { PATH: next }) ?? "not found",
-    codex: Bun.which("codex", { PATH: next }) ?? "not found",
-    tmux: Bun.which("tmux", { PATH: next }) ?? "not found",
+    claude: Bun.which("claude", { PATH: next }),
+    codex: Bun.which("codex", { PATH: next }),
+    tmux: Bun.which("tmux", { PATH: next }),
   };
   console.log(
-    `[agetor] PATH rehydrated (login-probe=${loginPath ? "ok" : "miss"}): ` +
-      `claude=${resolved.claude} codex=${resolved.codex} tmux=${resolved.tmux}`,
+    `[agetor] PATH rehydrated (login-probe=${loginPath ? "ok" : "miss"}, ` +
+      `extra-dirs=${extraDirs.length}): ` +
+      `claude=${resolved.claude ?? "not found"} ` +
+      `codex=${resolved.codex ?? "not found"} ` +
+      `tmux=${resolved.tmux ?? "not found"}`,
   );
   if (aliasHint) {
     console.log(
@@ -249,6 +296,16 @@ export function rehydratePath(): string {
         "(or point the harness at an absolute path in Settings → Harnesses).",
     );
   }
+
+  lastSnapshot = {
+    path: next,
+    loginProbeOk: loginPath !== null,
+    extraDirs,
+    defaultDirs,
+    resolved,
+    claudeAliasHint: aliasHint,
+    at: Date.now(),
+  };
 
   return next;
 }

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -26,6 +26,12 @@ import {
   type TmuxSource,
 } from "./tmux-resolution.ts";
 import { jsonlPathFor, mapJsonlEventToChunks } from "./claude-tmux.ts";
+import {
+  EXTRA_PATH_DIRS_PREF_KEY,
+  getLastRehydration,
+  parseExtraPathDirs,
+  rehydratePath,
+} from "./login-path.ts";
 import { listBranches } from "./worktree.ts";
 import { listAvailableCommands } from "./commands.ts";
 import { getDiscoveredModels, refreshDiscoveredModels } from "./agent-discovery.ts";
@@ -341,6 +347,92 @@ export function startApiServer() {
           // when the process goes away.
           void applyUpdate();
           return json({ ok: true }, { headers: corsHeaders(req) });
+        }),
+      },
+
+      // Environment diagnostics for the Settings → Environment panel and
+      // the first-run "claude not found" banner. Returns the same info the
+      // boot log prints (resolved bins, login-probe outcome) plus the
+      // user's saved extra-PATH list and the in-memory `process.env.PATH`.
+      // Mutation goes through PUT /env/extra-paths.
+      "/env": {
+        GET: authed((req) => {
+          const snap = getLastRehydration();
+          // Always echo `process.env.PATH` separately — the snapshot's
+          // `path` field is what rehydratePath wrote, but a later boot step
+          // could in principle have mutated it. Cheap to send both so the
+          // UI can show the live value.
+          return json(
+            {
+              snapshot: snap,
+              livePath: process.env.PATH ?? "",
+              extraDirs: parseExtraPathDirs(preferences.get(EXTRA_PATH_DIRS_PREF_KEY)),
+            },
+            { headers: corsHeaders(req) },
+          );
+        }),
+      },
+
+      "/env/extra-paths": {
+        PUT: authed(async (req) => {
+          const body = (await req.json().catch(() => ({}))) as { dirs?: unknown };
+          // Accept either an array of strings (preferred — UI sends this)
+          // or a single newline-joined string (round-trips raw textarea
+          // contents). Anything else is rejected so a buggy caller can't
+          // silently wipe the list with garbage.
+          let dirs: string[];
+          if (Array.isArray(body.dirs)) {
+            dirs = body.dirs.filter((d): d is string => typeof d === "string");
+          } else if (typeof body.dirs === "string") {
+            dirs = parseExtraPathDirs(body.dirs);
+          } else {
+            return json(
+              { error: "dirs must be string[] or a newline-separated string" },
+              { status: 400, headers: corsHeaders(req) },
+            );
+          }
+          // Cleaning: drop blanks, require absolute paths so a relative
+          // entry doesn't resolve against the agetor process cwd (which is
+          // never what the user means). Same rule we already enforce for
+          // harness `home` / `bin`. Reject `:` too — the textarea is
+          // one-dir-per-line, so an embedded colon almost certainly means
+          // the user pasted a `$PATH`-shaped string and would otherwise
+          // see their entry silently split in two by the colon-join into
+          // `process.env.PATH`.
+          const cleaned: string[] = [];
+          for (const raw of dirs) {
+            const d = raw.trim();
+            if (!d) continue;
+            if (!path.isAbsolute(d)) {
+              return json(
+                { error: `extra PATH entries must be absolute: "${d}"` },
+                { status: 400, headers: corsHeaders(req) },
+              );
+            }
+            if (d.includes(":")) {
+              return json(
+                {
+                  error:
+                    `extra PATH entries cannot contain ':' — put each directory on its own line: "${d}"`,
+                },
+                { status: 400, headers: corsHeaders(req) },
+              );
+            }
+            cleaned.push(d);
+          }
+          // Persist as one-per-line so a future hand-edit of the SQLite
+          // row is readable. The parser is tolerant on the way back in.
+          preferences.set(EXTRA_PATH_DIRS_PREF_KEY, cleaned.join("\n"));
+          // Re-run rehydration in-process so the next /agents probe (polled
+          // every 2s by the kanban header dots) reflects the new dirs
+          // without requiring a restart. Already-spawned tmux sessions
+          // won't see the change — that's expected and matches how PATH
+          // works on Unix.
+          rehydratePath({ extraDirs: cleaned });
+          return json(
+            { ok: true, snapshot: getLastRehydration(), extraDirs: cleaned },
+            { headers: corsHeaders(req) },
+          );
         }),
       },
 

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { AlertTriangle, Settings, X } from "lucide-react";
-import { api, type AgentModelMap } from "@/lib/api";
+import { api, type AgentModelMap, type EnvPayload } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { COLUMNS, type AgentStatus, type ColumnId, type GlobalEvent, type Harness, type Project, type Task } from "../shared/types.ts";
 import { AgentIcon } from "@/components/kanban/AgentIcon";
@@ -9,6 +9,7 @@ import { Column } from "@/components/kanban/Column";
 import { KanbanFilters } from "@/components/kanban/KanbanFilters";
 import { NewTaskForm } from "@/components/kanban/NewTaskForm";
 import { RunPanel } from "@/components/kanban/RunPanel";
+import { EnvMissingBanner } from "@/components/settings/EnvMissingBanner";
 import { SettingsDialog } from "@/components/settings/SettingsDialog";
 import { TmuxInstallDialog } from "@/components/tmux/TmuxInstallDialog";
 import { TmuxMissingBanner, errorIsTmuxMissing, isTmuxMissing } from "@/components/tmux/TmuxMissingBanner";
@@ -80,6 +81,10 @@ export default function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [tmuxDialogOpen, setTmuxDialogOpen] = useState(false);
   const [updateSnapshot, setUpdateSnapshot] = useState<UpdateSnapshot | null>(null);
+  // Boot-time PATH diagnostics. Powers the "claude not found" banner above
+  // the kanban; the Settings → Environment panel fetches its own copy on
+  // open so the two views can refresh independently.
+  const [env, setEnv] = useState<EnvPayload | null>(null);
   const [homeDir, setHomeDir] = useState<string>("");
   // Active data dir resolved server-side (~/.agetor for the packaged .app,
   // ~/.agetor-dev when launched via `bun run dev` / `dev:hmr`). Threaded to
@@ -144,6 +149,10 @@ export default function App() {
     // freshly-opened webview wouldn't know about an update that was already
     // downloaded by the previous main-process tick.
     api.getUpdateStatus().then(setUpdateSnapshot).catch(() => { /* fine */ });
+    // Boot-time env diagnostic (resolved claude/codex/tmux paths). Only used
+    // by the first-run banner — Settings refetches on open so a user editing
+    // the extras list always sees fresh server state.
+    api.getEnv().then(setEnv).catch(() => { /* fine */ });
     const t = setInterval(refresh, 2000);
     const a = setInterval(refreshAgents, 15_000);
     return () => {
@@ -461,6 +470,10 @@ export default function App() {
             show={isTmuxMissing(agents)}
             onResolve={() => setTmuxDialogOpen(true)}
           />
+          <EnvMissingBanner
+            env={env}
+            onOpenSettings={() => setSettingsOpen(true)}
+          />
           <KanbanFilters
             textQuery={textQuery}
             onTextQueryChange={setTextQuery}
@@ -506,7 +519,14 @@ export default function App() {
       />
       <SettingsDialog
         open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
+        onClose={() => {
+          setSettingsOpen(false);
+          // Refresh the boot-env snapshot — saving extras inside Settings
+          // re-runs rehydratePath server-side, so the banner here should
+          // disappear (or persist with the same hint) without waiting for
+          // a full reload.
+          void api.getEnv().then(setEnv).catch(() => { /* fine */ });
+        }}
         onChange={refreshAgents}
         homeDir={homeDir}
         dataDir={dataDir}

--- a/src/mainview/components/settings/EnvMissingBanner.tsx
+++ b/src/mainview/components/settings/EnvMissingBanner.tsx
@@ -1,0 +1,82 @@
+import { AlertTriangle, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { EnvPayload } from "@/lib/api";
+
+interface Props {
+  /** Snapshot from `GET /env`. Null while in-flight; once loaded we look
+   *  at `snapshot.resolved.claude` to decide whether to nag. */
+  env: EnvPayload | null;
+  onOpenSettings: () => void;
+}
+
+/**
+ * First-run nudge for packaged-DMG users whose login-shell PATH probe
+ * couldn't reach their `claude` install. The same diagnostic is in
+ * Console.app (the boot log) and in Settings → Environment, but most
+ * users won't think to dig through either — so we surface it inline.
+ *
+ * Only shows when:
+ *   - The env snapshot has loaded AND
+ *   - `resolved.claude` is null (binary not found anywhere we looked).
+ *
+ * **Scope is claude-only on purpose.** tmux has its own banner
+ * (`TmuxMissingBanner`), and codex is currently paused as a harness
+ * kind (see `src/bun/index.ts` near "codex is paused"), so a missing
+ * codex binary isn't a problem worth nagging about. When codex is
+ * unpaused, broaden the trigger to include any *enabled* harness whose
+ * binary is null — passing the harness list in alongside `env` is the
+ * minimal change.
+ *
+ * Dismissible per-session, re-arms on every false→true edge so a user
+ * who closes it and then breaks their install again gets nudged once
+ * more. The same pattern TmuxMissingBanner uses.
+ */
+export function EnvMissingBanner({ env, onOpenSettings }: Props) {
+  const show = env?.snapshot != null && env.snapshot.resolved.claude === null;
+  const [dismissed, setDismissed] = useState(false);
+  const prevShow = useRef(show);
+  useEffect(() => {
+    if (show && !prevShow.current) setDismissed(false);
+    prevShow.current = show;
+  }, [show]);
+  if (!show || dismissed) return null;
+  const aliasHint = env?.snapshot?.claudeAliasHint ?? false;
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex items-center gap-3 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-xs text-amber-200",
+      )}
+    >
+      <AlertTriangle className="size-3.5 shrink-0 text-amber-400" aria-hidden />
+      <span className="min-w-0 flex-1">
+        <span className="font-medium text-amber-100">
+          claude not found on PATH.
+        </span>{" "}
+        <span className="text-amber-200/80">
+          {aliasHint
+            ? "It looks like a shell alias/function — install the real binary, or add its dir in Settings → Environment."
+            : "Add the install directory in Settings → Environment so Agetor can launch it."}
+        </span>
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onOpenSettings}
+        className="h-7 border-amber-400/40 bg-amber-500/10 text-amber-100 hover:bg-amber-500/20"
+      >
+        Fix
+      </Button>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss"
+        className="rounded p-0.5 text-amber-300/70 hover:bg-amber-500/10 hover:text-amber-100"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
-import { ChevronLeft, Plus, Trash2, X } from "lucide-react";
-import { api, type HarnessesPayload, type HarnessInput } from "@/lib/api";
+import { AlertTriangle, Check, ChevronLeft, Plus, Trash2, X } from "lucide-react";
+import {
+  api,
+  type EnvPayload,
+  type HarnessesPayload,
+  type HarnessInput,
+} from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Dialog } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -98,6 +103,7 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
   const [defaultHarness, setDefaultHarness] = useState<string>("claude-code");
   const [tmuxSource, setTmuxSource] = useState<"system" | "bundled">("system");
   const [bundledTmuxAvailable, setBundledTmuxAvailable] = useState(false);
+  const [env, setEnv] = useState<EnvPayload | null>(null);
   const [view, setView] = useState<View>({ kind: "list" });
   const [busy, setBusy] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
@@ -110,14 +116,16 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
   const confirm = useConfirm();
 
   const refresh = async () => {
-    const [info, data, prefs, tmux] = await Promise.all([
+    const [info, data, prefs, tmux, envPayload] = await Promise.all([
       api.info().catch(() => ({ version: "?" })),
       api.listHarnesses().catch(() => ({ harnesses: [], statuses: [] })),
       api.listPreferences().catch((): Record<string, string> => ({})),
       api
         .getTmuxSource()
         .catch(() => ({ source: "system" as const, bundledAvailable: false, bundledPath: "", resolvedBin: "" })),
+      api.getEnv().catch((): EnvPayload | null => null),
     ]);
+    setEnv(envPayload);
     setVersion(info.version);
     setPayload(data);
     // The default-harness picker only lists *enabled* harnesses. If the
@@ -293,6 +301,8 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
           tmuxSource={tmuxSource}
           bundledTmuxAvailable={bundledTmuxAvailable}
           onPickTmuxSource={onPickTmuxSource}
+          env={env}
+          onEnvChange={setEnv}
           canAdd={!!dataDir}
           onAdd={() => setView({ kind: "templates" })}
           onEdit={(h) =>
@@ -377,6 +387,8 @@ function ListView({
   tmuxSource,
   bundledTmuxAvailable,
   onPickTmuxSource,
+  env,
+  onEnvChange,
   canAdd,
   onAdd,
   onEdit,
@@ -392,6 +404,13 @@ function ListView({
   tmuxSource: "system" | "bundled";
   bundledTmuxAvailable: boolean;
   onPickTmuxSource: (source: "system" | "bundled") => void;
+  /** Boot-time PATH resolution + the user's saved extra-PATH list. Null
+   *  while `/env` is still in-flight. */
+  env: EnvPayload | null;
+  /** Lets the EnvironmentSection refresh the parent's copy after a save
+   *  (the server returns the fresh snapshot) without forcing a full
+   *  Settings refresh round-trip. */
+  onEnvChange: (e: EnvPayload | null) => void;
   /** False while `dataDir` is still loading from `GET /defaults`. Adding a
    *  harness with an unresolved data dir would persist a broken HOME path
    *  (`/harnesses/claude-2` instead of `<dataDir>/harnesses/claude-2`). */
@@ -440,6 +459,9 @@ function ListView({
           binary if you don't want to install tmux system-wide.
         </p>
       </section>
+
+      <EnvironmentSection env={env} onEnvChange={onEnvChange} />
+
 
       <section className="space-y-2">
         <div className="flex items-center justify-between">
@@ -534,6 +556,206 @@ function ListView({
           })}
         </div>
       </section>
+    </div>
+  );
+}
+
+/**
+ * Boot-time environment diagnostics + the "Extra PATH directories" escape
+ * hatch. Saved dirs are prepended ahead of the login-shell PATH on every
+ * launch, so a user whose rc file doesn't expose their CLIs (e.g. nvm
+ * default unset, asdf inside an `if [ -t 0 ]` guard) can still point agetor
+ * at the right bin dir manually.
+ *
+ * The save handler re-rehydrates server-side, so the green/red dots flip
+ * within the next `/agents` poll (~2s). No restart needed for the bin
+ * probes; already-spawned tmux sessions keep their captured env though,
+ * so new task runs are when the change really takes effect.
+ */
+function EnvironmentSection({
+  env,
+  onEnvChange,
+}: {
+  env: EnvPayload | null;
+  onEnvChange: (e: EnvPayload | null) => void;
+}) {
+  // Local textarea state seeded from the persisted dirs. Decoupled from
+  // `env.extraDirs` so typing doesn't lose focus on every parent re-render,
+  // and so the Save button can detect a real dirty state.
+  //
+  // useState only consumes its initial value on first render. The Dialog
+  // unmounts its children on close (see `ui/dialog.tsx:116`), so this
+  // component remounts on every open — meaning useState gives us the
+  // freshest persisted value whenever env was already loaded at open time.
+  const [draft, setDraft] = useState((env?.extraDirs ?? []).join("\n"));
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  // Reseed when env arrives after first mount — i.e. the dialog opened
+  // before the parent's `/env` fetch resolved. Guarded on `draft === ""`
+  // so a user who started typing while loading doesn't get their input
+  // clobbered when env lands.
+  useEffect(() => {
+    if (env && draft === "") {
+      setDraft((env.extraDirs ?? []).join("\n"));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [env?.snapshot?.at]);
+
+  const parsedDraft = useMemo(
+    () =>
+      draft
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0),
+    [draft],
+  );
+
+  const persisted = env?.extraDirs ?? [];
+  const dirty =
+    parsedDraft.length !== persisted.length ||
+    parsedDraft.some((d, i) => d !== persisted[i]);
+
+  const onSave = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await api.setExtraPathDirs(parsedDraft);
+      // `result.snapshot` is typed nullable to match GET /env, but the
+      // server-side rehydrate runs synchronously inside the PUT handler so
+      // we always have one in practice. Fall back to the live PATH only if
+      // some future refactor stops returning a snapshot.
+      onEnvChange({
+        snapshot: result.snapshot,
+        livePath: result.snapshot?.path ?? "",
+        extraDirs: result.extraDirs,
+      });
+      setDraft(result.extraDirs.join("\n"));
+      setSavedAt(Date.now());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const snap = env?.snapshot;
+  const pathSegments = (snap?.path ?? env?.livePath ?? "").split(":").filter(Boolean);
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="text-xs text-muted-foreground">Environment</label>
+      </div>
+
+      {/* Resolved bins — same info the boot log prints to Console.app, but
+          in a place a user without a terminal can actually see. */}
+      <div className="space-y-1 rounded-md border border-border/60 px-3 py-2">
+        <BinRow label="claude" path={snap?.resolved.claude ?? null} />
+        <BinRow label="codex" path={snap?.resolved.codex ?? null} />
+        <BinRow label="tmux" path={snap?.resolved.tmux ?? null} />
+        <div className="pt-1 text-[11px] text-muted-foreground">
+          {snap == null
+            ? "Loading…"
+            : snap.loginProbeOk
+              ? "Login-shell PATH probe succeeded."
+              : "Login-shell PATH probe didn't return a result — only built-in default dirs and your extras are in PATH."}
+        </div>
+        {snap?.claudeAliasHint && (
+          <div className="flex items-start gap-1.5 pt-1 text-[11px] text-amber-500">
+            <AlertTriangle className="mt-0.5 size-3 shrink-0" />
+            <span>
+              <code className="font-mono">claude</code> looks like a shell
+              alias/function in your rc, not a real binary. Install it with{" "}
+              <code className="font-mono">npm i -g @anthropic-ai/claude-code</code>{" "}
+              or set a <strong>Bin override</strong> on the harness.
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Editable extras. Tailwind classes match the env-vars textarea in
+          the harness editor for visual consistency. */}
+      <div className="space-y-1">
+        <label className="text-xs text-muted-foreground">
+          Extra PATH directories (one absolute path per line)
+        </label>
+        <Textarea
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            setSavedAt(null);
+          }}
+          rows={3}
+          placeholder="/opt/homebrew/bin&#10;/Users/me/.local/bin"
+          className="font-mono text-xs"
+        />
+        <p className="text-[11px] leading-snug text-muted-foreground">
+          Prepended ahead of the auto-detected PATH on every launch. Use this when
+          the auto-probe can't reach your CLIs (e.g. nvm default not set, asdf
+          inside a tty guard).
+        </p>
+        {error && (
+          <p className="text-[11px] leading-snug text-destructive">{error}</p>
+        )}
+        <div className="flex items-center justify-between pt-1">
+          <span className="text-[11px] text-muted-foreground">
+            {savedAt && !dirty && (
+              <span className="inline-flex items-center gap-1 text-emerald-500">
+                <Check className="size-3" /> Saved — green/red dots refresh on the
+                next probe.
+              </span>
+            )}
+          </span>
+          <Button size="sm" onClick={onSave} disabled={busy || !dirty}>
+            {busy ? "Saving…" : "Save extras"}
+          </Button>
+        </div>
+      </div>
+
+      {/* Read-only PATH listing, collapsed by default so it doesn't dominate
+          the dialog. <details> is fine — no need for headless-ui machinery
+          for a debug aid. */}
+      <details className="rounded-md border border-border/60 px-3 py-2 text-[11px]">
+        <summary className="cursor-pointer select-none text-muted-foreground">
+          Resolved PATH ({pathSegments.length} {pathSegments.length === 1 ? "entry" : "entries"})
+        </summary>
+        <ol className="mt-2 space-y-0.5 font-mono">
+          {pathSegments.length === 0 && (
+            <li className="text-muted-foreground">(empty — boot hasn't run yet)</li>
+          )}
+          {pathSegments.map((p, i) => (
+            <li key={`${p}-${i}`} className="truncate" title={p}>
+              {i + 1}. {p}
+            </li>
+          ))}
+        </ol>
+      </details>
+    </section>
+  );
+}
+
+function BinRow({ label, path }: { label: string; path: string | null }) {
+  const ok = path !== null && path.length > 0;
+  return (
+    <div className="flex items-center gap-2 text-[12px]">
+      <span
+        className={cn(
+          "inline-block size-1.5 shrink-0 rounded-full",
+          ok ? "bg-emerald-500" : "bg-red-500",
+        )}
+      />
+      <code className="font-mono text-muted-foreground">{label}</code>
+      <span
+        className={cn(
+          "truncate font-mono",
+          ok ? "" : "text-red-500",
+        )}
+        title={path ?? "not found"}
+      >
+        {ok ? path : "not found"}
+      </span>
     </div>
   );
 }

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -3,6 +3,8 @@ import type {
   AgentStatus,
   AppEvent,
   ColumnId,
+  EnvPayload,
+  EnvSnapshot,
   GlobalEvent,
   Harness,
   HarnessStatus,
@@ -15,6 +17,8 @@ import type {
   TaskReference,
   UpdateStatus,
 } from "../../shared/types.ts";
+
+export type { EnvPayload, EnvSnapshot };
 
 export interface UpdateSnapshot {
   status: UpdateStatus;
@@ -195,6 +199,18 @@ export const api = {
     j<void>("/projects", { method: "DELETE", body: JSON.stringify({ path: p }) }),
   listBranches: (dir: string) =>
     j<BranchInfo[]>(`/projects/branches?path=${encodeURIComponent(dir)}`),
+  getEnv: () => j<EnvPayload>("/env"),
+  /**
+   * Snapshot is typed `| null` for symmetry with `GET /env`. In practice the
+   * server runs `rehydratePath()` inside the request handler so the snapshot
+   * is always populated by the time the response leaves; the nullable
+   * declaration just leaves an escape hatch if the contract ever weakens.
+   */
+  setExtraPathDirs: (dirs: string[]) =>
+    j<{ ok: true; snapshot: EnvSnapshot | null; extraDirs: string[] }>(
+      "/env/extra-paths",
+      { method: "PUT", body: JSON.stringify({ dirs }) },
+    ),
   getTmuxSource: () =>
     j<{
       source: "system" | "bundled";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -8,6 +8,53 @@ export type ColumnId = "backlog" | "ready" | "running" | "blocked" | "review" | 
  */
 export const TMUX_MISSING_REASON = "tmux is required to drive claude-code interactively";
 
+/**
+ * Snapshot of the most recent `rehydratePath()` call on the Bun side.
+ * Returned by `GET /env` and `PUT /env/extra-paths` so the Settings →
+ * Environment panel and the first-run "claude not found" banner can render
+ * a consistent picture of what we resolved at boot. Pure data — no runtime
+ * imports — so it lives here per the shared/types contract.
+ */
+export interface EnvSnapshot {
+  /** Final colon-joined PATH written to `process.env.PATH`. */
+  path: string;
+  /** Whether the login-shell PATH probe succeeded (markers found). */
+  loginProbeOk: boolean;
+  /** User-supplied extra dirs prepended ahead of everything else. */
+  extraDirs: string[];
+  /** Dirs added from the built-in default list (homebrew, nvm shims, …). */
+  defaultDirs: string[];
+  /** Resolved absolute paths (or null when missing) for the three CLIs the
+   *  agetor harnesses depend on. */
+  resolved: {
+    claude: string | null;
+    codex: string | null;
+    tmux: string | null;
+  };
+  /** True when `claude` appears as a shell alias/function but no external
+   *  binary was found — the boot log surfaces a one-time hint, and the UI
+   *  can show the same hint inline. */
+  claudeAliasHint: boolean;
+  /** When the snapshot was taken (epoch ms). */
+  at: number;
+}
+
+/**
+ * Response shape for `GET /env`. The snapshot may be null only in tests
+ * where `rehydratePath()` was never invoked — in prod, boot always calls it
+ * before the API server starts handling requests.
+ */
+export interface EnvPayload {
+  snapshot: EnvSnapshot | null;
+  /** Current `process.env.PATH` in the bun process. Usually equals
+   *  `snapshot.path`, but kept separate so a later mutation would be
+   *  visible to the UI. */
+  livePath: string;
+  /** Persisted extra-PATH dirs. The snapshot also carries them; this
+   *  field is the source of truth for the editor's initial value. */
+  extraDirs: string[];
+}
+
 export const COLUMNS: { id: ColumnId; label: string }[] = [
   { id: "backlog", label: "Backlog" },
   { id: "ready", label: "Ready" },


### PR DESCRIPTION
Users on installed DMGs hit launchd's minimal PATH, and our login-shell rehydration can still miss CLIs when rc files exit early, version managers sit behind tty guards, or the user installs to a non-standard dir. There's no macOS "permission" to grant for binary execution — what users actually need is visibility into what the auto-probe found and an escape hatch when it falls short.

- login-path: rehydratePath() accepts `{ extraDirs }`, captures the resolved bins + PATH + login-probe outcome as an EnvSnapshot, and exposes it via getLastRehydration(). Boot reads the `extra_path_dirs` preference and threads it in, so user-saved entries always win over the auto-detected list.
- server: GET /env returns the snapshot + live PATH + saved extras; PUT /env/extra-paths persists the list, re-runs rehydratePath in-process so the next /agents poll reflects the change, and rejects relative paths / embedded ':' so a pasted $PATH string fails loud instead of silently splitting.
- Settings → Environment: red/green dots for claude/codex/tmux with their resolved absolute paths, login-probe status line, alias hint when claude resolves to a shell function, editable extra-PATH textarea with dirty- state Save button, and a collapsible full-PATH listing for diagnostics.
- EnvMissingBanner: amber strip above the kanban when claude can't be resolved, with a "Fix" button that jumps to Settings. Codex is paused so intentionally claude-only for now; the banner comment notes the minimal change for when codex unpauses.
- Types: EnvSnapshot / EnvPayload live in src/shared/types.ts so the bun and webview sides import one definition.
- Tests: rehydratePath extras precedence, snapshot capture, and the parseExtraPathDirs helper.