### PR TITLE
fix(settings): surface harness delete/toggle failures as toasts

### DIFF
--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { ChevronLeft, Plus, Trash2, X } from "lucide-react";
-import { api, type HarnessesPayload, type HarnessInput } from "@/lib/api";
+import { toast } from "sonner";
+import { ApiError, api, type HarnessesPayload, type HarnessInput } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Dialog } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -90,6 +91,32 @@ function uniqueHarnessId(base: string, existing: Set<string>): string {
   let n = m ? parseInt(m[2]!, 10) + 1 : 2;
   while (existing.has(`${prefix}${n}`)) n++;
   return `${prefix}${n}`;
+}
+
+/** If `err` is the server's "harness in use" 409 (which carries a structured
+ *  `taskIds` list), resolve those ids to titles and return a human-readable
+ *  description for the failure toast. Returns null if the error isn't that
+ *  shape — caller falls back to the raw `error` message. */
+async function describeHarnessInUse(err: unknown): Promise<string | null> {
+  if (!(err instanceof ApiError)) return null;
+  const body = err.body;
+  if (!body || typeof body !== "object") return null;
+  const taskIds = (body as { taskIds?: unknown }).taskIds;
+  if (!Array.isArray(taskIds) || taskIds.length === 0) return null;
+  const ids = taskIds.filter((x): x is string => typeof x === "string");
+  if (ids.length === 0) return null;
+  let titles: string[];
+  try {
+    const tasks = await api.listTasks();
+    const byId = new Map(tasks.map((t) => [t.id, t.title]));
+    titles = ids.map((id) => byId.get(id) ?? `${id.slice(0, 8)}…`);
+  } catch {
+    // Listing tasks failed — fall back to id prefixes so the toast still
+    // identifies *which* tasks are blocking, even if not by name.
+    titles = ids.map((id) => `${id.slice(0, 8)}…`);
+  }
+  const noun = titles.length === 1 ? "task" : "tasks";
+  return `In use by ${titles.length} ${noun}: ${titles.join(", ")}`;
 }
 
 export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Props) {
@@ -189,7 +216,14 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
       await refresh();
       onChange?.();
     } catch (e) {
-      setFormError(e instanceof Error ? e.message : String(e));
+      // ListView doesn't render `formError` (only the Editor does), so a
+      // failed delete would otherwise be invisible. Surface it as a toast.
+      const message = e instanceof Error ? e.message : String(e);
+      const description = await describeHarnessInUse(e) ?? message;
+      toast.error(`Couldn't delete "${h.label}"`, {
+        description,
+        duration: Infinity,
+      });
     }
   };
 
@@ -241,7 +275,11 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
       onChange?.();
     } catch (e) {
       clearPending(h.id);
-      setFormError(e instanceof Error ? e.message : String(e));
+      const message = e instanceof Error ? e.message : String(e);
+      toast.error(`Couldn't ${next ? "enable" : "disable"} "${h.label}"`, {
+        description: message,
+        duration: Infinity,
+      });
     }
   };
 

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -126,6 +126,21 @@ const API_PORT = injected?.port ?? params.get("api") ?? "4317";
 const API_TOKEN = injected?.token ?? params.get("token") ?? "";
 const BASE = `http://127.0.0.1:${API_PORT}`;
 
+/** Error thrown for any non-2xx API response. Carries the parsed JSON body
+ *  so callers can read structured fields (e.g. the `taskIds` list returned
+ *  by `DELETE /harnesses/:id` when the harness is still in use) instead of
+ *  re-parsing the message string. */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
 async function j<T>(path: string, init?: RequestInit): Promise<T> {
   let res: Response;
   try {
@@ -153,7 +168,7 @@ async function j<T>(path: string, init?: RequestInit): Promise<T> {
     const msg = (body && typeof body === "object" && "error" in body && body.error)
       ? String(body.error)
       : `${res.status} ${res.statusText}`;
-    throw new Error(msg);
+    throw new ApiError(msg, res.status, body);
   }
   return body as T;
 }


### PR DESCRIPTION
Failed harness delete/toggle round-trips wrote to a `formError` state that only the Editor view renders, so errors from ListView (e.g. 409 "harness in use by 1 task(s)") landed in state and were never shown. Switch both handlers to `toast.error` and widen the API helper to throw `ApiError` carrying the parsed body, so the delete toast can resolve the blocking `taskIds` to task titles.