### PR TITLE
fix(claude-tmux): serialize tmux ops to fix lost message after /model change

### DIFF
--- a/src/bun/claude-tmux-queue.test.ts
+++ b/src/bun/claude-tmux-queue.test.ts
@@ -7,7 +7,7 @@ import { randomUUID } from "node:crypto";
 // Pre-set AGETOR_DATA_DIR before claude-tmux.ts's transitive db.ts import.
 process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-tmux-queue-"));
 
-const { __forTest } = await import("./claude-tmux.ts");
+const { __forTest, dismissTmuxPrompt } = await import("./claude-tmux.ts");
 
 // Each test gets its own taskId + JSONL file so they can't trample each
 // other. The dispatch logic is purely synchronous on flushSync (we don't
@@ -247,4 +247,271 @@ test("partial trailing line is left for the next flush", async () => {
   } finally {
     __forTest.uninstallSession(taskId);
   }
+});
+
+// ─── pasteChain ordering (regression for the "Turn Ended Bug" — model
+// change races a follow-up user paste, the user's message lands during
+// claude's transient slash-command processing and vanishes silently).
+// The fix is `queueTmuxOp` (and its `queuePaste` wrapper), which
+// serializes all tmux ops for a task behind a single chain and holds
+// the slot for the slash command's settle window so the next op lands
+// on a ready prompt. These tests drive the chain directly and assert
+// ordering + timing. ───
+
+/**
+ * Snapshot + restore the `AGETOR_TMUX_BIN` env var around a test body.
+ * The chain calls `pastePromptSync` → `tmux()` → `Bun.spawnSync(bin, …)`;
+ * pointing the bin at a no-op `true` lets the chain advance without
+ * needing a real tmux. Restoring on exit keeps the env clean for later
+ * tests in the same process (tmux probes elsewhere read this var).
+ *
+ * `/usr/bin/true` works on both macOS (where `/bin/true` doesn't exist)
+ * and most Linux distros. Choosing the path matters — a missing binary
+ * makes `Bun.spawnSync` throw `ENOENT`, which the `tmux()` helper catches
+ * and surfaces as `{ok: false}`. That silently degrades tests that need
+ * the tmux calls to "succeed" (e.g. `dismissTmuxPrompt` returning true).
+ */
+const FAKE_TMUX_BIN = "/usr/bin/true";
+
+function withFakeTmuxBin<T>(fn: () => Promise<T>): Promise<T> {
+  const prevBin = process.env.AGETOR_TMUX_BIN;
+  process.env.AGETOR_TMUX_BIN = FAKE_TMUX_BIN;
+  return fn().finally(() => {
+    if (prevBin === undefined) delete process.env.AGETOR_TMUX_BIN;
+    else process.env.AGETOR_TMUX_BIN = prevBin;
+  });
+}
+
+test("queuePaste: chained pastes run in FIFO order", async () => {
+  await withFakeTmuxBin(async () => {
+    const prev = __forTest.setSlashCommandSettleMs(0);
+    try {
+      const taskId = randomUUID();
+      const log: string[] = [];
+
+      // Resolve order observed via the .then chain on each returned promise.
+      const a = __forTest.queuePaste(taskId, "sess-x", "first", 0).then(() => log.push("a"));
+      const b = __forTest.queuePaste(taskId, "sess-x", "second", 0).then(() => log.push("b"));
+      const c = __forTest.queuePaste(taskId, "sess-x", "third", 0).then(() => log.push("c"));
+
+      await Promise.all([a, b, c]);
+      expect(log).toEqual(["a", "b", "c"]);
+      // Chain self-evicts when no follow-ups are pending.
+      expect(__forTest.pasteChains.has(taskId)).toBe(false);
+    } finally {
+      __forTest.setSlashCommandSettleMs(prev);
+    }
+  });
+});
+
+test("queuePaste: settle window holds the next paste for slash commands", async () => {
+  // Settle window chosen large enough that a 30ms scheduling tolerance
+  // still keeps the assertion meaningful (settle MUST add ≥ SETTLE−TOLERANCE
+  // vs. the 0ms baseline). Loose enough that a busy CI runner that wakes
+  // the timer a few ms early won't flake the test.
+  const SETTLE = 120;
+  const TOLERANCE = 30;
+  await withFakeTmuxBin(async () => {
+    const prev = __forTest.setSlashCommandSettleMs(SETTLE);
+    try {
+      const taskId = randomUUID();
+      const t0 = performance.now();
+      // First paste claims the slash-command settle window.
+      const slash = __forTest.queuePaste(
+        taskId,
+        "sess-x",
+        "/model claude-opus-4-7",
+        __forTest.getSlashCommandSettleMs(),
+      );
+      // Follow-up user paste: zero settle, but must wait behind the slash
+      // command's window before it runs.
+      const userPaste = __forTest.queuePaste(taskId, "sess-x", "real user msg", 0);
+
+      let slashResolvedAt: number | null = null;
+      let userResolvedAt: number | null = null;
+      void slash.then(() => { slashResolvedAt = performance.now() - t0; });
+      void userPaste.then(() => { userResolvedAt = performance.now() - t0; });
+
+      await userPaste;
+
+      // The slash paste resolves first, after ~SETTLE ms (the settle window).
+      expect(slashResolvedAt).not.toBeNull();
+      expect(slashResolvedAt!).toBeGreaterThanOrEqual(SETTLE - TOLERANCE);
+      // The user paste resolves AFTER the slash paste — never before.
+      expect(userResolvedAt).not.toBeNull();
+      expect(userResolvedAt!).toBeGreaterThanOrEqual(slashResolvedAt!);
+    } finally {
+      __forTest.setSlashCommandSettleMs(prev);
+    }
+  });
+});
+
+test("queuePaste: pastes for different taskIds don't block each other", async () => {
+  await withFakeTmuxBin(async () => {
+    const SETTLE = 120;
+    const prev = __forTest.setSlashCommandSettleMs(SETTLE);
+    try {
+      const taskA = randomUUID();
+      const taskB = randomUUID();
+
+      // Task A's slash command holds a 120ms settle window.
+      const slashA = __forTest.queuePaste(taskA, "sess-a", "/model X", SETTLE);
+      const t0 = performance.now();
+      // Task B's paste should be able to run immediately — independent
+      // chain. If we accidentally globalized the lock, this would wait
+      // ~SETTLE ms.
+      await __forTest.queuePaste(taskB, "sess-b", "user msg", 0);
+      const elapsed = performance.now() - t0;
+
+      // Generous upper bound — proves task-B is NOT serialized behind
+      // task-A's settle. On a healthy run elapsed is ~0–5ms.
+      expect(elapsed).toBeLessThan(SETTLE / 2);
+      await slashA;
+    } finally {
+      __forTest.setSlashCommandSettleMs(prev);
+    }
+  });
+});
+
+test("queueTmuxOp: dismissTmuxPrompt-style op serializes behind a queued paste", async () => {
+  // Regression for the dismiss/paste interleave: a modal click's `"1"`
+  // + Enter must not land between an in-flight paste's `paste-buffer`
+  // and its `Enter`. Both operations share the same chain, so the
+  // dismissal can only run after the paste's chain slot has settled.
+  await withFakeTmuxBin(async () => {
+    const prev = __forTest.setSlashCommandSettleMs(60);
+    try {
+      const taskId = randomUUID();
+      const order: string[] = [];
+
+      // A slash paste with settle holds the chain briefly.
+      const slash = __forTest.queuePaste(taskId, "sess-x", "/model X", 60)
+        .then(() => order.push("paste-done"));
+      // Dismissal queued behind it via the generic op primitive.
+      const dismiss = __forTest.queueTmuxOp(taskId, async () => {
+        // Sentinel inside the op body so we can confirm it ran after
+        // the paste's chain slot settled, not interleaved with it.
+        order.push("dismiss-body");
+      }).then(() => order.push("dismiss-done"));
+
+      await Promise.all([slash, dismiss]);
+      // The dismissal body MUST run after the paste's chain slot
+      // resolved — never between paste-buffer and Enter.
+      expect(order).toEqual(["paste-done", "dismiss-body", "dismiss-done"]);
+    } finally {
+      __forTest.setSlashCommandSettleMs(prev);
+    }
+  });
+});
+
+test("dismissTmuxPrompt waits behind an in-flight paste on the same task", async () => {
+  // Direct test of the user-facing function (not just the underlying
+  // queueTmuxOp primitive): a modal click that lands while a slash
+  // command is mid-settle must be held by the chain. This is what
+  // prevents the original "Turn Ended Bug" race from re-opening at the
+  // dismissal path.
+  await withFakeTmuxBin(async () => {
+    const SETTLE = 100;
+    const TOLERANCE = 30;
+    const prev = __forTest.setSlashCommandSettleMs(SETTLE);
+    const { taskId, jsonlPath } = freshSession();
+    const state = __forTest.installSession(taskId, jsonlPath);
+    try {
+      const t0 = performance.now();
+      // Slash command holds the chain for SETTLE ms.
+      const pastePromise = __forTest.queuePaste(
+        taskId,
+        state.sessionName,
+        "/model X",
+        SETTLE,
+        state,
+      );
+      // Modal dismissal queued behind it. With the chain wired up
+      // through dismissTmuxPrompt, this can only resolve after the
+      // paste's settle window has elapsed.
+      const dismissedAtPromise = dismissTmuxPrompt(taskId, "1").then((ok) => ({
+        elapsed: performance.now() - t0,
+        ok,
+      }));
+      await pastePromise;
+      const { elapsed, ok } = await dismissedAtPromise;
+      // Assert the body actually ran — a silently identity-gated body
+      // would still satisfy the timing bound below, so we need this
+      // first. `ok` is only set inside the body, after the second
+      // `send-keys`, so `true` proves the dismissal reached completion.
+      expect(ok).toBe(true);
+      expect(elapsed).toBeGreaterThanOrEqual(SETTLE - TOLERANCE);
+    } finally {
+      __forTest.setSlashCommandSettleMs(prev);
+      __forTest.uninstallSession(taskId);
+    }
+  });
+});
+
+test("dismissTmuxPrompt mid-body re-gate: trailing Enter skipped when session is disposed during the gap", async () => {
+  // Covers the residual race the entry-only identity gate left open:
+  // a `dropSession` lands during the 50ms gap between digit and Enter,
+  // and the trailing `send-keys Enter` would otherwise leak into the
+  // respawned pane as a stray confirmation. The thunk's `stillCurrent()`
+  // re-check before the second tmux call closes it.
+  await withFakeTmuxBin(async () => {
+    const prev = __forTest.setSlashCommandSettleMs(0);
+    const { taskId, jsonlPath } = freshSession();
+    const state = __forTest.installSession(taskId, jsonlPath);
+    try {
+      // Kick off the dismissal — its first send-keys runs synchronously
+      // before the 50ms sleep starts.
+      const dismissPromise = dismissTmuxPrompt(taskId, "1");
+      // After the first send-keys is on the wire but during the gap,
+      // drop and respawn the session for the same taskId. Wait ~20ms
+      // to land squarely inside the dismissal's 50ms internal sleep.
+      await Bun.sleep(20);
+      __forTest.uninstallSession(taskId);
+      __forTest.installSession(taskId, jsonlPath);
+
+      const ok = await dismissPromise;
+      // With the mid-body re-gate, the second send-keys is skipped, so
+      // `ok` (set only on the trailing send-keys success) stays false.
+      // Without the re-gate this test would observe `ok === true` AND
+      // the new session's pane would have received a stray Enter.
+      expect(ok).toBe(false);
+    } finally {
+      __forTest.uninstallSession(taskId);
+      __forTest.setSlashCommandSettleMs(prev);
+    }
+  });
+});
+
+test("queueTmuxOp: skips its body if the session was disposed between scheduling and execution", async () => {
+  // Closes the race where `sessionNameFor(taskId)` is deterministic, so
+  // a same-taskId respawn reuses the tmux session name — a previously-
+  // queued op would otherwise send keystrokes into the *new* session.
+  // The `expectedState` identity guard inside queueTmuxOp prevents that.
+  await withFakeTmuxBin(async () => {
+    const prev = __forTest.setSlashCommandSettleMs(0);
+    const { taskId, jsonlPath } = freshSession();
+    const state = __forTest.installSession(taskId, jsonlPath);
+    try {
+      let ranOldChainOp = false;
+      // Schedule an op against the ORIGINAL state. Use a microtask gap
+      // (Promise.resolve()) so the dispose below lands before the
+      // thunk would otherwise run.
+      const gated = __forTest.queueTmuxOp(taskId, async () => {
+        ranOldChainOp = true;
+      }, state);
+      // Dispose the original session and install a fresh one for the
+      // same taskId — simulates dropSession + a follow-up
+      // spawnClaudeViaTmux reusing the task.
+      __forTest.uninstallSession(taskId);
+      __forTest.installSession(taskId, jsonlPath);
+
+      await gated;
+      // The thunk MUST have been skipped — the session it was queued
+      // against is gone.
+      expect(ranOldChainOp).toBe(false);
+    } finally {
+      __forTest.uninstallSession(taskId);
+      __forTest.setSlashCommandSettleMs(prev);
+    }
+  });
 });

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -654,6 +654,13 @@ export function getCurrentPermissionMode(taskId: string): string | null {
  *
  * Returns true on apparent success (tmux command exited 0). Silently
  * returns false when no session is registered.
+ *
+ * Latency: serialized behind any in-flight tmux op for the same task
+ * (paste-prompts included), so a click that lands while a `/model X`
+ * settle window is still elapsing waits up to `slashCommandSettleMs`
+ * (default 700ms) before the digit goes out. The server route at
+ * `server.ts:1420` awaits this Promise, so the modal-click HTTP
+ * response inherits the wait.
  */
 export async function dismissTmuxPrompt(taskId: string, key: string): Promise<boolean> {
   const state = sessions.get(taskId);
@@ -667,10 +674,25 @@ export async function dismissTmuxPrompt(taskId: string, key: string): Promise<bo
   // then the Enter confirms. The brief gap guarantees the two keystrokes
   // land in distinct reads on claude's stdin; `await Bun.sleep` (not the
   // sync variant) keeps the gap off the SSE/scrape event loop.
-  const sent = tmux(["send-keys", "-t", state.sessionName, key]);
-  if (!sent.ok) return false;
-  await Bun.sleep(50);
-  return tmux(["send-keys", "-t", state.sessionName, "Enter"]).ok;
+  //
+  // Routed through `queueTmuxOp` so the digit + Enter pair can't
+  // interleave with an in-flight `queuePaste` for the same session — a
+  // racing user paste's `paste-buffer + Enter` between our digit and our
+  // Enter would land the paste text in the modal's input and confirm
+  // garbage. Sharing the chain serializes us behind any pending paste
+  // (and its settle window) before our keys go out.
+  let ok = false;
+  await queueTmuxOp(taskId, async (stillCurrent) => {
+    const sent = tmux(["send-keys", "-t", state.sessionName, key]);
+    if (!sent.ok) return;
+    await Bun.sleep(50);
+    // Re-gate before the trailing Enter: a `dropSession` during the
+    // 50ms gap (with a same-taskId respawn) would otherwise land the
+    // Enter in the new session's pane as a stray confirmation.
+    if (!stillCurrent()) return;
+    ok = tmux(["send-keys", "-t", state.sessionName, "Enter"]).ok;
+  }, state);
+  return ok;
 }
 
 /* ────────────────────────────────────────────────────────────────────────── *
@@ -792,6 +814,33 @@ interface TurnSlot {
 }
 
 const sessions = new Map<string, SessionState>(); // taskId → state
+
+/**
+ * Per-task FIFO of tmux operations (paste-prompt + modal-dismissal).
+ *
+ * Why this matters: PATCH /tasks/:id (model/effort change) and POST
+ * /runs/:id/input arrive as independent HTTP requests on localhost and
+ * can race to the orchestrator's tmux helpers. The webview can fire the
+ * input the instant PATCH resolves, while `reconcileTaskSession` is still
+ * pasting `/model X` into the pane. Without serialization the two
+ * `load-buffer` + `paste-buffer` + Enter sequences land back-to-back in
+ * tmux but reach claude's TUI while it's in a transient post-slash-command
+ * state — the user's paste was confirmed to vanish silently for ~49s in
+ * a real session (see "Turn Ended Bug" repro), then only re-appeared
+ * after a manual retry.
+ *
+ * The fix: a per-task lock that holds the next operation until the
+ * previous one's settle window has elapsed. Modal dismissals
+ * (`dismissTmuxPrompt`) share the same chain so a click on a numbered
+ * choice can't interleave its `"1"` + Enter keystrokes with an in-flight
+ * paste-buffer + Enter from `queuePaste`.
+ *
+ * The map's value is the tail promise of the in-flight chain; new ops
+ * append via `queueTmuxOp`. Entries self-evict on completion when no
+ * follow-up has chained behind them, so the map doesn't grow unbounded
+ * for long-lived sessions.
+ */
+const pasteChains = new Map<string, Promise<void>>(); // taskId → in-flight chain tail
 
 /* ────────────────────────────────────────────────────────────────────────── *
  * JSONL discovery + tail.
@@ -1616,7 +1665,7 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
     writeInput: (line) => {
       const s = sessions.get(opts.taskId);
       if (!s) return false;
-      pastePrompt(s.sessionName, line);
+      void queuePaste(opts.taskId, s.sessionName, line, 0, s);
       return true;
     },
     done,
@@ -1649,7 +1698,7 @@ export function sendTurn(taskId: string, prompt: string, onChunk: ChunkHandler):
   // replayed as a new user turn once the current one finishes. Our
   // `turnQueue` mirrors that: subsequent end_turn events pop slots in
   // FIFO order.
-  pastePrompt(state.sessionName, prompt);
+  void queuePaste(taskId, state.sessionName, prompt, 0, state);
   return makeAgent(taskId, done);
 }
 
@@ -1668,7 +1717,13 @@ export function sendTurn(taskId: string, prompt: string, onChunk: ChunkHandler):
 export function sendSlashCommand(taskId: string, line: string): boolean {
   const state = sessions.get(taskId);
   if (!state) return false;
-  pastePrompt(state.sessionName, line);
+  // Settle delay after slash commands: claude's TUI takes ~hundreds of ms
+  // to process `/model` / `/effort` and return to a ready input prompt.
+  // Without the wait, a follow-up user paste (e.g. the next `sendTurn`
+  // racing on localhost) lands during the transient state and gets
+  // silently dropped — see the `Turn Ended Bug` repro where a
+  // `/code-review` paste sat invisible for 49s after a model change.
+  void queuePaste(taskId, state.sessionName, line, slashCommandSettleMs, state);
   return true;
 }
 
@@ -1740,13 +1795,14 @@ export async function cycleToMode(taskId: string, targetAgetorMode: string): Pro
   const target = toClaudeModeString(targetAgetorMode);
 
   // `/plan` works from any state, no cycle math needed. Prefer it.
-  // Fire-and-forget — `pastePrompt`'s tmux load-buffer / paste-buffer /
+  // Fire-and-forget — `queuePaste`'s tmux load-buffer / paste-buffer /
   // send-keys helpers swallow errors, and verifying via the JSONL would
   // require the same listener machinery the Shift+Tab path uses; for
   // `plan` the slash command is reliable enough that the added complexity
-  // doesn't pay for itself.
+  // doesn't pay for itself. Uses the slash-command settle window so a
+  // racing user paste lands after claude has processed the mode switch.
   if (target === CLAUDE_MODE_PLAN) {
-    pastePrompt(state.sessionName, "/plan");
+    void queuePaste(taskId, state.sessionName, "/plan", slashCommandSettleMs, state);
     return { ok: true, presses: 0, via: "slash-plan" };
   }
 
@@ -1867,6 +1923,12 @@ function disposeSessionState(state: SessionState | undefined): void {
   state.onPermissionMode = null;
   const err = new Error("session killed");
   for (const slot of state.turnQueue.splice(0)) slot.reject?.(err);
+  // Drop the chain map entry — the identity gate inside `queueTmuxOp`
+  // will already skip any in-flight thunks that captured the now-disposed
+  // `state` (they won't run their bodies), so this delete is just
+  // hygiene to release the map slot eagerly instead of waiting for the
+  // chain's self-evict `.finally` to fire.
+  pasteChains.delete(state.taskId);
 }
 
 function makeAgent(taskId: string, done: Promise<number>): SpawnedAgent {
@@ -1885,7 +1947,7 @@ function makeAgent(taskId: string, done: Promise<number>): SpawnedAgent {
     writeInput: (line) => {
       const state = sessions.get(taskId);
       if (!state) return false;
-      pastePrompt(state.sessionName, line);
+      void queuePaste(taskId, state.sessionName, line, 0, state);
       return true;
     },
     done,
@@ -1956,6 +2018,21 @@ export const __forTest = {
    *  mismatch`. Exposed so tests can assert against the constant rather
    *  than hardcoding "3". */
   MAX_VERIFY_ATTEMPTS,
+  /** Override the slash-command settle window. Tests shrink it to ~0
+   *  to avoid sleeping on every paste-queue assertion. Returns the
+   *  previous value so the test can restore it in `afterEach`. */
+  setSlashCommandSettleMs(ms: number): number {
+    const prev = slashCommandSettleMs;
+    slashCommandSettleMs = ms;
+    return prev;
+  },
+  getSlashCommandSettleMs(): number { return slashCommandSettleMs; },
+  /** Direct access to the paste queue for assertions. Read-only — tests
+   *  inspect ordering by observing tmux side effects, not by mutating
+   *  the chain. */
+  pasteChains,
+  queuePaste,
+  queueTmuxOp,
 };
 
 /**
@@ -1963,8 +2040,11 @@ export const __forTest = {
  * `load-buffer -` to avoid shell-quoting issues (the prompt may contain
  * newlines, dollar signs, quotes, …), paste it into the active window, then
  * press Enter to submit.
+ *
+ * Sync core — callers go through `queuePaste` so back-to-back pastes for the
+ * same task can't interleave at the tmux layer. See `queuePaste` for why.
  */
-function pastePrompt(sessionName: string, text: string): void {
+function pastePromptSync(sessionName: string, text: string): void {
   // load-buffer reads from stdin; -b names a tmux buffer we can target.
   const buf = `agetor-${sessionName}`;
   const load = tmux(["load-buffer", "-b", buf, "-"], { stdinText: text });
@@ -1972,4 +2052,135 @@ function pastePrompt(sessionName: string, text: string): void {
   tmux(["paste-buffer", "-b", buf, "-t", sessionName]);
   tmux(["delete-buffer", "-b", buf]);
   tmux(["send-keys", "-t", sessionName, "Enter"]);
+}
+
+/**
+ * Settle window after a slash-command paste before releasing the chain.
+ *
+ * Picked conservatively at 700ms — comfortably above the ~hundreds of ms
+ * claude's TUI takes to consume a `/model` / `/effort` / `/plan` line
+ * and repaint a ready prompt on an idle session. The original repro
+ * ("Turn Ended Bug") showed 0ms is wrong; the exact upper bound hasn't
+ * been measured under load, so the choice favors "definitely safe" over
+ * "minimum perceptible latency." The cost is one delay per slash command,
+ * applied before the *next* operation — never before the slash itself.
+ *
+ * Important caveat about what this delay actually buys: the timer starts
+ * when `pastePromptSync` returns (i.e. when tmux's `send-keys Enter`
+ * exits), NOT when claude has finished processing the slash command. On
+ * an idle REPL these are close enough that 700ms covers consumption +
+ * repaint. When claude is mid-turn, the slash command queues inside
+ * claude's input buffer; the timer expires while claude is still on the
+ * prior turn, but order is preserved by claude's own FIFO buffer — so
+ * the next paste lands behind the slash command anyway. The fragile case
+ * the lock plugs is the idle-REPL transient state, which the original
+ * bug exposed.
+ *
+ * Tests shrink the value to keep the queue suite fast.
+ */
+let slashCommandSettleMs = 700;
+
+/**
+ * Append a tmux operation to the per-task chain. The `fn` thunk runs
+ * after every prior op for the same task has settled. Errors thrown by
+ * `fn` are logged but never rejected onto the returned promise — one
+ * transient tmux failure shouldn't poison every subsequent op for the
+ * session. The returned promise resolves once `fn` (including any internal
+ * delays it awaits) has settled, which is when the *next* chained op
+ * becomes eligible to run. Callers fire-and-forget unless they need to
+ * synchronize with the op's completion (e.g. `dismissTmuxPrompt`, which
+ * needs to read the result of the final `send-keys Enter`).
+ *
+ * Used directly for ops that aren't a simple `paste-buffer + Enter`
+ * (modal dismissals send individual `send-keys` with their own internal
+ * gap). `queuePaste` is the convenience wrapper for the common case.
+ *
+ * `expectedState`, when provided, is captured at scheduling time and
+ * compared against `sessions.get(taskId)` right before `fn` runs (the
+ * one-shot entry gate) AND surfaced to `fn` as the `stillCurrent()`
+ * predicate so thunks with internal awaits can re-check between tmux
+ * calls. This closes the narrow race where `sessionNameFor(taskId)` is
+ * deterministic, so a re-spawn for the same task reuses the same tmux
+ * session name and a previously-queued op would otherwise send
+ * keystrokes into the *new* session — including the case where
+ * `dropSession` lands DURING `fn`'s `Bun.sleep` gap, leaving the
+ * trailing tmux call to leak into the respawned pane.
+ *
+ * ⚠️ Production callers MUST pass `expectedState`. The parameter is
+ * optional only because the unit test suite (`claude-tmux-queue.test.ts`)
+ * needs to drive the chain without installing a full SessionState for
+ * every ordering assertion; omitting it disables the gate entirely. If
+ * you're wiring up a new tmux op from any non-test code, pass the
+ * `SessionState` you got from `sessions.get(taskId)` — that's what
+ * makes the gate fire. The `expectedState`-less form behaves as if the
+ * gate is permanently open.
+ *
+ * `fn` receives a `stillCurrent()` predicate it can call before any
+ * post-await tmux work. When `expectedState` is omitted the predicate
+ * is always `true` (consistent with no-gate behavior).
+ */
+function queueTmuxOp(
+  taskId: string,
+  fn: (stillCurrent: () => boolean) => void | Promise<void>,
+  expectedState?: SessionState,
+): Promise<void> {
+  const stillCurrent = (): boolean =>
+    expectedState === undefined || sessions.get(taskId) === expectedState;
+  const prev = pasteChains.get(taskId) ?? Promise.resolve();
+  const next = prev.then(async () => {
+    // Identity-gate at body entry. `sessions.get(taskId) !== expectedState`
+    // means the session this op was queued against is gone — either
+    // disposed without a respawn (sessions.get returns undefined) or
+    // disposed and respawned as a fresh SessionState reusing the
+    // taskId. In both cases the right behavior is to drop the op.
+    // `fn` itself can re-check via the same predicate between awaits.
+    if (!stillCurrent()) return;
+    await fn(stillCurrent);
+  }).catch((e) => {
+    console.error(`tmux op chain error for task ${taskId}:`, e);
+  });
+  pasteChains.set(taskId, next);
+  // Self-evict when this is still the tail — keeps the map from
+  // accumulating entries for tasks that have gone idle. If something
+  // chained after us, the newer entry now owns the slot and we leave
+  // it alone. Identity check guards against the racy ordering where
+  // a follow-up op's `set(taskId, newer)` runs before our finally fires.
+  void next.finally(() => {
+    if (pasteChains.get(taskId) === next) pasteChains.delete(taskId);
+  });
+  return next;
+}
+
+/**
+ * Convenience wrapper over `queueTmuxOp` for the common case: paste
+ * `text` into `sessionName` and (optionally) hold the chain for
+ * `settleMs` afterwards so claude's TUI has time to finish processing
+ * the line before the next op runs.
+ *
+ * The returned promise resolves AFTER the paste AND the settle delay —
+ * i.e. when the next chained op becomes eligible, NOT when tmux has
+ * received the paste. Callers awaiting "did tmux get the keystrokes"
+ * should not infer that from this promise; the only thing the promise
+ * guarantees is chain ordering.
+ *
+ * Pass `expectedState` to gate the paste on the session still being
+ * the one this paste was scheduled against — see `queueTmuxOp` for the
+ * race this closes.
+ */
+function queuePaste(
+  taskId: string,
+  sessionName: string,
+  text: string,
+  settleMs: number,
+  expectedState?: SessionState,
+): Promise<void> {
+  // No mid-body re-gate needed: pastePromptSync delivers all four tmux
+  // calls (load-buffer + paste-buffer + delete-buffer + send-keys Enter)
+  // synchronously before the optional settle sleep. The settle is pure
+  // waiting — no tmux calls happen after it within this body — so a
+  // dispose during the sleep can't leak keystrokes.
+  return queueTmuxOp(taskId, async () => {
+    pastePromptSync(sessionName, text);
+    if (settleMs > 0) await Bun.sleep(settleMs);
+  }, expectedState);
 }


### PR DESCRIPTION
Mid-session model/effort changes race the next user message: PATCH /tasks/:id and POST /runs/:id/input arrive as independent HTTP requests on localhost, and the user-message paste lands in claude's TUI while it's in a transient post-slash-command state. JSONL trace from the "Turn Ended Bug" repro showed a /code-review paste sitting silently for 49s before the user re-sent it.

Add a per-task chain (`pasteChains`) that serializes every tmux operation for a session:
- `queueTmuxOp(taskId, fn, expectedState?)`: generic FIFO primitive, passes a `stillCurrent()` predicate so thunks with internal awaits can re-gate before each tmux call.
- `queuePaste(...)`: convenience wrapper for paste-buffer + Enter, holds the chain for `slashCommandSettleMs` (700ms) after slash commands so claude's TUI repaints a ready prompt before the next paste lands.
- Identity gate: `expectedState` is captured at scheduling time and re-checked at body entry and inside the body, so a dispose+respawn reusing the same deterministic tmux session name can't leak keystrokes into the new pane.

Route every existing tmux op through the chain: `sendTurn`, `sendSlashCommand`, `cycleToMode` (/plan), both `writeInput` paths, and `dismissTmuxPrompt` (which previously bypassed serialization and could interleave its digit+Enter with an in-flight paste-buffer+Enter).

Tests cover: FIFO ordering, settle-window timing, per-task isolation, dismissTmuxPrompt routing through the chain, the dispose-between- scheduling-and-execution race, and the mid-body re-gate that prevents a stray Enter from reaching a respawned session.