### PR TITLE
feat(agents): default claude-code to Opus 4.7, add Opus 4.6 option

### DIFF
--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -47,6 +47,7 @@ export interface AgentRunOptions {
 const CLAUDE_MODEL_FLAG: Record<string, string> = {
   "opus-4.8": "claude-opus-4-8",
   "opus-4.7": "claude-opus-4-7",
+  "opus-4.6": "claude-opus-4-6",
   "sonnet-4.6": "claude-sonnet-4-6",
   "haiku-4.5": "claude-haiku-4-5",
 };

--- a/src/bun/effort-support.test.ts
+++ b/src/bun/effort-support.test.ts
@@ -33,10 +33,10 @@ test("claude haiku-4.5 exposes no effort options (CLI doesn't accept the flag)",
   expect(ids).toEqual([]);
 });
 
-test("claude null model falls back to DEFAULT_MODEL support set (opus-4.8)", () => {
+test("claude null model falls back to DEFAULT_MODEL support set (opus-4.7)", () => {
   // No model specified → use the agent's default model's support set. Since
-  // claude-code's DEFAULT_MODEL is opus-4.8, xhigh + max are both available.
-  expect(DEFAULT_MODEL["claude-code"]).toBe("opus-4.8");
+  // claude-code's DEFAULT_MODEL is opus-4.7, xhigh + max are both available.
+  expect(DEFAULT_MODEL["claude-code"]).toBe("opus-4.7");
   const ids = supportedEfforts("claude-code", null).map((o) => o.id);
   expect(ids).toContain("xhigh");
   expect(ids).toContain("max");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -314,7 +314,7 @@ export interface AgentOptions {
  * CLI happens to default to.
  */
 export const DEFAULT_MODEL: Record<AgentKind, string> = {
-  "claude-code": "opus-4.8",
+  "claude-code": "opus-4.7",
   "codex": "gpt-5.5",
 };
 export const DEFAULT_EFFORT: Record<AgentKind, string> = {
@@ -366,7 +366,7 @@ export const CODE_PLAN_MODE: Record<AgentKind, { code: string; plan: string }> =
  */
 export const EFFORT_OPTIONS: AgentOption[] = [
   { id: "max", label: "Max", hint: "Absolute maximum effort. Slowest, most thorough." },
-  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Opus 4.8 / 4.7 / codex only." },
+  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Opus 4.8 / 4.7 / 4.6 / codex only." },
   { id: "high", label: "High", hint: "Deep reasoning. The API default where supported." },
   { id: "medium", label: "Medium", hint: "Balanced speed vs. capability." },
   { id: "low", label: "Low", hint: "Most efficient. Best for simple tasks." },
@@ -399,6 +399,7 @@ export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> =
   "claude-code": {
     "opus-4.8": ["max", "xhigh", "high", "medium", "low"],
     "opus-4.7": ["max", "xhigh", "high", "medium", "low"],
+    "opus-4.6": ["max", "xhigh", "high", "medium", "low"],
     "sonnet-4.6": ["max", "high", "medium", "low"],
     // Haiku 4.5 doesn't support the effort parameter — `supportedEfforts`
     // returns `[]` and the picker disables itself.
@@ -442,6 +443,7 @@ const MODEL_MODE_DENY: Record<AgentKind, Record<string, string[]>> = {
   "claude-code": {
     "opus-4.8": [],
     "opus-4.7": [],
+    "opus-4.6": [],
     "sonnet-4.6": [],
     "haiku-4.5": [],
   },
@@ -462,7 +464,8 @@ export const AGENT_OPTIONS: Record<AgentKind, AgentOptions> = {
   "claude-code": {
     models: [
       { id: "opus-4.8", label: "Opus 4.8", hint: "Most capable; slower." },
-      { id: "opus-4.7", label: "Opus 4.7", hint: "Previous flagship." },
+      { id: "opus-4.7", label: "Opus 4.7", hint: "Prior flagship; same effort range as 4.8." },
+      { id: "opus-4.6", label: "Opus 4.6", hint: "Earlier Opus generation." },
       { id: "sonnet-4.6", label: "Sonnet 4.6", hint: "Balanced." },
       { id: "haiku-4.5", label: "Haiku 4.5", hint: "Fast and cheap." },
     ],


### PR DESCRIPTION
Make Opus 4.7 the pre-selected claude-code model (back from 4.8) and expose Opus 4.6 as a new curated option with full effort range and the same permission-mode support as the other Opus generations.