### PR TITLE
fix(claude-tmux): navigate modals with arrow keys so "Allow all edits" isn't downgraded to "Yes"

### DIFF
--- a/src/bun/claude-tmux-queue.test.ts
+++ b/src/bun/claude-tmux-queue.test.ts
@@ -429,7 +429,10 @@ test("dismissTmuxPrompt waits behind an in-flight paste on the same task", async
       // Modal dismissal queued behind it. With the chain wired up
       // through dismissTmuxPrompt, this can only resolve after the
       // paste's settle window has elapsed.
-      const dismissedAtPromise = dismissTmuxPrompt(taskId, "1").then((ok) => ({
+      const dismissedAtPromise = dismissTmuxPrompt(taskId, "1", {
+        choices: [{ key: "1", label: "Yes" }, { key: "2", label: "No" }],
+        cursorIndex: 0,
+      }).then((ok) => ({
         elapsed: performance.now() - t0,
         ok,
       }));
@@ -448,29 +451,40 @@ test("dismissTmuxPrompt waits behind an in-flight paste on the same task", async
   });
 });
 
-test("dismissTmuxPrompt mid-body re-gate: trailing Enter skipped when session is disposed during the gap", async () => {
+test("dismissTmuxPrompt mid-body re-gate (key '2', one Down + Enter): trailing Enter skipped on dispose mid-gap", async () => {
   // Covers the residual race the entry-only identity gate left open:
-  // a `dropSession` lands during the 50ms gap between digit and Enter,
-  // and the trailing `send-keys Enter` would otherwise leak into the
-  // respawned pane as a stray confirmation. The thunk's `stillCurrent()`
-  // re-check before the second tmux call closes it.
+  // a `dropSession` lands during the gap between the navigation arrow
+  // and the trailing Enter, and `send-keys Enter` would otherwise leak
+  // into the respawned pane as a stray confirmation. The thunk's
+  // `stillCurrent()` re-check before the Enter call closes it.
+  //
+  // Uses key "2" with cursorIndex=0 (delta = 1 → one Down) so there's a
+  // real inter-keystroke gap to test. Key "1" with cursorIndex=0 maps
+  // to "no navigation, just Enter" and would skip the gap entirely.
   await withFakeTmuxBin(async () => {
     const prev = __forTest.setSlashCommandSettleMs(0);
     const { taskId, jsonlPath } = freshSession();
     const state = __forTest.installSession(taskId, jsonlPath);
     try {
-      // Kick off the dismissal — its first send-keys runs synchronously
-      // before the 50ms sleep starts.
-      const dismissPromise = dismissTmuxPrompt(taskId, "1");
-      // After the first send-keys is on the wire but during the gap,
-      // drop and respawn the session for the same taskId. Wait ~20ms
-      // to land squarely inside the dismissal's 50ms internal sleep.
-      await Bun.sleep(20);
+      // Kick off the dismissal — its first send-keys (a Down) runs
+      // synchronously before the 30ms sleep starts.
+      const dismissPromise = dismissTmuxPrompt(taskId, "2", {
+        choices: [
+          { key: "1", label: "Yes" },
+          { key: "2", label: "Yes, allow all" },
+          { key: "3", label: "No" },
+        ],
+        cursorIndex: 0,
+      });
+      // After the Down is on the wire but during the gap, drop and
+      // respawn the session for the same taskId. ~15ms lands squarely
+      // inside the dismissal's 30ms internal sleep.
+      await Bun.sleep(15);
       __forTest.uninstallSession(taskId);
       __forTest.installSession(taskId, jsonlPath);
 
       const ok = await dismissPromise;
-      // With the mid-body re-gate, the second send-keys is skipped, so
+      // With the mid-body re-gate, the trailing Enter is skipped, so
       // `ok` (set only on the trailing send-keys success) stays false.
       // Without the re-gate this test would observe `ok === true` AND
       // the new session's pane would have received a stray Enter.

--- a/src/bun/claude-tmux-scraper.test.ts
+++ b/src/bun/claude-tmux-scraper.test.ts
@@ -27,6 +27,7 @@ test("matchNumberedModal — claude plan-mode dialog (cursor on choice 1)", () =
   expect(m!.choices[0]!.label).toBe("Yes");
   expect(m!.choices[1]!.label).toBe("Yes, allow all");
   expect(m!.choices[2]!.label).toBe("No");
+  expect(m!.cursorIndex).toBe(0);
 });
 
 test("matchNumberedModal — alt cursor glyph (›)", () => {
@@ -35,6 +36,36 @@ test("matchNumberedModal — alt cursor glyph (›)", () => {
   2. Pick B`;
   const m = matchNumberedModal(pane);
   expect(m?.choices.length).toBe(2);
+  expect(m?.cursorIndex).toBe(0);
+});
+
+test("matchNumberedModal — cursor on non-first choice (model picker shape)", () => {
+  // Regression for the "Allow all edits silently picks Yes" class of
+  // bug: selection modals (model picker, /login) open with the cursor
+  // on the *current* value, not option 1. The cursor index must
+  // reflect that so the dismissal path can navigate from the right
+  // starting position.
+  const pane = `Pick a model
+  1. Opus 4.7
+❯ 2. Sonnet 4.6
+  3. Haiku 4.5`;
+  const m = matchNumberedModal(pane);
+  expect(m).not.toBeNull();
+  expect(m!.cursorIndex).toBe(1);
+});
+
+test("matchNumberedModal — same labels with different cursor position yield different fingerprints", () => {
+  // Cursor position is part of the fingerprint so that an in-progress
+  // modal whose selection changed (e.g., user arrowed via real tmux
+  // attach) re-registers with the new starting position. Without
+  // this, the second-tick stability check would silently match the old
+  // fingerprint and the dismissal path would navigate from a stale
+  // cursor index.
+  const a = matchNumberedModal(`❯ 1. A\n  2. B\n  3. C`)!;
+  const b = matchNumberedModal(`  1. A\n❯ 2. B\n  3. C`)!;
+  expect(a.cursorIndex).toBe(0);
+  expect(b.cursorIndex).toBe(1);
+  expect(a.fingerprint).not.toBe(b.fingerprint);
 });
 
 test("matchNumberedModal — no cursor anywhere means it's a printed list, not a modal", () => {

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -679,53 +679,100 @@ export function getCurrentPermissionMode(taskId: string): string | null {
 }
 
 /**
- * Send a literal keystroke (or short sequence) to a task's tmux session
- * followed by Enter. Used by the `/tmux-prompts/:id/answer` route to
- * dismiss a Claude REPL modal the scraper detected — typing `"1"` then
- * Enter into the pane is how the user would manually pick choice 1.
+ * Dismiss a Claude REPL modal the scraper detected by sending keystrokes
+ * into the task's tmux session.
+ *
+ * Numbered modals: claude's modal is rendered by Ink's select-input,
+ * which navigates with arrow keys and confirms with Enter. **Digit
+ * keypresses do not move the cursor or confirm a choice** — they're
+ * silently dropped. Sending `"2"` + Enter therefore behaves like Enter
+ * alone: confirms whatever the cursor was on. The fix: arrow-key from
+ * the scraper-observed `cursorIndex` to the index of the target choice,
+ * then Enter. Positive delta → `Down`; negative → `Up`. This matters
+ * because the scraper catches a wider set of modals than permission
+ * prompts — the model picker and `/login` open with the cursor on the
+ * *current* value, not necessarily option 1.
+ *
+ * Y/N modals: pass `cursorIndex` as undefined — the function falls back
+ * to sending the literal `y`/`n` keystroke, which claude's confirm
+ * helper handles directly.
+ *
+ * Each arrow press is its own `send-keys` invocation with a small sleep
+ * between them. A bursted `Down Down Enter` lands as one read on
+ * claude's stdin and the trailing Enter can be consumed before the
+ * second Down propagates through the Ink reducer — the same race the
+ * original `digit + Enter` split was working around.
  *
  * NOT a chat message: we deliberately bypass the `load-buffer +
  * paste-buffer` flow `pastePrompt` uses, because that path delivers the
  * text into claude's input buffer to become the next prompt. The modal
- * wants a direct keypress, not a queued message.
+ * wants direct keypresses, not a queued message.
  *
- * Returns true on apparent success (tmux command exited 0). Silently
- * returns false when no session is registered.
+ * Returns true on apparent success (every tmux command exited 0).
+ * Silently returns false when no session is registered, when the target
+ * key isn't present in the supplied choices, or when the session is
+ * disposed mid-body (a `dropSession` + respawn during the inter-
+ * keystroke gap would otherwise leak the trailing Enter into the fresh
+ * pane as a stray confirmation).
  *
  * Latency: serialized behind any in-flight tmux op for the same task
  * (paste-prompts included), so a click that lands while a `/model X`
  * settle window is still elapsing waits up to `slashCommandSettleMs`
- * (default 700ms) before the digit goes out. The server route at
- * `server.ts:1420` awaits this Promise, so the modal-click HTTP
+ * (default 700ms) before the first keystroke goes out. The server route
+ * at `server.ts:1420` awaits this Promise, so the modal-click HTTP
  * response inherits the wait.
  */
-export async function dismissTmuxPrompt(taskId: string, key: string): Promise<boolean> {
+export async function dismissTmuxPrompt(
+  taskId: string,
+  key: string,
+  ctx: { choices: TmuxPromptChoice[]; cursorIndex?: number },
+): Promise<boolean> {
   const state = sessions.get(taskId);
   if (!state) return false;
-  // Two SEPARATE send-keys calls — not "key Enter" in one. A combined
-  // invocation makes tmux deliver "1\r" as a single read chunk, and
-  // claude's Ink select consumes only the digit (moves/highlights the
-  // choice) while the trailing carriage return is dropped — so the choice
-  // is never confirmed and the modal just sits there. Splitting them
-  // (mirrors pastePrompt's separate Enter) lets the digit register first,
-  // then the Enter confirms. The brief gap guarantees the two keystrokes
-  // land in distinct reads on claude's stdin; `await Bun.sleep` (not the
-  // sync variant) keeps the gap off the SSE/scrape event loop.
-  //
-  // Routed through `queueTmuxOp` so the digit + Enter pair can't
+  // Map the choice key to its 0-based position in the registered list.
+  // We use the *list* (not `parseInt(key) - 1`) so leading-zero or
+  // unexpected key shapes can never silently mis-navigate — and so a
+  // future modal that uses non-digit keys with arrow navigation would
+  // still work without changing this function.
+  const targetIndex = ctx.choices.findIndex((c) => c.key === key);
+  if (targetIndex < 0) return false;
+  const useArrowNav = typeof ctx.cursorIndex === "number";
+  const delta = useArrowNav ? targetIndex - ctx.cursorIndex! : 0;
+  const arrow = delta >= 0 ? "Down" : "Up";
+  const stepCount = Math.abs(delta);
+  // Routed through `queueTmuxOp` so our navigation + Enter sequence can't
   // interleave with an in-flight `queuePaste` for the same session — a
-  // racing user paste's `paste-buffer + Enter` between our digit and our
+  // racing user paste's `paste-buffer + Enter` between our arrow and our
   // Enter would land the paste text in the modal's input and confirm
   // garbage. Sharing the chain serializes us behind any pending paste
   // (and its settle window) before our keys go out.
   let ok = false;
   await queueTmuxOp(taskId, async (stillCurrent) => {
-    const sent = tmux(["send-keys", "-t", state.sessionName, key]);
-    if (!sent.ok) return;
-    await Bun.sleep(50);
-    // Re-gate before the trailing Enter: a `dropSession` during the
-    // 50ms gap (with a same-taskId respawn) would otherwise land the
-    // Enter in the new session's pane as a stray confirmation.
+    if (useArrowNav) {
+      // Numbered modal: arrow-key from cursorIndex to targetIndex.
+      // delta === 0 → no arrow at all, the trailing Enter alone
+      // confirms the current selection.
+      for (let i = 0; i < stepCount; i++) {
+        if (!tmux(["send-keys", "-t", state.sessionName, arrow]).ok) return;
+        // Small gap between arrow presses — defensive splitting that
+        // mirrors what the original `digit + Enter` path needed:
+        // bursting two arrow events as a single read into Ink's stdin
+        // has been observed (rarely) to coalesce into one cursor
+        // advance. The gap also lets the per-keystroke `stillCurrent()`
+        // re-gate fire if a `dropSession` lands mid-navigation.
+        await Bun.sleep(30);
+        if (!stillCurrent()) return;
+      }
+    } else {
+      // y/n style: send the literal keystroke.
+      if (!tmux(["send-keys", "-t", state.sessionName, key]).ok) return;
+      await Bun.sleep(50);
+      if (!stillCurrent()) return;
+    }
+    // Explicit re-gate before the trailing Enter — symmetric with the
+    // per-arrow check inside the loop and the y/n path above. Future
+    // edits that insert an `await` between the loop end and this Enter
+    // would otherwise reopen the dispose-during-gap race.
     if (!stillCurrent()) return;
     ok = tmux(["send-keys", "-t", state.sessionName, "Enter"]).ok;
   }, state);
@@ -1354,6 +1401,13 @@ interface ScrapeMatch {
   paneText: string;
   /** Buttons to render — `key` is what we send to tmux on click. */
   choices: TmuxPromptChoice[];
+  /** 0-based index of the choice marked by the `❯`/`›` cursor at scrape
+   *  time. Undefined when arrow navigation does not apply (y/N modals).
+   *  Threaded through to `dismissTmuxPrompt` so it knows how far to
+   *  navigate from the current selection — permission modals default to
+   *  index 0 (option 1), but the model picker / auth re-prompts open
+   *  with the cursor on the *current* value, anywhere in the list. */
+  cursorIndex?: number;
   /** Stable hash that survives across consecutive scrapes as long as the
    *  modal stays on screen unchanged. */
   fingerprint: string;
@@ -1397,13 +1451,27 @@ function matchNumberedModal(tail: string): ScrapeMatch | null {
     if (i > 0 && Number(numbered[i - 1]!.key) + 1 !== Number(numbered[i]!.key)) break;
   }
   if (tailRun.length < 2) return null;
+  // Cursor MUST land inside tailRun for the modal to be dismissible —
+  // otherwise the `❯` is on a printed list above the actual choice set
+  // (we'd send arrow keys into a phantom selector). Bail rather than
+  // register a half-known modal.
+  const cursorIndex = tailRun.findIndex((n) => n.cursorHere);
+  if (cursorIndex < 0) return null;
   const choices: TmuxPromptChoice[] = tailRun.map((n) => ({ key: n.key, label: n.label }));
   // Use the last ~12 lines for the displayed pane snippet so the user
   // sees the question text + the choices, not 40 lines of unrelated
   // context above.
   const paneText = lines.slice(-12).join("\n").trimEnd();
-  const fingerprint = sha1(`numbered:${choices.map((c) => `${c.key}|${c.label}`).join("/")}`);
-  return { paneText, choices, fingerprint };
+  // Cursor position is part of the fingerprint: if claude moves the
+  // highlight while the modal is on screen (e.g., user arrows around
+  // via a real tmux attach), we want to re-register so the dismissal
+  // path picks up the new starting position. Without this the second-
+  // tick stability check would silently match the old position and
+  // navigate from a stale index.
+  const fingerprint = sha1(
+    `numbered:${choices.map((c) => `${c.key}|${c.label}`).join("/")}|@${cursorIndex}`,
+  );
+  return { paneText, choices, cursorIndex, fingerprint };
 }
 
 /** Recognise `(y/N)` / `(Y/n)` / `[y/n]` confirmation prompts on the
@@ -1543,6 +1611,7 @@ function scrapeOnce(state: SessionState): void {
     runId,
     paneText: match.paneText,
     choices: match.choices,
+    cursorIndex: match.cursorIndex,
     fingerprint: match.fingerprint,
   });
 }

--- a/src/bun/interactions.ts
+++ b/src/bun/interactions.ts
@@ -174,6 +174,16 @@ export interface TmuxPromptRequest {
    *  what claude is asking. */
   paneText: string;
   choices: TmuxPromptChoice[];
+  /** 0-based index of the choice the scraper saw as currently selected
+   *  (the `❯`/`›` cursor line) at registration time. The dismissal path
+   *  uses this to compute how many `Down`/`Up` arrow presses to send
+   *  before Enter — claude's Ink select-input only responds to arrow
+   *  keys, not digit hotkeys. Permission modals default the cursor to
+   *  option 1 (index 0), but selection modals (model picker, auth re-
+   *  prompts) open with the cursor on the *current* value, which can be
+   *  anywhere. Undefined for prompts where arrow nav doesn't apply
+   *  (y/N modals — the literal `y`/`n` keystroke goes in directly). */
+  cursorIndex?: number;
   /** Stable hash of the matched block — used to debounce duplicate
    *  registrations across consecutive scrapes and to detect external
    *  dismissal (the prompt disappeared from the pane). */
@@ -504,6 +514,7 @@ export function registerTmuxPrompt(args: {
   runId: string;
   paneText: string;
   choices: TmuxPromptChoice[];
+  cursorIndex?: number;
   fingerprint: string;
 }): { id: string; req: TmuxPromptRequest; answer: Promise<TmuxPromptAnswer> } {
   // Defend the reserved-key namespace — `__external__` / `__cancelled__`
@@ -523,6 +534,7 @@ export function registerTmuxPrompt(args: {
     runId: args.runId,
     paneText: args.paneText,
     choices: args.choices,
+    cursorIndex: args.cursorIndex,
     fingerprint: args.fingerprint,
     createdAt: Date.now(),
   };

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -1440,7 +1440,10 @@ export function startApiServer() {
               { status: 410, headers: corsHeaders(req) },
             );
           }
-          const delivered = await dismissTmuxPrompt(pending.taskId, key);
+          const delivered = await dismissTmuxPrompt(pending.taskId, key, {
+            choices: pending.choices,
+            cursorIndex: pending.cursorIndex,
+          });
           if (!delivered) {
             return json(
               { ok: false, error: "failed to deliver keystroke to tmux" },


### PR DESCRIPTION
Claude's REPL modal is rendered by Ink's select-input, which navigates with arrow keys and confirms with Enter — digit keypresses are silently dropped. The previous dismissal path sent the choice digit + Enter, so clicking option 2 ("Yes, allow all edits during this session") ended up confirming the default cursor on option 1 ("Yes"), making claude re-prompt on the next edit.

The scraper now records the cursor index alongside the choices, and dismissTmuxPrompt arrow-keys from that index to the target choice's index before sending Enter. This also fixes selection modals (model picker, /login) where the cursor opens on the current value rather than option 1.

- thread cursorIndex through the scraper → registerTmuxPrompt → TmuxPromptRequest → server route → dismissTmuxPrompt
- include cursor position in the scrape fingerprint so a mid-modal arrow re-registers with the new starting position
- add explicit stillCurrent() re-gate before the final Enter
- map target index via choices.findIndex(c => c.key === key) so leading- zero or non-digit keys can never silently mis-navigate
- new scraper tests cover non-first cursor (model-picker shape) and fingerprint-changes-with-cursor