### PR TITLE
fix(task-card): prevent badge column from overflowing card width

### DIFF
--- a/src/mainview/components/kanban/TaskCard.tsx
+++ b/src/mainview/components/kanban/TaskCard.tsx
@@ -75,7 +75,7 @@ export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen, o
     >
       <CardHeader className="pb-2">
         <div className="flex items-start justify-between gap-2">
-          <CardTitle className="text-sm">{task.title}</CardTitle>
+          <CardTitle className="text-sm min-w-0 flex-1 break-words">{task.title}</CardTitle>
           <div className="flex shrink-0 flex-col items-end gap-1">
             <Badge variant="secondary" className="gap-1">
               <AgentIcon kind={task.agent} className="size-3" />


### PR DESCRIPTION
Long unbreakable tokens in the title (e.g. quoted identifiers from Sentry error messages) pushed the shrink-0 badge column past the card's right edge. Add min-w-0 flex-1 break-words to the CardTitle so the title can shrink below its longest-token width and wrap long tokens in place.