### PR TITLE
feat(kanban): add git diff viewer modal from task card and details

### DIFF
--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -33,7 +33,7 @@ import {
   markTmuxPromptAnswered,
   sessionExists,
 } from "./claude-tmux.ts";
-import { listBranches } from "./worktree.ts";
+import { getTaskDiff, listBranches } from "./worktree.ts";
 import { listAvailableCommands } from "./commands.ts";
 import { getDiscoveredModels, refreshDiscoveredModels } from "./agent-discovery.ts";
 import { getMainWindow } from "./window.ts";
@@ -786,6 +786,16 @@ export function startApiServer() {
 
       "/tasks/:id/runs": {
         GET: authed((req) => json(runs.listForTask(req.params.id), { headers: corsHeaders(req) })),
+      },
+
+      // Everything the task's worktree changed vs its pinned base ref. Returns
+      // a friendly `note` (empty `files`) when there's no worktree or no diff.
+      "/tasks/:id/diff": {
+        GET: authed(async (req) => {
+          const t = tasks.get(req.params.id);
+          if (!t) return json({ error: "not found" }, { status: 404, headers: corsHeaders(req) });
+          return json(await getTaskDiff(t), { headers: corsHeaders(req) });
+        }),
       },
 
       "/runs/:id/cancel": {

--- a/src/bun/worktree.test.ts
+++ b/src/bun/worktree.test.ts
@@ -172,6 +172,83 @@ test("prepareWorkdir re-attaches existing branch when worktree dir was manually 
   expect(log).toContain("agent work");
 });
 
+test("getTaskDiff returns a friendly note when the task has no worktree", async () => {
+  const { getTaskDiff } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  const off = await getTaskDiff(fakeTask({ workdir: repo, isolation: "none" }));
+  expect(off.files).toEqual([]);
+  expect(off.note).toContain("worktree isolation");
+
+  const notYet = await getTaskDiff(fakeTask({ workdir: repo, worktreePath: null }));
+  expect(notYet.files).toEqual([]);
+  expect(notYet.note).toContain("hasn't created a worktree");
+});
+
+test("getTaskDiff reports a clean worktree", async () => {
+  const { prepareWorkdir, getTaskDiff, resolveRef } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  const base = await resolveRef(repo, "HEAD");
+  const task = fakeTask({ workdir: repo, baseRef: base });
+  const prepared = await prepareWorkdir(task);
+  if ("error" in prepared) throw new Error(prepared.error);
+
+  const diff = await getTaskDiff({ ...task, worktreePath: prepared.worktreePath, branch: prepared.branch });
+  expect(diff.files).toEqual([]);
+  expect(diff.note).toContain("No changes");
+  if (base) expect(diff.base).toBe(base.slice(0, 7));
+});
+
+test("getTaskDiff surfaces modified, committed, and newly-created files", async () => {
+  const { prepareWorkdir, getTaskDiff, resolveRef } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  const base = await resolveRef(repo, "HEAD");
+  const task = fakeTask({ workdir: repo, baseRef: base });
+  const prepared = await prepareWorkdir(task);
+  if ("error" in prepared) throw new Error(prepared.error);
+  const cwd = prepared.cwd;
+
+  // Committed change to the tracked README.
+  writeFileSync(path.join(cwd, "README"), "hi\nthere\n");
+  await git(["commit", "-am", "edit readme"], cwd);
+  // Uncommitted new file (untracked).
+  writeFileSync(path.join(cwd, "fresh.txt"), "brand new\n");
+
+  const live = { ...task, worktreePath: prepared.worktreePath, branch: prepared.branch };
+  const diff = await getTaskDiff(live);
+
+  const readme = diff.files.find((f) => f.path === "README");
+  expect(readme).toBeDefined();
+  expect(readme!.status).toBe("modified");
+  expect(readme!.additions).toBeGreaterThan(0);
+  expect(readme!.hunks).toContain("there");
+
+  const fresh = diff.files.find((f) => f.path === "fresh.txt");
+  expect(fresh).toBeDefined();
+  expect(fresh!.status).toBe("added");
+  expect(fresh!.hunks).toContain("brand new");
+});
+
+test("getTaskDiff truncates a huge file's body but keeps honest line counts", async () => {
+  const { prepareWorkdir, getTaskDiff, resolveRef } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  const base = await resolveRef(repo, "HEAD");
+  const task = fakeTask({ workdir: repo, baseRef: base });
+  const prepared = await prepareWorkdir(task);
+  if ("error" in prepared) throw new Error(prepared.error);
+
+  // ~30k lines easily clears the 200 KB per-file cap.
+  const lineCount = 30_000;
+  writeFileSync(path.join(prepared.cwd, "huge.txt"), Array.from({ length: lineCount }, (_, i) => `line ${i}`).join("\n") + "\n");
+
+  const diff = await getTaskDiff({ ...task, worktreePath: prepared.worktreePath, branch: prepared.branch });
+  const huge = diff.files.find((f) => f.path === "huge.txt");
+  expect(huge).toBeDefined();
+  expect(huge!.truncated).toBe(true);
+  // Body is capped, but the additions count reflects the full file, not 0.
+  expect(huge!.hunks.length).toBeLessThanOrEqual(200_000);
+  expect(huge!.additions).toBe(lineCount);
+});
+
 test("removeWorktree tears down both the worktree and the branch", async () => {
   const { prepareWorkdir, removeWorktree } = await import("./worktree.ts");
   const repo = await makeRepo();

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 import { dataDir } from "./db.ts";
-import type { Task } from "../shared/types.ts";
+import type { DiffFile, Task, TaskDiff } from "../shared/types.ts";
 
 const WORKTREES_DIR = path.join(dataDir, "worktrees");
 
@@ -260,6 +260,161 @@ export async function prepareWorkdir(task: Task): Promise<PrepareResult> {
     worktreePath: wt,
     note: `created worktree at ${wt} on ${branch} (${baseLabel})`,
   };
+}
+
+// Hunks larger than this (per file) are truncated before crossing the API so
+// a generated lockfile or vendored blob can't bloat the payload / freeze the
+// renderer. The viewer surfaces the truncation.
+const PER_FILE_HUNK_CAP = 200_000;
+// Process at most this many newly-created (untracked) files. Each costs a
+// `git diff --no-index` spawn, so cap to keep a runaway scratch dir cheap.
+const MAX_UNTRACKED = 200;
+// Cap the total number of changed files crossing the API. A reformat-the-world
+// or accidentally-committed build dir shouldn't ship a multi-MB payload the
+// renderer then has to mount. The viewer surfaces the omission via `note`.
+const MAX_FILES = 500;
+
+/** Strip a leading `a/` or `b/` prefix and un-quote git's C-style path. */
+function cleanPath(raw: string): string | null {
+  let p = raw.trim();
+  if (p === "/dev/null") return null;
+  if (p.startsWith('"') && p.endsWith('"')) {
+    // git quotes paths containing unusual bytes; the escaping overlaps with
+    // JSON for the common cases (spaces, unicode). Best-effort un-quote.
+    try { p = JSON.parse(p) as string; } catch { /* keep quoted form */ }
+  }
+  if (p.startsWith("a/") || p.startsWith("b/")) p = p.slice(2);
+  return p;
+}
+
+/**
+ * Parse `git diff` (unified, --no-color) output into one entry per file.
+ * Sections start at each `diff --git …` line; the body keeps the extended
+ * header (`new file mode`, `rename to`, `Binary files …`) plus the `@@` hunks.
+ */
+function parseGitDiff(raw: string): DiffFile[] {
+  const files: DiffFile[] = [];
+  const headerRe = /^diff --git .*$/gm;
+  const starts: number[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = headerRe.exec(raw))) starts.push(m.index);
+
+  for (let i = 0; i < starts.length; i++) {
+    const section = raw.slice(starts[i], starts[i + 1] ?? raw.length);
+    const lines = section.split("\n");
+    let status: DiffFile["status"] = "modified";
+    let binary = false;
+    let oldPath: string | null = null;
+    let newPath: string | null = null;
+    let renameFrom: string | null = null;
+    let renameTo: string | null = null;
+    let hunkStart = -1;
+
+    for (let j = 1; j < lines.length; j++) {
+      const l = lines[j]!;
+      if (l.startsWith("new file mode")) status = "added";
+      else if (l.startsWith("deleted file mode")) status = "deleted";
+      else if (l.startsWith("rename from ")) { renameFrom = cleanPath(l.slice(12)); status = "renamed"; }
+      else if (l.startsWith("rename to ")) { renameTo = cleanPath(l.slice(10)); status = "renamed"; }
+      else if (l.startsWith("Binary files") || l.startsWith("GIT binary patch")) binary = true;
+      else if (l.startsWith("--- ")) oldPath = cleanPath(l.slice(4));
+      else if (l.startsWith("+++ ")) newPath = cleanPath(l.slice(4));
+      else if (l.startsWith("@@")) { hunkStart = j; break; }
+    }
+
+    const fullHunks = hunkStart >= 0 ? lines.slice(hunkStart).join("\n") : "";
+
+    // Count from the full hunks before any truncation so the summary line
+    // stays honest even when the rendered body is cut. (`+++`/`---` headers
+    // sit before the first `@@`, so they're never in `fullHunks` — the guards
+    // are belt-and-suspenders.)
+    let additions = 0;
+    let deletions = 0;
+    for (const l of fullHunks.split("\n")) {
+      if (l.startsWith("+") && !l.startsWith("+++")) additions++;
+      else if (l.startsWith("-") && !l.startsWith("---")) deletions++;
+    }
+
+    // Cap the rendered body, slicing at a line boundary so the last visible
+    // row isn't a partial line.
+    let hunks = fullHunks;
+    let truncated = false;
+    if (fullHunks.length > PER_FILE_HUNK_CAP) {
+      const cut = fullHunks.lastIndexOf("\n", PER_FILE_HUNK_CAP);
+      hunks = fullHunks.slice(0, cut > 0 ? cut : PER_FILE_HUNK_CAP);
+      truncated = true;
+    }
+
+    files.push({
+      path: renameTo ?? newPath ?? oldPath ?? "(unknown)",
+      oldPath: status === "renamed" ? renameFrom ?? oldPath : null,
+      status,
+      additions,
+      deletions,
+      binary,
+      hunks: binary ? "" : hunks,
+      truncated,
+    });
+  }
+  return files;
+}
+
+/**
+ * Compute everything a task's worktree changed relative to its pinned base ref
+ * — committed AND uncommitted changes to tracked files, plus newly created
+ * (untracked) files synthesized as full additions. Returns a friendly `note`
+ * (and empty `files`) when there's nothing to show: no worktree yet, isolation
+ * off, or a clean tree. Never throws.
+ */
+export async function getTaskDiff(task: Task): Promise<TaskDiff> {
+  if (task.isolation !== "worktree") {
+    return { base: null, files: [], note: "Diff isn't available for tasks running without worktree isolation." };
+  }
+  if (!task.worktreePath || !existsSync(task.worktreePath)) {
+    return { base: null, files: [], note: "This task hasn't created a worktree yet — run it to see its changes here." };
+  }
+
+  const cwd = task.worktreePath;
+  const base = task.baseRef ?? "HEAD";
+  const shortBase = task.baseRef ? task.baseRef.slice(0, 7) : null;
+
+  // Tracked changes (committed + working-tree) vs the pinned base.
+  const tracked = await git(["diff", "--no-color", base], cwd);
+  if (!tracked.ok) {
+    return { base: shortBase, files: [], note: `Could not compute diff: ${tracked.stderr || tracked.stdout || "git diff failed"}` };
+  }
+  const files = parseGitDiff(tracked.stdout);
+
+  // Newly created files aren't part of `git diff <base>`; surface them as
+  // full additions via --no-index (which exits 1 when content differs).
+  const listed = await git(["ls-files", "--others", "--exclude-standard", "-z"], cwd);
+  if (listed.ok) {
+    const rels = listed.stdout.split("\0").filter(Boolean).slice(0, MAX_UNTRACKED);
+    for (const rel of rels) {
+      const res = await git(["diff", "--no-color", "--no-index", "--", "/dev/null", rel], cwd);
+      if (res.exitCode !== 0 && res.exitCode !== 1) continue;
+      const [parsed] = parseGitDiff(res.stdout);
+      files.push(
+        parsed
+          ? { ...parsed, status: "added", path: rel, oldPath: null }
+          : { path: rel, oldPath: null, status: "added", additions: 0, deletions: 0, binary: false, hunks: "", truncated: false },
+      );
+    }
+  }
+
+  if (files.length === 0) {
+    return { base: shortBase, files: [], note: "No changes yet — the worktree matches its base." };
+  }
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  if (files.length > MAX_FILES) {
+    const total = files.length;
+    return {
+      base: shortBase,
+      files: files.slice(0, MAX_FILES),
+      note: `Showing the first ${MAX_FILES} of ${total} changed files — the rest are omitted to keep the viewer responsive.`,
+    };
+  }
+  return { base: shortBase, files };
 }
 
 /**

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { COLUMNS, type AgentStatus, type ColumnId, type GlobalEvent, type Harness, type Project, type Task } from "../shared/types.ts";
 import { AgentIcon } from "@/components/kanban/AgentIcon";
 import { Column } from "@/components/kanban/Column";
+import { DiffDialog } from "@/components/kanban/DiffDialog";
 import { KanbanFilters } from "@/components/kanban/KanbanFilters";
 import { NewTaskForm } from "@/components/kanban/NewTaskForm";
 import { EXIT_DURATION_MS as RUN_PANEL_EXIT_MS, RunPanel } from "@/components/kanban/RunPanel";
@@ -72,6 +73,7 @@ export default function App() {
   const [harnesses, setHarnesses] = useState<Harness[]>([]);
   const [agentModels, setAgentModels] = useState<AgentModelMap>({ "claude-code": [], codex: [] });
   const [selected, setSelected] = useState<Task | null>(null);
+  const [diffTask, setDiffTask] = useState<Task | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
   const [textQuery, setTextQuery] = useState("");
@@ -515,6 +517,7 @@ export default function App() {
                     onCancel={cancel}
                     onDelete={del}
                     onOpen={setSelected}
+                    onDiff={setDiffTask}
                   />
                 ))}
               </div>
@@ -529,6 +532,13 @@ export default function App() {
         agentModels={agentModels}
         homeDir={homeDir}
         onClose={() => setSelected(null)}
+        onShowDiff={setDiffTask}
+      />
+      <DiffDialog
+        open={!!diffTask}
+        taskId={diffTask?.id ?? null}
+        taskTitle={diffTask?.title}
+        onClose={() => setDiffTask(null)}
       />
       <SettingsDialog
         open={settingsOpen}

--- a/src/mainview/components/kanban/Column.tsx
+++ b/src/mainview/components/kanban/Column.tsx
@@ -13,9 +13,10 @@ interface Props {
   onCancel: (t: Task) => void;
   onDelete: (t: Task) => void;
   onOpen: (t: Task) => void;
+  onDiff: (t: Task) => void;
 }
 
-export function Column({ id, label, tasks, homeDir, onStart, onCancel, onDelete, onOpen }: Props) {
+export function Column({ id, label, tasks, homeDir, onStart, onCancel, onDelete, onOpen, onDiff }: Props) {
   const { setNodeRef, isOver } = useDroppable({ id });
   return (
     <div
@@ -41,6 +42,7 @@ export function Column({ id, label, tasks, homeDir, onStart, onCancel, onDelete,
             onCancel={onCancel}
             onDelete={onDelete}
             onOpen={onOpen}
+            onDiff={onDiff}
           />
         ))}
       </div>

--- a/src/mainview/components/kanban/DiffDialog.tsx
+++ b/src/mainview/components/kanban/DiffDialog.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  AlertCircle, ChevronDown, ChevronRight, FileMinus, FilePen, FilePlus,
+  FileSymlink, GitCompare, Loader2,
+} from "lucide-react";
+import { Dialog } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { api } from "@/lib/api";
+import type { DiffFile, TaskDiff } from "../../../shared/types.ts";
+
+interface Props {
+  open: boolean;
+  taskId: string | null;
+  taskTitle?: string;
+  onClose: () => void;
+}
+
+const STATUS_META: Record<DiffFile["status"], { label: string; icon: typeof FilePlus; cls: string }> = {
+  added: { label: "added", icon: FilePlus, cls: "text-emerald-400" },
+  modified: { label: "modified", icon: FilePen, cls: "text-amber-400" },
+  deleted: { label: "deleted", icon: FileMinus, cls: "text-rose-400" },
+  renamed: { label: "renamed", icon: FileSymlink, cls: "text-sky-400" },
+};
+
+/**
+ * Read-only viewer for everything a task's worktree changed vs its pinned base
+ * ref. Fetches on open, renders a per-file collapsible unified diff. When the
+ * task has no worktree (or nothing changed) the server returns a friendly
+ * `note` which we show in place of the file list.
+ */
+export function DiffDialog({ open, taskId, taskTitle, onClose }: Props) {
+  const [diff, setDiff] = useState<TaskDiff | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [openFiles, setOpenFiles] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!open || !taskId) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setDiff(null);
+    api
+      .getTaskDiff(taskId)
+      .then((d) => {
+        if (cancelled) return;
+        setDiff(d);
+        // Expand everything by default for small change sets; keep large ones
+        // collapsed so the dialog stays responsive.
+        setOpenFiles(d.files.length <= 8 ? new Set(d.files.map((f) => f.path)) : new Set());
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [open, taskId]);
+
+  const totals = useMemo(() => {
+    const files = diff?.files ?? [];
+    return files.reduce(
+      (acc, f) => ({ additions: acc.additions + f.additions, deletions: acc.deletions + f.deletions }),
+      { additions: 0, deletions: 0 },
+    );
+  }, [diff]);
+
+  const toggle = (path: string) =>
+    setOpenFiles((prev) => {
+      const next = new Set(prev);
+      next.has(path) ? next.delete(path) : next.add(path);
+      return next;
+    });
+
+  const allOpen = !!diff && diff.files.length > 0 && openFiles.size === diff.files.length;
+  const setAll = (on: boolean) =>
+    setOpenFiles(on && diff ? new Set(diff.files.map((f) => f.path)) : new Set());
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      labelledBy="diff-dialog-title"
+      className="flex max-h-[85vh] w-full max-w-4xl flex-col p-0"
+    >
+      <header className="flex items-start justify-between gap-3 border-b border-border/60 p-3">
+        <div className="min-w-0">
+          <div id="diff-dialog-title" className="flex items-center gap-2 text-sm font-semibold">
+            <GitCompare className="size-4 shrink-0 text-muted-foreground" />
+            Changes
+          </div>
+          <div className="mt-0.5 truncate text-xs text-muted-foreground">
+            {taskTitle ?? "Task"}
+            {diff?.base && <> · vs base <span className="font-mono">{diff.base}</span></>}
+          </div>
+        </div>
+        {diff && diff.files.length > 0 && (
+          <div className="flex shrink-0 items-center gap-3 text-xs">
+            <span className="font-mono">
+              {diff.files.length} {diff.files.length === 1 ? "file" : "files"}
+              {" "}
+              <span className="text-emerald-400">+{totals.additions}</span>{" "}
+              <span className="text-rose-400">−{totals.deletions}</span>
+            </span>
+            <Button size="sm" variant="ghost" onClick={() => setAll(!allOpen)}>
+              {allOpen ? "Collapse all" : "Expand all"}
+            </Button>
+          </div>
+        )}
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        {loading && (
+          <div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" /> Loading diff…
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="flex items-center justify-center gap-2 py-12 text-sm text-rose-400">
+            <AlertCircle className="size-4" /> {error}
+          </div>
+        )}
+
+        {!loading && !error && diff && diff.files.length === 0 && (
+          <div className="flex flex-col items-center justify-center gap-2 py-12 text-center text-sm text-muted-foreground">
+            <GitCompare className="size-6 opacity-40" />
+            {diff.note ?? "No changes to show."}
+          </div>
+        )}
+
+        {!loading && !error && diff && diff.files.length > 0 && (
+          <div className="flex flex-col gap-2">
+            {diff.note && (
+              <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+                {diff.note}
+              </div>
+            )}
+            {diff.files.map((f) => (
+              <FileBlock
+                key={f.path}
+                file={f}
+                open={openFiles.has(f.path)}
+                onToggle={() => toggle(f.path)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+}
+
+function FileBlock({ file, open, onToggle }: { file: DiffFile; open: boolean; onToggle: () => void }) {
+  const meta = STATUS_META[file.status];
+  const Icon = meta.icon;
+  return (
+    <div className="overflow-hidden rounded-md border border-border/60">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 bg-muted/40 px-2 py-1.5 text-left hover:bg-muted/70"
+      >
+        {open ? <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" /> : <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />}
+        <Icon className={cn("size-3.5 shrink-0", meta.cls)} />
+        <span className="min-w-0 flex-1 truncate font-mono text-xs">
+          {file.oldPath && <span className="text-muted-foreground">{file.oldPath} → </span>}
+          {file.path}
+        </span>
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+          {file.binary ? "binary" : <><span className="text-emerald-400">+{file.additions}</span> <span className="text-rose-400">−{file.deletions}</span></>}
+        </span>
+      </button>
+      {open && (
+        file.binary ? (
+          <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file — no textual diff.</div>
+        ) : (
+          <>
+            <DiffBody hunks={file.hunks} />
+            {file.truncated && (
+              <div className="border-t border-border/60 px-3 py-1.5 text-[11px] italic text-muted-foreground">
+                Diff truncated — this file's changes are too large to display in full.
+              </div>
+            )}
+          </>
+        )
+      )}
+    </div>
+  );
+}
+
+interface Row { old: number | null; neu: number | null; kind: "ctx" | "add" | "del" | "hunk" | "meta"; text: string }
+
+/** Turn a file's unified-diff hunks into numbered rows. */
+function toRows(hunks: string): Row[] {
+  const rows: Row[] = [];
+  let oldNo = 0;
+  let newNo = 0;
+  for (const line of hunks.split("\n")) {
+    if (line.startsWith("@@")) {
+      const m = /@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+      if (m) { oldNo = Number(m[1]); newNo = Number(m[2]); }
+      rows.push({ old: null, neu: null, kind: "hunk", text: line });
+    } else if (line.startsWith("+")) {
+      rows.push({ old: null, neu: newNo++, kind: "add", text: line.slice(1) });
+    } else if (line.startsWith("-")) {
+      rows.push({ old: oldNo++, neu: null, kind: "del", text: line.slice(1) });
+    } else if (line.startsWith("\\")) {
+      // "\ No newline at end of file"
+      rows.push({ old: null, neu: null, kind: "meta", text: line });
+    } else {
+      rows.push({ old: oldNo++, neu: newNo++, kind: "ctx", text: line.startsWith(" ") ? line.slice(1) : line });
+    }
+  }
+  // Drop a trailing empty context row produced by the final newline.
+  if (rows.length && rows[rows.length - 1]!.kind === "ctx" && rows[rows.length - 1]!.text === "") rows.pop();
+  return rows;
+}
+
+function DiffBody({ hunks }: { hunks: string }) {
+  const rows = useMemo(() => toRows(hunks), [hunks]);
+  return (
+    <div className="overflow-x-auto bg-card font-mono text-xs leading-relaxed">
+      {rows.map((r, i) => (
+        <div
+          key={i}
+          className={cn(
+            "flex",
+            r.kind === "add" && "bg-emerald-500/10",
+            r.kind === "del" && "bg-rose-500/10",
+            r.kind === "hunk" && "bg-sky-500/10 text-sky-300",
+            r.kind === "meta" && "text-muted-foreground",
+          )}
+        >
+          <span className="w-10 shrink-0 select-none border-r border-border/40 px-1 text-right text-muted-foreground/60">
+            {r.old ?? ""}
+          </span>
+          <span className="w-10 shrink-0 select-none border-r border-border/40 px-1 text-right text-muted-foreground/60">
+            {r.neu ?? ""}
+          </span>
+          <span
+            className={cn(
+              "shrink-0 select-none px-1 text-center",
+              r.kind === "add" && "text-emerald-400",
+              r.kind === "del" && "text-rose-400",
+            )}
+          >
+            {r.kind === "add" ? "+" : r.kind === "del" ? "−" : " "}
+          </span>
+          <span className="whitespace-pre px-1">{r.text || " "}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
   Bot, ClipboardList, FolderOpen, FileText, FilePenLine, FilePlus, Folder,
-  Globe, HelpCircle, ListTodo, MessageSquareQuote, Plug, Search, Send, Slash,
+  GitCompare, Globe, HelpCircle, ListTodo, MessageSquareQuote, Plug, Search, Send, Slash,
   Sparkles, Square, Terminal, Wrench, X,
 } from "lucide-react";
 import { api, type AgentModelMap, type AvailableCommand, type PendingInteraction } from "@/lib/api";
@@ -53,6 +53,8 @@ interface Props {
   agentModels: AgentModelMap;
   homeDir: string;
   onClose: () => void;
+  /** Open the git diff viewer for the given task. */
+  onShowDiff: (task: Task) => void;
 }
 
 const STATUS_VARIANT: Record<Run["status"], "default" | "secondary" | "outline" | "destructive"> = {
@@ -90,7 +92,7 @@ function formatTime(ts: number): string {
  * the kanban behind it stays visible but de-emphasized. The panel keeps the
  * last task mounted during the exit animation so the slide-out doesn't snap.
  */
-export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClose }: Props) {
+export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClose, onShowDiff }: Props) {
   // `mountedTask` lags behind `task` so that when the parent sets task → null
   // we keep rendering the old contents while the exit animation plays.
   const [mountedTask, setMountedTask] = useState<Task | null>(task);
@@ -169,6 +171,7 @@ export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClos
           agentModels={agentModels}
           homeDir={homeDir}
           onClose={onClose}
+          onShowDiff={onShowDiff}
         />
       </aside>
     </>
@@ -186,6 +189,7 @@ function RunPanelBody({
   agentModels,
   homeDir,
   onClose,
+  onShowDiff,
 }: {
   task: Task;
   agents: AgentStatus[];
@@ -193,6 +197,7 @@ function RunPanelBody({
   agentModels: AgentModelMap;
   homeDir: string;
   onClose: () => void;
+  onShowDiff: (task: Task) => void;
 }) {
   const kind = harnessKindOf(task.agent, harnesses);
   const [runs, setRuns] = useState<Run[]>([]);
@@ -547,6 +552,14 @@ function RunPanelBody({
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onShowDiff(task)}
+            title="View this task's changes (git diff)"
+          >
+            <GitCompare className="mr-1 size-3" /> Diff
+          </Button>
           <Button
             size="sm"
             variant="outline"

--- a/src/mainview/components/kanban/TaskCard.tsx
+++ b/src/mainview/components/kanban/TaskCard.tsx
@@ -1,6 +1,6 @@
 import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
-import { ArrowRight, FolderOpen, GitBranch, MessageCircleQuestion, Play, Square, Trash2 } from "lucide-react";
+import { ArrowRight, FolderOpen, GitBranch, GitCompare, MessageCircleQuestion, Play, Square, Trash2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -15,9 +15,10 @@ interface Props {
   onCancel: (t: Task) => void;
   onDelete: (t: Task) => void;
   onOpen: (t: Task) => void;
+  onDiff: (t: Task) => void;
 }
 
-export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen }: Props) {
+export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDiff }: Props) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: task.id,
   });
@@ -129,6 +130,9 @@ export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen }:
               <Square className="size-3" />
             </Button>
           )}
+          <Button size="icon" variant="ghost" onClick={() => onDiff(task)} title="View changes (git diff)">
+            <GitCompare className="size-3" />
+          </Button>
           <Button size="icon" variant="ghost" onClick={() => onDelete(task)} title="Delete task">
             <Trash2 className="size-3" />
           </Button>

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   Run,
   RunEvent,
   Task,
+  TaskDiff,
   TaskReference,
   UpdateStatus,
 } from "../../shared/types.ts";
@@ -277,6 +278,9 @@ export const api = {
   deleteTask: (id: string) => j<void>(`/tasks/${id}`, { method: "DELETE" }),
   startTask: (id: string) => j<{ runId: string }>(`/tasks/${id}/start`, { method: "POST" }),
   listRuns: (taskId: string) => j<Run[]>(`/tasks/${taskId}/runs`),
+  /** Everything the task's worktree changed vs its pinned base. Empty `files`
+   *  + a `note` when there's no worktree or no diff. */
+  getTaskDiff: (taskId: string) => j<TaskDiff>(`/tasks/${taskId}/diff`),
   cancelRun: (runId: string) =>
     j<{ cancelled: boolean }>(`/runs/${runId}/cancel`, { method: "POST" }),
   sendRunInput: (runId: string, line: string) =>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -492,6 +492,46 @@ export interface Run {
   claudeSessionId: string | null;
 }
 
+/** One changed file in a task's git diff (worktree vs its pinned base). */
+export interface DiffFile {
+  /** Repo-relative path of the file in its new state. */
+  path: string;
+  /** Previous path for renames; null otherwise. */
+  oldPath: string | null;
+  status: "added" | "modified" | "deleted" | "renamed";
+  /** Lines added (`+`) in this file's hunks. 0 for binary. */
+  additions: number;
+  /** Lines removed (`-`) in this file's hunks. 0 for binary. */
+  deletions: number;
+  /** True when git reports the file as binary (no textual hunks). */
+  binary: boolean;
+  /**
+   * Unified-diff body for this file (the `@@ … @@` hunks, without the
+   * `diff --git` header). Empty for binary files. May be truncated — see
+   * `truncated`.
+   */
+  hunks: string;
+  /** True when `hunks` was cut off because the file's diff was very large. */
+  truncated: boolean;
+}
+
+/**
+ * A task's git diff: everything its worktree changed relative to the pinned
+ * base ref (committed + uncommitted + newly created files). Returned by
+ * `GET /tasks/:id/diff`.
+ */
+export interface TaskDiff {
+  /** Short base sha the diff is computed against, or null when not applicable. */
+  base: string | null;
+  files: DiffFile[];
+  /**
+   * Friendly explanation when there's nothing to show — e.g. the task has no
+   * worktree yet, isolation is off, or the worktree is clean. Absent when
+   * `files` is non-empty.
+   */
+  note?: string;
+}
+
 /**
  * Streams the run panel listens on. Codex (and any unstructured agent)
  * uses the flat trio: stdout / stderr / status. Claude's JSONL is parsed


### PR DESCRIPTION
Open a read-only diff viewer for a task's worktree changes from either a GitCompare icon on the task card or a Diff button in the Task Details (RunPanel) header.

- New GET /tasks/:id/diff: getTaskDiff() in worktree.ts computes everything the worktree changed vs its pinned base ref — committed + uncommitted tracked changes plus newly created (untracked) files synthesized as additions via `git diff --no-index`. Returns a friendly note (empty files) for no-worktree / isolation-off / clean-tree cases. Per-file body capped at 200KB (sliced at a line boundary, counts taken from the full hunks) and the total file list capped at 500, each surfaced via note.
- DiffDialog renders per-file collapsible unified diffs with line numbers and +/- coloring, a summary header, and expand/collapse-all; no new deps.
- Shared DiffFile/TaskDiff types; api.getTaskDiff client method.
- Tests for no-worktree, clean tree, modified+committed+untracked, and truncation count honesty.