### PR TITLE
fix(claude-tmux): verify mode after Shift+Tab and retry on mismatch

### DIFF
--- a/src/bun/claude-tmux.test.ts
+++ b/src/bun/claude-tmux.test.ts
@@ -1,5 +1,12 @@
 import { test, expect } from "bun:test";
 import { homedir } from "node:os";
+
+// cycleToMode's tmux send-keys call runs `Bun.spawnSync` on the tmux
+// binary; point it at /bin/echo so the per-press spawn is fast and the
+// (irrelevant) exit code stays 0 instead of depending on whether real
+// tmux is installed on the test host.
+process.env.AGETOR_TMUX_BIN = "/bin/echo";
+
 import {
   CLAUDE_MODE_ACCEPT_EDITS,
   CLAUDE_MODE_AUTO,
@@ -8,6 +15,7 @@ import {
   CLAUDE_MODE_PLAN,
   cycleDistance,
   cycleOrderFor,
+  cycleToMode,
   encodeProjectPath,
   isAgetorInterceptReply,
   jsonlPathFor,
@@ -421,4 +429,177 @@ test("dispatchLine: permissionMode still updates when the event's uuid is alread
   }));
   expect(state.permissionMode).toBe("bypassPermissions");
   __forTest.uninstallSession(taskId);
+});
+
+test("cycleToMode: noop when already at target", async () => {
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-cycle-noop";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+  state.permissionMode = CLAUDE_MODE_ACCEPT_EDITS;
+  const result = await cycleToMode(taskId, "acceptEdits");
+  expect(result).toEqual({ ok: true, presses: 0, via: "noop" });
+  __forTest.uninstallSession(taskId);
+});
+
+test("cycleToMode: returns 'current mode unknown' before claude's first event", async () => {
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-cycle-unknown";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+  expect(state.permissionMode).toBeNull();
+  const result = await cycleToMode(taskId, "auto");
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.reason).toBe("current mode unknown");
+  __forTest.uninstallSession(taskId);
+});
+
+test("cycleToMode: success on first attempt when the JSONL event reports the target", async () => {
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-cycle-success";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+  state.permissionMode = CLAUDE_MODE_DEFAULT;
+  // cycleToMode installs the listener synchronously inside the Promise
+  // executor before tmux send-keys runs, so a synchronous dispatchLine
+  // call after invoking it (but before the await) fires the listener and
+  // resolves the verification.
+  const pending = cycleToMode(taskId, "auto");
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "permission-mode",
+    permissionMode: CLAUDE_MODE_AUTO,
+  }));
+  const result = await pending;
+  // Cycle: [default, acceptEdits, plan, auto] — 3 presses.
+  expect(result).toEqual({ ok: true, presses: 3, via: "shift-tab" });
+  __forTest.uninstallSession(taskId);
+});
+
+test("cycleToMode: retries from the newly-observed mode when the first press lands short", async () => {
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-cycle-retry";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+  state.permissionMode = CLAUDE_MODE_DEFAULT;
+  // First attempt: dispatch a "wrong" mode (acceptEdits) so cycleToMode
+  // observes the mismatch and retries. Second attempt: dispatch the target.
+  const pending = cycleToMode(taskId, "auto");
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "permission-mode",
+    permissionMode: CLAUDE_MODE_ACCEPT_EDITS,
+  }));
+  // Yield once so cycleToMode's await-continuation can install the next
+  // listener before we fire the next synthetic event.
+  await Promise.resolve();
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "permission-mode",
+    permissionMode: CLAUDE_MODE_AUTO,
+  }));
+  const result = await pending;
+  // Attempt 1: default → auto = 3 presses (lands on acceptEdits instead).
+  // Attempt 2: acceptEdits → auto = 2 presses. Total: 5.
+  expect(result).toEqual({ ok: true, presses: 5, via: "shift-tab" });
+  __forTest.uninstallSession(taskId);
+});
+
+test("cycleToMode: returns 'verification timed out' when no JSONL event follows", async () => {
+  const { __forTest } = await import("./claude-tmux.ts");
+  const prevTimeout = __forTest.setModeVerifyTimeoutMs(20);
+  try {
+    const taskId = "task-cycle-timeout";
+    const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+    state.permissionMode = CLAUDE_MODE_DEFAULT;
+    const result = await cycleToMode(taskId, "auto");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("verification timed out");
+      expect(result.attempts).toBe(1);
+      // lastObserved should still be the pre-press mode because the JSONL
+      // event never arrived to update it.
+      expect(result.lastObserved).toBe(CLAUDE_MODE_DEFAULT);
+    }
+    // Listener slot must be cleared after the timeout so a late event
+    // can't fire on a stale resolver.
+    expect(state.onPermissionMode).toBeNull();
+    __forTest.uninstallSession(taskId);
+  } finally {
+    __forTest.setModeVerifyTimeoutMs(prevTimeout);
+  }
+});
+
+test("cycleToMode: gives up with 'verification mismatch' after MAX_VERIFY_ATTEMPTS wrong modes", async () => {
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-cycle-mismatch";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+  state.permissionMode = CLAUDE_MODE_DEFAULT;
+  const pending = cycleToMode(taskId, "auto");
+  // Three wrong modes back to back — exhausts MAX_VERIFY_ATTEMPTS.
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "permission-mode",
+    permissionMode: CLAUDE_MODE_ACCEPT_EDITS,
+  }));
+  // Yield once so cycleToMode's await-continuation can install the next
+  // listener before we fire the next synthetic event.
+  await Promise.resolve();
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "permission-mode",
+    permissionMode: CLAUDE_MODE_PLAN,
+  }));
+  // Yield once so cycleToMode's await-continuation can install the next
+  // listener before we fire the next synthetic event.
+  await Promise.resolve();
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "permission-mode",
+    permissionMode: CLAUDE_MODE_DEFAULT,
+  }));
+  const result = await pending;
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.reason).toBe("verification mismatch");
+    expect(result.attempts).toBe(__forTest.MAX_VERIFY_ATTEMPTS);
+    expect(result.lastObserved).toBe(CLAUDE_MODE_DEFAULT);
+  }
+  __forTest.uninstallSession(taskId);
+});
+
+test("cycleToMode: /plan target bypasses the verify loop entirely", async () => {
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-cycle-plan";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+  state.permissionMode = CLAUDE_MODE_DEFAULT;
+  // No dispatched event — /plan returns immediately without waiting.
+  const result = await cycleToMode(taskId, "plan");
+  expect(result).toEqual({ ok: true, presses: 0, via: "slash-plan" });
+  expect(state.onPermissionMode).toBeNull();
+  __forTest.uninstallSession(taskId);
+});
+
+test("cycleToMode: overlapping calls don't clobber each other's listeners", async () => {
+  // Identity-guard regression test: without the `state.onPermissionMode
+  // === myListener` check in the timeout handler, the earlier call's
+  // setTimeout would null out the *later* call's listener, causing both
+  // calls to falsely time out. With the guard, the later caller wins
+  // (its listener fires on the next JSONL event) and the earlier caller
+  // gracefully times out without affecting the later one.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const prevTimeout = __forTest.setModeVerifyTimeoutMs(40);
+  try {
+    const taskId = "task-cycle-race";
+    const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+    state.permissionMode = CLAUDE_MODE_DEFAULT;
+
+    // Two overlapping calls. `b` is launched synchronously after `a`,
+    // so by the time the dispatch fires the session slot holds b's
+    // listener. b should win; a should fall through to timeout.
+    const a = cycleToMode(taskId, "auto");
+    const b = cycleToMode(taskId, "acceptEdits");
+    __forTest.dispatchLine(state, JSON.stringify({
+      type: "permission-mode",
+      permissionMode: CLAUDE_MODE_ACCEPT_EDITS,
+    }));
+    const [ra, rb] = await Promise.all([a, b]);
+
+    expect(rb).toEqual({ ok: true, presses: 1, via: "shift-tab" });
+    expect(ra.ok).toBe(false);
+    if (!ra.ok) expect(ra.reason).toBe("verification timed out");
+    __forTest.uninstallSession(taskId);
+  } finally {
+    __forTest.setModeVerifyTimeoutMs(prevTimeout);
+  }
 });

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -577,6 +577,17 @@ interface SessionState {
    */
   permissionMode: string | null;
   /**
+   * One-shot listener fired by `dispatchLine` immediately after it updates
+   * `permissionMode` from a JSONL `system` / `permission-mode` event.
+   * Installed by `cycleToMode` so it can verify whether a Shift+Tab press
+   * actually landed on the requested mode (claude's cycle is opaque — the
+   * account may not have `auto` access, the press may have hit a one-time
+   * opt-in modal, etc.). Cleared before invocation so a retry inside the
+   * callback can install a fresh listener for the next press without
+   * racing this fire.
+   */
+  onPermissionMode: ((mode: string) => void) | null;
+  /**
    * Whether `bypassPermissions` is in this session's Shift+Tab cycle. True
    * iff the session was launched with `--dangerously-skip-permissions` (the
    * agetor `bypass` mode emits exactly that). Reattached sessions default
@@ -728,6 +739,15 @@ function dispatchLine(state: SessionState, line: string): void {
   if ((evt.type === "system" || evt.type === "permission-mode")
     && typeof evt.permissionMode === "string") {
     state.permissionMode = evt.permissionMode;
+    // Fire any one-shot verification listener installed by `cycleToMode`.
+    // Snapshot+clear before invoking so a retry inside the listener can
+    // install a fresh listener for the next press without this fire
+    // clobbering it.
+    if (state.onPermissionMode) {
+      const cb = state.onPermissionMode;
+      state.onPermissionMode = null;
+      cb(evt.permissionMode);
+    }
   }
 
   if (uuid && state.seenLineUuids.has(uuid)) return;
@@ -1215,6 +1235,7 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
     // The JSONL's `system` event will overwrite this within a tick if
     // claude renegotiates, which is fine.
     permissionMode: opts.mode ? toClaudeModeString(opts.mode) : null,
+    onPermissionMode: null,
     // `bypass` is the only agetor mode that emits the launch flag
     // (--dangerously-skip-permissions) — that's what puts
     // `bypassPermissions` into the Shift+Tab cycle.
@@ -1332,6 +1353,7 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
     // (pre-seeded from run_events on reattach) the field still gets
     // overwritten with whatever mode claude is currently in.
     permissionMode: null,
+    onPermissionMode: null,
     // The launch flag isn't persisted across agetor restarts, so we can't
     // tell whether bypassPermissions is in the cycle on this reattach.
     // Conservatively assume not — cycling to bypass after a restart needs
@@ -1424,9 +1446,33 @@ export function sendSlashCommand(taskId: string, line: string): boolean {
   return true;
 }
 
+/** Reasons `cycleToMode` can fail. Modeled as a literal union (rather than
+ *  free-form strings) so a typo in either the producer or the consumer
+ *  branches surfaces at compile time — the failure path's user-facing
+ *  message depends on string equality, and a silent typo would route the
+ *  user to a generic fallback that doesn't match the actual problem. */
+export type CycleFailureReason =
+  | "no live session"
+  | "current mode unknown"
+  | "mode not in cycle"
+  | "verification timed out"
+  | "verification mismatch";
+
 export type CycleResult =
   | { ok: true; presses: number; via: "noop" | "slash-plan" | "shift-tab" }
-  | { ok: false; reason: string };
+  | { ok: false; reason: CycleFailureReason; target?: string; attempts?: number; lastObserved?: string | null };
+
+/** How many times `cycleToMode` will resend Shift+Tab presses before giving
+ *  up. Each press is verified against the next JSONL `permission-mode`
+ *  event; a mismatch (account isn't auto-eligible, cycle width assumed
+ *  wrong) triggers another attempt from the newly-observed mode. */
+const MAX_VERIFY_ATTEMPTS = 3;
+
+/** How long to wait for a `permission-mode` JSONL event after sending the
+ *  Shift+Tab presses before declaring the press "lost" (most likely
+ *  swallowed by claude's one-time auto opt-in modal). 1.5s comfortably
+ *  exceeds the ~100ms claude takes to emit the event in practice. */
+let modeVerifyTimeoutMs = 1500;
 
 /**
  * Switch a live claude session's permission mode to `targetAgetorMode` by
@@ -1436,63 +1482,132 @@ export type CycleResult =
  * prefer the `/plan` slash command instead: it's deterministic, doesn't
  * depend on knowing the current mode, and works from anywhere.
  *
+ * After each batch of presses we wait for the next JSONL `permission-mode`
+ * event and compare it to the target. A mismatch — account isn't
+ * auto-eligible (cycle is 3-wide instead of 4), assumed press count was
+ * off, etc. — triggers another attempt from the newly-observed mode, up
+ * to `MAX_VERIFY_ATTEMPTS` times. If the event never arrives within
+ * `modeVerifyTimeoutMs` (most likely cause: claude's one-time auto
+ * opt-in modal swallowed the keystrokes), we bail with `verification
+ * timed out` so the orchestrator can warn the user rather than report
+ * a successful mode change that didn't happen.
+ *
  * Returns:
  *   - `{ ok: true, via: "noop" }` when the session is already at the target.
  *   - `{ ok: true, via: "slash-plan" }` when we sent `/plan`.
- *   - `{ ok: true, via: "shift-tab", presses: N }` when we sent N tabs.
+ *   - `{ ok: true, via: "shift-tab", presses: N }` when N tabs got claude
+ *     to the target (verified by the JSONL event).
  *   - `{ ok: false, reason: "no live session" }` for an unknown task.
  *   - `{ ok: false, reason: "current mode unknown" }` before claude's first
- *     `system` event has arrived (rare — typically only at the very start of
- *     a session before its first JSONL entry).
- *   - `{ ok: false, reason: "unreachable in current cycle" }` when the
- *     target isn't in this session's cycle. The most common case is asking
- *     for `bypassPermissions` on a session that wasn't launched with the
- *     enabling flag — a respawn is required.
- *
- * Caveat — first cycle to `auto`: claude shows a one-time opt-in modal the
- * first time you cycle to auto on a given account. Our keystrokes pass
- * through but the cycle pauses on the modal until the user (or some other
- * keystroke) dismisses it. After the first acceptance, subsequent cycles
- * work without intervention.
+ *     `system` event has arrived.
+ *   - `{ ok: false, reason: "mode not in cycle", target }` when the target
+ *     isn't reachable (e.g. `bypassPermissions` without the launch flag —
+ *     a respawn is required).
+ *   - `{ ok: false, reason: "verification timed out", attempts, lastObserved }`
+ *     when no `permission-mode` event followed our keystrokes.
+ *   - `{ ok: false, reason: "verification mismatch", attempts, lastObserved }`
+ *     when every attempt landed somewhere other than the target.
  */
-export function cycleToMode(taskId: string, targetAgetorMode: string): CycleResult {
+export async function cycleToMode(taskId: string, targetAgetorMode: string): Promise<CycleResult> {
   const state = sessions.get(taskId);
   if (!state) return { ok: false, reason: "no live session" };
   const target = toClaudeModeString(targetAgetorMode);
 
   // `/plan` works from any state, no cycle math needed. Prefer it.
-  // No optimistic state update here — `pastePrompt` is fire-and-forget
-  // (its tmux load-buffer / paste-buffer / send-keys helpers swallow
-  // errors), so claiming success before claude has acknowledged would
-  // lie when the paste fails. The JSONL `permission-mode` event that
-  // follows `/plan` is the authoritative source.
+  // Fire-and-forget — `pastePrompt`'s tmux load-buffer / paste-buffer /
+  // send-keys helpers swallow errors, and verifying via the JSONL would
+  // require the same listener machinery the Shift+Tab path uses; for
+  // `plan` the slash command is reliable enough that the added complexity
+  // doesn't pay for itself.
   if (target === CLAUDE_MODE_PLAN) {
     pastePrompt(state.sessionName, "/plan");
     return { ok: true, presses: 0, via: "slash-plan" };
   }
 
-  const current = state.permissionMode;
-  if (!current) return { ok: false, reason: "current mode unknown" };
-  if (current === target) return { ok: true, presses: 0, via: "noop" };
+  if (!state.permissionMode) return { ok: false, reason: "current mode unknown" };
+  if (state.permissionMode === target) return { ok: true, presses: 0, via: "noop" };
 
   const cycle = cycleOrderFor(state.bypassEnabled);
-  const presses = cycleDistance(cycle, current, target);
-  if (presses === null) {
-    return { ok: false, reason: `mode '${target}' not in this session's cycle` };
+  if (cycleDistance(cycle, state.permissionMode, target) === null) {
+    return { ok: false, reason: "mode not in cycle", target };
   }
-  if (presses > 0) {
-    // One tmux invocation with N keys — cleaner than N sync spawns, and
-    // tmux delivers them as a single stream so claude's TUI doesn't get
-    // a chance to debounce them apart on slow terminals.
-    const keys = Array<string>(presses).fill("S-Tab");
-    tmux(["send-keys", "-t", state.sessionName, ...keys]);
+
+  let totalPresses = 0;
+  let attempts = 0;
+  while (attempts < MAX_VERIFY_ATTEMPTS) {
+    const current = state.permissionMode;
+    if (current === target) {
+      return { ok: true, presses: totalPresses, via: "shift-tab" };
+    }
+    // `current` is non-null on every iteration: the pre-loop guard
+    // returned early when permissionMode was null, and `dispatchLine`
+    // only ever writes strings to the field. The explicit check keeps
+    // TS narrowing happy for the cycleDistance call below.
+    const presses = current ? cycleDistance(cycle, current, target) : null;
+    if (presses === null) {
+      // Target was validated as in-cycle before the loop, so reaching
+      // here means claude moved to a mode we don't recognise between
+      // attempts (e.g. claude introduced a new mode). Bail rather than
+      // spin.
+      return {
+        ok: false,
+        reason: "verification mismatch",
+        attempts,
+        lastObserved: current,
+      };
+    }
+    totalPresses += presses;
+    attempts += 1;
+
+    // Install the listener BEFORE sending keys so a fast `permission-mode`
+    // event can't beat us. The Promise executor runs synchronously, so the
+    // assignment is in place before `tmux send-keys` returns.
+    //
+    // Identity guard: hold our listener in a local and only clear the
+    // session slot when it still points at *this* call's listener. Without
+    // it, two overlapping `cycleToMode` calls (e.g. a user double-PATCH on
+    // the same task) would have the earlier call's setTimeout-driven
+    // cleanup null out the later call's listener, falsely reporting
+    // `verification timed out` for both.
+    const observed = await new Promise<string | null>((resolve) => {
+      let myListener: ((mode: string) => void) | null = null;
+      const timer = setTimeout(() => {
+        if (state.onPermissionMode === myListener) state.onPermissionMode = null;
+        resolve(null);
+      }, modeVerifyTimeoutMs);
+      myListener = (mode) => {
+        clearTimeout(timer);
+        resolve(mode);
+      };
+      state.onPermissionMode = myListener;
+      // One tmux invocation with N keys — cleaner than N sync spawns, and
+      // tmux delivers them as a single stream so claude's TUI doesn't get
+      // a chance to debounce them apart on slow terminals.
+      const keys = Array<string>(presses).fill("S-Tab");
+      tmux(["send-keys", "-t", state.sessionName, ...keys]);
+    });
+
+    if (observed === null) {
+      return {
+        ok: false,
+        reason: "verification timed out",
+        attempts,
+        lastObserved: state.permissionMode,
+      };
+    }
+    if (observed === target) {
+      return { ok: true, presses: totalPresses, via: "shift-tab" };
+    }
+    // Mismatch — loop and retry from the newly-observed mode. `dispatchLine`
+    // has already updated `state.permissionMode` to `observed`.
   }
-  // Optimistic local update. The JSONL `permission-mode` event will arrive
-  // shortly after and overwrite this with claude's authoritative value —
-  // if a press landed somewhere unexpected (e.g. account isn't auto-eligible)
-  // the event corrects state.
-  state.permissionMode = target;
-  return { ok: true, presses, via: "shift-tab" };
+
+  return {
+    ok: false,
+    reason: "verification mismatch",
+    attempts,
+    lastObserved: state.permissionMode,
+  };
 }
 
 /**
@@ -1523,6 +1638,7 @@ function disposeSessionState(state: SessionState | undefined): void {
   state.scrapeTimer = null;
   state.scrapeLastFingerprint = null;
   state.onEndOfTurn = null;
+  state.onPermissionMode = null;
   const err = new Error("session killed");
   for (const slot of state.turnQueue.splice(0)) slot.reject?.(err);
 }
@@ -1578,6 +1694,7 @@ export const __forTest = {
       seenLineUuids: new Set(),
       onEndOfTurn: null,
       permissionMode: null,
+      onPermissionMode: null,
       bypassEnabled: false,
       scrapeTimer: null,
       scrapeLastFingerprint: null,
@@ -1598,6 +1715,20 @@ export const __forTest = {
   dispatchLine,
   matchNumberedModal,
   matchYesNoModal,
+  /** Override the JSONL verification timeout used by `cycleToMode`. Tests
+   *  shrink it to keep "timeout" cases fast. Returns the previous value
+   *  so the test can restore it in `afterEach`. */
+  setModeVerifyTimeoutMs(ms: number): number {
+    const prev = modeVerifyTimeoutMs;
+    modeVerifyTimeoutMs = ms;
+    return prev;
+  },
+  /** Read-only accessor for the current verify timeout. */
+  getModeVerifyTimeoutMs(): number { return modeVerifyTimeoutMs; },
+  /** Max attempts cycleToMode will make before reporting `verification
+   *  mismatch`. Exposed so tests can assert against the constant rather
+   *  than hardcoding "3". */
+  MAX_VERIFY_ATTEMPTS,
 };
 
 /**

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -554,7 +554,7 @@ function attachDoneHandler(
  *   • Anything else (codex; no live session): no-op — the change just
  *     persists for the next spawn.
  */
-export function reconcileTaskSession(taskId: string, before: Task, after: Task): void {
+export async function reconcileTaskSession(taskId: string, before: Task, after: Task): Promise<void> {
   const beforeKind = resolveHarness(before.agent)?.kind ?? null;
   const afterKind = resolveHarness(after.agent)?.kind ?? null;
   // Treat any harness id change as a session-killing event for claude — the
@@ -582,7 +582,7 @@ export function reconcileTaskSession(taskId: string, before: Task, after: Task):
   // and there's no canonical "unset" mode to dial claude back to, so
   // silently keeping the current posture is the least-surprising option.
   if (before.mode !== after.mode && after.mode) {
-    const result = cycleToMode(taskId, after.mode);
+    const result = await cycleToMode(taskId, after.mode);
     emitModeChangeStatus(taskId, after.mode, result);
   }
   if (before.model !== after.model && after.model) {
@@ -616,10 +616,39 @@ function emitModeChangeStatus(
     ? (result.via === "noop"
       ? null
       : `mode → ${agetorMode} (${result.via === "slash-plan" ? "via /plan" : `via Shift+Tab ×${result.presses}`})`)
-    : `⚠️ mode change to ${agetorMode} skipped: ${result.reason} — stop the run and start again to apply.`;
+    : formatModeChangeFailure(agetorMode, result);
   if (!data) return;
   runs.appendEvent(runId, "status", data);
   emit({ runId, taskId, stream: "status", data, ts });
+}
+
+/**
+ * Build the user-facing warning string for an unsuccessful `cycleToMode`
+ * outcome. Switch is exhaustive on `result.reason` (a literal union); the
+ * TS compiler flags any future reason that isn't handled here. The
+ * verification-* reasons carry the most diagnostic value — we surface
+ * the observed mode so the user can see exactly where claude landed.
+ */
+function formatModeChangeFailure(agetorMode: string, result: Extract<CycleResult, { ok: false }>): string {
+  const seen = result.lastObserved ?? "unknown";
+  switch (result.reason) {
+    case "verification timed out": {
+      // The auto opt-in modal is by far the most common reason a press
+      // produces no JSONL event, but only when the target is `auto`. For
+      // any other target the modal advice is misleading, so we drop it.
+      const tail = agetorMode === "auto"
+        ? " If this is the first time cycling to auto on this account, accept the opt-in prompt in the run panel and try again."
+        : "";
+      return `⚠️ mode change to ${agetorMode}: claude didn't acknowledge after ${result.attempts ?? "?"} attempt(s) (last seen: ${seen}).${tail}`;
+    }
+    case "verification mismatch":
+      return `⚠️ mode change to ${agetorMode} failed after ${result.attempts ?? "?"} attempt(s) (claude landed on ${seen}). Your account may not have access to this mode — pick a different one in the task details.`;
+    case "mode not in cycle":
+      return `⚠️ mode change to ${agetorMode} skipped: '${result.target ?? agetorMode}' isn't in this session's Shift+Tab cycle — stop the run and start again with that mode at launch.`;
+    case "no live session":
+    case "current mode unknown":
+      return `⚠️ mode change to ${agetorMode} skipped: ${result.reason} — stop the run and start again to apply.`;
+  }
 }
 
 export function cancelRun(runId: string): boolean {

--- a/src/bun/reconcile-session.test.ts
+++ b/src/bun/reconcile-session.test.ts
@@ -58,7 +58,7 @@ test("reconcileTaskSession resets mode/model/effort when the harness kind change
   tasks.insert(before);
 
   const after: Task = { ...before, agent: "codex-alias" };
-  reconcileTaskSession(before.id, before, after);
+  await reconcileTaskSession(before.id, before, after);
 
   const updated = tasks.get(before.id)!;
   // Reset mode → codex's first option (auto), and model/effort cleared.
@@ -83,7 +83,7 @@ test("reconcileTaskSession preserves mode/model/effort on same-kind alias swap",
   tasks.insert(before);
 
   const after: Task = { ...before, agent: "claude-alt" };
-  reconcileTaskSession(before.id, before, after);
+  await reconcileTaskSession(before.id, before, after);
 
   const updated = tasks.get(before.id)!;
   // Same kind → ids stay valid → keep the picks.
@@ -98,7 +98,7 @@ test("reconcileTaskSession is a no-op when there's no live tmux session", async 
   // simply return without throwing.
   const before = baseTask({ mode: "auto", model: null, effort: null });
   const after = baseTask({ mode: "plan", model: "opus-4.7", effort: "high" });
-  expect(() => reconcileTaskSession("nonexistent-task", before, after)).not.toThrow();
+  await expect(reconcileTaskSession("nonexistent-task", before, after)).resolves.toBeUndefined();
 });
 
 test("reconcileTaskSession drops the claude session when the agent flips", async () => {
@@ -107,12 +107,12 @@ test("reconcileTaskSession drops the claude session when the agent flips", async
   // exits cleanly (dropSession is best-effort and no-ops without a session).
   const before = baseTask({ agent: "claude-code" });
   const after = baseTask({ agent: "codex" });
-  expect(() => reconcileTaskSession("t1", before, after)).not.toThrow();
+  await expect(reconcileTaskSession("t1", before, after)).resolves.toBeUndefined();
 });
 
 test("reconcileTaskSession ignores codex tasks (no live tmux for codex)", async () => {
   const { reconcileTaskSession } = await import("./orchestrator.ts");
   const before = baseTask({ agent: "codex", mode: "auto" });
   const after = baseTask({ agent: "codex", mode: "ask" });
-  expect(() => reconcileTaskSession("t1", before, after)).not.toThrow();
+  await expect(reconcileTaskSession("t1", before, after)).resolves.toBeUndefined();
 });

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -754,7 +754,18 @@ export function startApiServer() {
           // Mirror behavioural changes onto a live claude session via slash
           // commands so the conversation context survives a model/mode/effort
           // change. Agent changes wipe the session — different harness entirely.
-          reconcileTaskSession(req.params.id, before, updated);
+          // Fire-and-forget: the mode-change path now verifies via the JSONL
+          // event before resolving, which can take up to 4.5s on the
+          // exhaust-retries path. The PATCH response payload only carries the
+          // updated Task row (already in hand); the verify outcome reaches
+          // the user through the `status` SSE events that
+          // `emitModeChangeStatus` writes. Blocking the response would add
+          // unbounded latency for no benefit. `.catch` keeps an unexpected
+          // throw from becoming an unhandledRejection — every failure mode
+          // the function knows about already surfaces via SSE.
+          reconcileTaskSession(req.params.id, before, updated).catch((err: unknown) => {
+            console.error("reconcileTaskSession failed:", err);
+          });
           return json(updated, { headers: corsHeaders(req) });
         }),
         DELETE: authed(async (req) => {


### PR DESCRIPTION
Mid-session mode changes were optimistic: after sending N Shift+Tab presses we updated `state.permissionMode` to the target and reported success, even when the press actually landed elsewhere (auto opt-in modal swallowed the keystrokes, account not auto-eligible so the cycle is 3-wide instead of 4, stale state). Users saw "mode → auto" in the run panel while claude was running with a different posture.

`cycleToMode` is now async and verifies each batch of presses against the next JSONL `permission-mode` event before returning. On mismatch it retries from the newly-observed mode (up to 3 attempts); on no event within 1.5s it bails as "verification timed out". The orchestrator surfaces both failure modes through the existing run- panel status SSE with the last observed mode so the user can see exactly where claude landed.

The PATCH /tasks/:id route fires the reconcile and-forget so the HTTP response stays fast — verification can take up to 4.5s on exhausted retries, and the outcome reaches the user via SSE either way. The listener slot on SessionState is identity-guarded so overlapping PATCHes don't clobber each other's verifications.