### PR TITLE
fix(claude-tmux): cycle Shift+Tab for mid-session mode changes

### DIFF
--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { MODEL_EFFORT_SUPPORT, type AgentKind, type Harness } from "../shared/types.ts";
 import {
   spawnClaudeViaTmux,
+  toClaudeModeString,
   type ChunkHandler,
   type SpawnedAgent,
 } from "./claude-tmux.ts";
@@ -180,46 +181,39 @@ export function buildCommand(
 
     // Permission mode. Null → "auto" for back-compat.
     //
-    // `auto` maps to claude's real `--permission-mode auto` (server-side AI
-    // classifier decides per call). The PreToolUse hook is installed with a
-    // narrow matcher (`^(AskUserQuestion|ExitPlanMode)$`) so it only fires
-    // on the two TUI-modal built-ins — every other tool call is invisible
-    // to our hook, which means claude's permission engine handles it and
-    // the classifier runs as designed. No per-tool approval cards in auto
-    // mode; cards only appear when claude itself surfaces an interactive
-    // tool (AskUserQuestion / ExitPlanMode).
+    // Most agetor mode ids translate 1:1 to claude's `--permission-mode`
+    // values via `toClaudeModeString` (which canonicalizes `bypass` →
+    // `bypassPermissions` and `ask` → `default`). Two cases bypass the
+    // straight translation:
     //
-    // `bypass` maps to `--dangerously-skip-permissions` with the same
-    // narrow matcher AND `installScopeForMode` strips the MCP + CLAUDE.md
-    // addendum — truly silent, no classifier, no clarifying-question
-    // channel. Hooks-off in the strongest sense. The narrow matcher stays
-    // so a stray AskUserQuestion / ExitPlanMode call doesn't deadlock.
+    //   - `bypass` → emit `--dangerously-skip-permissions` instead of the
+    //     `--permission-mode bypassPermissions` form. Both are valid, but
+    //     the legacy flag is what users see in claude's own docs and what
+    //     the hook scope check (`installScopeForMode`) keys off — keep
+    //     parity with that and the narrow PreToolUse matcher behavior
+    //     described below.
     //
-    // Other modes (`ask`, `plan`, `acceptEdits`) install the full `.*`
-    // hook so per-tool approval cards render in agetor's UI — claude's
-    // own TUI prompts are invisible to the user in detached tmux, so
-    // agetor's UI is the user's only window into per-call decisions.
+    //   - `ask` → emit nothing; claude lands in its built-in `default`
+    //     mode, which is exactly the "ask before each action" posture we
+    //     want for this id. Setting `--permission-mode default`
+    //     explicitly works too, but omitting it matches the prior
+    //     behavior so the launch transcript is unchanged.
     //
-    // See `installScopeForMode` in hook-installer.ts.
+    // Hook scope context: `auto` and `bypass` install the narrow
+    // PreToolUse matcher (`^(AskUserQuestion|ExitPlanMode)$`) so claude's
+    // own permission engine + classifier handles every other tool call;
+    // a `.*` matcher would short-circuit the classifier and force every
+    // tool through agetor's UI. Other modes (`ask`, `plan`,
+    // `acceptEdits`) install the full `.*` matcher so per-tool approval
+    // cards render in agetor's UI — claude's own TUI prompts are
+    // invisible in detached tmux, so agetor's UI is the user's only
+    // window into per-call decisions. See `installScopeForMode` in
+    // hook-installer.ts.
     const mode = opts.mode ?? "auto";
-    switch (mode) {
-      case "auto":
-        args.push("--permission-mode", "auto");
-        break;
-      case "bypass":
-        args.push("--dangerously-skip-permissions");
-        break;
-      case "acceptEdits":
-        args.push("--permission-mode", "acceptEdits");
-        break;
-      case "plan":
-        args.push("--permission-mode", "plan");
-        break;
-      case "ask":
-        break;
-      default:
-        args.push("--permission-mode", mode);
-        break;
+    if (mode === "bypass") {
+      args.push("--dangerously-skip-permissions");
+    } else if (mode !== "ask") {
+      args.push("--permission-mode", toClaudeModeString(mode));
     }
 
     args.push(...extra);

--- a/src/bun/claude-tmux.test.ts
+++ b/src/bun/claude-tmux.test.ts
@@ -1,11 +1,19 @@
 import { test, expect } from "bun:test";
 import { homedir } from "node:os";
 import {
+  CLAUDE_MODE_ACCEPT_EDITS,
+  CLAUDE_MODE_AUTO,
+  CLAUDE_MODE_BYPASS,
+  CLAUDE_MODE_DEFAULT,
+  CLAUDE_MODE_PLAN,
+  cycleDistance,
+  cycleOrderFor,
   encodeProjectPath,
   isAgetorInterceptReply,
   jsonlPathFor,
   mapJsonlEventToChunks,
   sessionNameFor,
+  toClaudeModeString,
 } from "./claude-tmux.ts";
 import {
   ASK_QUESTIONS_REPLY_PREFIX,
@@ -318,4 +326,99 @@ test("mapJsonlEventToChunks: end-of-turn marker also carries the line uuid", () 
   const res = mapJsonlEventToChunks(line, onChunk);
   expect(res.endOfTurn).toBe(true);
   expect(seen.find((s) => s.stream === "status")?.uuid).toBe("end-line");
+});
+
+test("toClaudeModeString translates agetor shorthand to canonical claude strings", () => {
+  expect(toClaudeModeString("bypass")).toBe(CLAUDE_MODE_BYPASS);
+  expect(toClaudeModeString("ask")).toBe(CLAUDE_MODE_DEFAULT);
+  // Already canonical / unknown — pass through verbatim.
+  expect(toClaudeModeString("auto")).toBe(CLAUDE_MODE_AUTO);
+  expect(toClaudeModeString("acceptEdits")).toBe(CLAUDE_MODE_ACCEPT_EDITS);
+  expect(toClaudeModeString("plan")).toBe(CLAUDE_MODE_PLAN);
+  expect(toClaudeModeString("dontAsk")).toBe("dontAsk");
+});
+
+test("cycleOrderFor: base 3 modes always present; bypass only when enabled; auto always at the end", () => {
+  expect(cycleOrderFor(false)).toEqual([
+    CLAUDE_MODE_DEFAULT,
+    CLAUDE_MODE_ACCEPT_EDITS,
+    CLAUDE_MODE_PLAN,
+    CLAUDE_MODE_AUTO,
+  ]);
+  expect(cycleOrderFor(true)).toEqual([
+    CLAUDE_MODE_DEFAULT,
+    CLAUDE_MODE_ACCEPT_EDITS,
+    CLAUDE_MODE_PLAN,
+    CLAUDE_MODE_BYPASS,
+    CLAUDE_MODE_AUTO,
+  ]);
+});
+
+test("cycleDistance returns press count via forward cycle", () => {
+  const cycle = cycleOrderFor(false); // default, acceptEdits, plan, auto
+  expect(cycleDistance(cycle, CLAUDE_MODE_DEFAULT, CLAUDE_MODE_ACCEPT_EDITS)).toBe(1);
+  expect(cycleDistance(cycle, CLAUDE_MODE_DEFAULT, CLAUDE_MODE_PLAN)).toBe(2);
+  expect(cycleDistance(cycle, CLAUDE_MODE_DEFAULT, CLAUDE_MODE_AUTO)).toBe(3);
+  // wrap-around: from auto to default is one press, not three back.
+  expect(cycleDistance(cycle, CLAUDE_MODE_AUTO, CLAUDE_MODE_DEFAULT)).toBe(1);
+  // same mode → 0 presses (caller can skip).
+  expect(cycleDistance(cycle, CLAUDE_MODE_PLAN, CLAUDE_MODE_PLAN)).toBe(0);
+});
+
+test("cycleDistance returns null when target isn't in the cycle (e.g. bypass without launch flag)", () => {
+  const cycle = cycleOrderFor(false); // bypass NOT included
+  expect(cycleDistance(cycle, CLAUDE_MODE_DEFAULT, CLAUDE_MODE_BYPASS)).toBeNull();
+  // Same for an unrecognized mode.
+  expect(cycleDistance(cycle, CLAUDE_MODE_DEFAULT, "dontAsk")).toBeNull();
+});
+
+test("cycleDistance with bypass enabled: order goes plan → bypass → auto", () => {
+  const cycle = cycleOrderFor(true);
+  // From bypass: one press lands on auto, two presses on default.
+  expect(cycleDistance(cycle, CLAUDE_MODE_BYPASS, CLAUDE_MODE_AUTO)).toBe(1);
+  expect(cycleDistance(cycle, CLAUDE_MODE_BYPASS, CLAUDE_MODE_DEFAULT)).toBe(2);
+  // plan → bypass is exactly one press (the new neighbour).
+  expect(cycleDistance(cycle, CLAUDE_MODE_PLAN, CLAUDE_MODE_BYPASS)).toBe(1);
+});
+
+test("system event updates state.permissionMode (dispatchLine path)", async () => {
+  // Use the test harness for SessionState since the watcher path needs a
+  // real fs but we only care that dispatchLine routes the permissionMode
+  // off `system` events into SessionState.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-mode-track";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+  expect(state.permissionMode).toBeNull();
+  __forTest.dispatchLine(
+    state,
+    JSON.stringify({ type: "system", permissionMode: "acceptEdits" }),
+  );
+  expect(state.permissionMode).toBe("acceptEdits");
+  // Subsequent permission-mode events overwrite.
+  __forTest.dispatchLine(
+    state,
+    JSON.stringify({ type: "permission-mode", permissionMode: "auto" }),
+  );
+  expect(state.permissionMode).toBe("auto");
+  __forTest.uninstallSession(taskId);
+});
+
+test("dispatchLine: permissionMode still updates when the event's uuid is already in seenLineUuids (reattach path)", async () => {
+  // On reattach, seenLineUuids is pre-seeded from run_events.line_uuid so
+  // the user-facing chunk replay stays idempotent. The permissionMode
+  // tracking has to run BEFORE that dedup check — otherwise the field
+  // would stay null until claude emitted a fresh mode event, and the
+  // first cycleToMode call after every restart would skip with
+  // "current mode unknown".
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-mode-track-dedup";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+  state.seenLineUuids.add("system-event-uuid-1");
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "system",
+    uuid: "system-event-uuid-1",
+    permissionMode: "bypassPermissions",
+  }));
+  expect(state.permissionMode).toBe("bypassPermissions");
+  __forTest.uninstallSession(taskId);
 });

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -112,6 +112,62 @@ export interface ClaudeLaunchOptions {
  * ────────────────────────────────────────────────────────────────────────── */
 
 /**
+ * Canonical permission-mode strings claude reports in its JSONL `system` /
+ * `permission-mode` events (and accepts at `--permission-mode`). Agetor's own
+ * mode ids (see AGENT_OPTIONS in shared/types.ts) overlap on `auto`,
+ * `acceptEdits`, `plan` but use shorthand for the other two: `bypass` →
+ * `bypassPermissions`, `ask` → `default`. Translate via `toClaudeModeString`.
+ */
+export const CLAUDE_MODE_DEFAULT = "default";
+export const CLAUDE_MODE_ACCEPT_EDITS = "acceptEdits";
+export const CLAUDE_MODE_PLAN = "plan";
+export const CLAUDE_MODE_BYPASS = "bypassPermissions";
+export const CLAUDE_MODE_AUTO = "auto";
+
+/** Translate an agetor mode id (from AGENT_OPTIONS) to claude's canonical
+ *  permission-mode string. Unknown ids fall through verbatim so future agetor
+ *  ids that happen to match claude's strings (e.g. `dontAsk`) just work. */
+export function toClaudeModeString(agetorMode: string): string {
+  switch (agetorMode) {
+    case "bypass": return CLAUDE_MODE_BYPASS;
+    case "ask": return CLAUDE_MODE_DEFAULT;
+    default: return agetorMode;
+  }
+}
+
+/**
+ * The Shift+Tab cycle order claude implements. The 3 base modes are always
+ * present; `bypassPermissions` only appears when claude was launched with one
+ * of `--permission-mode bypassPermissions`, `--dangerously-skip-permissions`,
+ * or `--allow-dangerously-skip-permissions`. `auto` appears when the account
+ * is eligible — we can't probe that programmatically, so we optimistically
+ * include it; if the user's account isn't eligible the press will land
+ * somewhere unexpected (and the JSONL event tells us where).
+ *
+ * Order documented at https://code.claude.com/docs/en/permission-modes —
+ * optional modes slot in after `plan`, bypass first then auto.
+ */
+export function cycleOrderFor(bypassEnabled: boolean): string[] {
+  const cycle = [CLAUDE_MODE_DEFAULT, CLAUDE_MODE_ACCEPT_EDITS, CLAUDE_MODE_PLAN];
+  if (bypassEnabled) cycle.push(CLAUDE_MODE_BYPASS);
+  cycle.push(CLAUDE_MODE_AUTO);
+  return cycle;
+}
+
+/**
+ * Compute the number of Shift+Tab presses to step from `current` to `target`
+ * within `cycle`. Returns null when either mode isn't in the cycle (caller
+ * should treat as "unreachable — needs a respawn"). Returns 0 when already
+ * at the target — caller can skip the keystrokes.
+ */
+export function cycleDistance(cycle: string[], current: string, target: string): number | null {
+  const curIdx = cycle.indexOf(current);
+  const tgtIdx = cycle.indexOf(target);
+  if (curIdx < 0 || tgtIdx < 0) return null;
+  return (tgtIdx - curIdx + cycle.length) % cycle.length;
+}
+
+/**
  * Encode an absolute filesystem path the way Claude Code does for its project
  * directory name under `~/.claude/projects/`. Every `/` AND `.` becomes `-` —
  * so `/Users/me/.agetor/x` collapses to `-Users-me--agetor-x` (note the
@@ -459,6 +515,23 @@ interface SessionState {
    *  waiting on `done`. Cleared after the first fire. Untouched on freshly-
    *  spawned sessions (those resolve via the turn slot's promise instead). */
   onEndOfTurn: (() => void) | null;
+  /**
+   * Most recently observed claude permission mode (canonical string from
+   * the JSONL `system` / `permission-mode` events — `default` / `acceptEdits`
+   * / `plan` / `bypassPermissions` / `auto` / `dontAsk`). Null until claude
+   * emits its first event. `cycleToMode` reads this to compute how many
+   * Shift+Tab presses are needed to land on the target.
+   */
+  permissionMode: string | null;
+  /**
+   * Whether `bypassPermissions` is in this session's Shift+Tab cycle. True
+   * iff the session was launched with `--dangerously-skip-permissions` (the
+   * agetor `bypass` mode emits exactly that). Reattached sessions default
+   * to false — we don't persist the launch flag across agetor restarts, so
+   * mid-cycle to bypass after a restart isn't supported (would need a
+   * respawn anyway, since claude requires the enabling flag at launch).
+   */
+  bypassEnabled: boolean;
 }
 
 interface TurnSlot {
@@ -555,6 +628,20 @@ function dispatchLine(state: SessionState, line: string): void {
     return;
   }
   const uuid = typeof evt.uuid === "string" ? evt.uuid : undefined;
+
+  // Mirror permission-mode events into SessionState so cycleToMode knows
+  // where claude is right now. This MUST run before the dedup early-return
+  // below: on reattach, `seenLineUuids` is pre-seeded from `run_events`, so
+  // the historical system/permission-mode lines would otherwise be silently
+  // skipped and `state.permissionMode` would stay null until claude emitted
+  // a fresh mode event. permissionMode is session metadata, not a per-line
+  // chunk the user sees twice — it's safe (and necessary) to update it on
+  // dedup hits.
+  if ((evt.type === "system" || evt.type === "permission-mode")
+    && typeof evt.permissionMode === "string") {
+    state.permissionMode = evt.permissionMode;
+  }
+
   if (uuid && state.seenLineUuids.has(uuid)) return;
 
   const slot = state.turnQueue[0];
@@ -769,6 +856,11 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
     lastChunk: null,
     seenLineUuids: new Set(),
     onEndOfTurn: null,
+    permissionMode: null,
+    // `bypass` is the only agetor mode that emits the launch flag
+    // (--dangerously-skip-permissions) — that's what puts
+    // `bypassPermissions` into the Shift+Tab cycle.
+    bypassEnabled: opts.mode === "bypass",
   };
   sessions.set(opts.taskId, state);
 
@@ -871,6 +963,18 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
     lastChunk: opts.onChunk,
     seenLineUuids: opts.seenLineUuids,
     onEndOfTurn: () => resolveDone?.(0),
+    // Replaying the JSONL from offset 0 re-runs every historical
+    // `system` / `permission-mode` line through `dispatchLine`. The
+    // permissionMode update there sits above the seenLineUuids dedup
+    // check, so even when the line's uuid is already in the dedup set
+    // (pre-seeded from run_events on reattach) the field still gets
+    // overwritten with whatever mode claude is currently in.
+    permissionMode: null,
+    // The launch flag isn't persisted across agetor restarts, so we can't
+    // tell whether bypassPermissions is in the cycle on this reattach.
+    // Conservatively assume not — cycling to bypass after a restart needs
+    // a respawn (claude requires the flag at launch anyway).
+    bypassEnabled: false,
   };
   // Belt to reconcileOrphans's sort-and-dedup suspender: if some prior
   // reattach (or other code path) already left a SessionState in the map
@@ -943,14 +1047,86 @@ export function sendTurn(taskId: string, prompt: string, onChunk: ChunkHandler):
  * whether to spawn fresh or surface an error.
  *
  * Used by the orchestrator to mirror inline config edits onto a live claude
- * session: `/permission-mode <id>`, `/model <id>`, `/effort <id>`. Keeping the
- * session alive preserves the conversation context across config changes.
+ * session: `/model <id>`, `/effort <id>`. (Permission-mode changes don't have
+ * a slash command — see `cycleToMode`.) Keeping the session alive preserves
+ * the conversation context across config changes.
  */
 export function sendSlashCommand(taskId: string, line: string): boolean {
   const state = sessions.get(taskId);
   if (!state) return false;
   pastePrompt(state.sessionName, line);
   return true;
+}
+
+export type CycleResult =
+  | { ok: true; presses: number; via: "noop" | "slash-plan" | "shift-tab" }
+  | { ok: false; reason: string };
+
+/**
+ * Switch a live claude session's permission mode to `targetAgetorMode` by
+ * sending the right number of `Shift+Tab` keystrokes (claude's only
+ * mid-session mode-switch mechanism — there's no `/permission-mode` slash
+ * command despite what the prior code assumed). For the `plan` target we
+ * prefer the `/plan` slash command instead: it's deterministic, doesn't
+ * depend on knowing the current mode, and works from anywhere.
+ *
+ * Returns:
+ *   - `{ ok: true, via: "noop" }` when the session is already at the target.
+ *   - `{ ok: true, via: "slash-plan" }` when we sent `/plan`.
+ *   - `{ ok: true, via: "shift-tab", presses: N }` when we sent N tabs.
+ *   - `{ ok: false, reason: "no live session" }` for an unknown task.
+ *   - `{ ok: false, reason: "current mode unknown" }` before claude's first
+ *     `system` event has arrived (rare — typically only at the very start of
+ *     a session before its first JSONL entry).
+ *   - `{ ok: false, reason: "unreachable in current cycle" }` when the
+ *     target isn't in this session's cycle. The most common case is asking
+ *     for `bypassPermissions` on a session that wasn't launched with the
+ *     enabling flag — a respawn is required.
+ *
+ * Caveat — first cycle to `auto`: claude shows a one-time opt-in modal the
+ * first time you cycle to auto on a given account. Our keystrokes pass
+ * through but the cycle pauses on the modal until the user (or some other
+ * keystroke) dismisses it. After the first acceptance, subsequent cycles
+ * work without intervention.
+ */
+export function cycleToMode(taskId: string, targetAgetorMode: string): CycleResult {
+  const state = sessions.get(taskId);
+  if (!state) return { ok: false, reason: "no live session" };
+  const target = toClaudeModeString(targetAgetorMode);
+
+  // `/plan` works from any state, no cycle math needed. Prefer it.
+  // No optimistic state update here — `pastePrompt` is fire-and-forget
+  // (its tmux load-buffer / paste-buffer / send-keys helpers swallow
+  // errors), so claiming success before claude has acknowledged would
+  // lie when the paste fails. The JSONL `permission-mode` event that
+  // follows `/plan` is the authoritative source.
+  if (target === CLAUDE_MODE_PLAN) {
+    pastePrompt(state.sessionName, "/plan");
+    return { ok: true, presses: 0, via: "slash-plan" };
+  }
+
+  const current = state.permissionMode;
+  if (!current) return { ok: false, reason: "current mode unknown" };
+  if (current === target) return { ok: true, presses: 0, via: "noop" };
+
+  const cycle = cycleOrderFor(state.bypassEnabled);
+  const presses = cycleDistance(cycle, current, target);
+  if (presses === null) {
+    return { ok: false, reason: `mode '${target}' not in this session's cycle` };
+  }
+  if (presses > 0) {
+    // One tmux invocation with N keys — cleaner than N sync spawns, and
+    // tmux delivers them as a single stream so claude's TUI doesn't get
+    // a chance to debounce them apart on slow terminals.
+    const keys = Array<string>(presses).fill("S-Tab");
+    tmux(["send-keys", "-t", state.sessionName, ...keys]);
+  }
+  // Optimistic local update. The JSONL `permission-mode` event will arrive
+  // shortly after and overwrite this with claude's authoritative value —
+  // if a press landed somewhere unexpected (e.g. account isn't auto-eligible)
+  // the event corrects state.
+  state.permissionMode = target;
+  return { ok: true, presses, via: "shift-tab" };
 }
 
 /**
@@ -1032,6 +1208,8 @@ export const __forTest = {
       lastChunk: null,
       seenLineUuids: new Set(),
       onEndOfTurn: null,
+      permissionMode: null,
+      bypassEnabled: false,
     };
     sessions.set(taskId, state);
     return state;

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -23,6 +23,8 @@ function resolveHarness(harnessId: string): Harness | null {
 }
 import { cancelPendingForTask, setBroadcaster, type AnyRequest } from "./interactions.ts";
 import {
+  cycleToMode,
+  type CycleResult,
   dropSession,
   listAgetorSessions,
   killSessionByName,
@@ -513,8 +515,10 @@ function attachDoneHandler(
  *   • Agent change (claude ↔ codex): kills any claude tmux session we had
  *     for this task. The new agent will spawn fresh on next Run.
  *   • Same-agent mode / model / effort change on a live claude session:
- *     send the matching `/permission-mode`, `/model`, `/effort` slash command
- *     via tmux. The session keeps running with the new posture.
+ *     for `/model` and `/effort` send the real slash command; for the
+ *     permission mode there is no slash command, so we call `cycleToMode`
+ *     which sends Shift+Tab keystrokes (or `/plan` when the target is plan).
+ *     The session keeps running with the new posture.
  *   • Anything else (codex; no live session): no-op — the change just
  *     persists for the next spawn.
  */
@@ -541,8 +545,13 @@ export function reconcileTaskSession(taskId: string, before: Task, after: Task):
   if (afterKind !== "claude-code") return;
   if (!sessionExists(taskId)) return;
 
+  // `after.mode` guard: a PATCH that clears the mode (mode → null) leaves
+  // the live session alone — the UI doesn't expose a "clear mode" control
+  // and there's no canonical "unset" mode to dial claude back to, so
+  // silently keeping the current posture is the least-surprising option.
   if (before.mode !== after.mode && after.mode) {
-    sendSlashCommand(taskId, `/permission-mode ${after.mode}`);
+    const result = cycleToMode(taskId, after.mode);
+    emitModeChangeStatus(taskId, after.mode, result);
   }
   if (before.model !== after.model && after.model) {
     sendSlashCommand(taskId, `/model ${toClaudeModelArg(after.model)}`);
@@ -550,6 +559,35 @@ export function reconcileTaskSession(taskId: string, before: Task, after: Task):
   if (before.effort !== after.effort && after.effort) {
     sendSlashCommand(taskId, `/effort ${after.effort}`);
   }
+}
+
+/**
+ * Surface a `cycleToMode` outcome on the task's most recent run so the user
+ * sees it in the run panel. Both success and skip ride the `status` stream
+ * — skipping is an orchestrator-side decision (e.g. asking for `bypass` on
+ * a session that wasn't launched with the flag), not an agent error, so
+ * `stderr` would mislead the user into thinking claude crashed. We
+ * disambiguate with a "⚠️" prefix on the skip case. Silent when there's no
+ * run row to attach to (shouldn't happen — a live tmux session implies at
+ * least one prior run — but defensive).
+ */
+function emitModeChangeStatus(
+  taskId: string,
+  agetorMode: string,
+  result: CycleResult,
+): void {
+  const recent = runs.listForTask(taskId)[0];
+  if (!recent) return;
+  const runId = recent.id;
+  const ts = Date.now();
+  const data = result.ok
+    ? (result.via === "noop"
+      ? null
+      : `mode → ${agetorMode} (${result.via === "slash-plan" ? "via /plan" : `via Shift+Tab ×${result.presses}`})`)
+    : `⚠️ mode change to ${agetorMode} skipped: ${result.reason} — stop the run and start again to apply.`;
+  if (!data) return;
+  runs.appendEvent(runId, "status", data);
+  emit({ runId, taskId, stream: "status", data, ts });
 }
 
 export function cancelRun(runId: string): boolean {


### PR DESCRIPTION
The old `reconcileTaskSession` sent `/permission-mode <id>` as a slash command, but no such command exists in Claude Code — claude received it as a literal user prompt and the session's mode stayed wherever it was launched (typically `acceptEdits`), which is why the run panel kept showing `permission-mode: acceptEdits` after the user picked `auto` in Task Details.

Replace it with a real switch path: track claude's current mode from its JSONL `system` / `permission-mode` events, compute how many `Shift+Tab` presses are needed to walk the documented cycle (`default → acceptEdits → plan → bypassPermissions? → auto?`), and send them in a single `tmux send-keys` call. `/plan` short-circuits to the real slash-command — deterministic and doesn't need to know the current mode. The permissionMode update sits above the seenLineUuids dedup so reattach after an agetor restart still hydrates the field. Surface the result on the run stream so the user sees `mode → auto (via Shift+Tab ×3)` (or, on unreachable targets like `bypass` from a non-bypass launch, a ⚠️ skip notice telling them to stop and restart).

Also unify the agetor → claude mode-id translation behind `toClaudeModeString` so the launch flag and the cycle math share one vocabulary.