### PR TITLE
fix(harness): auto-link claude native install into multi-account HOMEs

### DIFF
--- a/src/bun/agent-status.test.ts
+++ b/src/bun/agent-status.test.ts
@@ -88,9 +88,9 @@ function plantFakeNativeClaude(): { harnessHome: string } {
 test("claude-code alias is unavailable when the native-install integrity symlink is missing", async () => {
   const { harnessHome } = plantFakeNativeClaude();
   const alias: Harness = {
-    id: "claude-bravo",
+    id: "claude-alt",
     kind: "claude-code",
-    label: "Claude (bravo)",
+    label: "Claude (alt)",
     isBuiltin: false,
     home: harnessHome,
     bin: null,
@@ -115,9 +115,9 @@ test("claude-code alias is available when the integrity symlink is present", asy
   symlinkSync("/bin/echo", path.join(harnessBin, "claude"));
 
   const alias: Harness = {
-    id: "claude-bravo",
+    id: "claude-alt",
     kind: "claude-code",
-    label: "Claude (bravo)",
+    label: "Claude (alt)",
     isBuiltin: false,
     home: harnessHome,
     bin: null,

--- a/src/bun/agent-status.test.ts
+++ b/src/bun/agent-status.test.ts
@@ -1,4 +1,7 @@
-import { test, expect, beforeEach } from "bun:test";
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { checkHarness } from "./agent-status.ts";
 import type { AgentKind, Harness } from "../shared/types.ts";
 
@@ -7,10 +10,21 @@ function builtin(kind: AgentKind): Harness {
 }
 const checkAgent = (kind: AgentKind) => checkHarness(builtin(kind));
 
+// Capture once at load so the integrity-check tests below can restore the
+// file's entry PATH regardless of how the prior test interleaved.
+const ORIGINAL_PATH = process.env.PATH;
+let sandbox: string | null = null;
+
 beforeEach(() => {
   delete process.env.AGETOR_CODEX_BIN;
   delete process.env.AGETOR_CLAUDE_BIN;
   delete process.env.AGETOR_TMUX_BIN;
+  sandbox = null;
+});
+
+afterEach(() => {
+  process.env.PATH = ORIGINAL_PATH;
+  if (sandbox) rmSync(sandbox, { recursive: true, force: true });
 });
 
 test("returns available=true with version for a real binary (claude needs tmux too)", async () => {
@@ -41,4 +55,77 @@ test("returns available=false with install hint when the bin is missing", async 
   expect(status.path).toBeNull();
   expect(status.reason).toContain("not found on PATH");
   expect(status.installHint).toContain("codex");
+});
+
+/**
+ * Plant a fake native-install layout on PATH so detectClaudeNativeInstall
+ * recognises the system claude as native. Returns the harness HOME root and
+ * the binary path agent-status will probe via --version.
+ *
+ * Shape mirrors the real install:
+ *   <sandbox>/system/.local/share/claude/versions/<v>   (binary file)
+ *   <sandbox>/system/.local/bin/claude                  (symlink → version)
+ */
+function plantFakeNativeClaude(): { harnessHome: string } {
+  sandbox = mkdtempSync(path.join(tmpdir(), "agetor-agent-status-"));
+  const systemHome = path.join(sandbox, "system");
+  const versionsDir = path.join(systemHome, ".local", "share", "claude", "versions");
+  const sysBinDir = path.join(systemHome, ".local", "bin");
+  mkdirSync(versionsDir, { recursive: true });
+  mkdirSync(sysBinDir, { recursive: true });
+  const realBinary = path.join(versionsDir, "9.9.9");
+  writeFileSync(realBinary, "#!/bin/sh\necho 9.9.9 (fake)\n", { mode: 0o755 });
+  symlinkSync(realBinary, path.join(sysBinDir, "claude"));
+  process.env.PATH = `${sysBinDir}:${process.env.PATH}`;
+  // tmux probe needs to pass — point at any binary that exits 0 on --version.
+  process.env.AGETOR_TMUX_BIN = "/bin/echo";
+
+  const harnessHome = path.join(sandbox, "harness");
+  mkdirSync(harnessHome, { recursive: true });
+  return { harnessHome };
+}
+
+test("claude-code alias is unavailable when the native-install integrity symlink is missing", async () => {
+  const { harnessHome } = plantFakeNativeClaude();
+  const alias: Harness = {
+    id: "claude-bravo",
+    kind: "claude-code",
+    label: "Claude (bravo)",
+    isBuiltin: false,
+    home: harnessHome,
+    bin: null,
+    env: {},
+    enabled: true,
+  };
+
+  const status = await checkHarness(alias);
+  expect(status.available).toBe(false);
+  expect(status.reason).toContain(".local/bin/claude");
+  expect(status.reason).toContain("integrity check");
+  expect(status.installHint).toContain("repair");
+});
+
+test("claude-code alias is available when the integrity symlink is present", async () => {
+  const { harnessHome } = plantFakeNativeClaude();
+  // Pre-populate the same symlink that prepareClaudeHarnessHome would create.
+  const harnessBin = path.join(harnessHome, ".local", "bin");
+  mkdirSync(harnessBin, { recursive: true });
+  // Point at any string — existsSync only checks for presence, and probeVersion
+  // runs the actual system claude (via resolveBin → Bun.which), not this link.
+  symlinkSync("/bin/echo", path.join(harnessBin, "claude"));
+
+  const alias: Harness = {
+    id: "claude-bravo",
+    kind: "claude-code",
+    label: "Claude (bravo)",
+    isBuiltin: false,
+    home: harnessHome,
+    bin: null,
+    env: {},
+    enabled: true,
+  };
+
+  const status = await checkHarness(alias);
+  expect(status.available).toBe(true);
+  expect(status.reason).toBeNull();
 });

--- a/src/bun/agent-status.ts
+++ b/src/bun/agent-status.ts
@@ -1,9 +1,10 @@
 import { existsSync } from "node:fs";
-import { isAbsolute } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { TMUX_MISSING_REASON, type AgentKind, type Harness, type HarnessStatus } from "../shared/types.ts";
 import { resolveBin, harnessEnv } from "./agents.ts";
 import { harnesses } from "./db.ts";
 import { resolveTmuxBin } from "./tmux-resolution.ts";
+import { detectClaudeNativeInstall } from "./harness-setup.ts";
 
 const VERSION_PROBE_TIMEOUT_MS = 2000;
 
@@ -67,6 +68,14 @@ function resolveBinPath(bin: string): string | null {
  */
 const TMUX_INSTALL_HINT = "brew install tmux (macOS) or apt install tmux (Debian/Ubuntu)";
 
+/**
+ * Surfaced when a claude-code alias with a custom HOME is missing the
+ * native-install integrity-check symlink. `orchestrator.startTask` self-heals
+ * on the next run, so the cure is usually "just run the task again"; the
+ * second-line workaround is recreating the alias.
+ */
+const CLAUDE_NATIVE_REPAIR_HINT = "Start a task on this alias once — agetor will repair it. Or remove and re-add the alias in Settings.";
+
 export async function checkHarness(harness: Harness): Promise<HarnessStatus> {
   const bin = resolveBin(harness);
   const path = resolveBinPath(bin);
@@ -96,6 +105,29 @@ export async function checkHarness(harness: Harness): Promise<HarnessStatus> {
         reason: TMUX_MISSING_REASON,
         installHint: TMUX_INSTALL_HINT,
       };
+    }
+
+    // Native-install integrity check: claude validates `$HOME/.local/bin/claude`
+    // exists on every interactive launch — but `--version` short-circuits the
+    // check, so probeVersion would happily green-light a misconfigured alias
+    // whose tasks then explode at spawn time. Catch the gap explicitly when:
+    //   - the alias overrides HOME (built-in claude-code has home=null)
+    //   - the alias didn't pin a custom bin (we're using the system claude)
+    //   - the system claude is actually a native install
+    if (harness.home && !harness.bin && detectClaudeNativeInstall()) {
+      const integrityPath = join(harness.home, ".local", "bin", "claude");
+      if (!existsSync(integrityPath)) {
+        return {
+          harnessId: harness.id,
+          kind: harness.kind,
+          bin,
+          available: false,
+          path,
+          version: null,
+          reason: `${integrityPath} missing — claude's native-install integrity check will fail at launch`,
+          installHint: CLAUDE_NATIVE_REPAIR_HINT,
+        };
+      }
     }
   }
 

--- a/src/bun/harness-setup.test.ts
+++ b/src/bun/harness-setup.test.ts
@@ -1,0 +1,112 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync, readlinkSync, lstatSync, existsSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { detectClaudeNativeInstall, linkClaudeNativeBinIntoHome } from "./harness-setup.ts";
+
+let sandbox: string;
+// Capture once at module load so every test restores to the file's entry
+// PATH — not whatever a previous test happened to set. `afterEach`'s restore
+// becomes obviously correct regardless of test interleaving.
+const ORIGINAL_PATH = process.env.PATH;
+
+/**
+ * Construct a fake native-install layout under `<sandbox>/system/`:
+ *   .local/share/claude/versions/<v>   (real binary file)
+ *   .local/bin/claude                  (symlink → the version file)
+ * and put the bin dir on PATH so `Bun.which("claude")` resolves to it.
+ *
+ * Returns the symlink path that detectClaudeNativeInstall is expected to return.
+ */
+function installFakeClaude(version = "9.9.9"): { symlink: string; binary: string } {
+  const systemHome = path.join(sandbox, "system");
+  const versionsDir = path.join(systemHome, ".local", "share", "claude", "versions");
+  const binDir = path.join(systemHome, ".local", "bin");
+  mkdirSync(versionsDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  const binary = path.join(versionsDir, version);
+  // Marker file masquerading as the binary — detectClaudeNativeInstall only
+  // checks path shape, never executes anything.
+  writeFileSync(binary, "#!/bin/sh\necho fake claude\n", { mode: 0o755 });
+  const symlink = path.join(binDir, "claude");
+  symlinkSync(binary, symlink);
+  process.env.PATH = `${binDir}:${process.env.PATH}`;
+  return { symlink, binary };
+}
+
+beforeEach(() => {
+  sandbox = mkdtempSync(path.join(tmpdir(), "agetor-harness-setup-"));
+});
+
+afterEach(() => {
+  process.env.PATH = ORIGINAL_PATH;
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+test("detectClaudeNativeInstall recognizes the native install layout", () => {
+  const { symlink, binary } = installFakeClaude();
+  const detected = detectClaudeNativeInstall();
+  expect(detected).not.toBeNull();
+  expect(detected!.symlink).toBe(symlink);
+  // realpath canonicalises symlinks (e.g. /var → /private/var on macOS),
+  // so compare against the canonicalised expectation.
+  expect(detected!.binary).toBe(realpathSync(binary));
+});
+
+test("detectClaudeNativeInstall returns null when claude is not a native install", () => {
+  // Put a non-native fake on PATH (lives directly in a flat bin dir, not
+  // under `.local/share/claude/versions/`).
+  const binDir = path.join(sandbox, "npm-style", "bin");
+  mkdirSync(binDir, { recursive: true });
+  const bin = path.join(binDir, "claude");
+  writeFileSync(bin, "#!/bin/sh\n", { mode: 0o755 });
+  process.env.PATH = `${binDir}:${process.env.PATH}`;
+  expect(detectClaudeNativeInstall()).toBeNull();
+});
+
+test("linkClaudeNativeBinIntoHome populates a fresh harness HOME with the integrity symlink", () => {
+  const { symlink } = installFakeClaude();
+  const harnessHome = path.join(sandbox, "harness", "claude-bravo");
+  mkdirSync(harnessHome, { recursive: true });
+
+  const result = linkClaudeNativeBinIntoHome(harnessHome);
+  expect(result.linked).toBe(true);
+  expect(result.target).toBe(symlink);
+
+  const linkedPath = path.join(harnessHome, ".local", "bin", "claude");
+  expect(existsSync(linkedPath)).toBe(true);
+  expect(lstatSync(linkedPath).isSymbolicLink()).toBe(true);
+  // We point at the system *symlink*, not the resolved version binary, so
+  // future auto-updates retarget transparently.
+  expect(readlinkSync(linkedPath)).toBe(symlink);
+});
+
+test("linkClaudeNativeBinIntoHome is idempotent — second call leaves an existing link alone", () => {
+  installFakeClaude();
+  const harnessHome = path.join(sandbox, "harness", "claude-idempotent");
+  mkdirSync(harnessHome, { recursive: true });
+
+  const first = linkClaudeNativeBinIntoHome(harnessHome);
+  expect(first.linked).toBe(true);
+
+  const second = linkClaudeNativeBinIntoHome(harnessHome);
+  expect(second.linked).toBe(false);
+  expect(second.reason).toMatch(/already exists/);
+});
+
+test("linkClaudeNativeBinIntoHome is a no-op when system claude isn't a native install", () => {
+  const binDir = path.join(sandbox, "npm-style", "bin");
+  mkdirSync(binDir, { recursive: true });
+  const bin = path.join(binDir, "claude");
+  writeFileSync(bin, "#!/bin/sh\n", { mode: 0o755 });
+  process.env.PATH = `${binDir}:${process.env.PATH}`;
+
+  const harnessHome = path.join(sandbox, "harness", "claude-noop");
+  mkdirSync(harnessHome, { recursive: true });
+
+  const result = linkClaudeNativeBinIntoHome(harnessHome);
+  expect(result.linked).toBe(false);
+  expect(result.reason).toMatch(/not a native install/);
+  expect(existsSync(path.join(harnessHome, ".local", "bin", "claude"))).toBe(false);
+});

--- a/src/bun/harness-setup.test.ts
+++ b/src/bun/harness-setup.test.ts
@@ -67,7 +67,7 @@ test("detectClaudeNativeInstall returns null when claude is not a native install
 
 test("linkClaudeNativeBinIntoHome populates a fresh harness HOME with the integrity symlink", () => {
   const { symlink } = installFakeClaude();
-  const harnessHome = path.join(sandbox, "harness", "claude-bravo");
+  const harnessHome = path.join(sandbox, "harness", "claude-alt");
   mkdirSync(harnessHome, { recursive: true });
 
   const result = linkClaudeNativeBinIntoHome(harnessHome);

--- a/src/bun/harness-setup.ts
+++ b/src/bun/harness-setup.ts
@@ -1,0 +1,119 @@
+import { lstatSync, mkdirSync, realpathSync, symlinkSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Claude Code's native installer drops the binary at
+ * `~/.local/share/claude/versions/<VERSION>` and points `~/.local/bin/claude`
+ * at it. The CLI persists `installMethod: "native"` in `$HOME/.claude.json`
+ * after onboarding, and on every subsequent launch validates that marker by
+ * checking that `$HOME/.local/bin/claude` exists — if not, it bails with
+ * `installMethod is native, but claude command not found at <path>`.
+ *
+ * For multi-account harnesses we override HOME so each account gets its own
+ * `.claude/` / `.claude.json`. But the integrity check then points at the
+ * *new* HOME's `.local/bin/claude`, which we never populated — so claude
+ * refuses to start after the first onboarding launch.
+ *
+ * The fix is purely filesystem-side: pre-create `<harnessHome>/.local/bin/`
+ * and symlink `claude` to the system installation. Tracking the *symlink*
+ * rather than the resolved binary means harness logins pick up auto-updates
+ * for free (the system symlink retargets to the new version, the harness
+ * symlink-to-symlink walks through to it).
+ *
+ * This is claude-native-install-specific. npm-global / homebrew / other
+ * install methods don't write `installMethod: "native"` and don't trigger
+ * the check.
+ */
+
+const NATIVE_INSTALL_MARKER = `${path.sep}.local${path.sep}share${path.sep}claude${path.sep}versions${path.sep}`;
+
+export interface ClaudeNativeInstall {
+  /** Symlink path to symlink into harness homes (e.g. /Users/x/.local/bin/claude). */
+  symlink: string;
+  /** Resolved binary path (e.g. /Users/x/.local/share/claude/versions/2.1.143). */
+  binary: string;
+}
+
+/**
+ * Return the system claude install if it is a native install, else null.
+ * Resolution mirrors `resolveBin()` for built-in claude-code: `Bun.which`
+ * with an explicit PATH to dodge Bun's startup PATH cache.
+ *
+ * Detection is purely structural — we walk the realpath of whatever
+ * `claude` resolves to and check for the native-install path marker. This
+ * avoids depending on `homedir()` (the user might run with a non-standard
+ * HOME and still be on a native install).
+ */
+export function detectClaudeNativeInstall(): ClaudeNativeInstall | null {
+  const symlink = Bun.which("claude", { PATH: process.env.PATH });
+  if (!symlink) return null;
+  try {
+    const binary = realpathSync(symlink);
+    if (!binary.includes(NATIVE_INSTALL_MARKER)) return null;
+    return { symlink, binary };
+  } catch {
+    return null;
+  }
+}
+
+export interface LinkResult {
+  /** True if we created a new symlink, false if a no-op. */
+  linked: boolean;
+  /** Path of the link target (system claude symlink), if any. */
+  target: string | null;
+  /** Human-readable explanation, useful for logging. */
+  reason: string;
+}
+
+/**
+ * Ensure `<home>/.local/bin/claude` exists and points at the system native
+ * claude install. Idempotent: if anything already lives at the target path
+ * (symlink, file, dir), leave it alone. Errors never propagate — harness
+ * creation must succeed even if we can't link.
+ */
+export function linkClaudeNativeBinIntoHome(home: string): LinkResult {
+  const install = detectClaudeNativeInstall();
+  if (!install) {
+    return { linked: false, target: null, reason: "system claude is not a native install" };
+  }
+
+  const binDir = path.join(home, ".local", "bin");
+  const target = path.join(binDir, "claude");
+
+  // Use `lstatSync` (not `existsSync`) so dangling symlinks from a previous
+  // botched setup are also treated as "already present" — clobbering them
+  // could mask real problems the user should see.
+  try {
+    lstatSync(target);
+    return { linked: false, target: install.symlink, reason: `${target} already exists — left alone` };
+  } catch {
+    /* not present, proceed */
+  }
+
+  try {
+    mkdirSync(binDir, { recursive: true });
+    symlinkSync(install.symlink, target);
+    return { linked: true, target: install.symlink, reason: `linked ${target} → ${install.symlink}` };
+  } catch (e) {
+    return {
+      linked: false,
+      target: install.symlink,
+      reason: `failed to link ${target}: ${(e as Error).message}`,
+    };
+  }
+}
+
+/**
+ * Wrapper called from the harness create/update handlers. Logs the outcome
+ * to the bun console so support has a breadcrumb when a multi-account setup
+ * still fails. Returns the result so callers (and tests) can inspect.
+ */
+export function prepareClaudeHarnessHome(home: string): LinkResult {
+  const result = linkClaudeNativeBinIntoHome(home);
+  if (result.linked) {
+    console.log(`[harness-setup] ${result.reason}`);
+  } else if (result.reason.startsWith("failed")) {
+    console.warn(`[harness-setup] ${result.reason}`);
+  }
+  return result;
+}

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { db, tasks, runs, harnesses } from "./db.ts";
 import { spawnAgent, toClaudeModelArg } from "./agents.ts";
 import { checkHarness } from "./agent-status.ts";
+import { prepareClaudeHarnessHome } from "./harness-setup.ts";
 import {
   AGENT_OPTIONS,
   DEFAULT_EFFORT,
@@ -295,6 +296,15 @@ export async function startTask(taskId: string): Promise<{ runId: string } | { e
   // blocked. The user re-enables in Settings to recover.
   if (!harness.enabled) {
     return { error: `${harness.label} is disabled — re-enable it in Settings to start new runs.` };
+  }
+  // Self-heal for claude-code aliases created before the harness-setup fix
+  // shipped: pre-link the native-install integrity-check path so checkHarness
+  // (and the subsequent spawn) doesn't trip on `installMethod is native, but
+  // claude command not found at <harness home>/.local/bin/claude`. Idempotent
+  // and gated on `bin` being unset so users who pinned an explicit binary
+  // keep full control.
+  if (harness.kind === "claude-code" && harness.home && !harness.bin) {
+    prepareClaudeHarnessHome(harness.home);
   }
   const status = await checkHarness(harness);
   if (!status.available) {

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -16,6 +16,7 @@ import {
 } from "./db.ts";
 import { createTask, deleteTask, startTask, cancelRun, reconcileTaskSession, sendInput, subscribe, subscribeGlobal } from "./orchestrator.ts";
 import { checkAllHarnesses } from "./agent-status.ts";
+import { prepareClaudeHarnessHome } from "./harness-setup.ts";
 import { applyUpdate, checkForUpdate, getUpdateSnapshot } from "./updater.ts";
 import {
   bundledTmuxAvailable,
@@ -459,6 +460,13 @@ export function startApiServer() {
               bin,
               env,
             });
+            // Native-install claude validates `$HOME/.local/bin/claude` exists
+            // on every launch and errors out otherwise. When the user gives
+            // this harness its own HOME but no BIN, pre-link the system
+            // binary into the new HOME so the integrity check passes.
+            if (created.kind === "claude-code" && created.home && !created.bin) {
+              prepareClaudeHarnessHome(created.home);
+            }
             return json(created, { headers: corsHeaders(req) });
           } catch (e) {
             return json({ error: (e as Error).message }, { status: 400, headers: corsHeaders(req) });
@@ -528,6 +536,12 @@ export function startApiServer() {
           }
           try {
             const updated = harnesses.update(req.params.id, patch);
+            // Same rationale as the POST handler: if a claude-code alias
+            // gains (or changes) a custom HOME without an explicit BIN, make
+            // sure the native-install integrity-check path exists.
+            if (updated.kind === "claude-code" && updated.home && !updated.bin && "home" in body) {
+              prepareClaudeHarnessHome(updated.home);
+            }
             return json(updated, { headers: corsHeaders(req) });
           } catch (e) {
             if (e instanceof HarnessBuiltinError) {


### PR DESCRIPTION
Claude Code's native installer persists `installMethod: "native"` in `$HOME/.claude.json` and validates `$HOME/.local/bin/claude` exists on every interactive launch. Multi-account aliases that override HOME but leave BIN unset would error out with `installMethod is native, but claude command not found at <harness home>/.local/bin/claude` after the first onboarding launch.

New `harness-setup.ts` detects the native-install layout structurally (realpath under `.local/share/claude/versions/`) and pre-creates the integrity-check symlink in the harness HOME, pointing at the *system symlink* so auto-updates retarget transparently. Wired into:

- `POST /harnesses` and `PATCH /harnesses/:id` (home changes)
- `orchestrator.startTask` as a self-heal for aliases created before this fix shipped — idempotent, so newly-created aliases no-op
- `agent-status.checkHarness` now flags the broken state as `available: false` so the status dot stops lying about misconfigured aliases (`--version` short-circuits claude's own check)