### PR TITLE
feat(kanban): indicate when a task is awaiting user interaction

### DIFF
--- a/src/bun/approvals-endpoint.test.ts
+++ b/src/bun/approvals-endpoint.test.ts
@@ -54,6 +54,7 @@ async function seedPendingApproval(args: {
     createdAt: Date.now(),
     updatedAt: Date.now(),
     hasOpenableRun: false,
+    pendingInteractionCount: 0,
   });
   const { registerApproval } = await import("./interactions.ts");
   const { id } = registerApproval({

--- a/src/bun/db-openable.test.ts
+++ b/src/bun/db-openable.test.ts
@@ -43,6 +43,7 @@ function makeTask() {
     references: [],
     runId: null,
     hasOpenableRun: false,
+    pendingInteractionCount: 0,
     createdAt: now,
     updatedAt: now,
   });

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -5,6 +5,15 @@ import path from "node:path";
 import type { AgentKind, Harness, HarnessUsage, Project, Task, TaskReference, Run, RunEventStream } from "../shared/types.ts";
 import { migrate } from "./migrate.ts";
 import { migrations } from "./migrations/index.ts";
+// Interactions live in-memory in `interactions.ts`. The import creates a
+// cycle: db.ts → interactions.ts → db.ts (for `tasks`). It is safe ONLY
+// because both modules access each other's exports exclusively from
+// function bodies that run after module init — never at top level. Do
+// NOT add a top-level call site in either direction (e.g. a `const x =
+// tasks.get(...)` at module scope in interactions.ts) — under ESM live
+// bindings the unresolved cycle becomes an undefined-binding crash at
+// import time. Keep both sides lazy.
+import { countPendingForTask } from "./interactions.ts";
 
 // Hard guard against test fixtures silently leaking into the user's real
 // SQLite db. `bun test` runs every *.test.ts file in one process, so the
@@ -96,6 +105,7 @@ const toTask = (r: TaskRow): Task => ({
   // join (e.g. insert/update returning the freshly-written shape, where
   // no runs exist yet → false is the right default).
   hasOpenableRun: r.has_openable_run === 1,
+  pendingInteractionCount: countPendingForTask(r.id),
   createdAt: r.created_at,
   updatedAt: r.updated_at,
 });
@@ -143,7 +153,7 @@ export const tasks = {
     // Round-trip via `get` so the returned shape carries the computed
     // hasOpenableRun field (false for a brand-new task — but callers
     // that mutate t shouldn't accidentally get a stale shape).
-    return this.get(t.id) ?? { ...t, hasOpenableRun: false };
+    return this.get(t.id) ?? { ...t, hasOpenableRun: false, pendingInteractionCount: 0 };
   },
   update(id: string, patch: Partial<Task>): Task | null {
     const current = this.get(id);

--- a/src/bun/interactions.test.ts
+++ b/src/bun/interactions.test.ts
@@ -38,6 +38,7 @@ async function makeTaskWithCwd(id: string): Promise<string> {
     createdAt: Date.now(),
     updatedAt: Date.now(),
     hasOpenableRun: false,
+    pendingInteractionCount: 0,
   });
   return cwd;
 }
@@ -321,4 +322,45 @@ test("cancelPendingForTask resolves ask_questions + plan_approval entries", asyn
   const pa = await p.answer;
   expect(pa.choice).toBe("reject");
   expect(pa.revision).toBe("cancelled by user");
+});
+
+test("tasks.get / tasks.list expose pendingInteractionCount reflecting open interactions", async () => {
+  await makeTaskWithCwd("tCount");
+  const { tasks } = await import("./db.ts");
+  const {
+    registerApproval, registerQuestion, registerAskQuestions, registerPlanApproval,
+    answerApproval, answerQuestion,
+  } = await import("./interactions.ts");
+
+  // No interactions yet → 0.
+  expect(tasks.get("tCount")!.pendingInteractionCount).toBe(0);
+
+  // One of each kind from the four in-memory maps; counter should reflect all.
+  const ap = registerApproval({ taskId: "tCount", runId: "r1", toolName: "Bash", toolInput: { command: "ls" } });
+  registerQuestion({ taskId: "tCount", runId: "r1", question: "?" });
+  registerAskQuestions({
+    taskId: "tCount", runId: "r1",
+    questions: [{ question: "?", options: [{ label: "A" }] }],
+  });
+  registerPlanApproval({ taskId: "tCount", runId: "r1", plan: "P" });
+  expect(tasks.get("tCount")!.pendingInteractionCount).toBe(4);
+  // And the same count surfaces via tasks.list (the kanban's polling path).
+  const fromList = tasks.list().find((t) => t.id === "tCount");
+  expect(fromList?.pendingInteractionCount).toBe(4);
+
+  // Answering removes the entry from its map and decrements the count.
+  answerApproval(ap.id, { decision: "allow" });
+  await ap.answer;
+  expect(tasks.get("tCount")!.pendingInteractionCount).toBe(3);
+
+  // Counter is scoped to the task: a sibling task with no interactions reads 0.
+  await makeTaskWithCwd("tCountSibling");
+  expect(tasks.get("tCountSibling")!.pendingInteractionCount).toBe(0);
+
+  // Answer the bare question too; counter keeps dropping.
+  const q2 = registerQuestion({ taskId: "tCount", runId: "r1", question: "?" });
+  expect(tasks.get("tCount")!.pendingInteractionCount).toBe(4);
+  answerQuestion(q2.id, { selected: ["ok"] });
+  await q2.answer;
+  expect(tasks.get("tCount")!.pendingInteractionCount).toBe(3);
 });

--- a/src/bun/interactions.ts
+++ b/src/bun/interactions.ts
@@ -442,6 +442,18 @@ export function listPendingForTask(taskId: string): AnyRequest[] {
   return out.sort((a, b) => a.createdAt - b.createdAt);
 }
 
+/** Cheap counter used by `tasks.list()` / `tasks.get()` to surface the
+ *  pending-interaction badge on each kanban card without serializing the
+ *  full payloads. Linear scan over the four small in-memory Maps. */
+export function countPendingForTask(taskId: string): number {
+  let n = 0;
+  for (const e of approvals.values()) if (e.req.taskId === taskId) n++;
+  for (const e of questions.values()) if (e.req.taskId === taskId) n++;
+  for (const e of askQuestions.values()) if (e.req.taskId === taskId) n++;
+  for (const e of planApprovals.values()) if (e.req.taskId === taskId) n++;
+  return n;
+}
+
 /* ────────────────────────────────────────────────────────────────────────── *
  * Allow-rules (persistent, stored as native claude permission entries in the
  * task cwd's `.claude/settings.local.json`)

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -855,6 +855,9 @@ export async function createTask(
     // `Task` shape is complete; `tasks.insert` re-fetches and the real
     // value flows back to the caller.
     hasOpenableRun: false,
+    // Derived from the in-memory interactions Maps in `interactions.ts`; a
+    // brand-new task has no pending interactions, so 0 is the correct seed.
+    pendingInteractionCount: 0,
     createdAt: now,
     updatedAt: now,
   });

--- a/src/bun/reconcile-session.test.ts
+++ b/src/bun/reconcile-session.test.ts
@@ -31,6 +31,7 @@ function baseTask(overrides: Partial<Task> = {}): Task {
     references: [],
     runId: null,
     hasOpenableRun: false,
+    pendingInteractionCount: 0,
     createdAt: 0,
     updatedAt: 0,
     ...overrides,

--- a/src/bun/reconcile.test.ts
+++ b/src/bun/reconcile.test.ts
@@ -38,6 +38,7 @@ test("reconcileOrphans marks running rows as orphaned and returns tasks to ready
     references: [],
     runId,
     hasOpenableRun: false,
+    pendingInteractionCount: 0,
     createdAt: now,
     updatedAt: now,
   });

--- a/src/bun/task-events.test.ts
+++ b/src/bun/task-events.test.ts
@@ -59,6 +59,7 @@ function makeTaskRow(taskId: string, agent: Task["agent"] = "claude-code"): Task
     createdAt: Date.now(),
     updatedAt: Date.now(),
     hasOpenableRun: false,
+    pendingInteractionCount: 0,
   };
 }
 

--- a/src/bun/worktree.test.ts
+++ b/src/bun/worktree.test.ts
@@ -43,6 +43,7 @@ function fakeTask(overrides: Partial<Task> & { workdir: string }): Task {
     references: [],
     runId: null,
     hasOpenableRun: false,
+    pendingInteractionCount: 0,
     createdAt: 0,
     updatedAt: 0,
     ...overrides,

--- a/src/mainview/components/kanban/TaskCard.tsx
+++ b/src/mainview/components/kanban/TaskCard.tsx
@@ -1,6 +1,6 @@
 import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
-import { FolderOpen, GitBranch, Play, Square, Trash2 } from "lucide-react";
+import { ArrowRight, FolderOpen, GitBranch, MessageCircleQuestion, Play, Square, Trash2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -26,13 +26,30 @@ export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen }:
     ? { transform: CSS.Translate.toString(transform) }
     : undefined;
 
-  // Button precedence: Stop > Open > Run.
+  // Button precedence: Answer > Stop > Open > Run.
+  //  - Answer when at least one interaction (ask_user / AskUserQuestion /
+  //    ExitPlanMode / tool-approval) is pending OR codex flipped the task to
+  //    `blocked` via the approval-prompt heuristic. Opens the run panel; Stop
+  //    moves to a trailing icon slot so the user can still cancel.
   //  - Stop while the agent process is live (running OR blocked-awaiting-user).
   //  - Open once any run has reached succeeded/running/orphaned — there's
   //    something worth re-reading; Run stays reachable from inside the panel.
   //  - Run otherwise (no openable history yet, or only failed/cancelled).
   const active = task.column === "running" || task.column === "blocked";
   const openable = task.hasOpenableRun;
+  // Combine structured interactions with codex's narrative `blocked` signal.
+  // The latter has no answerable payload — the user resolves it from the run
+  // panel — but it represents the same "waiting on you" state to the user.
+  // When the only signal is `blocked` (no structured questions), we label the
+  // call-to-action "Review" instead of "Answer" to avoid promising a Q&A flow
+  // the panel can't deliver.
+  const pendingCount = task.pendingInteractionCount;
+  const blocked = task.column === "blocked";
+  const awaiting = pendingCount > 0 || blocked;
+  const awaitingLabel =
+    pendingCount > 1 ? `Answer (${pendingCount})`
+    : pendingCount === 1 ? "Answer"
+    : "Review";
 
   return (
     <Card
@@ -41,6 +58,7 @@ export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen }:
       className={cn(
         "cursor-grab select-none border-border/60 hover:border-border transition-colors",
         isDragging && "opacity-50",
+        awaiting && "ring-2 ring-amber-500/60 ring-offset-2 ring-offset-background animate-awaiting-pulse motion-reduce:animate-none",
       )}
       onClick={() => onOpen(task)}
       {...listeners}
@@ -82,7 +100,18 @@ export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen }:
           </div>
         )}
         <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
-          {active ? (
+          {awaiting ? (
+            <Button
+              size="sm"
+              className="gap-1 bg-amber-500 text-amber-950 hover:bg-amber-500/90 focus-visible:ring-amber-500"
+              onClick={() => onOpen(task)}
+              title={pendingCount > 0 ? "Open run panel to answer" : "Agent is waiting on you — open the run panel"}
+            >
+              <MessageCircleQuestion className="size-3" />
+              {awaitingLabel}
+              <ArrowRight className="size-3" />
+            </Button>
+          ) : active ? (
             <Button size="sm" variant="destructive" onClick={() => onCancel(task)}>
               <Square className="size-3" /> Stop
             </Button>
@@ -93,6 +122,11 @@ export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen }:
           ) : (
             <Button size="sm" onClick={() => onStart(task)}>
               <Play className="size-3" /> Run
+            </Button>
+          )}
+          {awaiting && active && (
+            <Button size="icon" variant="ghost" onClick={() => onCancel(task)} title="Stop">
+              <Square className="size-3" />
             </Button>
           )}
           <Button size="icon" variant="ghost" onClick={() => onDelete(task)} title="Delete task">

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -225,6 +225,17 @@ export interface Task {
    * persisted on the row itself.
    */
   hasOpenableRun: boolean;
+  /**
+   * Number of pending interactions waiting on the user for this task —
+   * `ask_user` MCP calls, `AskUserQuestion` / `ExitPlanMode` Claude built-ins,
+   * and tool-call approval requests. Computed in `tasks.list()` / `tasks.get()`
+   * via `countPendingForTask` (interactions live in memory; not persisted).
+   * Drives the kanban card's "Answer →" call-to-action.
+   *
+   * Codex's narrative `column='blocked'` signal is reflected via `task.column`,
+   * not this counter — the card combines both at render time.
+   */
+  pendingInteractionCount: number;
   createdAt: number;
   updatedAt: number;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,6 +43,20 @@ export default {
       fontFamily: {
         geist: ['"Geist Variable"', "ui-sans-serif", "system-ui", "sans-serif"],
       },
+      keyframes: {
+        // Slower, calmer than tailwind's default `pulse` — used by TaskCard
+        // to indicate "this card is waiting on you" without feeling anxious.
+        // Pulses `filter: drop-shadow` rather than `box-shadow` so it stacks
+        // cleanly on top of Tailwind's `ring-*` utilities (which themselves
+        // compile to box-shadow and would otherwise be clobbered).
+        "awaiting-pulse": {
+          "0%, 100%": { filter: "drop-shadow(0 0 6px rgba(245, 158, 11, 0.55))" },
+          "50%":      { filter: "drop-shadow(0 0 14px rgba(245, 158, 11, 0.85))" },
+        },
+      },
+      animation: {
+        "awaiting-pulse": "awaiting-pulse 2.4s ease-in-out infinite",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
Task cards now glow amber and swap their primary action for "Answer →" (or "Review →" for codex's narrative-blocked path) whenever an ask_user, AskUserQuestion, ExitPlanMode, or tool-approval request is pending for the task. Powers off a new server-computed `Task.pendingInteractionCount` field that piggybacks on the existing 2 s `/tasks` poll, so no per-card SSE wiring is needed.

- Add `countPendingForTask` helper in interactions.ts and wire it into tasks.list / tasks.get via toTask in db.ts (circular import is safe: both sides access each other lazily from function bodies only).
- TaskCard: new Answer > Stop > Open > Run button precedence with a trailing icon-only Stop when awaiting, a ring + filter:drop-shadow pulse keyframe that respects prefers-reduced-motion, and a "Review →" label when the only awaiting signal is column='blocked' (codex approval-prompt heuristic) so we don't promise a Q&A flow the panel can't deliver.
- interactions.test.ts: cover the live-compute path end-to-end (counter reflects all four maps, scopes per task, drops on answer).