### PR TITLE
fix(run-panel): dedupe user-message bubbles across live + JSONL paths

### DIFF
--- a/src/bun/claude-tmux.test.ts
+++ b/src/bun/claude-tmux.test.ts
@@ -386,6 +386,30 @@ test("mapJsonlEventToChunks: user.content[].text → `user` stream (array-form p
   expect(out).toEqual([{ stream: "user", data: "hello there" }]);
 });
 
+test("mapJsonlEventToChunks: CR/LF in user content is normalized to \\n (tmux paste-buffer delivers \\n as \\r, dedup keys on bytes)", () => {
+  // String-form: claude transcribes the pasted prompt verbatim, including
+  // the `\r` characters tmux substituted for our `\n`s. Without normalization
+  // the JSONL emit's data differs byte-for-byte from the live `sendInput`
+  // emit (which has the original `\n`s), breaking the run panel's dedup.
+  const s = recorder();
+  mapJsonlEventToChunks(
+    JSON.stringify({ type: "user", message: { content: "line one\r\rline two\r\nline three" } }),
+    s.onChunk,
+  );
+  expect(s.out).toEqual([{ stream: "user", data: "line one\n\nline two\nline three" }]);
+
+  // Array-form: same normalization applies to every text block.
+  const a = recorder();
+  mapJsonlEventToChunks(
+    JSON.stringify({
+      type: "user",
+      message: { content: [{ type: "text", text: "para one\r\rpara two" }] },
+    }),
+    a.onChunk,
+  );
+  expect(a.out).toEqual([{ stream: "user", data: "para one\n\npara two" }]);
+});
+
 test("mapJsonlEventToChunks: task-notification user message → `status` breadcrumb, not a user bubble", () => {
   const { out, onChunk } = recorder();
   const line = JSON.stringify({

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -409,8 +409,12 @@ function mapParsedEventToChunks(
               : "";
         // Strip a leading wrapper tag (`<local-command-caveat>`, `<task-notification>`,
         // …) so the breadcrumb reads as prose rather than raw markup.
+        // Split on any newline form — tmux/claude can leak `\r`-only
+        // separators into synthetic entries (same root cause as the
+        // human-turn CR normalization above), and `split("\n")` alone
+        // would leave the whole blob as one mashed line.
         const firstLine =
-          text.replace(/^\s*<[^>]+>/, "").split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
+          text.replace(/^\s*<[^>]+>/, "").split(/\r\n?|\n/).map((l) => l.trim()).find((l) => l.length > 0) ?? "";
         const summary = firstLine.length > 140 ? firstLine.slice(0, 137) + "…" : firstLine;
         // Never let a synthetic entry vanish without a trace: if it had content
         // but yielded no text line (e.g. a non-text block), emit a generic label
@@ -427,8 +431,16 @@ function mapParsedEventToChunks(
       // prompt the same way; the run panel's dedup keys user events on
       // (runId, data) only (ignoring ts), so the live + JSONL paths
       // collapse into one bubble per message.
+      //
+      // Normalize CR-only / CRLF newlines to `\n` before emitting. tmux's
+      // paste-buffer delivers our `\n`-separated prompt to claude's TUI as
+      // `\r`, and claude transcribes those `\r` characters into the JSONL
+      // verbatim. The live emit uses `\n`, so without this normalization
+      // the live and JSONL `data` strings differ byte-for-byte and the
+      // panel's dedup (keyed on `data.slice(0,200)`) misses → duplicate
+      // bubble for every multi-line user message.
       if (typeof content === "string") {
-        if (content) onChunk("user", content, uuid);
+        if (content) onChunk("user", content.replace(/\r\n?/g, "\n"), uuid);
       } else if (Array.isArray(content)) {
         for (const block of content) {
           if (block?.type === "tool_result") {
@@ -442,7 +454,7 @@ function mapParsedEventToChunks(
               isError,
             }), uuid);
           } else if (block?.type === "text" && block.text) {
-            onChunk("user", block.text, uuid);
+            onChunk("user", block.text.replace(/\r\n?/g, "\n"), uuid);
           }
           // Image / unknown blocks intentionally silent.
         }

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -113,6 +113,16 @@ export function publishGlobalEvent(e: GlobalEvent): void {
   emitGlobal(e);
 }
 
+/** Canonicalize CR/LF in user-supplied text before it's emitted as a
+ *  `user` stream event. The JSONL emit path in claude-tmux.ts does the
+ *  same — keeping both sides symmetric guarantees the panel's dedup
+ *  (keyed on `data.slice(0,200)`) collapses live + JSONL into one
+ *  bubble even when the input arrived with Windows line endings
+ *  (`\r\n`) from a clipboard paste. */
+function normalizeUserText(s: string): string {
+  return s.replace(/\r\n?/g, "\n");
+}
+
 /**
  * Update a task's column and broadcast the transition. Reads the row's
  * current column first so the global event carries `prev` — saves the UI
@@ -379,7 +389,7 @@ export async function startTask(taskId: string): Promise<{ runId: string } | { e
   // path will emit the same line again once claude writes it; the run
   // panel's dedup keys user events on (runId, data) so we don't double
   // up.
-  onChunk("user", promptWithRefs);
+  onChunk("user", normalizeUserText(promptWithRefs));
 
   const agent = spawnAgent({
     taskId,
@@ -730,8 +740,9 @@ export function sendInput(runId: string, line: string): SendInputResult {
   const ok = h.writeInput(line);
   if (ok) {
     const ts = Date.now();
-    runs.appendEvent(runId, "user", line);
-    emit({ runId, taskId: row.task_id, stream: "user", data: line, ts });
+    const data = normalizeUserText(line);
+    runs.appendEvent(runId, "user", data);
+    emit({ runId, taskId: row.task_id, stream: "user", data, ts });
     return { delivered: true, runId };
   }
   return { delivered: false, reason: "stdin write failed" };
@@ -791,7 +802,7 @@ function sendTurnInExistingSession(task: Task, taskId: string, line: string): st
   const harness = resolveHarness(task.agent);
   const kind: AgentKind = harness?.kind ?? "claude-code";
   const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
-  onChunk("user", line);
+  onChunk("user", normalizeUserText(line));
 
   const agent = sendTurn(taskId, line, onChunk);
   registerActiveRun(newRunId, taskId, task, agent);
@@ -839,7 +850,7 @@ function spawnResumedSession(task: Task, taskId: string, line: string): string {
   const harness = resolveHarness(task.agent);
   const kind: AgentKind = harness?.kind ?? "claude-code";
   const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
-  onChunk("user", line);
+  onChunk("user", normalizeUserText(line));
   onChunk(
     "status",
     priorSessionId

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -325,11 +325,18 @@ function RunPanelBody({
     // clock) and once from the JSONL parser when claude transcribes it
     // (ts=Date.now() at flush time, or synthetic baseTs+i during a
     // rebuild). Drop ts from the key for user events so the two paths
-    // collapse to one bubble per message.
+    // collapse to one bubble per message. Also normalize CR/LF in the
+    // key: tmux's paste-buffer delivers our `\n`-separated prompt to
+    // claude as `\r`, and the JSONL stores those `\r`s verbatim — so
+    // without normalization the live (`\n`) and JSONL (`\r`) copies
+    // differ byte-for-byte in the first 200 chars and slip past dedup.
+    // The bun side normalizes too (claude-tmux.ts); this is belt-and-
+    // suspenders for any other path that might leak a CR through.
     const seen = new Set<string>();
+    const normalizeForKey = (s: string) => s.replace(/\r\n?/g, "\n");
     const keyFor = (e: RunEvent) =>
       e.stream === "user"
-        ? `user|${e.runId}|${(e.data ?? "").slice(0, 200)}`
+        ? `user|${e.runId}|${normalizeForKey(e.data ?? "").slice(0, 200)}`
         : `${e.ts}|${e.runId}|${e.stream}|${(e.data ?? "").slice(0, 200)}`;
     const unsub = api.subscribeTask(task.id, (e) => {
       const key = keyFor(e);


### PR DESCRIPTION
tmux's paste-buffer delivers our \n-separated prompt to claude's TUI as \r, and claude transcribes those carriage returns into its session JSONL verbatim. The live sendInput emit used \n while the JSONL re-emit used \r, so the run panel's dedup key (data.slice(0,200)) missed and every multi-line user message rendered as two bubbles until the panel was closed and reopened.

Canonicalize CR/LF -> \n at every user-event emit site (claude-tmux JSONL parser + all three orchestrator live paths) and apply the same normalization in the run panel's dedup key as belt-and-suspenders. Also fix the isMeta synthetic-breadcrumb first-line extraction to split on any newline form so the same CR leakage doesn't squash the summary.