### PR TITLE
fix(approvals): honor saved allow-rules in plan mode

### DIFF
--- a/src/bun/approvals-endpoint.test.ts
+++ b/src/bun/approvals-endpoint.test.ts
@@ -243,7 +243,7 @@ test("POST /approvals — saved Edit rule still auto-allows in non-plan mode (re
   expect(__testing.approvalsSize()).toBe(0);
 });
 
-test("POST /approvals — plan mode skips the saved-rule fast-path and registers an approval", async () => {
+test("POST /approvals — plan mode honors saved rules (Allow always trumps plan mode)", async () => {
   const { state } = await seedTaskWithSavedRule({
     taskId: "t-saved-rule-plan",
     ruleEntry: "Edit(/tmp/**)",
@@ -251,11 +251,7 @@ test("POST /approvals — plan mode skips the saved-rule fast-path and registers
   state.permissionMode = "plan";
   const { __testing } = await import("./interactions.ts");
   __testing.reset();
-  // Don't await — the route blocks until the interaction answers, which
-  // is the *point*: in plan mode we want to surface to the UI, not
-  // short-circuit. Race the fetch against a short delay; the registry
-  // size assertion proves the interaction landed.
-  const pending = fetch(url(`/approvals?taskId=t-saved-rule-plan`), {
+  const res = await fetch(url(`/approvals?taskId=t-saved-rule-plan`), {
     method: "POST",
     headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
     body: JSON.stringify({
@@ -263,13 +259,37 @@ test("POST /approvals — plan mode skips the saved-rule fast-path and registers
       tool_input: { file_path: "/tmp/y", old_string: "c", new_string: "d" },
     }),
   });
-  // Give the server a tick to register before we assert.
+  // Saved rule short-circuits even in plan mode: "Allow always" is the
+  // user's explicit trust signal and holds across mode changes.
+  expect(res.status).toBe(200);
+  const body = await res.json() as { hookSpecificOutput?: { permissionDecision?: string } };
+  expect(body.hookSpecificOutput?.permissionDecision).toBe("allow");
+  expect(__testing.approvalsSize()).toBe(0);
+});
+
+test("POST /approvals — plan mode still intercepts mutating tools without a saved rule", async () => {
+  const { state } = await seedTaskWithSavedRule({
+    taskId: "t-plan-no-rule",
+    ruleEntry: "Edit(/some/other/path/**)",
+  });
+  state.permissionMode = "plan";
+  const { __testing } = await import("./interactions.ts");
+  __testing.reset();
+  // Don't await — the route blocks until the interaction answers, which
+  // is the *point*: in plan mode without a matching rule we want to
+  // surface to the UI, not short-circuit.
+  const pending = fetch(url(`/approvals?taskId=t-plan-no-rule`), {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: "/tmp/y", old_string: "c", new_string: "d" },
+    }),
+  });
   await new Promise((r) => setTimeout(r, 50));
   expect(__testing.approvalsSize()).toBe(1);
-  // Resolve via the answer endpoint so the awaiting fetch settles and
-  // doesn't leak across tests.
   const { listPendingForTask, answerApproval } = await import("./interactions.ts");
-  const list = listPendingForTask("t-saved-rule-plan");
+  const list = listPendingForTask("t-plan-no-rule");
   expect(list[0]?.kind).toBe("approval");
   if (list[0]?.kind === "approval") {
     answerApproval(list[0].id, { decision: "allow" });

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -1196,13 +1196,10 @@ export function startApiServer() {
           // generic ApprovalCard) shouldn't be able to disable the safety.
           const ALWAYS_INTERCEPT = new Set(["AskUserQuestion", "ExitPlanMode"]);
           // Plan mode is the user explicitly opting into "stop and ask
-          // before any write". A saved allow-rule from a prior non-plan
-          // run must not silently bypass that — otherwise the kanban
-          // shows "Agent is working…" while claude is actually paused on
-          // its plan-mode confirmation dialog inside tmux (see
-          // docs/can-we-apply-both-* plan). Read-only tools keep their
-          // fast-path even here: they can't mutate the workspace, so
-          // the plan-mode safety doesn't apply.
+          // before any write". Tools without a saved allow-rule still get
+          // intercepted; saved rules (created via "Allow always") are
+          // honored everywhere — "always" means always, including in
+          // plan mode. Read-only tools keep their fast-path either way.
           const PLAN_MODE_INTERCEPT = new Set([
             "Edit", "Write", "MultiEdit", "NotebookEdit", "Bash",
           ]);
@@ -1235,12 +1232,19 @@ export function startApiServer() {
             return json(makeHookResponse({ decision: "allow" }), { headers: corsHeaders(req) });
           }
           // Fast paths: safe tools and previously-saved rules auto-allow,
-          // except for the always-intercept set above. The allow-rule lookup
-          // now reads `.claude/settings.local.json` `permissions.allow` and
-          // matches per the claude pattern syntax (see claude-permissions.ts).
+          // except for the always-intercept set above. Order matters —
+          // the cheap, plan-gated safe/readOnlyBash check runs first so
+          // the common case (every grep/find/ls) skips the disk read in
+          // lookupAllowRule. The saved-rule path runs second and bypasses
+          // planModeForce: "Allow always" is the user's explicit trust
+          // signal and holds across mode changes. To revoke a rule,
+          // delete it from the Rules manager.
           if (!ALWAYS_INTERCEPT.has(toolName) && !planModeForce &&
-              (SAFE_TOOLS.has(toolName) || readOnlyBash ||
-               lookupAllowRule({ taskId, toolName, toolInput: payload.tool_input }) === "allow")) {
+              (SAFE_TOOLS.has(toolName) || readOnlyBash)) {
+            return json(makeHookResponse({ decision: "allow" }), { headers: corsHeaders(req) });
+          }
+          if (!ALWAYS_INTERCEPT.has(toolName) &&
+              lookupAllowRule({ taskId, toolName, toolInput: payload.tool_input }) === "allow") {
             return json(makeHookResponse({ decision: "allow" }), { headers: corsHeaders(req) });
           }
           // ─── Claude built-in interactive tools ─────────────────────────


### PR DESCRIPTION
"Allow always" is the user's explicit trust signal — it should hold across mode changes, not silently get overridden when they switch to plan mode. The saved-rule fast-path now runs unconditionally (still gated by ALWAYS_INTERCEPT for AskUserQuestion / ExitPlanMode), while plan mode keeps intercepting mutating tools that don't match any saved rule. Order the cheap safe/readOnlyBash check first so the common grep/find/ls case doesn't pay the lookupAllowRule disk read.