### PR TITLE
fix(claude-tmux): handle claude 2.1.x event types and reattach end_turn dedup

### DIFF
--- a/src/bun/claude-tmux.test.ts
+++ b/src/bun/claude-tmux.test.ts
@@ -154,6 +154,125 @@ test("mapJsonlEventToChunks: assistant with stop_reason=end_turn signals endOfTu
   expect(status?.data).toBe("turn complete");
 });
 
+test("mapJsonlEventToChunks: system{subtype:turn_duration} emits the duration as a status breadcrumb", () => {
+  // Claude 2.1.x writes a `system{subtype:"turn_duration"}` line right
+  // after the assistant end_turn. The end_turn itself already produced
+  // "turn complete"; this just adds the duration so the user sees at a
+  // glance whether the turn was quick or long.
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({
+    type: "system",
+    subtype: "turn_duration",
+    durationMs: 52647,
+    uuid: "9e139a67-4473-4578-bae0-9ce18c651c76",
+  });
+  const res = mapJsonlEventToChunks(line, onChunk);
+  expect(res.endOfTurn).toBe(false);
+  expect(out).toEqual([{ stream: "status", data: "turn duration: 53s" }]);
+});
+
+test("mapJsonlEventToChunks: system{subtype:away_summary} stays silent (resumption context, not user-relevant)", () => {
+  // away_summary is claude's own recap of what just happened, written for
+  // its future-self on resume. Surfacing it as a breadcrumb would just
+  // duplicate the assistant text the user already read.
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({
+    type: "system",
+    subtype: "away_summary",
+    content: "Goal was building the X feature; finished applying review fixes.",
+    uuid: "f85ee077-f89c-494e-9c50-951d29c76ddd",
+  });
+  mapJsonlEventToChunks(line, onChunk);
+  expect(out).toEqual([]);
+});
+
+test("mapJsonlEventToChunks: queue-operation enqueue with a task-notification payload becomes a background-task breadcrumb", () => {
+  // Claude 2.1.x delivers background-task completion notifications via
+  // `queue-operation` events; older versions delivered the same content
+  // as synthetic `user` entries with `origin.kind: "task-notification"`.
+  // The user-facing breadcrumb is the same — extract the `<summary>` and
+  // prefix with `background task:`.
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({
+    type: "queue-operation",
+    operation: "enqueue",
+    content: "<task-notification>\n<task-id>bt7k1k0qf</task-id>\n<summary>Background command \"Wait for dev server ready\" completed (exit code 0)</summary>\n</task-notification>",
+  });
+  mapJsonlEventToChunks(line, onChunk);
+  expect(out).toEqual([{
+    stream: "status",
+    data: `background task: Background command "Wait for dev server ready" completed (exit code 0)`,
+  }]);
+});
+
+test("mapJsonlEventToChunks: queue-operation remove stays silent (just the dequeue half of an enqueue/remove pair)", () => {
+  // The `remove` half is claude popping the notification off its input
+  // queue once it's been processed — it carries no content the user
+  // hasn't already seen from the matching `enqueue`.
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({ type: "queue-operation", operation: "remove" });
+  mapJsonlEventToChunks(line, onChunk);
+  expect(out).toEqual([]);
+});
+
+test("mapJsonlEventToChunks: queue-operation enqueue with a task-notification but no <summary> emits a generic 'completed' breadcrumb", () => {
+  // Mirrors the existing user/origin.kind handler's fallback so both
+  // delivery paths (synthetic user entry vs. queue-operation) produce
+  // the same UX for the same logical event. Without this, a 2.1.x
+  // task-notification payload missing its `<summary>` would go dark in
+  // the run panel even though something measurable completed.
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({
+    type: "queue-operation",
+    operation: "enqueue",
+    content: "<task-notification>\n<task-id>abc</task-id>\n<status>completed</status>\n</task-notification>",
+  });
+  mapJsonlEventToChunks(line, onChunk);
+  expect(out).toEqual([{ stream: "status", data: "background task completed" }]);
+});
+
+test("mapJsonlEventToChunks: queue-operation enqueue of an unrecognised payload type stays silent (no raw XML in the panel)", () => {
+  // Non-task-notification enqueues (future event kinds claude might
+  // queue) shouldn't dump arbitrary content into the user's run panel.
+  // The task-notification prefix check is the only allow-listed
+  // generic fallback.
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({
+    type: "queue-operation",
+    operation: "enqueue",
+    content: "<some-future-payload>opaque content</some-future-payload>",
+  });
+  mapJsonlEventToChunks(line, onChunk);
+  expect(out).toEqual([]);
+});
+
+test("formatTurnDuration: rolls 59999ms over to '1m' rather than printing '60s'", async () => {
+  // Round-then-branch boundary check. With a naive `(ms/1000).toFixed(0)`
+  // inside the `< 60_000` branch, 59999ms would render as "60s" — visually
+  // jarring next to a turn that's clearly already a minute. The roll-over
+  // matters for any duration that lands within 500ms of a minute boundary.
+  const { mapJsonlEventToChunks } = await import("./claude-tmux.ts");
+  const cases: Array<{ ms: number; expected: string }> = [
+    { ms: 250, expected: "250ms" },
+    { ms: 1500, expected: "1.5s" },
+    { ms: 9999, expected: "10.0s" },
+    { ms: 52647, expected: "53s" },
+    { ms: 59_499, expected: "59s" },
+    { ms: 59_999, expected: "1m" },
+    { ms: 60_000, expected: "1m" },
+    { ms: 90_500, expected: "1m 31s" },
+    { ms: 3_600_000, expected: "60m" },
+  ];
+  for (const { ms, expected } of cases) {
+    const out: { stream: string; data: string }[] = [];
+    mapJsonlEventToChunks(
+      JSON.stringify({ type: "system", subtype: "turn_duration", durationMs: ms, uuid: `dur-${ms}` }),
+      (stream, data) => out.push({ stream, data }),
+    );
+    expect(out[0]?.data).toBe(`turn duration: ${expected}`);
+  }
+});
+
 test("mapJsonlEventToChunks: user.content[].tool_result → `tool_result` stream with JSON payload", () => {
   const { out, onChunk } = recorder();
   const line = JSON.stringify({
@@ -513,6 +632,109 @@ test("system event updates state.permissionMode (dispatchLine path)", async () =
     JSON.stringify({ type: "permission-mode", permissionMode: "auto" }),
   );
   expect(state.permissionMode).toBe("auto");
+  __forTest.uninstallSession(taskId);
+});
+
+test("dispatchLine: already-seen end_turn still fires onEndOfTurn (reattach + crashed-before-status-update path)", async () => {
+  // Reattach scenario where agetor died in the narrow window between
+  // persisting the end_turn line to `run_events` and updating the run
+  // row to `succeeded`: on restart, seenLineUuids is pre-seeded from
+  // run_events, so the JSONL replay's end_turn line hits the dedup
+  // path. Without the popEndOfTurn carve-out, the slot/onEndOfTurn
+  // bookkeeping never runs and the run stays `running` forever — the
+  // exact UI symptom (badge stuck on "in progress" while the agent
+  // is actually done) that motivated this fix.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-end-turn-dedup-reattach";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+
+  let endOfTurnFired = false;
+  state.onEndOfTurn = () => { endOfTurnFired = true; };
+
+  // Seed the dedup set so the end_turn line is treated as already-seen,
+  // matching what `runs.seenLineUuids(runId)` would return on restart.
+  state.seenLineUuids.add("end-turn-uuid-1");
+
+  // Also: emitted chunks must NOT include this line's content — the prior
+  // process already broadcast it to SSE + persisted it to run_events.
+  const emitted: { stream: string; data: string }[] = [];
+  state.lastChunk = (stream, data) => emitted.push({ stream, data });
+
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "assistant",
+    uuid: "end-turn-uuid-1",
+    message: { role: "assistant", content: [{ type: "text", text: "done" }], stop_reason: "end_turn" },
+  }));
+
+  expect(endOfTurnFired).toBe(true);
+  // No duplicate "turn complete" / "done" — the prior process already
+  // emitted those.
+  expect(emitted).toEqual([]);
+  __forTest.uninstallSession(taskId);
+});
+
+test("dispatchLine: already-seen NON-end_turn line does NOT touch the turn queue or fire onEndOfTurn", async () => {
+  // Inverse of the end_turn carve-out: only end_turn lines should drive
+  // queue bookkeeping on the dedup path. A replayed tool_use or text
+  // assistant line must skip cleanly, leaving turnQueue + onEndOfTurn
+  // untouched. Guards against accidental over-trigger if isEndOfTurnEvent
+  // ever gets widened (e.g. to other stop_reason values).
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-non-end-turn-dedup";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+
+  // Push a slot and install an onEndOfTurn — both should survive the dispatch.
+  const recorded: { stream: string; data: string }[] = [];
+  void __forTest.pushTurnSlot(state, (stream, data) => {
+    recorded.push({ stream, data });
+  });
+  let endOfTurnFired = false;
+  state.onEndOfTurn = () => { endOfTurnFired = true; };
+
+  state.seenLineUuids.add("tool-use-uuid");
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "assistant",
+    uuid: "tool-use-uuid",
+    message: { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "Bash", input: {} }], stop_reason: "tool_use" },
+  }));
+
+  // Slot still queued, listener still armed, no chunk re-emitted.
+  expect(state.turnQueue.length).toBe(1);
+  expect(state.onEndOfTurn).not.toBeNull();
+  expect(endOfTurnFired).toBe(false);
+  expect(recorded).toEqual([]);
+  __forTest.uninstallSession(taskId);
+});
+
+test("dispatchLine: already-seen end_turn pops the head turn slot (mid-pipeline dedup edge case)", async () => {
+  // Same carve-out, but for the live-stream path: if for any reason a
+  // duplicate end_turn line gets dispatched (e.g. a watcher fired and a
+  // sync flush both reached the same offset across an unlucky await
+  // suspension), we still want to advance the queue exactly once and
+  // resolve the head slot's `done` — not leak the slot.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-end-turn-dedup-live";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+
+  const recorded: { stream: string; data: string }[] = [];
+  const donePromise = __forTest.pushTurnSlot(state, (stream, data) => {
+    recorded.push({ stream, data });
+  });
+
+  state.seenLineUuids.add("end-turn-uuid-2");
+
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "assistant",
+    uuid: "end-turn-uuid-2",
+    message: { role: "assistant", content: [], stop_reason: "end_turn" },
+  }));
+
+  // Slot popped, no chunks re-emitted on the slot's handler.
+  expect(state.turnQueue.length).toBe(0);
+  expect(recorded).toEqual([]);
+  // The slot's `done` promise resolves with exit code 0 (the dedup'd
+  // line was a real end_turn, just one we already saw).
+  expect(await donePromise).toBe(0);
   __forTest.uninstallSession(taskId);
 });
 

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -282,6 +282,11 @@ interface UserMessage {
  */
 interface ParsedJsonlEvent {
   type?: string;
+  /** Claude 2.1.x system events carry a `subtype` discriminator — observed
+   *  values: `turn_duration` (durationMs + messageCount, emitted right after
+   *  an assistant end_turn) and `away_summary` (recap text claude generated
+   *  for resumption). Older events leave this null. */
+  subtype?: string;
   uuid?: string;
   message?: AssistantMessage & UserMessage;
   permissionMode?: string;
@@ -300,6 +305,45 @@ interface ParsedJsonlEvent {
    *  "not a real turn" marker. We demote any isMeta entry to a status
    *  breadcrumb. `origin.kind` (above) is a narrower, nicer-summarized subset. */
   isMeta?: boolean;
+  /** Claude 2.1.x `queue-operation` events carry `operation` (`enqueue` /
+   *  `remove`) and, on enqueue, a string `content` payload. This is where
+   *  background task-notifications now arrive — older versions delivered
+   *  them as synthetic `user` entries with `origin.kind: "task-notification"`. */
+  operation?: string;
+  content?: string;
+  /** `system{subtype:"turn_duration"}` carries the turn's wall-clock duration
+   *  in milliseconds — surfaced as a status breadcrumb so the user sees how
+   *  long the turn took. */
+  durationMs?: number;
+}
+
+/**
+ * True for the assistant message that ends a turn. Pulled out so the dispatch
+ * loop can decide whether a JSONL line drives queue bookkeeping (slot pop /
+ * onEndOfTurn fire) WITHOUT first running `mapParsedEventToChunks` — that
+ * matters for the dedup path, which must still pop the slot for end_turn
+ * lines we've already replayed in a prior process, but must NOT re-emit any
+ * user-visible chunks.
+ */
+function isEndOfTurnEvent(evt: ParsedJsonlEvent): boolean {
+  return evt.type === "assistant" && evt.message?.stop_reason === "end_turn";
+}
+
+/** Human-friendly millisecond formatter for `turn_duration` breadcrumbs.
+ *  Mirrors how the rest of the run panel writes durations (seconds for
+ *  short turns; minutes+seconds beyond a minute). Kept inline rather than
+ *  pulled from a shared util because this is the only consumer and the
+ *  rules are trivial. */
+function formatTurnDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  // Round to whole seconds first, then branch — otherwise 59_999ms
+  // rounds-to-print as "60s" instead of rolling over to "1m".
+  if (ms < 10_000) return `${(ms / 1000).toFixed(1)}s`;
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds - m * 60;
+  return s === 0 ? `${m}m` : `${m}m ${s}s`;
 }
 
 export function mapJsonlEventToChunks(
@@ -464,6 +508,14 @@ function mapParsedEventToChunks(
     case "permission-mode":
       if (evt.permissionMode) {
         onChunk("status", `permission-mode: ${evt.permissionMode}`, uuid);
+      } else if (evt.subtype === "turn_duration" && typeof evt.durationMs === "number") {
+        // Emitted right after the assistant end_turn. The end_turn itself
+        // already produced a "turn complete" status; this just adds the
+        // duration so the user can see at a glance whether the turn was
+        // quick or long. The `away_summary` subtype that sometimes follows
+        // stays silent — it's claude's own resumption context, not
+        // user-relevant.
+        onChunk("status", `turn duration: ${formatTurnDuration(evt.durationMs)}`, uuid);
       }
       return { endOfTurn: false, lineUuid: uuid };
 
@@ -472,6 +524,33 @@ function mapParsedEventToChunks(
       // rolled up. Useful breadcrumb in the log.
       if (evt.summary) onChunk("status", `summary: ${evt.summary}`, uuid);
       return { endOfTurn: false, lineUuid: uuid };
+
+    case "queue-operation": {
+      // Claude 2.1.x delivers background-task completion notifications via
+      // queue-operation events: `enqueue` carries the `<task-notification>`
+      // payload, `remove` is the matching pop once claude has consumed it.
+      // Older versions used a synthetic `user` event with
+      // `origin.kind: "task-notification"` (the user branch above still
+      // handles that for forward/backward compat). queue-operation lines
+      // carry `uuid: null` so they bypass the seenLineUuids dedup
+      // entirely — that's fine, each enqueue is broadcast once per
+      // process and reattach hits a different file offset.
+      if (evt.operation === "enqueue" && typeof evt.content === "string") {
+        const summary = /<summary>([\s\S]*?)<\/summary>/.exec(evt.content)?.[1]?.trim();
+        // Mirror the existing user/origin.kind handler's fallback: when a
+        // task-notification payload arrives without a `<summary>` (older
+        // claude builds, malformed content, future variants), emit a
+        // generic "completed" breadcrumb rather than dropping the event
+        // silently — something measurable happened, and the run panel
+        // shouldn't go dark on it.
+        if (summary) {
+          onChunk("status", `background task: ${summary}`, uuid);
+        } else if (evt.content.startsWith("<task-notification>")) {
+          onChunk("status", "background task completed", uuid);
+        }
+      }
+      return { endOfTurn: false, lineUuid: uuid };
+    }
 
     default:
       // attachment, last-prompt, ai-title, agent-name, file-history-snapshot,
@@ -844,7 +923,19 @@ function dispatchLine(state: SessionState, line: string): void {
     }
   }
 
-  if (uuid && state.seenLineUuids.has(uuid)) return;
+  // Already-seen lines (the reattach replay-from-offset-0 path is the
+  // common case) skip chunk emission so the UI doesn't see duplicate
+  // events. But we still have to drive queue bookkeeping for an end_turn
+  // here: when agetor crashed in the narrow window between persisting
+  // the end_turn line to `run_events` and updating `runs.status =
+  // 'succeeded'`, the line is in seenLineUuids on restart but the run
+  // row is still 'running'. Without this branch, the replay'd end_turn
+  // would be dropped before `onEndOfTurn` could fire, and the run would
+  // stay 'running' (and the UI "in progress") forever.
+  if (uuid && state.seenLineUuids.has(uuid)) {
+    if (isEndOfTurnEvent(evt)) popEndOfTurn(state);
+    return;
+  }
 
   const slot = state.turnQueue[0];
   // Active turn → its handler. No active turn → fall back to the most
@@ -855,23 +946,33 @@ function dispatchLine(state: SessionState, line: string): void {
   const onChunk: ChunkHandler = slot?.onChunk ?? state.lastChunk ?? (() => {});
   const { endOfTurn } = mapParsedEventToChunks(evt, onChunk);
   if (uuid) state.seenLineUuids.add(uuid);
-  if (endOfTurn) {
-    if (slot) {
-      state.turnQueue.shift();
-      state.lastChunk = slot.onChunk;
-      const resolve = slot.resolve;
-      slot.resolve = null;
-      slot.reject = null;
-      resolve?.(0);
-    } else if (state.onEndOfTurn) {
-      // Reattached run: no in-process promise to resolve, but the orchestrator
-      // still needs to flip the run row to `succeeded`. Fire-once: clear
-      // before calling so a follow-up turn on the same session (which would
-      // never happen without a new slot being pushed first) can't re-trigger.
-      const handler = state.onEndOfTurn;
-      state.onEndOfTurn = null;
-      handler();
-    }
+  if (endOfTurn) popEndOfTurn(state);
+}
+
+/** Advance the turn queue on end_turn — either pop the head slot and
+ *  resolve its `done` promise (fresh-spawn / live-stream path), or fire the
+ *  one-shot `onEndOfTurn` listener (reattach path, where there's no slot
+ *  but the orchestrator still needs to know the run completed). Shared by
+ *  the dedup-skip and normal-dispatch branches of `dispatchLine` so a
+ *  replayed end_turn whose chunk emission was suppressed still drives the
+ *  run-row state transition. */
+function popEndOfTurn(state: SessionState): void {
+  const slot = state.turnQueue[0];
+  if (slot) {
+    state.turnQueue.shift();
+    state.lastChunk = slot.onChunk;
+    const resolve = slot.resolve;
+    slot.resolve = null;
+    slot.reject = null;
+    resolve?.(0);
+  } else if (state.onEndOfTurn) {
+    // Reattached run: no in-process promise to resolve, but the orchestrator
+    // still needs to flip the run row to `succeeded`. Fire-once: clear
+    // before calling so a follow-up turn on the same session (which would
+    // never happen without a new slot being pushed first) can't re-trigger.
+    const handler = state.onEndOfTurn;
+    state.onEndOfTurn = null;
+    handler();
   }
 }
 
@@ -1411,9 +1512,12 @@ export interface ReattachOptions {
   /** Per-run chunk handler that persists to run_events + broadcasts on SSE.
    *  Built by the orchestrator the same way it does for fresh runs. */
   onChunk: ChunkHandler;
-  /** Dedup set seeded from `runs.seenLineUuids(runId)`. The dispatcher skips
-   *  any line whose uuid is already in this set, preventing double-emission
-   *  of events that the previous process already streamed and persisted. */
+  /** Dedup set seeded from `runs.seenLineUuidsForTask(taskId)` — every uuid
+   *  the previous process persisted across *every* run of this task. The
+   *  dispatcher skips any line whose uuid is already in this set, so the
+   *  replay from offset 0 doesn't double-emit events and doesn't fire
+   *  `onEndOfTurn` on end_turn lines belonging to long-completed prior
+   *  turns. */
   seenLineUuids: Set<string>;
 }
 

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -557,14 +557,26 @@ export const runs = {
       );
     }
   },
-  /** Return the set of JSONL line uuids already persisted for this run. Used
-   *  by reattachRun to seed an in-memory dedup set so re-tailing from offset
-   *  0 (after agetor restarts and finds the tmux session still alive) skips
-   *  events we already streamed during the previous process's lifetime. */
-  seenLineUuids(runId: string): Set<string> {
+  /** Return every JSONL line uuid already persisted across *every* run of
+   *  this task. Used by `reattachSession` to seed the in-memory dedup set so
+   *  re-tailing the per-session JSONL from offset 0 (after an agetor
+   *  restart) skips events we already streamed in the previous process.
+   *
+   *  Scoped to the task (not just the reattached run) on purpose: one tmux
+   *  session = one JSONL file = all of a task's turns. The replay from
+   *  offset 0 will encounter end_turn lines from prior, already-`succeeded`
+   *  run rows; without those uuids in the dedup set the dispatcher would
+   *  re-emit them onto the reattached (still-`running`) run's chunk
+   *  handler — corrupting its event history and, worse, firing
+   *  `onEndOfTurn` on the wrong turn and prematurely resolving the
+   *  current run. */
+  seenLineUuidsForTask(taskId: string): Set<string> {
     const rows = db.query<{ line_uuid: string }, [string]>(
-      `SELECT line_uuid FROM run_events WHERE run_id = ? AND line_uuid IS NOT NULL`,
-    ).all(runId);
+      `SELECT e.line_uuid
+       FROM run_events e
+       JOIN runs r ON r.id = e.run_id
+       WHERE r.task_id = ? AND e.line_uuid IS NOT NULL`,
+    ).all(taskId);
     return new Set(rows.map((r) => r.line_uuid));
   },
 };

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -226,7 +226,7 @@ export function reconcileOrphans(): number {
         sessionId: row.claude_session_id as string,
         configDir: harness?.home ?? null,
         onChunk,
-        seenLineUuids: runs.seenLineUuids(row.id),
+        seenLineUuids: runs.seenLineUuidsForTask(row.task_id),
       });
       if (spawned) {
         registerActiveRun(row.id, row.task_id, task, spawned);


### PR DESCRIPTION
End-of-turn detection used to skip the slot pop / onEndOfTurn fire when the line's uuid was already in seenLineUuids — so a run row left in `running` after an agetor crash (event persisted, status not yet flipped) stayed stuck in `running` forever on reattach. Carve-out: dedup'd end_turn lines now drive queue bookkeeping via a shared `popEndOfTurn` helper without re-emitting any user-visible chunks.

Reattach now seeds the dedup set across every run of the task (`seenLineUuidsForTask`) instead of just the reattached run — historical end_turn lines from prior, already-`succeeded` turns are no longer re-dispatched onto the current run's chunk handler (which would have prematurely resolved it).

Two new claude 2.1.x event types are now surfaced:
  - `queue-operation` with a `<task-notification>` payload → the same "background task: <summary>" status breadcrumb the old synthetic user/origin.kind path emitted (with a generic "completed" fallback when no summary is present, matching legacy behavior).
  - `system{subtype:"turn_duration"}` → "turn duration: 53s" breadcrumb after each end_turn. `away_summary` stays silent (resumption context).

Adds `formatTurnDuration` with round-to-seconds-before-branching so 59999ms rolls over to "1m" instead of "60s".

Tests: 10 new (event mapping for queue-operation + turn_duration + away_summary, formatTurnDuration boundary table, dedup carve-out for end_turn slot pop + reattach onEndOfTurn fire, negative dedup test).