### PR TITLE
feat(approvals): share "Allow always" rules across tasks and modes

### DIFF
--- a/src/bun/approvals-endpoint.test.ts
+++ b/src/bun/approvals-endpoint.test.ts
@@ -66,8 +66,17 @@ async function seedPendingApproval(args: {
   return { approvalId: id, cwd };
 }
 
+/** Allow-rules now persist to the agetor-global `<dataDir>/settings.local.json`
+ *  (so an approval on task A auto-allows the same call on task B). Resolved
+ *  lazily from `db.ts`'s `dataDir` because Bun shares modules across test
+ *  files — see the matching note in interactions.test.ts. */
+async function globalAllowFile(): Promise<string> {
+  const { dataDir } = await import("./db.ts");
+  return path.join(dataDir, "settings.local.json");
+}
+
 test("/approvals/:id/answer forwards explicit `entry` to permissions.allow", async () => {
-  const { approvalId, cwd } = await seedPendingApproval({
+  const { approvalId } = await seedPendingApproval({
     taskId: "t-endpoint-explicit",
     toolName: "Bash",
     toolInput: { command: "git status" },
@@ -84,13 +93,13 @@ test("/approvals/:id/answer forwards explicit `entry` to permissions.allow", asy
   expect(res.status).toBe(200);
   expect(await res.json()).toEqual({ ok: true });
 
-  const settings = JSON.parse(readFileSync(path.join(cwd, ".claude", "settings.local.json"), "utf8"));
+  const settings = JSON.parse(readFileSync(await globalAllowFile(), "utf8"));
   expect(settings.permissions.allow).toContain("Bash(git *)");
   expect(settings.permissions.allow).not.toContain("Bash(git status)");
 });
 
 test("/approvals/:id/answer with remember=true and no `entry` falls back to most-specific", async () => {
-  const { approvalId, cwd } = await seedPendingApproval({
+  const { approvalId } = await seedPendingApproval({
     taskId: "t-endpoint-default",
     toolName: "Bash",
     toolInput: { command: "npm test" },
@@ -103,13 +112,15 @@ test("/approvals/:id/answer with remember=true and no `entry` falls back to most
   });
   expect(res.status).toBe(200);
 
-  const settings = JSON.parse(readFileSync(path.join(cwd, ".claude", "settings.local.json"), "utf8"));
+  const settings = JSON.parse(readFileSync(await globalAllowFile(), "utf8"));
   // Default-derive picks bash_exact for Bash → the exact command verbatim.
-  expect(settings.permissions.allow).toEqual(["Bash(npm test)"]);
+  // The rule from the previous test ("Bash(git *)") is also present since
+  // the global file persists across cases in this file.
+  expect(settings.permissions.allow).toContain("Bash(npm test)");
 });
 
-test("/approvals/:id/answer with decision=deny does NOT write any settings file", async () => {
-  const { approvalId, cwd } = await seedPendingApproval({
+test("/approvals/:id/answer with decision=deny does NOT write the saved rule", async () => {
+  const { approvalId } = await seedPendingApproval({
     taskId: "t-endpoint-deny",
     toolName: "Bash",
     toolInput: { command: "rm -rf /" },
@@ -122,7 +133,14 @@ test("/approvals/:id/answer with decision=deny does NOT write any settings file"
     body: JSON.stringify({ decision: "deny", remember: true, entry: "Bash(rm *)" }),
   });
   expect(res.status).toBe(200);
-  expect(existsSync(path.join(cwd, ".claude", "settings.local.json"))).toBe(false);
+  // The earlier tests in this file may have populated the global file; what
+  // matters is that "Bash(rm *)" never made it in.
+  const file = await globalAllowFile();
+  if (existsSync(file)) {
+    const settings = JSON.parse(readFileSync(file, "utf8"));
+    const allow = (settings.permissions?.allow ?? []) as string[];
+    expect(allow).not.toContain("Bash(rm *)");
+  }
 });
 
 test("/approvals/:id/answer rejects invalid decision values", async () => {

--- a/src/bun/hook-installer.test.ts
+++ b/src/bun/hook-installer.test.ts
@@ -280,11 +280,14 @@ test("ensureInstalledForCwd: overwrites inside an agetor-owned worktree", async 
 });
 
 test("ensureInstalled preserves `permissions.allow` across re-spawns (regression)", async () => {
-  // Repro of the bug where ensureInstalled built a fresh settings object on
-  // every call, clobbering allow-rules written by saveAllowRule between the
-  // first task spawn and a re-run. This test simulates: (1) initial install,
-  // (2) saveAllowRule appends an entry, (3) re-spawn calls ensureInstalled
-  // again — the entry must survive.
+  // Repro of the bug where ensureInstalled built a fresh settings object
+  // on every call, clobbering pre-existing `permissions.allow` entries
+  // between the first task spawn and a re-run. Today those entries come
+  // from: legacy agetor builds (saveAllowRule used to write per-cwd),
+  // direct user edits, or a manual `claude` invocation inside the
+  // worktree. This test simulates: (1) initial install, (2) an entry is
+  // written into the same settings file, (3) re-spawn calls
+  // ensureInstalled again — the entry must survive.
   const { ensureInstalled } = await import("./hook-installer.ts");
   const owned = path.join(process.env.AGETOR_DATA_DIR!, "worktrees", "regression-task");
   require("node:fs").mkdirSync(owned, { recursive: true });
@@ -292,10 +295,8 @@ test("ensureInstalled preserves `permissions.allow` across re-spawns (regression
   // 1. First install (fresh worktree, no settings file).
   ensureInstalled(owned, "full");
 
-  // 2. Simulate saveAllowRule writing a permissions.allow entry into the
-  //    same settings file. (We don't import saveAllowRule here to keep
-  //    this test focused on hook-installer behavior; the merge logic in
-  //    appendPermissionEntry is exercised by interactions.test.ts.)
+  // 2. Simulate a permissions.allow entry landing in the same settings
+  //    file (from any of the sources noted above).
   const settingsFile = path.join(owned, ".claude", "settings.local.json");
   const after1 = JSON.parse(require("node:fs").readFileSync(settingsFile, "utf8"));
   after1.permissions = { allow: ["Bash(git status)"] };

--- a/src/bun/hook-installer.ts
+++ b/src/bun/hook-installer.ts
@@ -205,12 +205,14 @@ function includeMcpForScope(scope: InstallScope): boolean {
 
 export function ensureInstalled(cwd: string, scope: InstallScope = "full"): InstalledPaths {
   // Even though we own the worktree dir, the settings.local.json INSIDE it
-  // is shared with `saveAllowRule` (which appends `permissions.allow`
-  // entries). A fresh-object write would clobber those rules on every task
-  // re-spawn. So owned-worktree installs use the same merge path as
-  // user-repo installs, only relaxed on the malformed-JSON branch (we
-  // wrote the file last; if it's malformed, that's our bug to recover
-  // from, not the user's data).
+  // may still hold `permissions.allow` entries we have to preserve across
+  // re-spawns: legacy entries from older agetor builds (back when
+  // `saveAllowRule` wrote per-cwd), rules the user hand-added, and any
+  // entries left over from a direct `claude` invocation inside the
+  // worktree. A fresh-object write would clobber those. So owned-worktree
+  // installs use the same merge path as user-repo installs, only relaxed
+  // on the malformed-JSON branch (we wrote the file last; if it's
+  // malformed, that's our bug to recover from, not the user's data).
   //
   // We DO write the CLAUDE.md addendum here (unlike ensureInstalledMerged
   // which leaves user repos alone). The addendum teaches claude when to
@@ -439,8 +441,8 @@ function applyAgetorSettings(
 /** Atomic JSON write: stringify, write to a sibling tempfile, rename onto
  *  the target. rename is atomic on POSIX, so a partial write can never
  *  leave the destination corrupted. Crucial for settings.local.json which
- *  multiple subsystems (hook-installer, interactions/saveAllowRule) merge
- *  into during normal operation. */
+ *  hook-installer merges into on every task spawn while preserving any
+ *  pre-existing user / legacy entries underneath. */
 function writeJsonAtomic(file: string, value: unknown): void {
   const tmp = `${file}.tmp.${process.pid}.${randomUUID().slice(0, 8)}`;
   writeFileSync(tmp, JSON.stringify(value, null, 2));

--- a/src/bun/interactions.test.ts
+++ b/src/bun/interactions.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, beforeEach } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -8,9 +8,25 @@ import path from "node:path";
 // process, falling back to ~/.agetor and polluting the user's real db.
 process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-int-"));
 
+/** Allow-rules are now stored agetor-wide at `<dataDir>/settings.local.json`,
+ *  not per-task. Tests share this single file across cases — wipe between
+ *  tests so a leftover rule from one case can't auto-allow in the next.
+ *
+ *  Resolved lazily from `db.ts`'s `dataDir` export (rather than the env var)
+ *  because Bun's test runner shares one process across files: if a sibling
+ *  file imported `db.ts` first, `dataDir` is frozen to *that* file's env,
+ *  not ours. Trusting `dataDir` always agrees with what `interactions.ts`
+ *  actually writes to. */
+async function globalAllowFile(): Promise<string> {
+  const { dataDir } = await import("./db.ts");
+  return path.join(dataDir, "settings.local.json");
+}
+
 beforeEach(async () => {
   const { __testing } = await import("./interactions.ts");
   __testing.reset();
+  const file = await globalAllowFile();
+  if (existsSync(file)) rmSync(file);
 });
 
 /** Insert a Task row pointing at a fresh temp directory so the JSON-file
@@ -69,10 +85,12 @@ test("answerApproval with remember=true persists a rule (default-derive: bash_ex
   answerApproval(id, { decision: "allow", remember: true });
   await answer;
 
-  // The rule should be written to <cwd>/.claude/settings.local.json as a
-  // native claude permission entry.
-  const settings = JSON.parse(readFileSync(path.join(cwd, ".claude", "settings.local.json"), "utf8"));
+  // The rule should be written to the agetor-global settings file as a
+  // native claude permission entry — NOT to the task cwd anymore. That's
+  // what makes the next task auto-allow the same call.
+  const settings = JSON.parse(readFileSync(await globalAllowFile(), "utf8"));
   expect(settings.permissions.allow).toContain("Bash(npm test)");
+  expect(existsSync(path.join(cwd, ".claude", "settings.local.json"))).toBe(false);
 
   // And subsequent lookups should hit it.
   expect(lookupAllowRule({ taskId: "t2", toolName: "Bash", toolInput: { command: "npm test" } })).toBe("allow");
@@ -80,12 +98,13 @@ test("answerApproval with remember=true persists a rule (default-derive: bash_ex
   expect(lookupAllowRule({ taskId: "t2", toolName: "Bash", toolInput: { command: "npm install" } })).toBeNull();
   // A different tool must NOT auto-allow.
   expect(lookupAllowRule({ taskId: "t2", toolName: "Edit", toolInput: { file_path: "/foo" } })).toBeNull();
-  // A different task with no settings file → null.
-  expect(lookupAllowRule({ taskId: "other-task", toolName: "Bash", toolInput: { command: "npm test" } })).toBeNull();
+  // A different task (even one that doesn't exist) auto-allows — that's
+  // the cross-task share guarantee.
+  expect(lookupAllowRule({ taskId: "other-task", toolName: "Bash", toolInput: { command: "npm test" } })).toBe("allow");
 });
 
 test("answerApproval honors an explicit entry from the granularity chooser", async () => {
-  const cwd = await makeTaskWithCwd("t2b");
+  await makeTaskWithCwd("t2b");
   const { registerApproval, answerApproval, lookupAllowRule } = await import("./interactions.ts");
   const { id, answer } = registerApproval({
     taskId: "t2b",
@@ -97,7 +116,7 @@ test("answerApproval honors an explicit entry from the granularity chooser", asy
   answerApproval(id, { decision: "allow", remember: true, entry: "Bash(git *)" });
   await answer;
 
-  const settings = JSON.parse(readFileSync(path.join(cwd, ".claude", "settings.local.json"), "utf8"));
+  const settings = JSON.parse(readFileSync(await globalAllowFile(), "utf8"));
   expect(settings.permissions.allow).toContain("Bash(git *)");
   // Prefix matches any `git ...` (word boundary; `gitleaks` does NOT match).
   expect(lookupAllowRule({ taskId: "t2b", toolName: "Bash", toolInput: { command: "git log" } })).toBe("allow");
@@ -114,40 +133,74 @@ test("answerApproval with decision='deny' does NOT save a rule, even with rememb
     toolInput: { command: "rm something" },
   });
   answerApproval(id, { decision: "deny", remember: true });
-  // No settings file should be created.
+  // Neither the global settings file nor the legacy per-task one should be created.
+  expect(existsSync(await globalAllowFile())).toBe(false);
   expect(existsSync(path.join(cwd, ".claude", "settings.local.json"))).toBe(false);
   expect(lookupAllowRule({ taskId: "t3", toolName: "Bash", toolInput: { command: "rm something" } })).toBeNull();
 });
 
-test("saveAllowRule preserves pre-existing user entries when merging", async () => {
-  const cwd = await makeTaskWithCwd("t-merge");
+test("saveAllowRule preserves pre-existing entries in the global file when merging", async () => {
   const { mkdirSync, writeFileSync } = await import("node:fs");
-  mkdirSync(path.join(cwd, ".claude"), { recursive: true });
-  // Seed a pre-existing user-authored permissions.allow + unrelated key.
+  mkdirSync(path.dirname(await globalAllowFile()), { recursive: true });
+  // Seed a pre-existing permissions.allow + unrelated user-authored key.
   writeFileSync(
-    path.join(cwd, ".claude", "settings.local.json"),
+    await globalAllowFile(),
     JSON.stringify({
       permissions: { allow: ["Bash(ls *)"] },
       customUserKey: { keep: "this" },
     }, null, 2),
   );
 
+  await makeTaskWithCwd("t-merge");
   const { saveAllowRule } = await import("./interactions.ts");
   saveAllowRule({ taskId: "t-merge", toolName: "Bash", toolInput: { command: "npm test" } });
 
-  const settings = JSON.parse(readFileSync(path.join(cwd, ".claude", "settings.local.json"), "utf8"));
+  const settings = JSON.parse(readFileSync(await globalAllowFile(), "utf8"));
   expect(settings.permissions.allow).toEqual(["Bash(ls *)", "Bash(npm test)"]);
   expect(settings.customUserKey).toEqual({ keep: "this" });
 });
 
 test("saveAllowRule is idempotent — repeated saves of the same entry dedupe", async () => {
-  const cwd = await makeTaskWithCwd("t-dedupe");
+  await makeTaskWithCwd("t-dedupe");
   const { saveAllowRule } = await import("./interactions.ts");
   saveAllowRule({ taskId: "t-dedupe", toolName: "Bash", toolInput: { command: "npm test" } });
   saveAllowRule({ taskId: "t-dedupe", toolName: "Bash", toolInput: { command: "npm test" } });
   saveAllowRule({ taskId: "t-dedupe", toolName: "Bash", toolInput: { command: "npm test" } });
-  const settings = JSON.parse(readFileSync(path.join(cwd, ".claude", "settings.local.json"), "utf8"));
+  const settings = JSON.parse(readFileSync(await globalAllowFile(), "utf8"));
   expect(settings.permissions.allow).toEqual(["Bash(npm test)"]);
+});
+
+test("saved allow-rule applies across tasks — saving on task A auto-allows on task B", async () => {
+  await makeTaskWithCwd("t-share-A");
+  await makeTaskWithCwd("t-share-B");
+  const { saveAllowRule, lookupAllowRule } = await import("./interactions.ts");
+  // Approve on A.
+  saveAllowRule({ taskId: "t-share-A", toolName: "Bash", toolInput: { command: "git status" } });
+  // Lookup on B (different cwd) matches the same global rule.
+  expect(lookupAllowRule({
+    taskId: "t-share-B", toolName: "Bash", toolInput: { command: "git status" },
+  })).toBe("allow");
+});
+
+test("lookupAllowRule still honors legacy per-task .claude/settings.local.json (back-compat)", async () => {
+  const cwd = await makeTaskWithCwd("t-legacy");
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  mkdirSync(path.join(cwd, ".claude"), { recursive: true });
+  // Pretend an older agetor build saved a per-task rule here.
+  writeFileSync(
+    path.join(cwd, ".claude", "settings.local.json"),
+    JSON.stringify({ permissions: { allow: ["Bash(legacy-cmd)"] } }, null, 2),
+  );
+  const { lookupAllowRule } = await import("./interactions.ts");
+  expect(lookupAllowRule({
+    taskId: "t-legacy", toolName: "Bash", toolInput: { command: "legacy-cmd" },
+  })).toBe("allow");
+  // …but it's scoped to that task — a different task can't see it via the
+  // legacy file (only via the global file).
+  await makeTaskWithCwd("t-legacy-sibling");
+  expect(lookupAllowRule({
+    taskId: "t-legacy-sibling", toolName: "Bash", toolInput: { command: "legacy-cmd" },
+  })).toBeNull();
 });
 
 test("registerQuestion resolves with selected + custom from answerQuestion", async () => {

--- a/src/bun/interactions.ts
+++ b/src/bun/interactions.ts
@@ -6,7 +6,7 @@ import {
   matchesPermissionEntry,
   type ApprovalRememberScope,
 } from "../shared/claude-permissions.ts";
-import { tasks } from "./db.ts";
+import { dataDir, tasks } from "./db.ts";
 
 /**
  * In-process registry for user interactions claude needs to drive through
@@ -17,9 +17,12 @@ import { tasks } from "./db.ts";
  * Everything here is in-memory. Pending interactions don't survive an agetor
  * restart, by design: on boot we kill all `agetor-*` tmux sessions, which
  * tears down the curl / MCP children waiting on these promises. Allow-rules
- * (the "Allow always for this task" persistent decisions) live as native
- * claude permission strings in the task cwd's `.claude/settings.local.json`
- * — see `saveAllowRule` / `lookupAllowRule` below.
+ * (the "Allow always" persistent decisions) live as native claude permission
+ * strings in the agetor-global `<dataDir>/settings.local.json`, so an approval
+ * granted in one task auto-allows the same tool call in every other task and
+ * across mode changes. The legacy per-task `.claude/settings.local.json` is
+ * still consulted as a read-only fallback so previously-saved rules keep
+ * working — see `saveAllowRule` / `lookupAllowRule` below.
  */
 
 export type InteractionKind =
@@ -643,12 +646,21 @@ export function countPendingForTask(taskId: string): number {
 
 /* ────────────────────────────────────────────────────────────────────────── *
  * Allow-rules (persistent, stored as native claude permission entries in the
- * task cwd's `.claude/settings.local.json`)
+ * agetor-global `<dataDir>/settings.local.json`)
  *
  * Why this storage shape rather than our own DB table:
- *   1. Human-readable — `cat .claude/settings.local.json` shows everything.
- *   2. Version-controllable — settings.local.json travels with the repo.
- *   3. Mirrors claude's conventions — no parallel system to learn.
+ *   1. Human-readable — `cat ~/.agetor/settings.local.json` shows everything.
+ *   2. Mirrors claude's conventions — no parallel system to learn.
+ *
+ * Why global (one file for all tasks) rather than per-task:
+ *   Approvals are about which tool calls the user trusts on their machine,
+ *   not which they trust *in this repo*. Saving per-task meant the same
+ *   approval card popped up on every new task and after every mode change —
+ *   exactly the friction "Allow always" is supposed to eliminate.
+ *
+ * Back-compat: per-task `.claude/settings.local.json` is still consulted as
+ * a read-only fallback in `lookupAllowRule`, so rules saved by older agetor
+ * builds keep working.
  *
  * Note: claude itself never consults these entries in our setup — our
  * PreToolUse hook always returns a terminal decision before claude's
@@ -664,28 +676,32 @@ export interface AllowRuleArgs {
   toolInput: unknown;
 }
 
-/** Look up whether the task has a saved allow-rule that matches this tool
- *  call. Walks `permissions.allow` in the task's effective settings file.
- *  Returns "allow" on first match, null otherwise. */
+/** Look up whether a saved allow-rule matches this tool call. Consults the
+ *  agetor-global allow-list first (the source of truth for new saves), then
+ *  falls back to the legacy per-task `.claude/settings.local.json` so older
+ *  rules keep working. Returns "allow" on first match, null otherwise. */
 export function lookupAllowRule(args: AllowRuleArgs): "allow" | null {
-  const cwd = resolveTaskCwd(args.taskId);
-  if (!cwd) return null;
-  for (const entry of readPermissionsAllow(cwd)) {
+  for (const entry of readGlobalPermissionsAllow()) {
     if (matchesPermissionEntry(entry, args.toolName, args.toolInput)) return "allow";
+  }
+  const cwd = resolveTaskCwd(args.taskId);
+  if (cwd) {
+    for (const entry of readPermissionsAllow(cwd)) {
+      if (matchesPermissionEntry(entry, args.toolName, args.toolInput)) return "allow";
+    }
   }
   return null;
 }
 
-/** Save an allow-rule for the task. If `entry` is supplied, it's stored
- *  verbatim. Otherwise the most-specific scope for the tool is derived from
- *  `toolInput`. Falls back to the bare tool name if no scope can be
- *  derived (always works). */
+/** Save an allow-rule to the agetor-global allow-list so every task — current
+ *  and future — auto-allows the same call. If `entry` is supplied, it's
+ *  stored verbatim. Otherwise the most-specific scope for the tool is
+ *  derived from `toolInput`. Falls back to the bare tool name if no scope
+ *  can be derived (always works). */
 export function saveAllowRule(args: AllowRuleArgs & { entry?: string }): void {
-  const cwd = resolveTaskCwd(args.taskId);
-  if (!cwd) return;
   const entry = (args.entry && args.entry.trim()) || pickDefaultEntry(args.toolName, args.toolInput);
   if (!entry) return;
-  appendPermissionEntry(cwd, entry);
+  appendGlobalPermissionEntry(entry);
 }
 
 /** Tool names whose `toolInput.file_path` is the canonical scoping key.
@@ -725,12 +741,41 @@ function resolveTaskCwd(taskId: string): string | null {
   return task.worktreePath ?? task.workdir ?? null;
 }
 
-/** Read the `permissions.allow` array from `<cwd>/.claude/settings.local.json`.
- *  Returns an empty array on missing file, parse errors, or unexpected shape
- *  — failing closed (the user just sees more cards, not fewer) is the right
- *  failure mode here. */
+/** Path to the agetor-global allow-list. Lives at the root of dataDir
+ *  (not under `.claude/`) because it isn't claude's settings — it's
+ *  agetor's, just borrowing claude's permission-entry format as the
+ *  on-disk shape. */
+function globalAllowFile(): string {
+  return path.join(dataDir, "settings.local.json");
+}
+
+/** Read the `permissions.allow` array from the agetor-global settings file.
+ *  Same fail-closed semantics as `readPermissionsAllow`. */
+function readGlobalPermissionsAllow(): string[] {
+  return readPermissionsAllowFromFile(globalAllowFile());
+}
+
+/** Append a single `permissions.allow` entry to the agetor-global settings
+ *  file. Creates `<dataDir>/settings.local.json` if missing. Merge-safe:
+ *  preserves all other keys, dedupes against existing entries, atomic
+ *  rename on write. */
+function appendGlobalPermissionEntry(entry: string): void {
+  mkdirSync(dataDir, { recursive: true });
+  appendPermissionEntryToFile(globalAllowFile(), entry);
+}
+
+/** Read the `permissions.allow` array from a legacy per-task settings file.
+ *  Kept so `lookupAllowRule` can still surface rules saved by older agetor
+ *  builds (which wrote per-cwd) — see the back-compat note on the
+ *  allow-rules section header. Returns an empty array on missing file,
+ *  parse errors, or unexpected shape — failing closed (the user just sees
+ *  more cards, not fewer) is the right failure mode here. */
 function readPermissionsAllow(cwd: string): string[] {
-  const file = path.join(cwd, ".claude", "settings.local.json");
+  return readPermissionsAllowFromFile(path.join(cwd, ".claude", "settings.local.json"));
+}
+
+/** Shared reader used by both the global and per-task allow-list helpers. */
+function readPermissionsAllowFromFile(file: string): string[] {
   if (!existsSync(file)) return [];
   let raw: string;
   try {
@@ -753,15 +798,12 @@ function readPermissionsAllow(cwd: string): string[] {
   return allow.filter((e): e is string => typeof e === "string");
 }
 
-/** Append a single `permissions.allow` entry to the task's settings file.
- *  Merge-safe: preserves all other keys, dedupes against existing entries.
- *  Creates the file if missing. Logs and skips on malformed pre-existing
- *  JSON rather than overwriting the user's edits. */
-function appendPermissionEntry(cwd: string, entry: string): void {
-  const dir = path.join(cwd, ".claude");
-  mkdirSync(dir, { recursive: true });
-  const file = path.join(dir, "settings.local.json");
-
+/** Atomic, merge-safe writer for a `{ permissions: { allow: [...] } }`
+ *  settings file. Preserves all other keys, dedupes against existing
+ *  entries, logs and skips on malformed pre-existing JSON rather than
+ *  overwriting the user's edits. Caller is responsible for ensuring the
+ *  parent directory exists. */
+function appendPermissionEntryToFile(file: string, entry: string): void {
   let settings: Record<string, unknown> = {};
   if (existsSync(file)) {
     let raw: string;


### PR DESCRIPTION
Saved permission rules now live in a single agetor-global file (<dataDir>/settings.local.json) instead of each task's <cwd>/.claude/settings.local.json, so approving a tool call on one task auto-allows the same call on every other task and survives mode changes. lookupAllowRule still consults the legacy per-task file as a read-only fallback so rules saved by older builds keep working. Plan-mode safety carve-out is unchanged.