### PR TITLE
feat(ui): drag/drop + paste macOS screenshots into prompt fields

### DIFF
--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { Utils } from "electrobun/bun";
@@ -798,6 +798,60 @@ export function startApiServer() {
           }
           const ok = Utils.openPath(abs);
           return json({ opened: ok, path: abs }, { headers: corsHeaders(req) });
+        }),
+      },
+
+      // Persist a screenshot blob to `${dataDir}/screenshots/` and return its
+      // absolute path. Backs the textarea drag/drop + paste flows on the
+      // webview — macOS floating-thumbnail drags and clipboard pastes carry
+      // an image blob with no filesystem path, so the only way to give an
+      // agent an absolute path to read is to write the bytes out first.
+      "/screenshots": {
+        POST: authed(async (req) => {
+          const ctype = (req.headers.get("content-type") ?? "").toLowerCase();
+          const allowed: Record<string, string> = {
+            "image/png": "png",
+            "image/jpeg": "jpg",
+            "image/gif": "gif",
+            "image/webp": "webp",
+          };
+          const ext = allowed[ctype.split(";")[0].trim()];
+          if (!ext) {
+            return json(
+              { error: `unsupported content-type: ${ctype || "(missing)"}` },
+              { status: 415, headers: corsHeaders(req) },
+            );
+          }
+          const MAX = 25 * 1024 * 1024;
+          // Reject oversized uploads via Content-Length before allocating
+          // the body — a buggy client shouldn't be able to pin RAM by
+          // streaming gigabytes only to see a 413 at the end. Clients
+          // omitting the header still hit the post-read check below.
+          const claimed = Number(req.headers.get("content-length") ?? "");
+          if (Number.isFinite(claimed) && claimed > MAX) {
+            return json(
+              { error: `image exceeds ${MAX} bytes` },
+              { status: 413, headers: corsHeaders(req) },
+            );
+          }
+          const buf = await req.arrayBuffer();
+          if (buf.byteLength > MAX) {
+            return json(
+              { error: `image exceeds ${MAX} bytes` },
+              { status: 413, headers: corsHeaders(req) },
+            );
+          }
+          if (buf.byteLength === 0) {
+            return json({ error: "empty body" }, { status: 400, headers: corsHeaders(req) });
+          }
+          const dir = path.join(dataDir, "screenshots");
+          mkdirSync(dir, { recursive: true });
+          const ts = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "_").slice(0, 19);
+          const id = crypto.randomUUID().slice(0, 8);
+          const basename = `screenshot-${ts}-${id}.${ext}`;
+          const abs = path.join(dir, basename);
+          await Bun.write(abs, buf);
+          return json({ path: abs, basename }, { headers: corsHeaders(req) });
         }),
       },
 

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -24,10 +24,12 @@ import { BranchPicker } from "./BranchPicker";
 import { ProjectPicker } from "./ProjectPicker";
 import {
   ReferencesPicker,
-  extractDroppedRefs,
+  captureDroppedOrPastedItems,
   mergeRefs,
+  type CapturedItem,
 } from "./ReferencesPicker";
 import { SlashAutocomplete } from "./SlashAutocomplete";
+import { spliceAtSelection, readCaret, restoreCaret } from "@/lib/textarea-insert";
 
 const initialMode = (kind: AgentKind) => AGENT_OPTIONS[kind].modes[0]?.id ?? "auto";
 
@@ -125,6 +127,7 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
   }, [availableHarnesses, agent]);
   const [references, setReferences] = useState<TaskReference[]>([]);
   const [dragging, setDragging] = useState(false);
+  const [dropHint, setDropHint] = useState<string | null>(null);
   const [agentCommands, setAgentCommands] = useState<AvailableCommand[]>([]);
   const promptRef = useRef<HTMLTextAreaElement>(null);
 
@@ -303,6 +306,7 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
     setPrompt("");
     setBaseRef("");
     setReferences([]);
+    setDropHint(null);
     // Keep `workdir`, `model`, `effort`, `mode` set on purpose — the next
     // task should default to the same project + picks the user just used.
   };
@@ -322,11 +326,52 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
   const onAsideDragLeave = (e: React.DragEvent) => {
     if (e.currentTarget === e.target) setDragging(false);
   };
-  const onAsideDrop = (e: React.DragEvent) => {
+  const applyCaptured = (items: CapturedItem[]) => {
+    if (!items.length) return;
+    setReferences((cur) => mergeRefs(cur, items.map((i) => i.ref)));
+    const marker = items.map((i) => `[${i.basename}]`).join(" ");
+    // Read the caret synchronously (DOM state, not React state) then drive
+    // setPrompt with a functional updater so two captures landing back-to-
+    // back across an async boundary don't see stale `prompt` closures.
+    const selection = readCaret(promptRef.current);
+    let caret = 0;
+    setPrompt((cur) => {
+      const r = spliceAtSelection(cur, selection, marker);
+      caret = r.caret;
+      return r.next;
+    });
+    restoreCaret(promptRef.current, caret);
+  };
+  const reportCapture = ({ items, skipped, error }: {
+    items: CapturedItem[];
+    skipped: number;
+    error?: string;
+  }) => {
+    if (error) setDropHint(`Couldn't save screenshot: ${error}`);
+    else if (skipped && !items.length) setDropHint("Nothing to attach — drag a file from Finder, or a screenshot blob.");
+    else setDropHint(null);
+  };
+  const onAsideDrop = async (e: React.DragEvent) => {
     e.preventDefault();
     setDragging(false);
-    const { additions } = extractDroppedRefs(e);
-    if (additions.length) setReferences((cur) => mergeRefs(cur, additions));
+    setDropHint(null);
+    const dt = e.dataTransfer;
+    const result = await captureDroppedOrPastedItems(dt);
+    reportCapture(result);
+    applyCaptured(result.items);
+  };
+  const onPromptPaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const cd = e.clipboardData;
+    if (!cd) return;
+    // Only intercept when the clipboard actually carries a file — otherwise
+    // let the default text paste run.
+    const hasFile = Array.from(cd.items ?? []).some((it) => it.kind === "file");
+    if (!hasFile) return;
+    e.preventDefault();
+    setDropHint(null);
+    const result = await captureDroppedOrPastedItems(cd);
+    reportCapture(result);
+    applyCaptured(result.items);
   };
 
   return (
@@ -365,7 +410,8 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
               ref={promptRef}
               placeholder="What should the agent do? Type / for commands."
               value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
+              onChange={(e) => { setPrompt(e.target.value); if (dropHint) setDropHint(null); }}
+              onPaste={onPromptPaste}
               rows={6}
               className="resize-none"
             />
@@ -376,6 +422,9 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
               textareaRef={promptRef}
             />
           </div>
+          {dropHint && (
+            <p className="text-[10px] text-muted-foreground">{dropHint}</p>
+          )}
         </div>
 
         <ReferencesPicker

--- a/src/mainview/components/kanban/ReferencesPicker.tsx
+++ b/src/mainview/components/kanban/ReferencesPicker.tsx
@@ -3,7 +3,10 @@ import { FilePlus, FolderPlus, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { iconForRef, refBasename } from "@/lib/file-icons";
+import { captureDroppedOrPastedItems, type ElectroFile } from "@/lib/capture-refs";
 import type { TaskReference } from "../../../shared/types.ts";
+
+export { captureDroppedOrPastedItems, type CapturedItem, type CaptureResult } from "@/lib/capture-refs";
 
 interface Props {
   refs: TaskReference[];
@@ -16,12 +19,6 @@ interface Props {
   /** Extra className on the outer container. */
   className?: string;
 }
-
-// `File` in WKWebView (Electrobun) carries a non-standard `path` property that
-// holds the absolute filesystem path. We rely on it for the picker AND drop
-// paths — without it we can't build a `TaskReference`. Plain-browser drops
-// fall back to a one-liner hint.
-type ElectroFile = File & { path?: string };
 
 /**
  * Derive a folder's absolute path from a single File in a `webkitdirectory`
@@ -47,41 +44,6 @@ function deriveFolderRoot(file: ElectroFile): string | null {
     if (!r) break;
   }
   return a || null;
-}
-
-export interface DropExtractResult {
-  additions: TaskReference[];
-  /** Items that lacked a filesystem path. Caller may want to show a hint
-   *  when nothing was added. */
-  skipped: number;
-}
-
-/**
- * Pure helper exported so containers (e.g. NewTaskForm's outer aside) can
- * forward drops to the picker without duplicating the WKWebView quirks.
- */
-export function extractDroppedRefs(e: React.DragEvent | DragEvent): DropExtractResult {
-  const additions: TaskReference[] = [];
-  let skipped = 0;
-  if (!e.dataTransfer) return { additions, skipped };
-  const items = e.dataTransfer.items ? Array.from(e.dataTransfer.items) : [];
-  if (items.length) {
-    for (const item of items) {
-      if (item.kind !== "file") continue;
-      const file = item.getAsFile() as ElectroFile | null;
-      const entry = item.webkitGetAsEntry?.();
-      const isDir = entry?.isDirectory ?? false;
-      const abs = file?.path ?? null;
-      if (!abs) { skipped++; continue; }
-      additions.push({ path: abs, isDirectory: isDir });
-    }
-  } else if (e.dataTransfer.files?.length) {
-    for (const f of Array.from(e.dataTransfer.files) as ElectroFile[]) {
-      if (!f.path) { skipped++; continue; }
-      additions.push({ path: f.path, isDirectory: false });
-    }
-  }
-  return { additions, skipped };
 }
 
 /** Dedupe additions against an existing list, returning a new array. */
@@ -160,16 +122,18 @@ export function ReferencesPicker({
     e.target.value = "";
   };
 
-  const onDrop = (e: React.DragEvent) => {
+  const onDrop = async (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setDragging(false);
     setHint(null);
-    const { additions, skipped } = extractDroppedRefs(e);
-    if (skipped && !additions.length) {
-      setHint("Drag from Finder — these items had no filesystem path.");
+    const { items, skipped, error } = await captureDroppedOrPastedItems(e.dataTransfer);
+    if (error) {
+      setHint(`Couldn't save screenshot: ${error}`);
+    } else if (skipped && !items.length) {
+      setHint("Drag a file from Finder, or a screenshot from the macOS thumbnail.");
     }
-    append(additions);
+    append(items.map((i) => i.ref));
   };
 
   const onDragOver = (e: React.DragEvent) => {

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -40,7 +40,13 @@ import { iconForRef, refBasename } from "@/lib/file-icons";
 import { appendReferences } from "../../../shared/refs.ts";
 import { proposeAllowRules, type AllowRuleProposal } from "../../../shared/claude-permissions.ts";
 import { AgentIcon } from "./AgentIcon";
-import { ReferencesPicker } from "./ReferencesPicker";
+import {
+  ReferencesPicker,
+  captureDroppedOrPastedItems,
+  mergeRefs,
+  type CapturedItem,
+} from "./ReferencesPicker";
+import { spliceAtSelection, readCaret, restoreCaret } from "@/lib/textarea-insert";
 import { SlashAutocomplete } from "./SlashAutocomplete";
 
 interface Props {
@@ -392,6 +398,7 @@ function RunPanelBody({
   const [sendRefs, setSendRefs] = useState<TaskReference[]>([]);
   const [sending, setSending] = useState(false);
   const [sendHint, setSendHint] = useState<string | null>(null);
+  const [sendDragging, setSendDragging] = useState(false);
   // `/`-command and skill autocomplete for the send field. Same list the
   // New Task form uses — depends on (agent, workdir, branch) so a slash
   // command available in this project shows up here too.
@@ -463,6 +470,69 @@ function RunPanelBody({
   const stop = async () => {
     if (!liveRunId) return;
     try { await api.cancelRun(liveRunId); } catch { /* surfaced via log */ }
+  };
+
+  // Drag/drop + paste capture for the message textarea. Mirrors the
+  // NewTaskForm sidebar flow: pathful files come straight through, blob
+  // screenshots (macOS floating thumbnail, clipboard paste) get uploaded
+  // to `~/.agetor/screenshots/` first. Captured items land both as chips
+  // in `sendRefs` *and* as `[basename]` markers at the cursor.
+  const applySendCaptured = (items: CapturedItem[]) => {
+    if (!items.length) return;
+    setSendRefs((cur) => mergeRefs(cur, items.map((i) => i.ref)));
+    const marker = items.map((i) => `[${i.basename}]`).join(" ");
+    const selection = readCaret(sendRef.current);
+    let caret = 0;
+    setInput((cur) => {
+      const r = spliceAtSelection(cur, selection, marker);
+      caret = r.caret;
+      return r.next;
+    });
+    restoreCaret(sendRef.current, caret);
+  };
+  const onSendDragOver = (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes("Files")) return;
+    // Always preventDefault on a file dragover so WKWebView doesn't fall back
+    // to its native handler (navigate / open). The visual ring only lights up
+    // when canSend is true, but the wrapper still claims the drop.
+    e.preventDefault();
+    if (canSend) setSendDragging(true);
+  };
+  const onSendDragLeave = (e: React.DragEvent) => {
+    // Always clear when `canSend` flipped to false mid-drag — otherwise the
+    // ring can outlive the drag if the task transitioned out of running.
+    if (!canSend) { setSendDragging(false); return; }
+    if (e.currentTarget === e.target) setSendDragging(false);
+  };
+  const reportSendCapture = ({ items, skipped, error }: {
+    items: CapturedItem[];
+    skipped: number;
+    error?: string;
+  }) => {
+    if (error) setSendHint(`Couldn't save screenshot: ${error}`);
+    else if (skipped && !items.length) setSendHint("Nothing to attach — drag a file from Finder, or a screenshot blob.");
+  };
+  const onSendDrop = async (e: React.DragEvent) => {
+    // preventDefault unconditionally so a stray drop while !canSend doesn't
+    // hand the file to WKWebView's native handler.
+    e.preventDefault();
+    setSendDragging(false);
+    if (!canSend) return;
+    setSendHint(null);
+    const result = await captureDroppedOrPastedItems(e.dataTransfer);
+    reportSendCapture(result);
+    applySendCaptured(result.items);
+  };
+  const onSendPaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const cd = e.clipboardData;
+    if (!cd) return;
+    const hasFile = Array.from(cd.items ?? []).some((it) => it.kind === "file");
+    if (!hasFile) return;
+    e.preventDefault();
+    setSendHint(null);
+    const result = await captureDroppedOrPastedItems(cd);
+    reportSendCapture(result);
+    applySendCaptured(result.items);
   };
 
   return (
@@ -571,8 +641,19 @@ function RunPanelBody({
           run — the backend reattaches to the live tmux session if there is one,
           or spawns a fresh one seeded with the previous turn's last response
           when the original session is gone. The button is given the same fixed
-          height as the textarea so they baseline together. */}
-      <div className="shrink-0 space-y-1.5 border-t border-border/60 p-2">
+          height as the textarea so they baseline together. The whole dock is
+          one drop zone so dragging a screenshot anywhere over the input area
+          (chips, textarea, send button gap) routes through the same capture
+          path. */}
+      <div
+        className={cn(
+          "relative shrink-0 space-y-1.5 border-t border-border/60 p-2",
+          sendDragging && "ring-2 ring-inset ring-primary",
+        )}
+        onDragOver={onSendDragOver}
+        onDragLeave={onSendDragLeave}
+        onDrop={onSendDrop}
+      >
         {canSend && (
           <ReferencesPicker
             variant="inline"
@@ -586,6 +667,7 @@ function RunPanelBody({
               ref={sendRef}
               value={input}
               onChange={(e) => setInput(e.target.value)}
+              onPaste={onSendPaste}
               onKeyDown={(e) => {
                 // Enter to send; Shift+Enter for a newline. SlashAutocomplete
                 // attaches a native keydown listener that calls preventDefault

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -102,9 +102,13 @@ export type PendingInteraction =
 declare global {
   interface Window { __AGETOR?: { port: string; token: string } }
 }
-const injected = window.__AGETOR;
+// Guard `window` access for the test runtime (`bun test` runs this module
+// outside a browser). Production paths always have a real window, so the
+// `?? undefined` fallback never trips at runtime in the app.
+const _win = typeof window !== "undefined" ? window : undefined;
+const injected = _win?.__AGETOR;
 const params = new URLSearchParams(
-  (window.location.hash || window.location.search).replace(/^[#?]/, ""),
+  ((_win?.location.hash || _win?.location.search) ?? "").replace(/^[#?]/, ""),
 );
 const API_PORT = injected?.port ?? params.get("api") ?? "4317";
 const API_TOKEN = injected?.token ?? params.get("token") ?? "";
@@ -259,6 +263,28 @@ export const api = {
       method: "POST",
       body: JSON.stringify(input),
     }),
+
+  /** Persist an in-memory image (clipboard paste or macOS floating-thumbnail
+   *  drag) to disk and get back its absolute path. Bypasses `j()` because the
+   *  body is raw bytes, not JSON. */
+  uploadScreenshot: async (blob: Blob): Promise<{ path: string; basename: string }> => {
+    const res = await fetch(`${BASE}/screenshots`, {
+      method: "POST",
+      headers: {
+        "content-type": blob.type || "application/octet-stream",
+        "authorization": `Bearer ${API_TOKEN}`,
+      },
+      body: blob,
+    });
+    const body = await res.json().catch(() => null);
+    if (!res.ok) {
+      const msg = body && typeof body === "object" && "error" in body && body.error
+        ? String((body as { error: unknown }).error)
+        : `${res.status} ${res.statusText}`;
+      throw new Error(msg);
+    }
+    return body as { path: string; basename: string };
+  },
 
   /** Interactions: tool-call approvals and clarifying questions. */
   answerApproval: (

--- a/src/mainview/lib/capture-refs.test.ts
+++ b/src/mainview/lib/capture-refs.test.ts
@@ -1,0 +1,177 @@
+import { test, expect } from "bun:test";
+import { captureDroppedOrPastedItems, type ScreenshotUploader } from "./capture-refs.ts";
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Test plumbing: a stub `DataTransfer` that quacks loud enough for the
+ * helper. We can't `new DataTransfer()` in the bun runtime — it's a
+ * browser-only constructor — so we build a literal that matches the shape
+ * the helper actually reads (`items` or `files`, both as `[].length`-able
+ * iterables).
+ * ────────────────────────────────────────────────────────────────────────── */
+
+interface FakeItem {
+  kind: "file" | "string";
+  file: File | null;
+  isDirectory?: boolean;
+}
+
+function makeTransfer(items: FakeItem[]): DataTransfer {
+  return {
+    items: items.map((it) => ({
+      kind: it.kind,
+      getAsFile: () => it.file,
+      webkitGetAsEntry: () => (it.isDirectory ? { isDirectory: true } : { isDirectory: false }),
+    })) as unknown as DataTransferItemList,
+    files: items
+      .filter((it) => it.kind === "file" && it.file)
+      .map((it) => it.file!) as unknown as FileList,
+    types: [],
+  } as unknown as DataTransfer;
+}
+
+/** A DataTransfer that only exposes `.files` — no `.items` array. Some
+ *  plain-browser drag sources land here (and older `ClipboardData` shapes). */
+function makeFilesOnlyTransfer(files: File[]): DataTransfer {
+  return {
+    items: { length: 0 } as unknown as DataTransferItemList,
+    files: files as unknown as FileList,
+    types: [],
+  } as unknown as DataTransfer;
+}
+
+/** A DataTransfer whose items lack `webkitGetAsEntry` entirely — covers the
+ *  optional-chain fallback in `collectFiles`. */
+function makeNoEntryTransfer(files: File[]): DataTransfer {
+  return {
+    items: files.map((f) => ({
+      kind: "file",
+      getAsFile: () => f,
+      // intentionally omit webkitGetAsEntry
+    })) as unknown as DataTransferItemList,
+    files: files as unknown as FileList,
+    types: [],
+  } as unknown as DataTransfer;
+}
+
+function pathfulFile(name: string, path: string): File {
+  const f = new File(["x"], name, { type: "image/png" });
+  // The WKWebView `path` quirk — attach a non-standard property.
+  (f as File & { path?: string }).path = path;
+  return f;
+}
+
+function blobImage(name: string, type = "image/png"): File {
+  return new File(["x"], name, { type });
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+
+test("returns empty when source is null", async () => {
+  const noopUploader: ScreenshotUploader = async () => ({ path: "", basename: "" });
+  const r = await captureDroppedOrPastedItems(null, noopUploader);
+  expect(r).toEqual({ items: [], skipped: 0 });
+});
+
+test("pathful file lands as a ref without invoking the uploader", async () => {
+  let uploads = 0;
+  const uploader: ScreenshotUploader = async () => {
+    uploads++;
+    return { path: "/never/used", basename: "never" };
+  };
+  const dt = makeTransfer([
+    { kind: "file", file: pathfulFile("foo.png", "/Users/x/foo.png") },
+  ]);
+  const r = await captureDroppedOrPastedItems(dt, uploader);
+  expect(uploads).toBe(0);
+  expect(r.items).toHaveLength(1);
+  expect(r.items[0]!.ref).toEqual({ path: "/Users/x/foo.png", isDirectory: false });
+  expect(r.items[0]!.basename).toBe("foo.png");
+  expect(r.skipped).toBe(0);
+  expect(r.error).toBeUndefined();
+});
+
+test("folder drop preserves isDirectory: true (regression guard)", async () => {
+  const noopUploader: ScreenshotUploader = async () => ({ path: "", basename: "" });
+  const dt = makeTransfer([
+    { kind: "file", file: pathfulFile("src", "/Users/x/src"), isDirectory: true },
+  ]);
+  const r = await captureDroppedOrPastedItems(dt, noopUploader);
+  expect(r.items).toHaveLength(1);
+  expect(r.items[0]!.ref.isDirectory).toBe(true);
+  expect(r.items[0]!.ref.path).toBe("/Users/x/src");
+});
+
+test("path-less image blob is uploaded and the returned path is used", async () => {
+  const uploader: ScreenshotUploader = async (blob) => {
+    expect(blob).toBeInstanceOf(File);
+    return { path: "/Users/x/.agetor/screenshots/uuid.png", basename: "uuid.png" };
+  };
+  const dt = makeTransfer([{ kind: "file", file: blobImage("clipboard.png") }]);
+  const r = await captureDroppedOrPastedItems(dt, uploader);
+  expect(r.items).toHaveLength(1);
+  expect(r.items[0]!.ref).toEqual({
+    path: "/Users/x/.agetor/screenshots/uuid.png",
+    isDirectory: false,
+  });
+  expect(r.items[0]!.basename).toBe("uuid.png");
+});
+
+test("upload failure surfaces as error, not silent drop", async () => {
+  const uploader: ScreenshotUploader = async () => {
+    throw new Error("413 image exceeds 25 MB");
+  };
+  const dt = makeTransfer([{ kind: "file", file: blobImage("huge.png") }]);
+  const r = await captureDroppedOrPastedItems(dt, uploader);
+  expect(r.items).toHaveLength(0);
+  expect(r.error).toMatch(/413/);
+});
+
+test("non-image blob without a path is skipped (and uploader is not called)", async () => {
+  let uploads = 0;
+  const uploader: ScreenshotUploader = async () => { uploads++; return { path: "", basename: "" }; };
+  const dt = makeTransfer([
+    { kind: "file", file: new File(["x"], "notes.txt", { type: "text/plain" }) },
+  ]);
+  const r = await captureDroppedOrPastedItems(dt, uploader);
+  expect(uploads).toBe(0);
+  expect(r.items).toHaveLength(0);
+  expect(r.skipped).toBe(1);
+});
+
+test("falls back to source.files when source.items is empty", async () => {
+  const noopUploader: ScreenshotUploader = async () => ({ path: "", basename: "" });
+  const f = pathfulFile("only-files.png", "/abs/only-files.png");
+  const dt = makeFilesOnlyTransfer([f]);
+  const r = await captureDroppedOrPastedItems(dt, noopUploader);
+  expect(r.items).toHaveLength(1);
+  expect(r.items[0]!.ref).toEqual({ path: "/abs/only-files.png", isDirectory: false });
+});
+
+test("missing webkitGetAsEntry doesn't blow up; isDirectory defaults to false", async () => {
+  const noopUploader: ScreenshotUploader = async () => ({ path: "", basename: "" });
+  const f = pathfulFile("no-entry.png", "/abs/no-entry.png");
+  const dt = makeNoEntryTransfer([f]);
+  const r = await captureDroppedOrPastedItems(dt, noopUploader);
+  expect(r.items).toHaveLength(1);
+  expect(r.items[0]!.ref.isDirectory).toBe(false);
+});
+
+test("mixed payload: pathful, blob, and skipped — all classified correctly", async () => {
+  const uploader: ScreenshotUploader = async () => ({ path: "/tmp/screenshot.png", basename: "screenshot.png" });
+  const dt = makeTransfer([
+    { kind: "file", file: pathfulFile("a.png", "/abs/a.png") },
+    { kind: "file", file: blobImage("paste.png") },
+    { kind: "file", file: new File(["x"], "ignore.bin", { type: "application/octet-stream" }) },
+    { kind: "file", file: pathfulFile("dir", "/abs/dir"), isDirectory: true },
+  ]);
+  const r = await captureDroppedOrPastedItems(dt, uploader);
+  expect(r.items).toHaveLength(3);
+  expect(r.skipped).toBe(1);
+  // Order is preserved from the input.
+  expect(r.items.map((i) => i.ref.path)).toEqual([
+    "/abs/a.png",
+    "/tmp/screenshot.png",
+    "/abs/dir",
+  ]);
+  expect(r.items[2]!.ref.isDirectory).toBe(true);
+});

--- a/src/mainview/lib/capture-refs.ts
+++ b/src/mainview/lib/capture-refs.ts
@@ -1,0 +1,110 @@
+import type { TaskReference } from "../../shared/types.ts";
+import { api } from "./api";
+import { refBasename } from "./path";
+
+// `File` in WKWebView (Electrobun) carries a non-standard `path` property that
+// holds the absolute filesystem path. We rely on it for the picker AND drop
+// paths — without it we can't build a `TaskReference`. Plain-browser drops
+// (and clipboard image blobs) fall back to the upload path.
+export type ElectroFile = File & { path?: string };
+
+export interface CapturedItem {
+  /** Goes in the references chip list. */
+  ref: TaskReference;
+  /** Used by callers to insert a `[basename]` marker at the textarea cursor. */
+  basename: string;
+}
+
+export interface CaptureResult {
+  items: CapturedItem[];
+  /** Non-image, no-path items that couldn't be turned into a reference. */
+  skipped: number;
+  /** Set when the upload endpoint rejected one or more blobs. */
+  error?: string;
+}
+
+interface CollectedFile {
+  file: ElectroFile;
+  /** Set when the source was a `DataTransferItem` whose
+   *  `webkitGetAsEntry()` exposes `isDirectory: true`. Clipboard pastes
+   *  and plain `.files` lists can never carry directories, so they're
+   *  always false in that branch. */
+  isDirectory: boolean;
+}
+
+/** Pull `File`s out of either a drop (`DataTransfer`) or a paste
+ *  (`ClipboardEvent.clipboardData`). Preserves directory-ness for the
+ *  drop path — losing it would silently strip the trailing `/` from
+ *  folder refs in the prompt body. */
+function collectFiles(source: DataTransfer): CollectedFile[] {
+  const out: CollectedFile[] = [];
+  if (source.items?.length) {
+    for (const it of Array.from(source.items)) {
+      if (it.kind !== "file") continue;
+      const f = it.getAsFile() as ElectroFile | null;
+      if (!f) continue;
+      const entry = it.webkitGetAsEntry?.();
+      out.push({ file: f, isDirectory: entry?.isDirectory ?? false });
+    }
+  } else if (source.files?.length) {
+    for (const f of Array.from(source.files) as ElectroFile[]) {
+      out.push({ file: f, isDirectory: false });
+    }
+  }
+  return out;
+}
+
+export type ScreenshotUploader = (blob: Blob) => Promise<{ path: string; basename: string }>;
+
+/**
+ * Handle drag/drop *and* clipboard paste. For each carried file:
+ *   - If the WKWebView quirk gives us `file.path`, use it as-is.
+ *   - Otherwise, if the file is an `image/*` blob (the macOS floating
+ *     screenshot thumbnail and Cmd+V image paste both arrive this way),
+ *     upload it via the injected `uploader` and use the absolute path the
+ *     server writes it to.
+ *   - Anything else (e.g. text/html drags, non-image blob) is skipped.
+ *
+ * Uploads run in parallel; the function awaits all of them before
+ * returning so callers can apply state updates once.
+ *
+ * `uploader` is parameterised for testability — production callers omit it
+ * and pick up the real `api.uploadScreenshot`.
+ */
+export async function captureDroppedOrPastedItems(
+  source: DataTransfer | null,
+  uploader: ScreenshotUploader = api.uploadScreenshot,
+): Promise<CaptureResult> {
+  if (!source) return { items: [], skipped: 0 };
+  const collected = collectFiles(source);
+  if (!collected.length) return { items: [], skipped: 0 };
+  const pending: Array<Promise<CapturedItem | { skipped: true } | { error: string }>> = [];
+  for (const { file: f, isDirectory } of collected) {
+    if (f.path) {
+      pending.push(Promise.resolve({
+        ref: { path: f.path, isDirectory },
+        basename: refBasename(f.path),
+      }));
+      continue;
+    }
+    if (f.type && f.type.startsWith("image/")) {
+      pending.push(
+        uploader(f)
+          .then((r) => ({ ref: { path: r.path, isDirectory: false }, basename: r.basename }))
+          .catch((e: Error) => ({ error: e.message })),
+      );
+      continue;
+    }
+    pending.push(Promise.resolve({ skipped: true }));
+  }
+  const settled = await Promise.all(pending);
+  const items: CapturedItem[] = [];
+  let skipped = 0;
+  let error: string | undefined;
+  for (const r of settled) {
+    if ("ref" in r) items.push(r);
+    else if ("error" in r) error = r.error;
+    else skipped++;
+  }
+  return { items, skipped, ...(error ? { error } : {}) };
+}

--- a/src/mainview/lib/file-icons.tsx
+++ b/src/mainview/lib/file-icons.tsx
@@ -12,6 +12,9 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import type { TaskReference } from "../../shared/types.ts";
+import { refBasename } from "./path";
+
+export { refBasename };
 
 const IMAGE = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico", "avif", "heic"]);
 const CODE = new Set([
@@ -65,9 +68,3 @@ export function iconForRef(ref: Pick<TaskReference, "path" | "isDirectory">): Lu
   return File;
 }
 
-/** Last path segment, trimmed of trailing slashes. Falls back to the input. */
-export function refBasename(p: string): string {
-  const trimmed = p.replace(/[\\/]+$/, "");
-  const slash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
-  return slash >= 0 ? trimmed.slice(slash + 1) || trimmed : trimmed;
-}

--- a/src/mainview/lib/path.ts
+++ b/src/mainview/lib/path.ts
@@ -1,0 +1,8 @@
+/** Last path segment, with trailing slashes stripped and both `/` and `\`
+ *  treated as separators. Returns the whole string if there's no separator
+ *  (handles bare filenames coming from the picker fallback). */
+export function refBasename(p: string): string {
+  const trimmed = p.replace(/[\\/]+$/, "");
+  const slash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return slash >= 0 ? trimmed.slice(slash + 1) || trimmed : trimmed;
+}

--- a/src/mainview/lib/textarea-insert.ts
+++ b/src/mainview/lib/textarea-insert.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure splice: given the current textarea value and the live `selectionStart`
+ * / `selectionEnd` (or `null` to append), compute the next value and the
+ * caret position that should follow the inserted token. Surrounds the
+ * insertion with single spaces when adjacent characters aren't already
+ * whitespace so the marker stays a clean grep-friendly token.
+ *
+ * Pure → safe to call from inside a `setState((cur) => …)` updater, which
+ * is how callers avoid the closure-staleness race when two captures land
+ * across an async boundary.
+ */
+export interface Splice {
+  next: string;
+  caret: number;
+}
+
+export function spliceAtSelection(
+  value: string,
+  selection: { start: number; end: number } | null,
+  insertion: string,
+): Splice {
+  const start = selection?.start ?? value.length;
+  const end = selection?.end ?? value.length;
+  const before = value.slice(0, start);
+  const after = value.slice(end);
+  const needLeadingSpace = before.length > 0 && !/\s$/.test(before);
+  const needTrailingSpace = after.length > 0 && !/^\s/.test(after);
+  const token = `${needLeadingSpace ? " " : ""}${insertion}${needTrailingSpace ? " " : ""}`;
+  return { next: before + token + after, caret: start + token.length };
+}
+
+/** Read the live caret position from the textarea, but only when it's
+ *  focused. An unfocused textarea has a meaningless `selectionStart` (often
+ *  0 or stale) — we want to append in that case, which the splice helper
+ *  does when given `null`. */
+export function readCaret(el: HTMLTextAreaElement | null): { start: number; end: number } | null {
+  if (!el || document.activeElement !== el) return null;
+  return { start: el.selectionStart ?? 0, end: el.selectionEnd ?? 0 };
+}
+
+/** Restore the caret on the next frame, after React has flushed the new
+ *  `value` into the DOM. WKWebView occasionally throws if `value` hasn't
+ *  propagated yet — the try/catch keeps the marker visible even when the
+ *  caret restore fails. */
+export function restoreCaret(el: HTMLTextAreaElement | null, caret: number): void {
+  if (!el) return;
+  requestAnimationFrame(() => {
+    el.focus();
+    try { el.setSelectionRange(caret, caret); } catch { /* see above */ }
+  });
+}


### PR DESCRIPTION
Both NewTaskForm prompt and RunPanel message textareas now accept dragged screenshots, files, and folders from Finder, the macOS floating-thumbnail drag, and clipboard image paste. Pathful sources use file.path via the WKWebView quirk; blob sources (floating thumbnail, clipboard) are written to ~/.agetor/screenshots/ via a new gated POST /screenshots endpoint and the returned absolute path is inserted as a [basename] marker at the cursor plus a chip in the references list.