### PR TITLE
feat(models): add Claude Opus 4.8 and GPT-5.5, set as defaults

### DIFF
--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -135,6 +135,16 @@ test("claude-code 'opus-4.7' + 'auto' translates to --model and --permission-mod
   ]);
 });
 
+test("claude-code 'opus-4.8' maps to --model claude-opus-4-8", () => {
+  const { cmd } = buildCommand(builtin("claude-code"), "do thing", { ...claudeDefaults, model: "opus-4.8", mode: "auto" });
+  expect(cmd).toEqual([
+    "claude",
+    "--model", "claude-opus-4-8",
+    "--permission-mode", "auto",
+    "do thing",
+  ]);
+});
+
 test("claude-code 'bypass' mode emits --dangerously-skip-permissions", () => {
   const { cmd } = buildCommand(builtin("claude-code"), "x", { ...claudeDefaults, mode: "bypass" });
   expect(cmd).toContain("--dangerously-skip-permissions");
@@ -272,6 +282,17 @@ test("codex 'ask' mode drops --full-auto so codex prompts as usual", () => {
     "codex", "exec",
     "--model", "gpt-5-codex",
     "-c", "model_reasoning_effort=high",
+    "hi",
+  ]);
+});
+
+test("codex model 'gpt-5.5' passes through verbatim as --model", () => {
+  const { cmd } = buildCommand(builtin("codex"), "hi", { ...codexDefaults, model: "gpt-5.5", mode: "auto" });
+  expect(cmd).toEqual([
+    "codex", "exec",
+    "--model", "gpt-5.5",
+    "-c", "model_reasoning_effort=high",
+    "--full-auto",
     "hi",
   ]);
 });

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -45,6 +45,7 @@ export interface AgentRunOptions {
 // curated list doesn't know about yet). Codex accepts the friendly ids as-is
 // so it doesn't need a translation table.
 const CLAUDE_MODEL_FLAG: Record<string, string> = {
+  "opus-4.8": "claude-opus-4-8",
   "opus-4.7": "claude-opus-4-7",
   "sonnet-4.6": "claude-sonnet-4-6",
   "haiku-4.5": "claude-haiku-4-5",

--- a/src/bun/effort-support.test.ts
+++ b/src/bun/effort-support.test.ts
@@ -1,6 +1,15 @@
 import { test, expect } from "bun:test";
 import { DEFAULT_MODEL, supportedEfforts } from "../shared/types.ts";
 
+test("claude opus-4.8 supports xhigh + max", () => {
+  const ids = supportedEfforts("claude-code", "opus-4.8").map((o) => o.id);
+  expect(ids).toContain("max");
+  expect(ids).toContain("xhigh");
+  expect(ids).toContain("high");
+  expect(ids).toContain("medium");
+  expect(ids).toContain("low");
+});
+
 test("claude opus-4.7 supports xhigh + max", () => {
   const ids = supportedEfforts("claude-code", "opus-4.7").map((o) => o.id);
   expect(ids).toContain("max");
@@ -24,14 +33,23 @@ test("claude haiku-4.5 exposes no effort options (CLI doesn't accept the flag)",
   expect(ids).toEqual([]);
 });
 
-test("claude null model falls back to DEFAULT_MODEL support set (opus-4.7)", () => {
+test("claude null model falls back to DEFAULT_MODEL support set (opus-4.8)", () => {
   // No model specified → use the agent's default model's support set. Since
-  // claude-code's DEFAULT_MODEL is opus-4.7, xhigh + max are both available.
-  expect(DEFAULT_MODEL["claude-code"]).toBe("opus-4.7");
+  // claude-code's DEFAULT_MODEL is opus-4.8, xhigh + max are both available.
+  expect(DEFAULT_MODEL["claude-code"]).toBe("opus-4.8");
   const ids = supportedEfforts("claude-code", null).map((o) => o.id);
   expect(ids).toContain("xhigh");
   expect(ids).toContain("max");
   expect(ids).toContain("high");
+});
+
+test("codex gpt-5.5 supports xhigh but not max", () => {
+  const ids = supportedEfforts("codex", "gpt-5.5").map((o) => o.id);
+  expect(ids).toContain("xhigh");
+  expect(ids).toContain("high");
+  expect(ids).toContain("medium");
+  expect(ids).toContain("low");
+  expect(ids).not.toContain("max");
 });
 
 test("codex gpt-5 supports xhigh but not max", () => {
@@ -41,7 +59,7 @@ test("codex gpt-5 supports xhigh but not max", () => {
 });
 
 test("unknown model falls back to the agent's DEFAULT_MODEL support set", () => {
-  // codex's default is gpt-5-codex which has the same set as gpt-5.
+  // codex's default is gpt-5.5 which has the same set as gpt-5.
   const ids = supportedEfforts("codex", "future-codex-9000").map((o) => o.id);
   expect(ids).toContain("xhigh");
   expect(ids).not.toContain("max");

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -221,7 +221,7 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
   const selectedStatus = agents.find((a) => a.harnessId === agent);
   const { models: staticModels } = AGENT_OPTIONS[kind];
   // `auto` is only valid on models that support real `--permission-mode auto`
-  // (Opus 4.7 today); other models would error at spawn. supportedModes
+  // (all current claude models); other models would error at spawn. supportedModes
   // filters the dropdown so the user can't pick an incompatible combo.
   const modes = supportedModes(kind, model);
   // Merge in any models the agent's CLI surfaced at boot. We dedup by id and

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -200,7 +200,7 @@ export interface Task {
    */
   mode: string | null;
   /**
-   * Friendly model id ("opus-4.7", "sonnet-4.6", "haiku-4.5", "gpt-5", …).
+   * Friendly model id ("opus-4.8", "sonnet-4.6", "haiku-4.5", "gpt-5", …).
    * Mapped to a `--model <name>` flag in `src/bun/agents.ts`. NULL means
    * "use the agent's default model" (no flag passed).
    */
@@ -286,8 +286,8 @@ export interface AgentOptions {
  * CLI happens to default to.
  */
 export const DEFAULT_MODEL: Record<AgentKind, string> = {
-  "claude-code": "opus-4.7",
-  "codex": "gpt-5-codex",
+  "claude-code": "opus-4.8",
+  "codex": "gpt-5.5",
 };
 export const DEFAULT_EFFORT: Record<AgentKind, string> = {
   "claude-code": "high",
@@ -338,7 +338,7 @@ export const CODE_PLAN_MODE: Record<AgentKind, { code: string; plan: string }> =
  */
 export const EFFORT_OPTIONS: AgentOption[] = [
   { id: "max", label: "Max", hint: "Absolute maximum effort. Slowest, most thorough." },
-  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Opus 4.7 / codex only." },
+  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Opus 4.8 / 4.7 / codex only." },
   { id: "high", label: "High", hint: "Deep reasoning. The API default where supported." },
   { id: "medium", label: "Medium", hint: "Balanced speed vs. capability." },
   { id: "low", label: "Low", hint: "Most efficient. Best for simple tasks." },
@@ -354,7 +354,8 @@ export const EFFORT_OPTIONS: AgentOption[] = [
  *     Haiku 4.5 → effort parameter NOT supported
  *   - Codex `model_reasoning_effort`:
  *       https://developers.openai.com/codex/config-advanced
- *     gpt-5 / gpt-5-codex → low/medium/high/xhigh (minimal kept out of UI)
+ *     gpt-5.5 / gpt-5 / gpt-5-codex → low/medium/high/xhigh
+ *     (minimal kept out of UI)
  *
  * An empty list means "this model does not accept the effort flag at all"
  * (e.g. Haiku 4.5) — the UI collapses the dropdown and `buildCommand` emits
@@ -362,12 +363,13 @@ export const EFFORT_OPTIONS: AgentOption[] = [
  */
 export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> = {
   // Per https://platform.claude.com/docs/en/build-with-claude/effort the
-  // effort parameter is API-supported only on Opus 4.7 / Opus 4.6 / Sonnet 4.6
-  // / Opus 4.5 (xhigh is Opus-4.7-only; Sonnet 4.6 has no xhigh; Haiku 4.5
+  // effort parameter is API-supported on Opus 4.8 / 4.7 / 4.6 / Sonnet 4.6
+  // / Opus 4.5 (xhigh is Opus-only; Sonnet 4.6 has no xhigh; Haiku 4.5
   // doesn't support effort at all). The `/effort` CLI command accepts more
   // levels but the underlying API request would fail for unsupported pairs,
   // so we filter at the picker rather than letting the user fire bad runs.
   "claude-code": {
+    "opus-4.8": ["max", "xhigh", "high", "medium", "low"],
     "opus-4.7": ["max", "xhigh", "high", "medium", "low"],
     "sonnet-4.6": ["max", "high", "medium", "low"],
     // Haiku 4.5 doesn't support the effort parameter — `supportedEfforts`
@@ -375,6 +377,7 @@ export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> =
     "haiku-4.5": [],
   },
   codex: {
+    "gpt-5.5": ["xhigh", "high", "medium", "low"],
     "gpt-5": ["xhigh", "high", "medium", "low"],
     "gpt-5-codex": ["xhigh", "high", "medium", "low"],
   },
@@ -403,12 +406,13 @@ export function supportedEfforts(agent: AgentKind, model: string | null): AgentO
  * directly) every mode agetor surfaces is universally supported across
  * claude models, so the deny list is empty. Kept as a structure rather
  * than removed so the picker stays ready for a future model-specific
- * carve-out (historic case: `--permission-mode auto` was Opus-only on
+ * carve-out (historic case: `--permission-mode auto` was Opus-4.7-only on
  * earlier releases). Unknown model ids fall back to the default model's
  * deny set — better than spawning a CLI-arg error mid-run.
  */
 const MODEL_MODE_DENY: Record<AgentKind, Record<string, string[]>> = {
   "claude-code": {
+    "opus-4.8": [],
     "opus-4.7": [],
     "sonnet-4.6": [],
     "haiku-4.5": [],
@@ -429,7 +433,8 @@ export function supportedModes(agent: AgentKind, model: string | null): AgentOpt
 export const AGENT_OPTIONS: Record<AgentKind, AgentOptions> = {
   "claude-code": {
     models: [
-      { id: "opus-4.7", label: "Opus 4.7", hint: "Most capable; slower." },
+      { id: "opus-4.8", label: "Opus 4.8", hint: "Most capable; slower." },
+      { id: "opus-4.7", label: "Opus 4.7", hint: "Previous flagship." },
       { id: "sonnet-4.6", label: "Sonnet 4.6", hint: "Balanced." },
       { id: "haiku-4.5", label: "Haiku 4.5", hint: "Fast and cheap." },
     ],
@@ -448,8 +453,9 @@ export const AGENT_OPTIONS: Record<AgentKind, AgentOptions> = {
   },
   codex: {
     models: [
-      { id: "gpt-5", label: "GPT-5" },
+      { id: "gpt-5.5", label: "GPT-5.5", hint: "Most capable; recommended default." },
       { id: "gpt-5-codex", label: "GPT-5 Codex" },
+      { id: "gpt-5", label: "GPT-5" },
     ],
     modes: [
       { id: "auto", label: "Auto (--full-auto)", hint: "Run without approval prompts." },


### PR DESCRIPTION
Wire Opus 4.8 (claude-opus-4-8) through the claude-code flag map, effort support, mode deny list, and curated picker, and make it the default model. Add GPT-5.5 (gpt-5.5) to codex's effort support and picker and make it the codex default. Opus 4.7 / GPT-5 / GPT-5 Codex remain selectable.

Update doc comments and add tests covering the new flag mappings, effort support, and verbatim passthrough.