### PR TITLE
fix(run-panel): open links in the OS default browser

### DIFF
--- a/src/bun/open-external.test.ts
+++ b/src/bun/open-external.test.ts
@@ -1,0 +1,136 @@
+import { test, expect, beforeAll, afterAll, mock } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-open-external-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+// Distinct from other server-test ports so parallel test runs don't fight.
+process.env.AGETOR_API_PORT = "4423";
+
+// Stub electrobun's native bridge before server.ts imports it — otherwise
+// `Utils.openExternal` would actually pop a browser tab during the test run.
+// Same approach as notifications.test.ts. The recorded array lets each test
+// assert what the route ultimately handed to the OS.
+const opened: string[] = [];
+mock.module("electrobun/bun", () => ({
+  Utils: {
+    openExternal: (url: string) => {
+      opened.push(url);
+      return true;
+    },
+    openPath: () => true,
+    openFileDialog: async () => [],
+    showNotification: () => { /* noop */ },
+  },
+  BrowserWindow: class { /* unused */ },
+  ApplicationMenu: { setApplicationMenu: () => { /* noop */ } },
+  Updater: { /* noop */ },
+}));
+
+let server: { stop: () => void };
+let token: string;
+
+beforeAll(async () => {
+  await import("./db.ts");
+  const { startApiServer, API_TOKEN } = await import("./server.ts");
+  server = startApiServer() as unknown as { stop: () => void };
+  token = API_TOKEN;
+});
+
+afterAll(() => {
+  server?.stop?.();
+});
+
+const post = (body: unknown, headers: Record<string, string> = {}) =>
+  fetch("http://127.0.0.1:4423/open-external", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+
+test("requires a token", async () => {
+  const res = await fetch("http://127.0.0.1:4423/open-external", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://example.com" }),
+  });
+  expect(res.status).toBe(401);
+});
+
+test("rejects missing url", async () => {
+  opened.length = 0;
+  const res = await post({});
+  expect(res.status).toBe(400);
+  expect(opened).toEqual([]);
+});
+
+test("rejects empty / whitespace url", async () => {
+  opened.length = 0;
+  const res = await post({ url: "   " });
+  expect(res.status).toBe(400);
+  expect(opened).toEqual([]);
+});
+
+test("rejects javascript: scheme", async () => {
+  opened.length = 0;
+  const res = await post({ url: "javascript:alert(1)" });
+  expect(res.status).toBe(400);
+  expect(opened).toEqual([]);
+});
+
+test("rejects file: scheme", async () => {
+  opened.length = 0;
+  const res = await post({ url: "file:///etc/passwd" });
+  expect(res.status).toBe(400);
+  expect(opened).toEqual([]);
+});
+
+test("rejects data: scheme", async () => {
+  opened.length = 0;
+  const res = await post({ url: "data:text/html,<script>alert(1)</script>" });
+  expect(res.status).toBe(400);
+  expect(opened).toEqual([]);
+});
+
+test("rejects custom scheme", async () => {
+  opened.length = 0;
+  const res = await post({ url: "vscode://open?file=/tmp/x" });
+  expect(res.status).toBe(400);
+  expect(opened).toEqual([]);
+});
+
+test("opens http URL", async () => {
+  opened.length = 0;
+  const res = await post({ url: "http://example.com/x" });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ opened: true, url: "http://example.com/x" });
+  expect(opened).toEqual(["http://example.com/x"]);
+});
+
+test("opens https URL", async () => {
+  opened.length = 0;
+  const res = await post({ url: "https://example.com/y" });
+  expect(res.status).toBe(200);
+  expect(opened).toEqual(["https://example.com/y"]);
+});
+
+test("opens mailto URL", async () => {
+  opened.length = 0;
+  const res = await post({ url: "mailto:foo@example.com" });
+  expect(res.status).toBe(200);
+  expect(opened).toEqual(["mailto:foo@example.com"]);
+});
+
+test("error body does not echo the raw URL", async () => {
+  // Server-side log-injection hygiene: even though the route is authed and
+  // the response is JSON, keep user-supplied URL strings out of the reflected
+  // error message in case downstream logging picks the body up unsanitized.
+  const res = await post({ url: "javascript:NEEDLE_TOKEN_xyz" });
+  const body = await res.text();
+  expect(body).not.toContain("NEEDLE_TOKEN_xyz");
+});

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -1043,6 +1043,29 @@ export function startApiServer() {
         }),
       },
 
+      // Open a URL in the OS default browser via Electrobun's native bridge.
+      // Restricted to http(s)/mailto so an attacker-controlled prompt can't
+      // launch `file://` or custom-scheme handlers from a webview click.
+      "/open-external": {
+        POST: authed(async (req) => {
+          const body = (await req.json().catch(() => ({}))) as { url?: string };
+          const raw = typeof body.url === "string" ? body.url.trim() : "";
+          if (!raw) {
+            return json({ error: "url required" }, { status: 400, headers: corsHeaders(req) });
+          }
+          if (!/^(https?|mailto):/i.test(raw)) {
+            // Don't echo the raw URL — keeps user-supplied content out of any
+            // downstream log line that might pick the response body up.
+            return json(
+              { error: "unsupported url scheme (only http, https, mailto)" },
+              { status: 400, headers: corsHeaders(req) },
+            );
+          }
+          const ok = Utils.openExternal(raw);
+          return json({ opened: ok, url: raw }, { headers: corsHeaders(req) });
+        }),
+      },
+
       // Open a native macOS open-panel and return whatever the user picked as
       // file/folder references. This is the reliable way to get absolute
       // paths into the prompt: WKWebView never populates the non-standard

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -1537,15 +1537,9 @@ function UserMessageBlock({ text }: { text: string }) {
             remarkPlugins={[remarkGfm]}
             components={{
               a: ({ href, children, ...rest }) => (
-                <a
-                  {...rest}
-                  href={href}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="text-primary underline-offset-2 hover:underline"
-                >
+                <ExternalLink {...rest} href={href}>
                   {children}
-                </a>
+                </ExternalLink>
               ),
               code: ({ className, children, ...props }) => {
                 const isBlock = /language-/.test(className ?? "");
@@ -1600,15 +1594,9 @@ function AssistantBlock({ text }: { text: string }) {
         components={{
           // External links open in the system browser via the OS handler.
           a: ({ href, children, ...rest }) => (
-            <a
-              {...rest}
-              href={href}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="text-primary underline-offset-2 hover:underline"
-            >
+            <ExternalLink {...rest} href={href}>
               {children}
-            </a>
+            </ExternalLink>
           ),
           code: ({ className, children, ...props }) => {
             const isBlock = /language-/.test(className ?? "");
@@ -1753,6 +1741,37 @@ function ToolResultBlock({ result }: { result: ParsedToolResult | null }) {
       </div>
       <ToolResultBody result={result} />
     </div>
+  );
+}
+
+/**
+ * Anchor that hands off http(s)/mailto navigation to the OS default browser
+ * via Electrobun's `Utils.openExternal`. The webview is sandboxed —
+ * `target="_blank"` is a no-op there — so every link in agent output has to
+ * round-trip through the main process to reach a real browser.
+ */
+function ExternalLink({
+  href,
+  className,
+  children,
+  ...rest
+}: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  const safe = typeof href === "string" && /^(https?|mailto):/i.test(href) ? href : null;
+  return (
+    <a
+      {...rest}
+      href={safe ?? "#"}
+      onClick={(e) => {
+        e.preventDefault();
+        if (!safe) return;
+        void api.openExternal(safe).catch((err: unknown) => {
+          toast.error(err instanceof Error ? err.message : "Could not open link");
+        });
+      }}
+      className={cn("text-primary underline-offset-2 hover:underline", className)}
+    >
+      {children}
+    </a>
   );
 }
 
@@ -1974,7 +1993,7 @@ function ToolInputBody({ name, input }: { name: string; input: unknown }) {
         {rawUrl && (
           <Field label="url">
             {safeUrl ? (
-              <a className="font-mono text-primary underline-offset-2 hover:underline" href={safeUrl} target="_blank" rel="noreferrer">{safeUrl}</a>
+              <ExternalLink className="font-mono" href={safeUrl}>{safeUrl}</ExternalLink>
             ) : (
               <span className="font-mono text-muted-foreground" title="non-http(s) URL — rendered as plain text for safety">{rawUrl}</span>
             )}

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -337,6 +337,17 @@ export const api = {
     }),
 
   /**
+   * Open an http(s) or mailto URL in the OS default browser. The webview is
+   * sandboxed; `target="_blank"` does nothing, so anchor clicks need to
+   * round-trip through the Bun main process to reach `Utils.openExternal`.
+   */
+  openExternal: (url: string) =>
+    j<{ opened: boolean; url: string }>(`/open-external`, {
+      method: "POST",
+      body: JSON.stringify({ url }),
+    }),
+
+  /**
    * Open the claude-code task's tmux session in a new Terminal.app window.
    * Returns the session name on success. Server-side checks the session is
    * actually live and that the task uses a claude-code harness.


### PR DESCRIPTION
Anchor clicks in the task-details sidebar were inert because WKWebView treats `target="_blank"` as a no-op. Route http(s)/mailto links through a new authed `/open-external` endpoint that calls `Utils.openExternal`. Scheme-allowlisted on both sides so a prompt-driven `javascript:` or `file:` link can't reach the OS handler.