### PR TITLE
fix(claude-tmux): stage end_turn one line to suppress mid-turn split-…

### DIFF
--- a/src/bun/claude-tmux.test.ts
+++ b/src/bun/claude-tmux.test.ts
@@ -20,6 +20,7 @@ import {
   isAgetorInterceptReply,
   jsonlPathFor,
   mapJsonlEventToChunks,
+  rebuildEventsFromJsonl,
   sessionNameFor,
   toClaudeModeString,
 } from "./claude-tmux.ts";
@@ -142,7 +143,12 @@ test("mapJsonlEventToChunks: image content block surfaces as a placeholder so th
   expect(out[0]).toEqual({ stream: "assistant", data: "[image]" });
 });
 
-test("mapJsonlEventToChunks: assistant with stop_reason=end_turn signals endOfTurn + status", () => {
+test("mapJsonlEventToChunks: assistant with stop_reason=end_turn signals endOfTurn (no banner — banner is emitted by dispatchLine on confirmation)", () => {
+  // mapJsonlEventToChunks now returns endOfTurn:true as a STAGING signal, not
+  // a fire signal. The "turn complete" banner is emitted by firePendingEndTurn
+  // in dispatchLine once the next line confirms the turn is really over. This
+  // prevents spurious banners when claude stamps end_turn on every split line
+  // of a response (thinking, text, tool_use) including mid-flight ones.
   const { out, onChunk } = recorder();
   const line = JSON.stringify({
     type: "assistant",
@@ -150,8 +156,50 @@ test("mapJsonlEventToChunks: assistant with stop_reason=end_turn signals endOfTu
   });
   const res = mapJsonlEventToChunks(line, onChunk);
   expect(res.endOfTurn).toBe(true);
-  const status = out.find((r) => r.stream === "status");
-  expect(status?.data).toBe("turn complete");
+  // Text chunk emitted normally.
+  expect(out.some((r) => r.stream === "assistant" && r.data === "done")).toBe(true);
+  // Banner NOT emitted here — dispatchLine emits it when confirmed.
+  expect(out.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(false);
+});
+
+test("mapJsonlEventToChunks: stop_reason=end_turn with a tool_use block returns endOfTurn:true (staging signal) but no banner", () => {
+  // All end_turn lines — regardless of content type — return endOfTurn:true as
+  // a staging signal for dispatchLine. The "turn complete" banner is NOT emitted
+  // here; dispatchLine suppresses it until the next line confirms the turn is
+  // over (i.e., is not a same-message continuation or a tool_result). The
+  // tool_use chunk itself is still streamed normally.
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({
+    type: "assistant",
+    message: {
+      content: [{ type: "tool_use", id: "t1", name: "Bash", input: { cmd: "ls" } }],
+      stop_reason: "end_turn",
+    },
+  });
+  const res = mapJsonlEventToChunks(line, onChunk);
+  expect(res.endOfTurn).toBe(true);
+  // tool_use chunk still emitted — it carries real work.
+  expect(out.some((r) => r.stream === "tool_use")).toBe(true);
+  // Banner NOT emitted; dispatchLine emits it when confirmed.
+  expect(out.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(false);
+});
+
+test("mapJsonlEventToChunks: stop_reason=end_turn with text+tool_use still returns endOfTurn:true (staging) with no banner", () => {
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({
+    type: "assistant",
+    message: {
+      content: [
+        { type: "text", text: "let me check that" },
+        { type: "tool_use", id: "t2", name: "Read", input: {} },
+      ],
+      stop_reason: "end_turn",
+    },
+  });
+  const res = mapJsonlEventToChunks(line, onChunk);
+  expect(res.endOfTurn).toBe(true);
+  expect(out.some((r) => r.stream === "assistant" && r.data === "let me check that")).toBe(true);
+  expect(out.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(false);
 });
 
 test("mapJsonlEventToChunks: system{subtype:turn_duration} emits the duration as a status breadcrumb", () => {
@@ -571,7 +619,10 @@ test("mapJsonlEventToChunks: forwards the JSONL line uuid as the third onChunk a
   expect(seen[0]?.uuid).toBe("line-uuid-123");
 });
 
-test("mapJsonlEventToChunks: end-of-turn marker also carries the line uuid", () => {
+test("mapJsonlEventToChunks: end-of-turn marker carries the line uuid on the return value", () => {
+  // The banner no longer comes from mapJsonlEventToChunks (it's emitted by
+  // dispatchLine's firePendingEndTurn when the turn is confirmed). The uuid is
+  // still accessible via res.lineUuid for the caller to stage correctly.
   const seen: { stream: string; uuid?: string }[] = [];
   const onChunk = (s: string, _d: string, uuid?: string) => seen.push({ stream: s, uuid });
   const line = JSON.stringify({
@@ -581,7 +632,9 @@ test("mapJsonlEventToChunks: end-of-turn marker also carries the line uuid", () 
   });
   const res = mapJsonlEventToChunks(line, onChunk);
   expect(res.endOfTurn).toBe(true);
-  expect(seen.find((s) => s.stream === "status")?.uuid).toBe("end-line");
+  expect(res.lineUuid).toBe("end-line");
+  // No "status" chunk from this function — the banner is emitted later by dispatchLine.
+  expect(seen.find((s) => s.stream === "status")).toBeUndefined();
 });
 
 test("toClaudeModeString translates agetor shorthand to canonical claude strings", () => {
@@ -660,40 +713,212 @@ test("system event updates state.permissionMode (dispatchLine path)", async () =
 });
 
 test("dispatchLine: already-seen end_turn still fires onEndOfTurn (reattach + crashed-before-status-update path)", async () => {
-  // Reattach scenario where agetor died in the narrow window between
-  // persisting the end_turn line to `run_events` and updating the run
-  // row to `succeeded`: on restart, seenLineUuids is pre-seeded from
-  // run_events, so the JSONL replay's end_turn line hits the dedup
-  // path. Without the popEndOfTurn carve-out, the slot/onEndOfTurn
-  // bookkeeping never runs and the run stays `running` forever — the
-  // exact UI symptom (badge stuck on "in progress" while the agent
-  // is actually done) that motivated this fix.
+  // Reattach scenario where agetor died in the narrow window between persisting
+  // the end_turn to `run_events` and updating the run row to `succeeded`. On
+  // restart seenLineUuids is pre-seeded, so the replayed end_turn hits the
+  // dedup path. It must STILL drive popEndOfTurn (via staging + firing on the
+  // next non-continuation line) so the run row transitions. Without this the
+  // run stays `running` (badge stuck "in progress") forever.
   const { __forTest } = await import("./claude-tmux.ts");
   const taskId = "task-end-turn-dedup-reattach";
   const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
 
   let endOfTurnFired = false;
   state.onEndOfTurn = () => { endOfTurnFired = true; };
-
-  // Seed the dedup set so the end_turn line is treated as already-seen,
-  // matching what `runs.seenLineUuids(runId)` would return on restart.
   state.seenLineUuids.add("end-turn-uuid-1");
 
-  // Also: emitted chunks must NOT include this line's content — the prior
-  // process already broadcast it to SSE + persisted it to run_events.
   const emitted: { stream: string; data: string }[] = [];
   state.lastChunk = (stream, data) => emitted.push({ stream, data });
 
   __forTest.dispatchLine(state, JSON.stringify({
     type: "assistant",
     uuid: "end-turn-uuid-1",
-    message: { role: "assistant", content: [{ type: "text", text: "done" }], stop_reason: "end_turn" },
+    message: { id: "msg-R", role: "assistant", content: [{ type: "text", text: "done" }], stop_reason: "end_turn" },
   }));
 
+  // Staged, not yet fired — needs a confirming next line.
+  expect(endOfTurnFired).toBe(false);
+  expect(state.pendingEndTurn?.messageId).toBe("msg-R");
+
+  // Non-continuation line fires it.  emitBanner:false so no "turn complete" emitted.
+  __forTest.dispatchLine(state, JSON.stringify({ type: "system", subtype: "turn_duration", durationMs: 1000 }));
   expect(endOfTurnFired).toBe(true);
-  // No duplicate "turn complete" / "done" — the prior process already
-  // emitted those.
-  expect(emitted).toEqual([]);
+  // Prior process already emitted "turn complete" — no duplicate.
+  expect(emitted.some((e) => e.data === "turn complete")).toBe(false);
+  __forTest.uninstallSession(taskId);
+});
+
+test("dispatchLine: end_turn staging — tool_use line stages but tool_result cancels, slot never popped", async () => {
+  // The core of the fix: claude stamps end_turn on a tool_use split line.
+  // dispatchLine STAGES the pending end_turn (doesn't pop the slot yet).
+  // When the tool_result arrives on the next dispatchLine call, isEndTurnContinuation
+  // returns true → the pending is cancelled. The slot stays alive — the turn isn't over.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-staging-tooluse-cancel";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+
+  const recorded: { stream: string; data: string }[] = [];
+  void __forTest.pushTurnSlot(state, (stream, data) => recorded.push({ stream, data }));
+
+  // The buggy end_turn+tool_use line — should stage, not fire.
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "assistant",
+    uuid: "et-tu",
+    message: { id: "msg-abc", role: "assistant",
+      content: [{ type: "tool_use", id: "t1", name: "Bash", input: {} }],
+      stop_reason: "end_turn" },
+  }));
+  expect(state.pendingEndTurn?.messageId).toBe("msg-abc");
+  expect(state.turnQueue.length).toBe(1); // not popped yet
+
+  // tool_result arrives → continuation → cancel the pending
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "user",
+    uuid: "tr-1",
+    message: { content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }] },
+  }));
+  expect(state.pendingEndTurn).toBeNull();
+  expect(state.turnQueue.length).toBe(1); // still alive
+  expect(recorded.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(false);
+  __forTest.uninstallSession(taskId);
+});
+
+test("dispatchLine: end_turn staging — thinking/text split lines stage+cancel, real end fires on confirmation", async () => {
+  // Reproduces the EXACT Guest Mode failure sequence:
+  // line 120: end_turn [thinking]  → stage (was previously STILL_FIRES with hasPendingToolUse fix)
+  // line 121: end_turn [text]      → same message.id → cancel staged, re-stage
+  // line 122: end_turn [tool_use]  → same message.id → cancel, re-stage
+  // line 123: user [tool_result]   → continuation    → cancel
+  // No slot pop at any point — the turn is still in progress.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-staging-thinking-cancel";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+
+  const recorded: { stream: string; data: string }[] = [];
+  const donePromise = __forTest.pushTurnSlot(state, (stream, data) => recorded.push({ stream, data }));
+
+  const mkLine = (blk: object, uuid: string) => JSON.stringify({
+    type: "assistant", uuid,
+    message: { id: "msg-XYZ", role: "assistant", content: [blk], stop_reason: "end_turn" },
+  });
+
+  __forTest.dispatchLine(state, mkLine({ type: "thinking", thinking: "hmm" }, "u1"));
+  expect(state.pendingEndTurn?.messageId).toBe("msg-XYZ");
+  expect(state.turnQueue.length).toBe(1);
+
+  __forTest.dispatchLine(state, mkLine({ type: "text", text: "I'll check" }, "u2"));
+  expect(state.pendingEndTurn?.messageId).toBe("msg-XYZ"); // re-staged
+  expect(state.turnQueue.length).toBe(1);
+
+  __forTest.dispatchLine(state, mkLine({ type: "tool_use", id: "t1", name: "Bash", input: {} }, "u3"));
+  expect(state.pendingEndTurn?.messageId).toBe("msg-XYZ"); // re-staged
+  expect(state.turnQueue.length).toBe(1);
+
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "user", uuid: "u4",
+    message: { content: [{ type: "tool_result", tool_use_id: "t1", content: "done" }] },
+  }));
+  expect(state.pendingEndTurn).toBeNull(); // cancelled
+  expect(state.turnQueue.length).toBe(1); // still alive
+
+  // Now a new different message arrives (a real turn end) → pending is null already,
+  // so no spurious fire. Verify no banner was emitted throughout.
+  expect(recorded.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(false);
+
+  // Cleanup: the donePromise never resolves (turn didn't end); that's correct.
+  // Reject it to avoid test hanging.
+  state.turnQueue[0]?.reject?.(new Error("cleanup"));
+  await donePromise.catch(() => {});
+  __forTest.uninstallSession(taskId);
+});
+
+test("dispatchLine: pending end_turn fires when next line is a non-continuation (real turn end confirmed)", async () => {
+  // When a real end_turn is followed by a non-tool_result, non-same-message
+  // line (e.g. a new user text prompt, or a last-prompt event), the pending
+  // fires: emits "turn complete" banner and pops the slot.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-staging-fires-on-confirm";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+
+  const recorded: { stream: string; data: string }[] = [];
+  const donePromise = __forTest.pushTurnSlot(state, (stream, data) => recorded.push({ stream, data }));
+
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "assistant", uuid: "et-real",
+    message: { id: "msg-REAL", role: "assistant",
+      content: [{ type: "text", text: "all done!" }], stop_reason: "end_turn" },
+  }));
+  expect(state.pendingEndTurn?.messageId).toBe("msg-REAL");
+  expect(state.turnQueue.length).toBe(1); // not popped yet
+
+  // Non-continuation line (a system event — different type, no same message.id)
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "system", uuid: "sys-1", subtype: "turn_duration", durationMs: 5000,
+  }));
+
+  // Pending fired: banner emitted, slot popped
+  expect(state.pendingEndTurn).toBeNull();
+  expect(state.turnQueue.length).toBe(0);
+  expect(recorded.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(true);
+  expect(await donePromise).toBe(0);
+  __forTest.uninstallSession(taskId);
+});
+
+test("dispatchLine: already-seen end_turn (reattach/dedup) is staged and fires on next non-continuation line", async () => {
+  // The crash-between-persist-and-status-update case: an already-seen end_turn
+  // is staged (not fired immediately). On the next call with a non-continuation
+  // line, it fires — no banner (emitBanner:false), but popEndOfTurn runs so
+  // the run-row transitions correctly.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-dedup-et-staged";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+
+  let endOfTurnFired = false;
+  state.onEndOfTurn = () => { endOfTurnFired = true; };
+  state.seenLineUuids.add("seen-et-uuid");
+
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "assistant", uuid: "seen-et-uuid",
+    message: { id: "msg-SEEN", role: "assistant",
+      content: [{ type: "text", text: "done" }], stop_reason: "end_turn" },
+  }));
+  // Staged, not fired yet.
+  expect(state.pendingEndTurn?.messageId).toBe("msg-SEEN");
+  expect(endOfTurnFired).toBe(false);
+
+  // Next non-continuation line fires it (emitBanner:false since it was dedup).
+  __forTest.dispatchLine(state, JSON.stringify({ type: "system", subtype: "turn_duration", durationMs: 1000 }));
+  expect(state.pendingEndTurn).toBeNull();
+  expect(endOfTurnFired).toBe(true);
+  __forTest.uninstallSession(taskId);
+});
+
+test("dispatchLine: already-seen end_turn tool_use (dedup) cancelled by next tool_result — onEndOfTurn never fires", async () => {
+  // Dedup + tool_use: the pending is staged with emitBanner:false. If the
+  // next line is a tool_result (continuation), the pending is cancelled and
+  // onEndOfTurn never fires. The run SHOULD NOT be marked done here.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-dedup-tooluse-cancel";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+
+  let endOfTurnFired = false;
+  state.onEndOfTurn = () => { endOfTurnFired = true; };
+  state.seenLineUuids.add("seen-tu-uuid");
+
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "assistant", uuid: "seen-tu-uuid",
+    message: { id: "msg-TU", role: "assistant",
+      content: [{ type: "tool_use", id: "t1", name: "Bash", input: {} }],
+      stop_reason: "end_turn" },
+  }));
+  expect(state.pendingEndTurn?.messageId).toBe("msg-TU");
+
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "user",
+    message: { content: [{ type: "tool_result", tool_use_id: "t1", content: "done" }] },
+  }));
+  expect(state.pendingEndTurn).toBeNull();
+  expect(endOfTurnFired).toBe(false);
   __forTest.uninstallSession(taskId);
 });
 
@@ -730,12 +955,11 @@ test("dispatchLine: already-seen NON-end_turn line does NOT touch the turn queue
   __forTest.uninstallSession(taskId);
 });
 
-test("dispatchLine: already-seen end_turn pops the head turn slot (mid-pipeline dedup edge case)", async () => {
-  // Same carve-out, but for the live-stream path: if for any reason a
-  // duplicate end_turn line gets dispatched (e.g. a watcher fired and a
-  // sync flush both reached the same offset across an unlucky await
-  // suspension), we still want to advance the queue exactly once and
-  // resolve the head slot's `done` — not leak the slot.
+test("dispatchLine: already-seen end_turn pops the head turn slot after next confirming line (mid-pipeline dedup edge case)", async () => {
+  // Duplicate end_turn (watcher + sync-flush reaching same offset): the slot
+  // must be popped exactly once after the confirming next line. With staging,
+  // the dedup'd end_turn stages the pending (emitBanner:false), and the next
+  // non-continuation line fires it — resolving done and popping the slot.
   const { __forTest } = await import("./claude-tmux.ts");
   const taskId = "task-end-turn-dedup-live";
   const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
@@ -750,16 +974,161 @@ test("dispatchLine: already-seen end_turn pops the head turn slot (mid-pipeline 
   __forTest.dispatchLine(state, JSON.stringify({
     type: "assistant",
     uuid: "end-turn-uuid-2",
-    message: { role: "assistant", content: [], stop_reason: "end_turn" },
+    message: { id: "msg-D2", role: "assistant", content: [], stop_reason: "end_turn" },
   }));
 
-  // Slot popped, no chunks re-emitted on the slot's handler.
+  // Staged — not popped yet.
+  expect(state.turnQueue.length).toBe(1);
+  expect(state.pendingEndTurn?.messageId).toBe("msg-D2");
+
+  // Confirming next line (a system event — not a continuation).
+  __forTest.dispatchLine(state, JSON.stringify({ type: "system", subtype: "turn_duration", durationMs: 100 }));
+
+  // Slot now popped; no duplicate chunks; done resolves.
   expect(state.turnQueue.length).toBe(0);
-  expect(recorded).toEqual([]);
-  // The slot's `done` promise resolves with exit code 0 (the dedup'd
-  // line was a real end_turn, just one we already saw).
+  expect(state.pendingEndTurn).toBeNull();
+  // No "turn complete" re-emitted (emitBanner:false on the dedup path).
+  expect(recorded.some((r) => r.data === "turn complete")).toBe(false);
   expect(await donePromise).toBe(0);
   __forTest.uninstallSession(taskId);
+});
+
+test("flush: fires a staged end_turn after END_TURN_IDLE_FIRE_MS with no new data (idle path)", async () => {
+  // Edge case: end_turn is the very last write to the JSONL — no following
+  // last-prompt, mode event, or tool_result arrives to trigger the fire
+  // via normal continuation logic. flush() detects idle (no new bytes +
+  // stagedAt age ≥ END_TURN_IDLE_FIRE_MS) and fires the pending directly.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const { mkdtempSync, writeFileSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const dir = mkdtempSync("/tmp/agetor-flush-idle-test-");
+  const jsonlPath = join(dir, "session.jsonl");
+  // Write a single end_turn line — this is the whole file.
+  writeFileSync(jsonlPath, JSON.stringify({
+    type: "assistant", uuid: "et-idle",
+    message: { id: "msg-IDLE", role: "assistant",
+      content: [{ type: "text", text: "done" }], stop_reason: "end_turn" },
+  }) + "\n");
+
+  const taskId = "task-flush-idle";
+  const state = __forTest.installSession(taskId, jsonlPath);
+  const recorded: { stream: string; data: string }[] = [];
+  const donePromise = __forTest.pushTurnSlot(state, (stream, data) => recorded.push({ stream, data }));
+
+  // First flush: reads the end_turn line, stages the pending.
+  await __forTest.flush(state);
+  expect(state.pendingEndTurn?.messageId).toBe("msg-IDLE");
+  expect(state.turnQueue.length).toBe(1); // not popped yet
+
+  // Second flush with no new data but NOT yet past the idle threshold — still pending.
+  await __forTest.flush(state);
+  expect(state.pendingEndTurn).not.toBeNull(); // still waiting
+
+  // Backdate stagedAt past the idle threshold, then flush again with no data.
+  const pending = state.pendingEndTurn;
+  if (!pending) throw new Error("expected pending end_turn before idle backdate");
+  pending.stagedAt -= 1000; // older than END_TURN_IDLE_FIRE_MS (800ms)
+  await __forTest.flush(state);
+
+  // Idle path fires: pending cleared, slot popped, banner emitted, done resolves.
+  expect(state.pendingEndTurn).toBeNull();
+  expect(state.turnQueue.length).toBe(0);
+  expect(recorded.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(true);
+  expect(await donePromise).toBe(0);
+  __forTest.uninstallSession(taskId);
+});
+
+test("staging: a cancelled run drops its pending end_turn so a late JSONL line cannot fire a stale banner", async () => {
+  // Race condition the prior review flagged: after the staging refactor,
+  // there's a window between staging an end_turn and the next line confirming
+  // it. If the user cancels in that window, the kill paths must drop
+  // state.pendingEndTurn — otherwise the late line fires firePendingEndTurn,
+  // emitting a "turn complete" banner via state.lastChunk on a run the
+  // orchestrator has already marked `cancelled`.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-cancel-clears-pending";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+  const recorded: { stream: string; data: string }[] = [];
+  state.lastChunk = (stream, data) => recorded.push({ stream, data });
+
+  // Stage a pending end_turn manually (mirrors what dispatchLine does after
+  // an end_turn line arrives but before the next line confirms it).
+  state.pendingEndTurn = {
+    messageId: "msg-CANCEL",
+    uuid: "uuid-cancelled",
+    emitBanner: true,
+    stagedAt: Date.now(),
+  };
+
+  // Simulate the cancel cleanup the kill paths do.
+  state.pendingEndTurn = null;
+  for (const slot of state.turnQueue.splice(0)) slot.reject?.(new Error("cancelled"));
+
+  // Now a late JSONL line arrives (e.g., claude's response to Ctrl+C, or the
+  // idle-fire path in flush). Without the cleanup the staged pending would
+  // fire here; with it, firePendingEndTurn becomes a no-op.
+  __forTest.firePendingEndTurn(state);
+  __forTest.dispatchLine(state, JSON.stringify({ type: "system", subtype: "turn_duration", durationMs: 100 }));
+
+  // No "turn complete" banner emitted on the cancelled run.
+  expect(recorded.some((r) => r.data === "turn complete")).toBe(false);
+  __forTest.uninstallSession(taskId);
+});
+
+test("rebuildEventsFromJsonl: emits 'turn complete' for a real turn end (rebuild endpoint parity)", () => {
+  // The /runs/:id/rebuild-events endpoint must produce the SAME event shape
+  // as the live SSE path — including "turn complete" banners. Looping
+  // mapJsonlEventToChunks per-line would emit zero banners after the staging
+  // refactor (banner moved to firePendingEndTurn). rebuildEventsFromJsonl
+  // drives a synthetic SessionState through the same dispatch pipeline so the
+  // banner survives.
+  const lines = [
+    JSON.stringify({ type: "assistant", uuid: "u1",
+      message: { id: "msg-A", role: "assistant", content: [{ type: "text", text: "hello" }], stop_reason: "end_turn" } }),
+    JSON.stringify({ type: "system", subtype: "turn_duration", durationMs: 1000 }),
+  ].join("\n");
+  const out: { stream: string; data: string }[] = [];
+  rebuildEventsFromJsonl(lines, (stream, data) => out.push({ stream, data }));
+  // Text emitted, banner emitted (in correct order: text then turn complete then duration).
+  expect(out.some((r) => r.stream === "assistant" && r.data === "hello")).toBe(true);
+  expect(out.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(true);
+  expect(out.some((r) => r.stream === "status" && r.data === "turn duration: 1.0s")).toBe(true);
+});
+
+test("rebuildEventsFromJsonl: suppresses spurious 'turn complete' for split-line end_turn (Guest Mode quirk)", () => {
+  // Same staging guarantee on the rebuild path: an end_turn line followed by
+  // a tool_result (continuation) must NOT produce a "turn complete" banner.
+  // Without this the rebuild would emit the same spurious dividers the live
+  // tailer used to emit before the staging fix.
+  const lines = [
+    JSON.stringify({ type: "assistant", uuid: "u1",
+      message: { id: "msg-A", role: "assistant",
+        content: [{ type: "tool_use", id: "t1", name: "Bash", input: {} }],
+        stop_reason: "end_turn" } }),
+    JSON.stringify({ type: "user", uuid: "u2",
+      message: { content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }] } }),
+  ].join("\n");
+  const out: { stream: string; data: string }[] = [];
+  rebuildEventsFromJsonl(lines, (stream, data) => out.push({ stream, data }));
+  expect(out.some((r) => r.stream === "tool_use")).toBe(true);
+  expect(out.some((r) => r.stream === "tool_result")).toBe(true);
+  expect(out.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(false);
+});
+
+test("rebuildEventsFromJsonl: fires staged end_turn at EOF (last line is the turn end)", () => {
+  // Edge case mirrors flush()'s idle-fire path: if the JSONL's last line is
+  // an end_turn (no following line to confirm via continuation check), the
+  // EOF fire in rebuildEventsFromJsonl must still emit the banner so the
+  // rebuilt stream isn't missing the closing divider.
+  const lines = [
+    JSON.stringify({ type: "assistant", uuid: "u1",
+      message: { id: "msg-A", role: "assistant",
+        content: [{ type: "text", text: "all done" }], stop_reason: "end_turn" } }),
+  ].join("\n");
+  const out: { stream: string; data: string }[] = [];
+  rebuildEventsFromJsonl(lines, (stream, data) => out.push({ stream, data }));
+  expect(out.some((r) => r.stream === "assistant" && r.data === "all done")).toBe(true);
+  expect(out.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(true);
 });
 
 test("dispatchLine: permissionMode still updates when the event's uuid is already in seenLineUuids (reattach path)", async () => {

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -318,15 +318,41 @@ interface ParsedJsonlEvent {
 }
 
 /**
- * True for the assistant message that ends a turn. Pulled out so the dispatch
- * loop can decide whether a JSONL line drives queue bookkeeping (slot pop /
- * onEndOfTurn fire) WITHOUT first running `mapParsedEventToChunks` — that
- * matters for the dedup path, which must still pop the slot for end_turn
- * lines we've already replayed in a prior process, but must NOT re-emit any
- * user-visible chunks.
+ * True for an assistant JSONL line that claims to end a turn. Used by
+ * `dispatchLine` to decide whether to stage a pending end_turn. The claim
+ * may be spurious — claude stamps `stop_reason: "end_turn"` on *every* split
+ * line of a response (thinking, text, tool_use) even when the message is
+ * still mid-flight calling tools. `isEndTurnContinuation` in `dispatchLine`
+ * cancels the staged pending when the next line proves the turn isn't over.
  */
 function isEndOfTurnEvent(evt: ParsedJsonlEvent): boolean {
   return evt.type === "assistant" && evt.message?.stop_reason === "end_turn";
+}
+
+/**
+ * True when `next` proves that a staged end_turn was spurious — i.e. the
+ * turn is still in progress. Two cases:
+ *
+ * 1. Another split line of the *same* API-response message — claude stamped
+ *    `end_turn` on every block of the response, not just the last one.
+ *    Detected by matching `message.id` on both the staged and new lines.
+ *
+ * 2. A `user` line carrying `tool_result` blocks — the staged end_turn line
+ *    contained a tool_use, and this is the result coming back. The turn
+ *    cannot be over if a tool call is still being serviced.
+ */
+function isEndTurnContinuation(
+  next: ParsedJsonlEvent,
+  stagedMessageId: string | null,
+): boolean {
+  if (next.type === "assistant"
+      && stagedMessageId !== null
+      && next.message?.id === stagedMessageId) return true;
+  if (next.type === "user") {
+    const content = next.message?.content;
+    if (Array.isArray(content) && content.some((b) => b?.type === "tool_result")) return true;
+  }
+  return false;
 }
 
 /** Human-friendly millisecond formatter for `turn_duration` breadcrumbs.
@@ -509,8 +535,13 @@ function mapParsedEventToChunks(
             break;
         }
       }
+      // Signal a candidate turn-end. `dispatchLine` stages this and confirms
+      // it's real only when the *next* line is not a same-message continuation
+      // or a tool_result — see `isEndTurnContinuation`. The "turn complete"
+      // banner is emitted there, not here, so it never fires for spurious
+      // mid-flight splits (claude stamps end_turn on every content block of
+      // a response, not just the last one).
       if (msg.stop_reason === "end_turn") {
-        onChunk("status", "turn complete", uuid);
         return { endOfTurn: true, lineUuid: uuid };
       }
       return { endOfTurn: false, lineUuid: uuid };
@@ -781,6 +812,30 @@ interface SessionState {
    *  pending map, and we'd register a ghost duplicate before
    *  tmux/claude actually repainted. */
   recentlyAnsweredFingerprints: Map<string, number>;
+  /**
+   * A turn-end (`stop_reason: "end_turn"`) that has been observed but not yet
+   * confirmed as real. Claude stamps `end_turn` on *every* split line of a
+   * response (thinking, text, tool_use blocks) even when the message is still
+   * mid-flight. We stage the signal here and fire it — calling `popEndOfTurn`
+   * and emitting "turn complete" — only when the *next* JSONL line is not a
+   * same-message continuation or a `tool_result` (`isEndTurnContinuation`).
+   * Null when no end_turn is pending.
+   */
+  pendingEndTurn: {
+    /** `message.id` of the staged line — used to recognise same-response
+     *  split continuations (another content block of the same API call). */
+    messageId: string | null;
+    /** JSONL `uuid` of the staged line — forwarded as the dedup key on the
+     *  "turn complete" status event. */
+    uuid: string | undefined;
+    /** Whether to emit the "turn complete" banner when firing. False on the
+     *  reattach / dedup path where the prior process already broadcast it. */
+    emitBanner: boolean;
+    /** `Date.now()` when the pending was staged. Lets the idle path in
+     *  `flush` fire the pending after a short grace period when no further
+     *  JSONL data arrives (e.g., the end_turn line is truly the last write). */
+    stagedAt: number;
+  } | null;
 }
 
 interface TurnSlot {
@@ -792,6 +847,56 @@ interface TurnSlot {
 }
 
 const sessions = new Map<string, SessionState>(); // taskId → state
+
+/**
+ * Build a SessionState. Caller supplies the path-/launch-specific fields and
+ * any non-default initial state; the factory fills in the timer / scrape /
+ * staging defaults consistently. Centralising this keeps the four
+ * construction sites (`spawnClaudeViaTmux`, `reattachSession`,
+ * `rebuildEventsFromJsonl`, `__forTest.installSession`) from drifting when a
+ * new SessionState field is added — the previous reviews caught two cases
+ * where the field list got out of sync.
+ *
+ * Does NOT touch the global `sessions` map — callers register themselves.
+ */
+interface MakeSessionStateOpts {
+  taskId: string;
+  sessionName: string;
+  cwd: string;
+  jsonlPath: string;
+  offset?: number;
+  turnQueue?: TurnSlot[];
+  lastChunk?: ChunkHandler | null;
+  seenLineUuids?: Set<string>;
+  onEndOfTurn?: (() => void) | null;
+  permissionMode?: string | null;
+  bypassEnabled?: boolean;
+}
+
+function makeSessionState(o: MakeSessionStateOpts): SessionState {
+  return {
+    taskId: o.taskId,
+    sessionName: o.sessionName,
+    cwd: o.cwd,
+    jsonlPath: o.jsonlPath,
+    offset: o.offset ?? 0,
+    turnQueue: o.turnQueue ?? [],
+    lastChunk: o.lastChunk ?? null,
+    seenLineUuids: o.seenLineUuids ?? new Set(),
+    onEndOfTurn: o.onEndOfTurn ?? null,
+    permissionMode: o.permissionMode ?? null,
+    bypassEnabled: o.bypassEnabled ?? false,
+    // Defaults shared by every site — timers, scrape state, staging buffers.
+    watcher: null,
+    pollTimer: null,
+    onPermissionMode: null,
+    scrapeTimer: null,
+    scrapeLastFingerprint: null,
+    lastJsonlAppendAt: 0,
+    recentlyAnsweredFingerprints: new Map(),
+    pendingEndTurn: null,
+  };
+}
 
 /* ────────────────────────────────────────────────────────────────────────── *
  * JSONL discovery + tail.
@@ -883,91 +988,16 @@ function resumeJsonlOffset(jsonlPath: string): number {
   }
 }
 
-/** Dispatch one parsed JSONL line through the active turn slot's handler,
- *  advancing the queue when the line ends a turn. Shared between the
- *  async `flush` (file watcher / poll) and the sync `flushSync` (called
- *  from `sendTurn` so we drain leftover content before queueing a new
- *  turn). */
-function dispatchLine(state: SessionState, line: string): void {
-  // Parse once, then route. The parsed event carries `uuid` (claude stamps
-  // one per JSONL line); we use it as the dedup key — if we've already
-  // dispatched this line in a previous process (and it's still in
-  // run_events), skip the whole line so SSE-broadcast and run_events stay
-  // idempotent across an agetor restart.
-  let evt: ParsedJsonlEvent;
-  try {
-    evt = JSON.parse(line);
-  } catch (e) {
-    // Surface the parse error through whichever handler would have received
-    // a normal chunk — same routing as mapJsonlEventToChunks's own catch.
-    const handler = state.turnQueue[0]?.onChunk ?? state.lastChunk;
-    handler?.("stderr", `jsonl parse error: ${(e as Error).message}`);
-    return;
-  }
-  const uuid = typeof evt.uuid === "string" ? evt.uuid : undefined;
-
-  // Mirror the latest mode-bearing JSONL event into SessionState. Two
-  // consumers depend on this being current: `cycleToMode` (Shift+Tab
-  // press math against the live mode) and the `/approvals` route's
-  // plan-mode safety net (skip the saved-rule fast-path when claude is
-  // in `plan`, regardless of what the saved rule says).
-  //
-  // IMPORTANT: this update MUST stay above the seenLineUuids early-
-  // return below. On reattach the dedup set is pre-seeded from
-  // run_events, so every replayed line — including the mode event the
-  // prior process recorded — would otherwise be silently skipped and
-  // state.permissionMode would stay null. The mode is session metadata,
-  // not a per-line chunk the user sees twice, so re-applying it on a
-  // dedup hit is cheap and idempotent. Both event types carry the mode
-  // string (claude emits `system` at session start with the launch mode,
-  // then `permission-mode` for every mid-session change).
-  if ((evt.type === "system" || evt.type === "permission-mode")
-    && typeof evt.permissionMode === "string") {
-    state.permissionMode = evt.permissionMode;
-    // Fire any one-shot verification listener installed by `cycleToMode`.
-    // Snapshot+clear before invoking so a retry inside the listener can
-    // install a fresh listener for the next press without this fire
-    // clobbering it.
-    if (state.onPermissionMode) {
-      const cb = state.onPermissionMode;
-      state.onPermissionMode = null;
-      cb(evt.permissionMode);
-    }
-  }
-
-  // Already-seen lines (the reattach replay-from-offset-0 path is the
-  // common case) skip chunk emission so the UI doesn't see duplicate
-  // events. But we still have to drive queue bookkeeping for an end_turn
-  // here: when agetor crashed in the narrow window between persisting
-  // the end_turn line to `run_events` and updating `runs.status =
-  // 'succeeded'`, the line is in seenLineUuids on restart but the run
-  // row is still 'running'. Without this branch, the replay'd end_turn
-  // would be dropped before `onEndOfTurn` could fire, and the run would
-  // stay 'running' (and the UI "in progress") forever.
-  if (uuid && state.seenLineUuids.has(uuid)) {
-    if (isEndOfTurnEvent(evt)) popEndOfTurn(state);
-    return;
-  }
-
-  const slot = state.turnQueue[0];
-  // Active turn → its handler. No active turn → fall back to the most
-  // recently popped slot's handler so trailing metadata (permission-mode,
-  // summary, etc.) still threads onto the turn it belongs to instead of
-  // disappearing. If neither exists (session just opened, nothing emitted
-  // yet) it's safe to drop.
-  const onChunk: ChunkHandler = slot?.onChunk ?? state.lastChunk ?? (() => {});
-  const { endOfTurn } = mapParsedEventToChunks(evt, onChunk);
-  if (uuid) state.seenLineUuids.add(uuid);
-  if (endOfTurn) popEndOfTurn(state);
-}
+/** How long a staged end_turn waits with no new JSONL data before we fire
+ *  it anyway. Covers the edge case where the end_turn line is the very last
+ *  write to the file (i.e., claude wrote nothing after it — no last-prompt,
+ *  no mode event). Two poll cycles at the 400ms pollTimer interval. */
+const END_TURN_IDLE_FIRE_MS = 800;
 
 /** Advance the turn queue on end_turn — either pop the head slot and
  *  resolve its `done` promise (fresh-spawn / live-stream path), or fire the
  *  one-shot `onEndOfTurn` listener (reattach path, where there's no slot
- *  but the orchestrator still needs to know the run completed). Shared by
- *  the dedup-skip and normal-dispatch branches of `dispatchLine` so a
- *  replayed end_turn whose chunk emission was suppressed still drives the
- *  run-row state transition. */
+ *  but the orchestrator still needs to know the run completed). */
 function popEndOfTurn(state: SessionState): void {
   const slot = state.turnQueue[0];
   if (slot) {
@@ -986,6 +1016,145 @@ function popEndOfTurn(state: SessionState): void {
     state.onEndOfTurn = null;
     handler();
   }
+}
+
+/** Fire the staged `pendingEndTurn` — emit the "turn complete" banner (if
+ *  appropriate) and advance the turn queue. Called from `dispatchLine` when
+ *  the next line confirms the pending was a real turn-end, from `flushSync`
+ *  when a new prompt is being queued (new prompt = previous turn is over), and
+ *  from `flush` when no new data has arrived for long enough to rule out a
+ *  same-message continuation. */
+function firePendingEndTurn(state: SessionState): void {
+  const pending = state.pendingEndTurn;
+  if (!pending) return;
+  state.pendingEndTurn = null;
+  if (pending.emitBanner) {
+    // Emit through whichever handler is active. The slot hasn't been popped
+    // yet, so the active slot is still the right target.
+    const onChunk = state.turnQueue[0]?.onChunk ?? state.lastChunk ?? (() => {});
+    onChunk("status", "turn complete", pending.uuid);
+  }
+  popEndOfTurn(state);
+}
+
+/** Dispatch one parsed JSONL line through the active turn slot's handler,
+ *  advancing the queue when the line ends a turn. Shared between the
+ *  async `flush` (file watcher / poll) and the sync `flushSync` (called
+ *  from `sendTurn` so we drain leftover content before queueing a new
+ *  turn).
+ *
+ * Turn-end detection uses one-line staging to handle a claude streaming
+ * quirk: claude stamps `stop_reason: "end_turn"` on *every* split line of a
+ * response (thinking, text, tool_use blocks), not just the last. We stage the
+ * end_turn signal here and confirm — firing `popEndOfTurn` + "turn complete"
+ * — only when the NEXT line is not a same-message continuation or a
+ * tool_result. This prevents both the "run flips to succeeded mid-turn" bug
+ * and the spurious "TURN COMPLETE" divider spam it caused. */
+function dispatchLine(state: SessionState, line: string): void {
+  let evt: ParsedJsonlEvent;
+  try {
+    evt = JSON.parse(line);
+  } catch (e) {
+    const handler = state.turnQueue[0]?.onChunk ?? state.lastChunk;
+    handler?.("stderr", `jsonl parse error: ${(e as Error).message}`);
+    return;
+  }
+  const uuid = typeof evt.uuid === "string" ? evt.uuid : undefined;
+
+  // Mirror the latest mode-bearing JSONL event into SessionState.
+  // IMPORTANT: this update MUST stay above the seenLineUuids early-return.
+  // On reattach the dedup set is pre-seeded from run_events, so every
+  // replayed line — including mode events the prior process recorded — would
+  // otherwise be silently skipped and state.permissionMode would stay null.
+  if ((evt.type === "system" || evt.type === "permission-mode")
+    && typeof evt.permissionMode === "string") {
+    state.permissionMode = evt.permissionMode;
+    if (state.onPermissionMode) {
+      const cb = state.onPermissionMode;
+      state.onPermissionMode = null;
+      cb(evt.permissionMode);
+    }
+  }
+
+  // Staging step: the new line either confirms or cancels the pending end_turn.
+  // This must run before the dedup check so replayed lines also drive staging.
+  if (state.pendingEndTurn) {
+    if (isEndTurnContinuation(evt, state.pendingEndTurn.messageId)) {
+      // Same message still going, or tool_result for a tool_use in that
+      // message → the staged end_turn was spurious. Discard it.
+      state.pendingEndTurn = null;
+    } else {
+      // Something unrelated started → the previous turn truly ended. Fire.
+      firePendingEndTurn(state);
+    }
+  }
+
+  // Already-seen lines (reattach replay-from-offset-0) skip chunk emission
+  // but still stage an end_turn so the run-row status transition can fire
+  // when the next line confirms it. The banner is suppressed (emitBanner:
+  // false) because the prior process already broadcast it.
+  if (uuid && state.seenLineUuids.has(uuid)) {
+    if (isEndOfTurnEvent(evt)) {
+      state.pendingEndTurn = {
+        messageId: evt.message?.id ?? null,
+        uuid,
+        emitBanner: false,
+        stagedAt: Date.now(),
+      };
+    }
+    return;
+  }
+
+  const slot = state.turnQueue[0];
+  // Active turn → its handler. No active turn → fall back to the most
+  // recently popped slot's handler so trailing metadata still reaches the
+  // correct run. If neither exists it's safe to drop.
+  const onChunk: ChunkHandler = slot?.onChunk ?? state.lastChunk ?? (() => {});
+  const { endOfTurn } = mapParsedEventToChunks(evt, onChunk);
+  if (uuid) state.seenLineUuids.add(uuid);
+  if (endOfTurn) {
+    // Stage: don't resolve the turn yet. The banner and slot-pop happen in
+    // `firePendingEndTurn` once the next line confirms this isn't a mid-flight
+    // split. If the file ends here, `flush` fires it after END_TURN_IDLE_FIRE_MS.
+    state.pendingEndTurn = {
+      messageId: evt.message?.id ?? null,
+      uuid,
+      emitBanner: true,
+      stagedAt: Date.now(),
+    };
+  }
+}
+
+/**
+ * Re-emit a finished session's JSONL as a chunk stream, using the same
+ * staging logic the live tailer uses. Drives `dispatchLine` against a
+ * synthetic single-slot SessionState — the slot's handler is `onChunk`, so
+ * every event (including "turn complete" banners that `firePendingEndTurn`
+ * emits when a turn is confirmed) flows through to the caller in the same
+ * shape the live SSE path produces. Fires any pending end_turn at EOF, since
+ * no further line can ever arrive to confirm it.
+ *
+ * Used by the `/runs/:id/rebuild-events` endpoint. Must NOT touch the live
+ * `sessions` map — the synthetic state is local and discarded on return.
+ */
+export function rebuildEventsFromJsonl(text: string, onChunk: ChunkHandler): void {
+  // Single synthetic slot routes every chunk to the caller's onChunk.
+  // Resolve/reject are no-ops — popEndOfTurn calls resolve?.(0) which is
+  // fine; the slot exists purely to carry the handler.
+  const state = makeSessionState({
+    taskId: "__rebuild__",
+    sessionName: "__rebuild__",
+    cwd: "/",
+    jsonlPath: "/__rebuild__",
+    turnQueue: [{ onChunk, resolve: null, reject: null }],
+    lastChunk: onChunk,
+  });
+  for (const line of text.split("\n")) {
+    if (line.trim()) dispatchLine(state, line);
+  }
+  // EOF — no continuation can ever arrive. Fire any staged pending so the
+  // last turn's "turn complete" banner makes it into the output.
+  if (state.pendingEndTurn) firePendingEndTurn(state);
 }
 
 /**
@@ -1016,6 +1185,11 @@ function flushSync(state: SessionState): void {
     if (!line) continue;
     dispatchLine(state, line);
   }
+  // flushSync is called from sendTurn before pushing a new prompt slot.
+  // A new human prompt is definitive proof the previous turn ended — fire any
+  // staged end_turn now so it resolves on the correct (old) slot, not the one
+  // we're about to push.
+  if (state.pendingEndTurn) firePendingEndTurn(state);
 }
 
 /** Read the file from `offset` to EOF, advancing the cursor. */
@@ -1056,7 +1230,17 @@ async function flush(state: SessionState): Promise<void> {
     state.turnQueue[0]?.onChunk("stderr", `jsonl read error: ${(e as Error).message}`);
     return;
   }
-  if (!chunk.text) return;
+  if (!chunk.text) {
+    // No new data. Fire any staged end_turn that has been waiting long enough
+    // for a continuation to arrive — if none came, the turn is over. The
+    // threshold is two poll cycles so a same-batch continuation arriving in
+    // the immediately next flush doesn't trigger a false fire.
+    if (state.pendingEndTurn
+        && Date.now() - state.pendingEndTurn.stagedAt >= END_TURN_IDLE_FIRE_MS) {
+      firePendingEndTurn(state);
+    }
+    return;
+  }
   // A sync flush already consumed (some of) what we just read. The bytes
   // we'd dispatch are duplicates → drop them. The next watcher / poll
   // tick will pick up anything appended after the sync flush from the
@@ -1433,18 +1617,12 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
   const initialOffset = resumeJsonlOffset(jsonlPath);
 
   // Allocate the per-session state up front so flush() can find it.
-  const state: SessionState = {
+  const state = makeSessionState({
     taskId: opts.taskId,
     sessionName,
     cwd: opts.cwd,
     jsonlPath,
     offset: initialOffset,
-    watcher: null,
-    pollTimer: null,
-    turnQueue: [],
-    lastChunk: null,
-    seenLineUuids: new Set(),
-    onEndOfTurn: null,
     // Canonical claude mode string (e.g. "plan", "bypassPermissions"),
     // not the agetor-internal id ("plan", "bypass"). Seeding here means
     // the plan-mode safety check in `/approvals` works from the very
@@ -1456,16 +1634,11 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
     // task.mode since the prior session, in which case the launch flags
     // are the truth and the JSONL is stale.
     permissionMode: opts.mode ? toClaudeModeString(opts.mode) : null,
-    onPermissionMode: null,
     // `bypass` is the only agetor mode that emits the launch flag
     // (--dangerously-skip-permissions) — that's what puts
     // `bypassPermissions` into the Shift+Tab cycle.
     bypassEnabled: opts.mode === "bypass",
-    scrapeTimer: null,
-    scrapeLastFingerprint: null,
-    lastJsonlAppendAt: 0,
-    recentlyAnsweredFingerprints: new Map(),
-  };
+  });
   sessions.set(opts.taskId, state);
 
   const done = new Promise<number>((resolve, reject) => {
@@ -1502,8 +1675,12 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
       opts.onChunk("stderr", `--- tmux pane ---\n${pane}\n--- end pane ---`);
       killTaskSession(opts.taskId);
       sessions.delete(opts.taskId);
-      // Reject every queued turn so all dependent promises settle.
+      // Reject every queued turn so all dependent promises settle. Drop any
+      // staged end_turn — without claude's JSONL we can't confirm it, and
+      // letting it fire later would emit a "turn complete" for a turn that
+      // never actually completed.
       const err = new Error("jsonl-discovery-timeout");
+      state.pendingEndTurn = null;
       for (const slot of state.turnQueue.splice(0)) slot.reject?.(err);
       return;
     }
@@ -1557,39 +1734,30 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
     rejectDone = rej;
   });
 
-  const state: SessionState = {
+  // Replaying the JSONL from offset 0 re-runs every historical
+  // `system` / `permission-mode` line through `dispatchLine`. The
+  // permissionMode update there sits above the seenLineUuids dedup
+  // check, so even when the line's uuid is already in the dedup set
+  // (pre-seeded from run_events on reattach) the field still gets
+  // overwritten with whatever mode claude is currently in.
+  //
+  // The launch flag isn't persisted across agetor restarts, so we can't
+  // tell whether bypassPermissions is in the cycle on this reattach.
+  // Conservatively assume not (bypassEnabled defaults to false) — cycling
+  // to bypass after a restart needs a respawn (claude requires the flag
+  // at launch anyway).
+  const state = makeSessionState({
     taskId: opts.taskId,
     sessionName,
     cwd: opts.cwd,
     jsonlPath,
-    offset: 0,
-    watcher: null,
-    pollTimer: null,
-    turnQueue: [],
     // Trailing metadata that lands before the first new turn slot still
     // wants to flow to run_events — route it through the reattach handler
     // by seeding lastChunk, same pattern as spawnClaudeViaTmux.
     lastChunk: opts.onChunk,
     seenLineUuids: opts.seenLineUuids,
     onEndOfTurn: () => resolveDone?.(0),
-    // Replaying the JSONL from offset 0 re-runs every historical
-    // `system` / `permission-mode` line through `dispatchLine`. The
-    // permissionMode update there sits above the seenLineUuids dedup
-    // check, so even when the line's uuid is already in the dedup set
-    // (pre-seeded from run_events on reattach) the field still gets
-    // overwritten with whatever mode claude is currently in.
-    permissionMode: null,
-    onPermissionMode: null,
-    // The launch flag isn't persisted across agetor restarts, so we can't
-    // tell whether bypassPermissions is in the cycle on this reattach.
-    // Conservatively assume not — cycling to bypass after a restart needs
-    // a respawn (claude requires the flag at launch anyway).
-    bypassEnabled: false,
-    scrapeTimer: null,
-    scrapeLastFingerprint: null,
-    lastJsonlAppendAt: 0,
-    recentlyAnsweredFingerprints: new Map(),
-  };
+  });
   // Belt to reconcileOrphans's sort-and-dedup suspender: if some prior
   // reattach (or other code path) already left a SessionState in the map
   // for this taskId, dispose its watcher + pollTimer before we overwrite
@@ -1607,8 +1775,11 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
       // Stop-the-turn semantics match `makeAgent`: send Ctrl+C, reject any
       // queued slots (none here, but future-proof), reject the reattach
       // done promise so the orchestrator's done-handler records `cancelled`.
+      // Drop any staged end_turn so a late-arriving JSONL line can't fire it
+      // post-cancel and emit a spurious "turn complete" banner.
       tmux(["send-keys", "-t", s.sessionName, "C-c"]);
       const err = new Error("cancelled");
+      s.pendingEndTurn = null;
       for (const slot of s.turnQueue.splice(0)) slot.reject?.(err);
       s.onEndOfTurn = null;
       rejectDone?.(err);
@@ -1865,6 +2036,7 @@ function disposeSessionState(state: SessionState | undefined): void {
   state.scrapeLastFingerprint = null;
   state.onEndOfTurn = null;
   state.onPermissionMode = null;
+  state.pendingEndTurn = null;
   const err = new Error("session killed");
   for (const slot of state.turnQueue.splice(0)) slot.reject?.(err);
 }
@@ -1875,11 +2047,14 @@ function makeAgent(taskId: string, done: Promise<number>): SpawnedAgent {
       // Interrupt every queued turn for this task. Ctrl+C aborts whatever
       // claude is doing in the TUI and clears its queued-input buffer
       // (anything we'd pasted while it was thinking). Reject the full
-      // queue so each run's done settles with "cancelled".
+      // queue so each run's done settles with "cancelled". Drop any staged
+      // end_turn so a late-arriving JSONL line can't fire it post-cancel
+      // and emit a spurious "turn complete" banner on the cancelled run.
       const state = sessions.get(taskId);
       if (!state) return;
       tmux(["send-keys", "-t", state.sessionName, "C-c"]);
       const err = new Error("cancelled");
+      state.pendingEndTurn = null;
       for (const slot of state.turnQueue.splice(0)) slot.reject?.(err);
     },
     writeInput: (line) => {
@@ -1907,26 +2082,12 @@ export const __forTest = {
   /** Register a synthetic session keyed on taskId, returning the queue
    *  + offset surface for assertions. */
   installSession(taskId: string, jsonlPath: string): SessionState {
-    const state: SessionState = {
+    const state = makeSessionState({
       taskId,
       sessionName: `agetor-test-${taskId}`,
       cwd: "/tmp",
       jsonlPath,
-      offset: 0,
-      watcher: null,
-      pollTimer: null,
-      turnQueue: [],
-      lastChunk: null,
-      seenLineUuids: new Set(),
-      onEndOfTurn: null,
-      permissionMode: null,
-      onPermissionMode: null,
-      bypassEnabled: false,
-      scrapeTimer: null,
-      scrapeLastFingerprint: null,
-      lastJsonlAppendAt: 0,
-      recentlyAnsweredFingerprints: new Map(),
-    };
+    });
     sessions.set(taskId, state);
     return state;
   },
@@ -1939,6 +2100,7 @@ export const __forTest = {
   flushSync,
   flush,
   dispatchLine,
+  firePendingEndTurn,
   matchNumberedModal,
   matchYesNoModal,
   resumeJsonlOffset,

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -30,7 +30,7 @@ import {
   dismissTmuxPrompt,
   getCurrentPermissionMode,
   jsonlPathFor,
-  mapJsonlEventToChunks,
+  rebuildEventsFromJsonl,
   markTmuxPromptAnswered,
   sessionExists,
   sessionNameFor,
@@ -1489,8 +1489,11 @@ export function startApiServer() {
           if (!existsSync(jsonlPath)) {
             return json({ events: [], reason: `JSONL not found at ${jsonlPath}` }, { headers: corsHeaders(req) });
           }
-          // Parse every line via the same mapper live tailing uses so the
-          // output shape is identical to streamed events.
+          // Drive the JSONL through the same staging pipeline live tailing
+          // uses, so the rebuilt event stream contains "turn complete"
+          // banners (emitted by firePendingEndTurn when a turn is confirmed
+          // real) in the same positions the live stream produced them. Going
+          // through mapJsonlEventToChunks directly would emit zero banners.
           const baseTs = run.startedAt;
           let i = 0;
           const events: RunEvent[] = [];
@@ -1506,10 +1509,7 @@ export function startApiServer() {
               ts: baseTs + i++,
             });
           };
-          const text = readFileSync(jsonlPath, "utf8");
-          for (const line of text.split("\n")) {
-            if (line.trim()) mapJsonlEventToChunks(line, onChunk);
-          }
+          rebuildEventsFromJsonl(readFileSync(jsonlPath, "utf8"), onChunk);
           return json({ events, source: jsonlPath }, { headers: corsHeaders(req) });
         } catch (e) {
           const msg = (e as Error).message ?? String(e);


### PR DESCRIPTION
…line completion

Claude stamps `stop_reason: "end_turn"` on every split line of an API response (thinking, text, tool_use blocks), not just the last. The live tailer was treating each one as a real turn end, firing "TURN COMPLETE" banners and flipping the run to `succeeded` while claude was still mid-flight calling tools — the symptom in the Guest Mode session (22 spurious banners + premature card move to `review`).

Replace the immediate-fire on end_turn with one-line staging in `dispatchLine`: the signal is held in `state.pendingEndTurn` and fires (emitting the banner + popping the slot via `firePendingEndTurn`) only when the next line is not a same-message continuation (`message.id` match) or a `tool_result` envelope. `flushSync` fires any pending before queueing a new prompt; `flush` fires after a 2-poll idle window so a session whose final write is the end_turn line still completes.

The `/runs/:id/rebuild-events` endpoint went through `mapJsonlEventToChunks` directly and would have lost every banner after the staging move — added `rebuildEventsFromJsonl` which drives a synthetic single-slot SessionState through the same dispatch pipeline so the rebuild stream stays identical to the live stream.

Other fixes:
- All cancel/teardown paths (`makeAgent.kill`, `reattachSession.kill`, jsonl-discovery-timeout, `disposeSessionState`) drop the staged pending so a late-arriving JSONL line cannot emit a stale "turn complete" on the cancelled run.
- Extracted `makeSessionState` factory so the four construction sites share one definition — the previous review caught two fields drifting out of sync when `pendingEndTurn` was added.

Empirically verified against prod JSONLs: buggy Guest Mode session 22 spurious banners → 0; clean session 5 (double-counted split message) → 4 (one per distinct API response).

Tests: 76 pass / 0 fail in claude-tmux.test.ts.