### PR TITLE
feat(approvals): add "Approve & auto" plan action and persist mode on approve

### DIFF
--- a/src/bun/approvals-endpoint.test.ts
+++ b/src/bun/approvals-endpoint.test.ts
@@ -364,6 +364,58 @@ test("POST /approvals — acceptEdits mode auto-allows read-only Bash", async ()
   expect(__testing.approvalsSize()).toBe(0);
 });
 
+test("POST /approvals — acceptEdits mode auto-allows edit tools (Edit/Write/MultiEdit/NotebookEdit)", async () => {
+  // Honors the badge contract: when task.mode is acceptEdits (set via
+  // PATCH or via "Approve & implement" on a plan card), edit tools must
+  // flow without a card. Bash and other non-edit tools still ask.
+  const { __testing: pre } = await import("./interactions.ts");
+  pre.reset();
+  const { state } = await seedTaskWithSavedRule({
+    taskId: "t-accept-edits",
+    ruleEntry: "Edit(/tmp/**)", // unrelated; just satisfies the seed helper
+  });
+  state.permissionMode = "acceptEdits";
+  for (const toolName of ["Edit", "Write", "MultiEdit", "NotebookEdit"]) {
+    const res = await fetch(url(`/approvals?taskId=t-accept-edits`), {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        tool_name: toolName,
+        tool_input: { file_path: "/anywhere/else.ts", old_string: "a", new_string: "b" },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { hookSpecificOutput?: { permissionDecision?: string } };
+    expect(body.hookSpecificOutput?.permissionDecision).toBe("allow");
+  }
+  const { __testing } = await import("./interactions.ts");
+  expect(__testing.approvalsSize()).toBe(0);
+});
+
+test("POST /approvals — acceptEdits mode still intercepts mutating Bash (rm)", async () => {
+  // The flip side of the edit-tools fast-path: Bash is not in
+  // ACCEPT_EDITS_TOOLS, so a destructive shell call still draws a card.
+  const { __testing: pre } = await import("./interactions.ts");
+  pre.reset();
+  const { state } = await seedTaskWithSavedRule({
+    taskId: "t-accept-mut-bash",
+    ruleEntry: "Edit(/tmp/**)",
+  });
+  state.permissionMode = "acceptEdits";
+  const pending = fetch(url(`/approvals?taskId=t-accept-mut-bash`), {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ tool_name: "Bash", tool_input: { command: "rm -rf /tmp/x" } }),
+  });
+  await new Promise((r) => setTimeout(r, 50));
+  const { __testing, listPendingForTask, answerApproval } = await import("./interactions.ts");
+  expect(__testing.approvalsSize()).toBe(1);
+  const list = listPendingForTask("t-accept-mut-bash");
+  if (list[0]?.kind === "approval") answerApproval(list[0].id, { decision: "allow" });
+  const res = await pending;
+  expect(res.status).toBe(200);
+});
+
 test("POST /approvals — auto mode auto-allows arbitrary Bash without registering an approval", async () => {
   // Regression: when a task was launched in `ask` mode and the user later
   // PATCHes the mode to `auto`, the FULL hook matcher is still installed

--- a/src/bun/interactions.test.ts
+++ b/src/bun/interactions.test.ts
@@ -350,14 +350,30 @@ test("registerPlanApproval resolves with the choice from answerPlanApproval", as
   expect((await answer).choice).toBe("approve_implement");
 });
 
+test("planApprovalTargetMode returns agetor-canonical mode ids for each approve choice", async () => {
+  const { planApprovalTargetMode } = await import("./interactions.ts");
+  // Strings here MUST match AGENT_OPTIONS["claude-code"].modes ids in
+  // shared/types.ts — they're persisted directly to `task.mode` and feed
+  // the UI's mode dropdown. Regression guard against the "default" vs
+  // "ask" typo (claude's internal string vs agetor's mode id).
+  expect(planApprovalTargetMode({ choice: "approve_auto" })).toBe("auto");
+  expect(planApprovalTargetMode({ choice: "approve_implement" })).toBe("acceptEdits");
+  expect(planApprovalTargetMode({ choice: "approve_ask" })).toBe("ask");
+  expect(planApprovalTargetMode({ choice: "reject" })).toBeNull();
+});
+
 test("formatPlanApprovalReason maps each choice to a distinct natural-language instruction", async () => {
-  const { formatPlanApprovalReason } = await import("./interactions.ts");
+  const { formatPlanApprovalReason, PLAN_APPROVED_REPLY_PREFIX } = await import("./interactions.ts");
+  const auto = formatPlanApprovalReason({ choice: "approve_auto" });
   const impl = formatPlanApprovalReason({ choice: "approve_implement" });
   const ask = formatPlanApprovalReason({ choice: "approve_ask" });
   const reject = formatPlanApprovalReason({ choice: "reject", revision: "use option B instead" });
+  expect(auto).toContain("auto mode");
+  expect(auto.startsWith(PLAN_APPROVED_REPLY_PREFIX)).toBe(true);
   expect(impl).toContain("auto-accept");
   expect(ask).toContain("confirm before");
   expect(reject).toContain("option B instead");
+  expect(auto).not.toEqual(impl);
   expect(impl).not.toEqual(ask);
   expect(impl).not.toEqual(reject);
 });

--- a/src/bun/interactions.ts
+++ b/src/bun/interactions.ts
@@ -131,11 +131,12 @@ export interface PlanApprovalRequest {
 }
 
 export interface PlanApprovalAnswer {
-  /** approve_implement → auto-accept edits and proceed
+  /** approve_auto      → proceed in auto mode (bypass all approval prompts)
+   *  approve_implement → auto-accept edits and proceed
    *  approve_ask       → proceed but ask before each edit
    *  reject            → don't proceed; let claude revise (`revision` carries
    *                      the user's free-text feedback) */
-  choice: "approve_implement" | "approve_ask" | "reject";
+  choice: "approve_auto" | "approve_implement" | "approve_ask" | "reject";
   revision?: string;
 }
 
@@ -480,8 +481,26 @@ export function answerPlanApproval(id: string, answer: PlanApprovalAnswer): bool
 /** Map a plan-approval choice into the natural-language string claude reads
  *  as the deny reason. Phrased as the user's response so claude can adapt
  *  its next turn without further prompting. */
+/** Map a plan-approval choice to the agetor-canonical `task.mode` value
+ *  that should be applied to the live session (and persisted to the task
+ *  row) when the user approves. Returns `null` for `reject` — the task
+ *  stays in plan mode while claude revises. Strings here MUST match
+ *  AGENT_OPTIONS["claude-code"].modes ids in `shared/types.ts`; the
+ *  `toClaudeModeString` mapping in claude-tmux.ts handles the agetor →
+ *  claude string remap (e.g. `ask → default`). */
+export function planApprovalTargetMode(ans: PlanApprovalAnswer): string | null {
+  switch (ans.choice) {
+    case "approve_auto":      return "auto";
+    case "approve_implement": return "acceptEdits";
+    case "approve_ask":       return "ask";
+    case "reject":            return null;
+  }
+}
+
 export function formatPlanApprovalReason(ans: PlanApprovalAnswer): string {
   switch (ans.choice) {
+    case "approve_auto":
+      return `${PLAN_APPROVED_REPLY_PREFIX} and wants you to proceed in auto mode. Implement it now — do not pause for any approvals, including Bash and other tool calls.`;
     case "approve_implement":
       return `${PLAN_APPROVED_REPLY_PREFIX} and wants you to implement it now. Proceed with the edits — auto-accept changes (do not pause for per-edit approvals).`;
     case "approve_ask":

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -63,6 +63,7 @@ import {
   listPendingForTask,
   lookupAllowRule,
   makeHookResponse,
+  planApprovalTargetMode,
   registerApproval,
   registerAskQuestions,
   registerPlanApproval,
@@ -1206,6 +1207,11 @@ export function startApiServer() {
           const PLAN_MODE_INTERCEPT = new Set([
             "Edit", "Write", "MultiEdit", "NotebookEdit", "Bash",
           ]);
+          // File-edit tools that auto-allow under acceptEdits — mirrors
+          // claude's own acceptEdits scope (edits flow, Bash still asks).
+          const ACCEPT_EDITS_TOOLS = new Set([
+            "Edit", "Write", "MultiEdit", "NotebookEdit",
+          ]);
           // A `Bash` call whose command is confidently read-only (grep/find/
           // ls/cat/…) is treated like the dedicated read-only tools: it can't
           // mutate the workspace, so it auto-allows even in ask/acceptEdits
@@ -1232,6 +1238,18 @@ export function startApiServer() {
           // approval cards for routine Bash even after switching to auto.
           if (!ALWAYS_INTERCEPT.has(toolName) &&
               (currentMode === "auto" || currentMode === "bypassPermissions")) {
+            return json(makeHookResponse({ decision: "allow" }), { headers: corsHeaders(req) });
+          }
+          // acceptEdits fast-path: edit tools auto-allow (matches claude's
+          // own acceptEdits semantics — file edits flow without prompts,
+          // everything else still asks). Without this, a task in acceptEdits
+          // mode (either set via PATCH or via "Approve & implement" on a
+          // plan-mode card) still draws an approval card for every Edit,
+          // contradicting the badge. Bash and other non-edit tools fall
+          // through to the standard interactive flow.
+          if (!ALWAYS_INTERCEPT.has(toolName) &&
+              currentMode === "acceptEdits" &&
+              ACCEPT_EDITS_TOOLS.has(toolName)) {
             return json(makeHookResponse({ decision: "allow" }), { headers: corsHeaders(req) });
           }
           // Fast paths: safe tools and previously-saved rules auto-allow,
@@ -1268,6 +1286,36 @@ export function startApiServer() {
             const plan = parseExitPlanInput(payload.tool_input);
             const { answer } = registerPlanApproval({ taskId, runId, plan });
             const ans = await answer;
+            // Approve choices also flip the live claude session's permission
+            // mode (and persist `task.mode`) so the PreToolUse hook's
+            // auto/bypass fast-path kicks in for subsequent tools and the
+            // kanban badge reflects reality. Without this, claude stays in
+            // `plan` mode and every Bash/Edit still draws a card even after
+            // "Approve & auto". Reuses the same reconciliation helper that
+            // PATCH /tasks/:id uses for mode edits.
+            const targetMode = planApprovalTargetMode(ans);
+            if (targetMode) {
+              const before = tasks.get(taskId);
+              if (before && before.mode !== targetMode) {
+                const updated = tasks.update(taskId, { mode: targetMode });
+                if (updated) {
+                  // Block the hook response on cycle-and-verify (unlike PATCH
+                  // /tasks/:id, which is fire-and-forget). The deny+reason we
+                  // return here unblocks claude to issue its next tool call
+                  // immediately, but `getCurrentPermissionMode` only flips
+                  // once the JSONL `permission-mode` event arrives — so a
+                  // fire-and-forget here lets claude's next Bash hit the
+                  // PreToolUse hook with `currentMode` still "plan" and draw
+                  // an approval card the user just opted out of. Cycle
+                  // verification takes ~100–400ms in the happy path, up to
+                  // 4.5s on retry — an acceptable wait on a button-click
+                  // boundary the user is already engaged with.
+                  await reconcileTaskSession(taskId, before, updated).catch((err: unknown) => {
+                    console.error("reconcileTaskSession (plan approval) failed:", err);
+                  });
+                }
+              }
+            }
             return json(
               makeHookResponse({ decision: "deny", reason: formatPlanApprovalReason(ans) }),
               { headers: corsHeaders(req) },

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -2976,15 +2976,18 @@ function AskQuestionsCard({
 
 /**
  * Card for claude's built-in ExitPlanMode (intercepted via PreToolUse
- * hook). Renders the plan body verbatim plus three action buttons:
+ * hook). Renders the plan body verbatim plus four action buttons:
  *
- *   • Approve & implement      — claude auto-accepts edits going forward
- *   • Approve, ask before each — claude asks before each file change
+ *   • Approve & auto           — switches task to auto, no further prompts
+ *   • Approve & implement      — switches task to acceptEdits (auto-accept
+ *                                edits, ask for Bash etc.)
+ *   • Approve, ask before each — switches task to default (ask each change)
  *   • Reject / revise          — claude rewrites the plan with feedback
  *
  * The chosen action becomes a natural-language string the server emits as
- * the hook's `permissionDecisionReason`. Claude reads it as if its TUI
- * modal had returned that choice and proceeds.
+ * the hook's `permissionDecisionReason`, and the server also calls
+ * cycleToMode + tasks.update so the live session and the kanban badge
+ * follow.
  */
 function PlanApprovalCard({
   req,
@@ -2995,11 +2998,16 @@ function PlanApprovalCard({
 }) {
   const [revising, setRevising] = useState(false);
   const [revision, setRevision] = useState("");
-  const [submitting, setSubmitting] = useState(false);
+  // `submittingChoice` tracks which button was clicked so we can render
+  // "Sending…" on that specific button. `submitting` is the boolean any
+  // disabled={} predicate should read.
+  type Choice = "approve_auto" | "approve_implement" | "approve_ask" | "reject";
+  const [submittingChoice, setSubmittingChoice] = useState<Choice | null>(null);
+  const submitting = submittingChoice !== null;
 
-  const decide = async (choice: "approve_implement" | "approve_ask" | "reject") => {
+  const decide = async (choice: Choice) => {
     if (submitting) return;
-    setSubmitting(true);
+    setSubmittingChoice(choice);
     try {
       await api.answerPlanApproval(req.id, {
         choice,
@@ -3007,9 +3015,11 @@ function PlanApprovalCard({
       });
       onResolved(req.id);
     } finally {
-      setSubmitting(false);
+      setSubmittingChoice(null);
     }
   };
+  const labelFor = (choice: Choice, fallback: string) =>
+    submittingChoice === choice ? "Sending…" : fallback;
 
   return (
     <div className="rounded-md border border-primary/60 bg-card p-3 ring-1 ring-primary/40">
@@ -3047,7 +3057,7 @@ function PlanApprovalCard({
               size="sm"
               disabled={submitting}
             >
-              {submitting ? "Sending…" : "Send revision request"}
+              {labelFor("reject", "Send revision request")}
             </Button>
           </>
         ) : (
@@ -3066,14 +3076,22 @@ function PlanApprovalCard({
               size="sm"
               disabled={submitting}
             >
-              Approve, ask each edit
+              {labelFor("approve_ask", "Approve, ask each edit")}
+            </Button>
+            <Button
+              onClick={() => void decide("approve_auto")}
+              variant="secondary"
+              size="sm"
+              disabled={submitting}
+            >
+              {labelFor("approve_auto", "Approve & auto")}
             </Button>
             <Button
               onClick={() => void decide("approve_implement")}
               size="sm"
               disabled={submitting}
             >
-              {submitting ? "Sending…" : "Approve & implement"}
+              {labelFor("approve_implement", "Approve & implement")}
             </Button>
           </>
         )}

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -410,7 +410,7 @@ export const api = {
   /** Answer claude's ExitPlanMode (intercepted via PreToolUse hook). */
   answerPlanApproval: (
     id: string,
-    body: { choice: "approve_implement" | "approve_ask" | "reject"; revision?: string },
+    body: { choice: "approve_auto" | "approve_implement" | "approve_ask" | "reject"; revision?: string },
   ) =>
     j<{ ok: boolean }>(`/plan-approvals/${id}/answer`, {
       method: "POST",


### PR DESCRIPTION
ExitPlanMode previously offered only "Approve & implement" (acceptEdits-ish behaviour) and "Approve, ask each edit", and the chosen action only sent a natural-language hint to claude — the live session stayed in plan mode and task.mode never changed, so every subsequent Bash/Edit still drew a card.

This adds a third "Approve & auto" choice and, for all three approve paths, maps the choice to an agetor-canonical task.mode (auto / acceptEdits / ask), persists it, and awaits reconcileTaskSession so the hook fast-path sees the new mode before claude's next tool call. Also extends the PreToolUse auto-allow fast-path so acceptEdits skips the card for Edit/Write/MultiEdit/ NotebookEdit (honouring the badge contract), while non-edit tools like Bash still ask.

The choice→mode mapping lives in planApprovalTargetMode() so the "default" vs "ask" string distinction is exercised by a table test.