### PR TITLE
fix(kanban): make Task Details panel reliably closeable

### DIFF
--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -8,7 +8,7 @@ import { AgentIcon } from "@/components/kanban/AgentIcon";
 import { Column } from "@/components/kanban/Column";
 import { KanbanFilters } from "@/components/kanban/KanbanFilters";
 import { NewTaskForm } from "@/components/kanban/NewTaskForm";
-import { RunPanel } from "@/components/kanban/RunPanel";
+import { EXIT_DURATION_MS as RUN_PANEL_EXIT_MS, RunPanel } from "@/components/kanban/RunPanel";
 import { SettingsDialog } from "@/components/settings/SettingsDialog";
 import { TmuxInstallDialog } from "@/components/tmux/TmuxInstallDialog";
 import { TmuxMissingBanner, errorIsTmuxMissing, isTmuxMissing } from "@/components/tmux/TmuxMissingBanner";
@@ -159,6 +159,28 @@ export default function App() {
     const fresh = tasks.find((t) => t.id === selected.id);
     if (fresh && fresh !== selected) setSelected(fresh);
   }, [tasks, selected]);
+
+  // Once the user opens a task's panel, any "Waiting on you" toast for that
+  // task is noise — they're already looking at the prompt. Clearing it also
+  // removes one more high-z-index click target that could otherwise sit on
+  // top of the panel header and eat clicks meant for the X button.
+  useEffect(() => {
+    if (!selected) return;
+    dismissPending(selected.id);
+  }, [selected?.id]);
+
+  // `panelMounted` follows `selected !== null` on open but lags by the
+  // RunPanel's exit animation on close, so the Toaster doesn't snap back to
+  // the right edge (and slide under the receding panel) for ~250ms.
+  const [panelMounted, setPanelMounted] = useState(false);
+  useEffect(() => {
+    if (selected) {
+      setPanelMounted(true);
+      return;
+    }
+    const t = setTimeout(() => setPanelMounted(false), RUN_PANEL_EXIT_MS);
+    return () => clearTimeout(t);
+  }, [selected]);
 
   // Refs mirror the latest tasks + selected task so the global-events
   // subscription (which closes over its handler ONCE on mount) can read
@@ -475,7 +497,7 @@ export default function App() {
             projects={projects}
           />
           <ErrorToast error={error} onDismiss={() => setError(null)} />
-          <Toaster />
+          <Toaster panelOpen={panelMounted} />
           {/* Kanban gets all remaining vertical space and scrolls horizontally
               on its own — the bottom bar stays anchored regardless of column
               count. */}

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -63,7 +63,7 @@ const STATUS_VARIANT: Record<Run["status"], "default" | "secondary" | "outline" 
   failed: "destructive",
 };
 
-const EXIT_DURATION_MS = 250;
+export const EXIT_DURATION_MS = 250;
 
 function formatDuration(r: Run): string {
   const end = r.endedAt ?? Date.now();
@@ -115,6 +115,33 @@ export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClos
     const t = setTimeout(() => setMountedTask(null), EXIT_DURATION_MS);
     return () => clearTimeout(t);
   }, [open, mountedTask]);
+
+  // Escape closes the panel — but only when no higher-priority dismissable
+  // layer is up: a modal Dialog (confirm, edit, settings, tmux-missing —
+  // each renders `[role="dialog"][aria-modal="true"]`) or an open
+  // search-select / multi-search-select popover (marked with
+  // `[data-popover-open]`). Esc peels one layer at a time, top down.
+  //
+  // Note: stopPropagation/stopImmediatePropagation can't help here because
+  // both the panel and the popovers attach to `document`, so DOM markers
+  // are the order-independent way to coordinate the handoff.
+  //
+  // onClose is captured into a ref because the parent passes an inline arrow
+  // function — depending on it directly would tear down + re-add the listener
+  // on every kanban poll (every 2s).
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"], [data-popover-open]')) return;
+      e.preventDefault();
+      onCloseRef.current();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
 
   if (!mountedTask) return null;
 

--- a/src/mainview/components/ui/multi-search-select.tsx
+++ b/src/mainview/components/ui/multi-search-select.tsx
@@ -128,6 +128,9 @@ export function MultiSearchSelect<T extends string>({
 
       {open && (
         <div
+          // Marker for enclosing Esc handlers (RunPanel) to bail and let
+          // this popover consume Escape first.
+          data-popover-open=""
           className={cn(
             "absolute left-0 right-0 z-50 overflow-hidden rounded-md border border-border bg-card text-card-foreground shadow-xl",
             placement === "top" ? "bottom-full mb-1" : "top-full mt-1",

--- a/src/mainview/components/ui/search-select.tsx
+++ b/src/mainview/components/ui/search-select.tsx
@@ -125,6 +125,9 @@ export function SearchSelect({
 
       {open && (
         <div
+          // Marker for enclosing Esc handlers (RunPanel) to bail and let
+          // this popover consume Escape first.
+          data-popover-open=""
           className={cn(
             "absolute left-0 right-0 z-50 overflow-hidden rounded-md border border-border bg-card text-card-foreground shadow-xl",
             placement === "top" ? "bottom-full mb-1" : "top-full mt-1",

--- a/src/mainview/components/ui/sonner.tsx
+++ b/src/mainview/components/ui/sonner.tsx
@@ -1,8 +1,19 @@
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
+// 520px RunPanel + 16px gap. When the panel is open, push toasts left of it
+// so they don't sit on top of the panel header (where the X button lives) —
+// sonner's hardcoded z-index of ~1e9 otherwise eats clicks meant for X.
+const PANEL_OFFSET_RIGHT = 536;
+
+interface Props extends ToasterProps {
+  /** True while the right-side RunPanel is mounted. Shifts toasts left so
+   *  they never overlap the panel's close button. */
+  panelOpen?: boolean;
+}
+
 // Dark-only — agetor's index.html hardcodes `<html class="dark">`. If we ever
 // add a light mode, swap this for `next-themes` and read the active theme.
-export function Toaster(props: ToasterProps) {
+export function Toaster({ panelOpen = false, ...props }: Props) {
   return (
     <Sonner
       theme="dark"
@@ -10,7 +21,7 @@ export function Toaster(props: ToasterProps) {
       // Clears the 40px header so toasts don't sit on top of the Settings
       // button (anchored top-right). Sonner's default offset is ~32px which
       // would overlap.
-      offset={56}
+      offset={panelOpen ? { top: 56, right: PANEL_OFFSET_RIGHT } : 56}
       richColors
       closeButton
       toastOptions={{


### PR DESCRIPTION
Lingering Infinity-duration toasts (failed / waiting-on-you) sit at z-index ~1e9 over the panel's top-right corner, swallowing clicks meant for the X. Esc was never wired up either. Three fixes:

- RunPanel listens for Escape while open; bails when a modal Dialog or open search-select popover is layered on top so Esc peels one layer at a time. onClose is captured into a ref to avoid re-subscribing on every kanban poll.
- Toaster shifts its right offset by the panel width when the panel is mounted, so toasts land left of it rather than on top of the header. The shift is held through the panel's 250ms exit animation to avoid a snap-back during slide-out.
- Opening a task's panel auto-dismisses any pending "Waiting on you" toast for that task — one fewer high-z-index click target.

search-select / multi-search-select mark their open popovers with data-popover-open so RunPanel's Esc bail check can detect them (stopPropagation can't help — both listen on document).