### PR TITLE
feat(kanban): filter tasks by harness

### DIFF
--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -77,6 +77,7 @@ export default function App() {
   const [textQuery, setTextQuery] = useState("");
   const [repoFilter, setRepoFilter] = useState<string[]>([]);
   const [statusFilter, setStatusFilter] = useState<ColumnId[]>([]);
+  const [harnessFilter, setHarnessFilter] = useState<string[]>([]);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [tmuxDialogOpen, setTmuxDialogOpen] = useState(false);
   const [updateSnapshot, setUpdateSnapshot] = useState<UpdateSnapshot | null>(null);
@@ -277,13 +278,21 @@ export default function App() {
         if (!hay.includes(q)) return false;
       }
       if (repoFilter.length > 0 && !repoFilter.includes(t.workdir)) return false;
+      if (harnessFilter.length > 0 && !harnessFilter.includes(t.agent)) return false;
       return true;
     });
-  }, [tasks, textQuery, repoFilter]);
+  }, [tasks, textQuery, repoFilter, harnessFilter]);
 
   const visibleColumns = useMemo(
     () => (statusFilter.length === 0 ? COLUMNS : COLUMNS.filter((c) => statusFilter.includes(c.id))),
     [statusFilter],
+  );
+
+  // Distinct harness ids referenced by any task — feeds the harness filter so
+  // ids belonging to removed harnesses still show up as filter options.
+  const taskAgentIds = useMemo(
+    () => Array.from(new Set(tasks.map((t) => t.agent))),
+    [tasks],
   );
 
   const surfaceError = (e: unknown) =>
@@ -472,7 +481,11 @@ export default function App() {
             onRepoFilterChange={setRepoFilter}
             statusFilter={statusFilter}
             onStatusFilterChange={setStatusFilter}
+            harnessFilter={harnessFilter}
+            onHarnessFilterChange={setHarnessFilter}
             projects={projects}
+            harnesses={harnesses}
+            taskAgentIds={taskAgentIds}
           />
           <ErrorToast error={error} onDismiss={() => setError(null)} />
           <Toaster />

--- a/src/mainview/components/kanban/KanbanFilters.tsx
+++ b/src/mainview/components/kanban/KanbanFilters.tsx
@@ -1,8 +1,9 @@
-import { Folder, Search, Tag } from "lucide-react";
+import { Cpu, Folder, Search, Tag } from "lucide-react";
+import { AgentIcon } from "@/components/kanban/AgentIcon";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { MultiSearchSelect } from "@/components/ui/multi-search-select";
-import { COLUMNS, type ColumnId, type Project } from "../../../shared/types.ts";
+import { COLUMNS, type ColumnId, type Harness, type Project } from "../../../shared/types.ts";
 
 interface Props {
   textQuery: string;
@@ -11,7 +12,15 @@ interface Props {
   onRepoFilterChange: (v: string[]) => void;
   statusFilter: ColumnId[];
   onStatusFilterChange: (v: ColumnId[]) => void;
+  harnessFilter: string[];
+  onHarnessFilterChange: (v: string[]) => void;
   projects: Project[];
+  harnesses: Harness[];
+  /** Distinct harness ids referenced by any current task. Used to surface
+   *  orphan ids (referenced by tasks but no longer registered) as filter
+   *  options, so users can still narrow to historical runs of a removed
+   *  harness. */
+  taskAgentIds: string[];
 }
 
 const basename = (p: string) => {
@@ -27,7 +36,11 @@ export function KanbanFilters({
   onRepoFilterChange,
   statusFilter,
   onStatusFilterChange,
+  harnessFilter,
+  onHarnessFilterChange,
   projects,
+  harnesses,
+  taskAgentIds,
 }: Props) {
   const repoItems = projects.map((p) => ({
     value: p.path,
@@ -35,11 +48,42 @@ export function KanbanFilters({
     hint: p.path,
   }));
   const statusItems = COLUMNS.map((c) => ({ value: c.id, label: c.label } as const));
+  // Order: enabled harnesses first, then disabled (marked with a hint), then
+  // orphan ids referenced by tasks but no longer registered as a harness — so
+  // historical runs of a removed harness stay filterable.
+  const known = new Set(harnesses.map((h) => h.id));
+  const enabledItems = harnesses.filter((h) => h.enabled).map((h) => ({
+    value: h.id,
+    label: h.label,
+    icon: <AgentIcon kind={h.kind} className="size-3.5" />,
+  }));
+  const disabledItems = harnesses.filter((h) => !h.enabled).map((h) => ({
+    value: h.id,
+    label: h.label,
+    hint: "disabled",
+    icon: <AgentIcon kind={h.kind} className="size-3.5" />,
+  }));
+  const orphanItems = taskAgentIds
+    .filter((id) => !known.has(id))
+    .map((id) => ({ value: id, label: id, hint: "removed" }));
+  const harnessItems = [...enabledItems, ...disabledItems, ...orphanItems];
   const anyActive =
-    textQuery !== "" || repoFilter.length > 0 || statusFilter.length > 0;
+    textQuery !== ""
+    || repoFilter.length > 0
+    || statusFilter.length > 0
+    || harnessFilter.length > 0;
 
   return (
     <div className="flex shrink-0 items-center gap-2 border-b border-border/60 px-4 py-2">
+      <MultiSearchSelect
+        values={harnessFilter}
+        onChange={onHarnessFilterChange}
+        items={harnessItems}
+        emptyLabel="All harnesses"
+        placeholder="Search harnesses…"
+        leadingIcon={<Cpu className="size-3.5" />}
+        className="w-48"
+      />
       <div className="relative flex-1 max-w-md">
         <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden />
         <Input
@@ -75,6 +119,7 @@ export function KanbanFilters({
             onTextQueryChange("");
             onRepoFilterChange([]);
             onStatusFilterChange([]);
+            onHarnessFilterChange([]);
           }}
         >
           Clear

--- a/src/mainview/components/ui/multi-search-select.tsx
+++ b/src/mainview/components/ui/multi-search-select.tsx
@@ -10,6 +10,8 @@ export interface MultiSearchSelectItem<T extends string = string> {
   hint?: string;
   /** Render at the top of the list above non-pinned items. */
   pinned?: boolean;
+  /** Optional glyph rendered on the left side of the option row. */
+  icon?: ReactNode;
 }
 
 interface Props<T extends string> {
@@ -93,14 +95,16 @@ export function MultiSearchSelect<T extends string>({
 
   const valueSet = useMemo(() => new Set(values), [values]);
 
+  const selectedSingle = useMemo(
+    () => (values.length === 1 ? items.find((i) => i.value === values[0]) : undefined),
+    [values, items],
+  );
   const triggerLabel = useMemo(() => {
     if (values.length === 0) return emptyLabel;
-    if (values.length === 1) {
-      const only = items.find((i) => i.value === values[0]);
-      return only?.label ?? values[0]!;
-    }
+    if (values.length === 1) return selectedSingle?.label ?? values[0]!;
     return `${values.length} selected`;
-  }, [values, items, emptyLabel]);
+  }, [values, selectedSingle, emptyLabel]);
+  const triggerIcon = selectedSingle?.icon ?? leadingIcon;
 
   const toggle = (value: T) => {
     if (valueSet.has(value)) onChange(values.filter((v) => v !== value));
@@ -119,7 +123,7 @@ export function MultiSearchSelect<T extends string>({
           disabled && "cursor-not-allowed opacity-50",
         )}
       >
-        {leadingIcon && <span className="shrink-0 text-muted-foreground">{leadingIcon}</span>}
+        {triggerIcon && <span className="shrink-0 text-muted-foreground">{triggerIcon}</span>}
         <span className={cn("min-w-0 flex-1 truncate", values.length === 0 && "text-muted-foreground")}>
           {triggerLabel}
         </span>
@@ -166,6 +170,11 @@ export function MultiSearchSelect<T extends string>({
                       )}
                       aria-hidden
                     />
+                    {item.icon && (
+                      <span className="mt-0.5 flex size-3.5 shrink-0 items-center justify-center">
+                        {item.icon}
+                      </span>
+                    )}
                     <span className="min-w-0 flex-1">
                       <span className="block truncate">{item.label}</span>
                       {item.hint && (


### PR DESCRIPTION
Adds a harness multi-select to the left of the search field, mirroring the repo/status filter pattern. Each option row shows the underlying agent glyph; the trigger swaps to that glyph when a single harness is selected. Disabled harnesses are kept (marked "disabled") and orphan ids referenced by tasks but no longer registered surface as "removed" options so historical runs stay filterable.