### PR TITLE
fix(orchestrator): move claude task to BLOCKED on API error so user can retry

### DIFF
--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { MODEL_EFFORT_SUPPORT, type AgentKind, type Harness } from "../shared/types.ts";
 import {
+  CLAUDE_API_ERROR_STATUS_PREFIX,
   spawnClaudeViaTmux,
   toClaudeModeString,
   type ChunkHandler,
@@ -286,8 +287,31 @@ function makeFakeAgent(taskId: string, prompt: string, onChunk: ChunkHandler): S
   const record: string[] = [`spawn:${prompt}`];
   let resolveDone!: (code: number) => void;
   const done = new Promise<number>((res) => { resolveDone = res; });
-  setTimeout(() => onChunk("stdout", `fake response to: ${prompt}`), 5);
-  setTimeout(() => { onChunk("status", "turn complete"); resolveDone(0); }, 20);
+  // Test hook: simulate a claude code API error mid-turn so orchestrator
+  // tests can exercise the api-error → `blocked` column flip without having
+  // to plumb a real synthetic-message JSONL through the driver. Mirrors what
+  // claude-tmux.ts emits on an `isApiErrorMessage` line: the user-facing
+  // text on the assistant stream + the sentinel api-error status chunk that
+  // makeChunkHandler pattern-matches on. Resolves the turn with code 0
+  // because that's what popEndOfTurn does — the orchestrator distinguishes
+  // it from a real success via the handle.apiError flag, not exit code.
+  if (process.env.AGETOR_FAKE_CLAUDE_API_ERROR === "1") {
+    // Emit the chunks promptly (this is what flips the column to `blocked`
+    // in the live path), but allow an optional resolve delay so
+    // cancellation-precedence tests have a window to fire `cancelRun`
+    // between the column flip and the done resolution. Without the delay
+    // both events would land within the same tick and there'd be nowhere
+    // to insert the cancel.
+    const resolveDelayMs = Number(process.env.AGETOR_FAKE_CLAUDE_RESOLVE_DELAY_MS ?? 5) || 5;
+    setTimeout(() => {
+      onChunk("assistant", "API Error: 529 Overloaded. This is a server-side issue, usually temporary.");
+      onChunk("status", `${CLAUDE_API_ERROR_STATUS_PREFIX}HTTP 529 — turn aborted; blocked for manual retry`);
+    }, 5);
+    setTimeout(() => { resolveDone(0); }, resolveDelayMs);
+  } else {
+    setTimeout(() => onChunk("stdout", `fake response to: ${prompt}`), 5);
+    setTimeout(() => { onChunk("status", "turn complete"); resolveDone(0); }, 20);
+  }
   const inst: FakeDriverInstance = {
     _record: record,
     kill: () => { record.push("kill"); },

--- a/src/bun/claude-tmux.test.ts
+++ b/src/bun/claude-tmux.test.ts
@@ -8,6 +8,7 @@ import { homedir } from "node:os";
 process.env.AGETOR_TMUX_BIN = "/bin/echo";
 
 import {
+  CLAUDE_API_ERROR_STATUS_PREFIX,
   CLAUDE_MODE_ACCEPT_EDITS,
   CLAUDE_MODE_AUTO,
   CLAUDE_MODE_BYPASS,
@@ -200,6 +201,66 @@ test("mapJsonlEventToChunks: stop_reason=end_turn with text+tool_use still retur
   expect(res.endOfTurn).toBe(true);
   expect(out.some((r) => r.stream === "assistant" && r.data === "let me check that")).toBe(true);
   expect(out.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(false);
+});
+
+test("mapJsonlEventToChunks: synthetic isApiErrorMessage line emits an api-error status and signals endOfTurn so the run resolves", () => {
+  // Without this branch the run would sit in `running` forever — claude
+  // stamps stop_reason: "stop_sequence" (not end_turn) on API-error
+  // messages, so the regular end_turn detection misses them. The
+  // orchestrator's chunk handler pattern-matches on the api-error status
+  // prefix to flip the task to the `blocked` column.
+  //
+  // Uses a uuid-aware recorder (the shared `recorder()` drops the third
+  // arg) because this test specifically asserts that the status chunk is
+  // emitted with `uuid: undefined` so the partial unique index on
+  // `(run_id, line_uuid)` doesn't drop the row.
+  const out: { stream: string; data: string; uuid: string | undefined }[] = [];
+  const onChunk = (stream: Record["stream"], data: string, uuid?: string) => out.push({ stream, data, uuid });
+  const line = JSON.stringify({
+    type: "assistant",
+    uuid: "err-1",
+    isApiErrorMessage: true,
+    apiErrorStatus: 529,
+    message: {
+      stop_reason: "stop_sequence",
+      content: [{ type: "text", text: "API Error: 529 Overloaded. This is a server-side issue, usually temporary — try again in a moment." }],
+    },
+  });
+  const res = mapJsonlEventToChunks(line, onChunk);
+  expect(res.endOfTurn).toBe(true);
+  // The user-facing error text still rides the regular assistant stream
+  // with the JSONL line uuid (so it dedups on reattach).
+  const assistantRow = out.find((r) => r.stream === "assistant" && r.data.startsWith("API Error: 529"));
+  expect(assistantRow).toBeDefined();
+  expect(assistantRow!.uuid).toBe("err-1");
+  // Sentinel status chunk the orchestrator pattern-matches on. Must start
+  // with the full prefix (trailing space/colon rules out a hypothetical
+  // future status that begins with the word "api").
+  const status = out.find((r) => r.stream === "status" && r.data.startsWith(CLAUDE_API_ERROR_STATUS_PREFIX));
+  expect(status).toBeDefined();
+  expect(status!.data).toContain("HTTP 529");
+  // Critically: emitted with uuid:undefined. If we reused the assistant
+  // line's uuid the partial unique index would silently drop this row via
+  // INSERT OR IGNORE and the breadcrumb would vanish on panel reload.
+  expect(status!.uuid).toBeUndefined();
+});
+
+test("mapJsonlEventToChunks: isApiErrorMessage without apiErrorStatus still emits a sentinel status (HTTP suffix omitted)", () => {
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({
+    type: "assistant",
+    uuid: "err-2",
+    isApiErrorMessage: true,
+    message: {
+      stop_reason: "stop_sequence",
+      content: [{ type: "text", text: "API Error: connection reset" }],
+    },
+  });
+  const res = mapJsonlEventToChunks(line, onChunk);
+  expect(res.endOfTurn).toBe(true);
+  const status = out.find((r) => r.stream === "status" && r.data.startsWith(CLAUDE_API_ERROR_STATUS_PREFIX));
+  expect(status).toBeDefined();
+  expect(status!.data).not.toContain("HTTP");
 });
 
 test("mapJsonlEventToChunks: system{subtype:turn_duration} emits the duration as a status breadcrumb", () => {

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -321,7 +321,23 @@ interface ParsedJsonlEvent {
    *  in milliseconds — surfaced as a status breadcrumb so the user sees how
    *  long the turn took. */
   durationMs?: number;
+  /** Claude code stamps `isApiErrorMessage: true` (with `model: "<synthetic>"`
+   *  and `stop_reason: "stop_sequence"`) on assistant lines it synthesises to
+   *  surface an Anthropic API failure to the user (e.g. 529 Overloaded, 400
+   *  validation errors). The text block carries the user-facing error string.
+   *  These never get a real `end_turn`, so without special-casing them the
+   *  run would sit in `running` forever. */
+  isApiErrorMessage?: boolean;
+  /** HTTP status of the underlying API failure (paired with isApiErrorMessage). */
+  apiErrorStatus?: number;
 }
+
+/** Status-chunk prefix the orchestrator looks for to flip a claude task into
+ *  the `blocked` column when the agent hit an API error mid-turn. The colon +
+ *  space act as a separator so a future status starting with the word "api"
+ *  can't accidentally match. Centralised so the producer (claude-tmux) and
+ *  consumer (orchestrator) can't drift. */
+export const CLAUDE_API_ERROR_STATUS_PREFIX = "api error: ";
 
 /**
  * True for an assistant JSONL line that claims to end a turn. Used by
@@ -332,7 +348,14 @@ interface ParsedJsonlEvent {
  * cancels the staged pending when the next line proves the turn isn't over.
  */
 function isEndOfTurnEvent(evt: ParsedJsonlEvent): boolean {
-  return evt.type === "assistant" && evt.message?.stop_reason === "end_turn";
+  if (evt.type !== "assistant") return false;
+  // API-error messages never carry stop_reason: "end_turn" (they're
+  // synthetic — claude stamps stop_reason: "stop_sequence"), but they
+  // terminate the turn just as definitively from the orchestrator's
+  // perspective. Treat them as turn-ends here so the reattach replay path
+  // also stages them; the live path is covered by mapParsedEventToChunks
+  // returning endOfTurn:true on the same predicate.
+  return evt.message?.stop_reason === "end_turn" || evt.isApiErrorMessage === true;
 }
 
 /**
@@ -540,6 +563,26 @@ function mapParsedEventToChunks(
             // here as we grow renderers.
             break;
         }
+      }
+      // Synthetic API-error message — claude code injects these when the
+      // Anthropic API call fails (529 Overloaded, 400 validation, etc.).
+      // The text block above already surfaced the user-facing error string;
+      // emit a sentinel `status` chunk the orchestrator can pattern-match on
+      // to flip the task into the `blocked` column, and signal endOfTurn so
+      // the run row resolves instead of sitting in `running` forever.
+      //
+      // Emitted with `uuid: undefined` (not the JSONL line uuid) on purpose:
+      // the assistant text block above was just appended to run_events with
+      // that uuid, and the partial unique index on `(run_id, line_uuid)`
+      // would silently drop this status via INSERT OR IGNORE if we reused
+      // it. The NULL key path inserts unconditionally, so the breadcrumb
+      // also shows up on panel reload — not just live SSE.
+      if (evt.isApiErrorMessage === true) {
+        const detail = typeof evt.apiErrorStatus === "number"
+          ? `HTTP ${evt.apiErrorStatus} — turn aborted; blocked for manual retry`
+          : "turn aborted; blocked for manual retry";
+        onChunk("status", `${CLAUDE_API_ERROR_STATUS_PREFIX}${detail}`);
+        return { endOfTurn: true, lineUuid: uuid };
       }
       // Signal a candidate turn-end. `dispatchLine` stages this and confirms
       // it's real only when the *next* line is not a same-message continuation

--- a/src/bun/orchestrator-blocked.test.ts
+++ b/src/bun/orchestrator-blocked.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import type { GlobalEvent } from "../shared/types.ts";
 
 // Top-level: db.ts captures AGETOR_DATA_DIR at first import.
 process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-blk-"));
@@ -11,6 +12,12 @@ process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-blk-"));
 // claude branch. Use codex's stub binary to exercise the flip.
 process.env.AGETOR_CODEX_BIN = "/bin/echo";
 process.env.AGETOR_CODEX_ARGS = "Do you want me to apply this patch?";
+// Point claude + tmux at /bin/echo so the availability probe in startTask
+// passes on hosts where neither binary is installed (CI). The claude fake
+// driver bypasses the real binary anyway — this just satisfies the
+// preflight check.
+process.env.AGETOR_CLAUDE_BIN = "/bin/echo";
+process.env.AGETOR_TMUX_BIN = "/bin/echo";
 
 test("orchestrator flips codex task to 'blocked' on approval-prompt output", async () => {
   const { createTask, startTask, subscribe } = await import("./orchestrator.ts");
@@ -53,4 +60,122 @@ test("orchestrator flips codex task to 'blocked' on approval-prompt output", asy
   // surfaced via the status event + a transient column change.
   expect(statuses.some((s) => s.startsWith("blocked"))).toBe(true);
   expect(after).not.toBeNull();
+});
+
+test("orchestrator leaves claude task in 'blocked' column when the run hits an API error", async () => {
+  const { createTask, startTask, subscribeGlobal } = await import("./orchestrator.ts");
+  const { tasks, runs } = await import("./db.ts");
+
+  // Use the fake claude driver and ask it to simulate an API error mid-turn.
+  // The driver emits the same sentinel status chunk claude-tmux emits on a
+  // real `isApiErrorMessage` JSONL line, then resolves done(0). The
+  // orchestrator's chunk handler should flip the column to `blocked`, and
+  // the done handler should keep it there (not bounce back to `ready`).
+  process.env.AGETOR_CLAUDE_DRIVER = "fake";
+  process.env.AGETOR_FAKE_CLAUDE_API_ERROR = "1";
+
+  // Subscribe to global events so we can also assert the column transition
+  // carried `reason: "api-error"` — that's what selects the new
+  // `toastApiError` over the generic `toastPending` in the webview.
+  const globals: GlobalEvent[] = [];
+  const unsub = subscribeGlobal((e) => globals.push(e));
+
+  try {
+    const created = await createTask({
+      title: "api error",
+      prompt: "anything",
+      agent: "claude-code",
+      workdir: process.cwd(),
+      isolation: "none",
+    });
+    if ("error" in created) throw new Error(created.error);
+    const task = created.task;
+
+    const res = await startTask(task.id);
+    if ("error" in res) throw new Error(`startTask failed: ${res.error}`);
+    const runId = res.runId;
+
+    // Driver resolves done(0) at ~5ms; allow plenty of slack so the done
+    // handler has run and applied its column transition.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const after = tasks.get(task.id);
+    expect(after?.column).toBe("blocked");
+
+    const runRow = runs.get(runId);
+    // Even though the driver resolved with exit 0, the api-error path forces
+    // status=failed so the badge and history are honest.
+    expect(runRow?.status).toBe("failed");
+
+    // The `reason` on the column event is what routes the UI to the
+    // red "API error — retry" toast. A regression that silently dropped
+    // the 4th arg from updateColumn would still leave the column at
+    // `blocked` (other findings cover that) but would land on the
+    // generic "Waiting on you" toast — which is exactly the UX the
+    // user complained about. Assert the field explicitly.
+    const apiErrorCol = globals.find(
+      (e) => e.kind === "column" && e.taskId === task.id && e.column === "blocked",
+    );
+    expect(apiErrorCol).toBeDefined();
+    if (apiErrorCol?.kind !== "column") throw new Error("expected column event");
+    expect(apiErrorCol.reason).toBe("api-error");
+  } finally {
+    unsub();
+    delete process.env.AGETOR_CLAUDE_DRIVER;
+    delete process.env.AGETOR_FAKE_CLAUDE_API_ERROR;
+  }
+});
+
+test("orchestrator: cancellation wins over api-error in column resolution (cancelled task → 'ready', not 'blocked')", async () => {
+  const { createTask, startTask, cancelRun } = await import("./orchestrator.ts");
+  const { tasks, runs } = await import("./db.ts");
+
+  // Same fake-api-error path as above, but with a resolve delay so we can
+  // fire `cancelRun` before the synthetic api-error done(0) lands. Both
+  // `handle.apiError` and `handle.cancelled` will be true when the done
+  // handler runs — it must defer to the cancellation, mirroring the
+  // newStatus resolution.
+  process.env.AGETOR_CLAUDE_DRIVER = "fake";
+  process.env.AGETOR_FAKE_CLAUDE_API_ERROR = "1";
+  process.env.AGETOR_FAKE_CLAUDE_RESOLVE_DELAY_MS = "120";
+
+  try {
+    const created = await createTask({
+      title: "api error then cancel",
+      prompt: "anything",
+      agent: "claude-code",
+      workdir: process.cwd(),
+      isolation: "none",
+    });
+    if ("error" in created) throw new Error(created.error);
+    const task = created.task;
+
+    const res = await startTask(task.id);
+    if ("error" in res) throw new Error(`startTask failed: ${res.error}`);
+    const runId = res.runId;
+
+    // Wait long enough for the api-error chunk to land (it flips the
+    // column to `blocked` immediately) but well before the delayed
+    // done(0) resolves — that's the window where cancellation has to
+    // take precedence.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(tasks.get(task.id)?.column).toBe("blocked");
+
+    cancelRun(runId);
+
+    // Now wait past the resolve delay so the done handler runs.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const after = tasks.get(task.id);
+    // Cancellation routes the column to `ready` (mirroring the
+    // pre-api-error contract for cancelled runs), NOT `blocked`.
+    expect(after?.column).toBe("ready");
+
+    const runRow = runs.get(runId);
+    expect(runRow?.status).toBe("cancelled");
+  } finally {
+    delete process.env.AGETOR_CLAUDE_DRIVER;
+    delete process.env.AGETOR_FAKE_CLAUDE_API_ERROR;
+    delete process.env.AGETOR_FAKE_CLAUDE_RESOLVE_DELAY_MS;
+  }
 });

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -29,6 +29,7 @@ import {
   type InteractionResolved,
 } from "./interactions.ts";
 import {
+  CLAUDE_API_ERROR_STATUS_PREFIX,
   cycleToMode,
   type CycleResult,
   dropSession,
@@ -76,6 +77,12 @@ interface ActiveRun {
    *  heuristic match. Stays unset on claude-code — interactive claude doesn't
    *  surface narrative through stdout that would false-positive. */
   blocked: boolean;
+  /** Set when claude code emitted an `isApiErrorMessage` line during this
+   *  run (e.g. 529 Overloaded). The chunk handler flips the column to
+   *  `blocked` immediately; the done handler reads this on resolution to
+   *  keep the column at `blocked` (instead of bouncing to `ready`) and
+   *  record the run as `failed`. */
+  apiError: boolean;
 }
 const active = new Map<string, ActiveRun>(); // runId -> handle
 
@@ -129,12 +136,17 @@ function normalizeUserText(s: string): string {
  * from keeping its own diff state. Pass `null` for `runId` when the change
  * isn't tied to a specific run (e.g. orphan reconciliation).
  */
-function updateColumn(taskId: string, runId: string | null, next: ColumnId): void {
+function updateColumn(
+  taskId: string,
+  runId: string | null,
+  next: ColumnId,
+  reason?: "api-error" | "approval",
+): void {
   const before = tasks.get(taskId);
   const prev: ColumnId | null = before?.column ?? null;
   tasks.update(taskId, { column: next });
   if (prev !== next) {
-    emitGlobal({ kind: "column", taskId, runId, column: next, prev, ts: Date.now() });
+    emitGlobal({ kind: "column", taskId, runId, column: next, prev, ts: Date.now(), reason });
   }
 }
 
@@ -241,6 +253,25 @@ export function reconcileOrphans(): number {
       });
       if (spawned) {
         registerActiveRun(row.id, row.task_id, task, spawned);
+        // Pre-seed `handle.apiError` when the prior process had already
+        // emitted the api-error status to run_events for this run. The
+        // reattach replay can't re-emit it — the assistant-line uuid is in
+        // seenLineUuids, so `dispatchLine` short-circuits before the
+        // mapper runs — so without this seed `attachDoneHandler` would
+        // resolve with `wasApiError=false` and bounce the column from the
+        // (correctly-persisted) `blocked` back to `review` on the first
+        // pending-end-turn fire. `EXISTS` short-circuits on first match
+        // and reads more clearly than `COUNT(*) > 0`.
+        const priorApiError = db.query<{ found: 0 | 1 }, [string, string]>(
+          `SELECT EXISTS(
+             SELECT 1 FROM run_events
+             WHERE run_id = ? AND stream = 'status' AND data LIKE ?
+           ) AS found`,
+        ).get(row.id, `${CLAUDE_API_ERROR_STATUS_PREFIX}%`)?.found ?? 0;
+        if (priorApiError === 1) {
+          const handle = active.get(row.id);
+          if (handle) handle.apiError = true;
+        }
         attachDoneHandler(row.id, row.task_id, spawned);
         reattachedTaskIds.add(row.task_id);
         // Visible seam in the run panel so the user can tell where the
@@ -433,6 +464,26 @@ function makeChunkHandler(
   return (stream: RunEvent["stream"], data: string, lineUuid?: string) => {
     runs.appendEvent(runId, stream, data, lineUuid);
     emit({ runId, taskId, stream, data, ts: Date.now() });
+    // Claude API-error path: claude-tmux emits a sentinel status chunk on
+    // synthetic `isApiErrorMessage` lines (529, 400, …) and resolves the
+    // turn. Flip to `blocked` here so the card stops sitting in `running`,
+    // and mark the handle so `attachDoneHandler` doesn't bounce it back to
+    // `ready` when the resolution lands a moment later.
+    if (
+      kind === "claude-code"
+      && stream === "status"
+      && data.startsWith(CLAUDE_API_ERROR_STATUS_PREFIX)
+    ) {
+      const handle = active.get(runId);
+      if (handle && !handle.apiError) {
+        handle.apiError = true;
+        const task = tasks.get(taskId);
+        if (task && task.runId === runId) {
+          updateColumn(taskId, runId, "blocked", "api-error");
+        }
+      }
+      return;
+    }
     if (kind !== "codex") return;
     const handle = active.get(runId);
     const promptingMode = mode && mode !== "auto";
@@ -444,7 +495,7 @@ function makeChunkHandler(
       && isApprovalPrompt(data)
     ) {
       handle.blocked = true;
-      updateColumn(taskId, runId, "blocked");
+      updateColumn(taskId, runId, "blocked", "approval");
       emit({
         runId,
         taskId,
@@ -468,6 +519,7 @@ function registerActiveRun(
     kill: () => agent.kill(),
     cancelled: false,
     blocked: false,
+    apiError: false,
     writeInput: (line) => agent.writeInput(line),
   });
 }
@@ -486,10 +538,16 @@ function attachDoneHandler(
     .then((code) => {
       const handle = active.get(runId);
       const wasCancelled = handle?.cancelled ?? false;
+      const wasApiError = handle?.apiError ?? false;
       active.delete(runId);
 
+      // API error overrides the exit-code mapping: claude resolves the turn
+      // with code 0 (the synthetic message stages a clean end_turn), but the
+      // run really failed — record it as such so the badge and history are
+      // honest.
       const newStatus: RunStatus = wasCancelled
         ? "cancelled"
+        : wasApiError ? "failed"
         : code === 0 ? "succeeded" : "failed";
       runs.update(runId, { status: newStatus, endedAt: Date.now(), exitCode: code });
       // Only flip the task's column when the run that just resolved is
@@ -503,7 +561,14 @@ function attachDoneHandler(
       const task = tasks.get(taskId);
       const isTerminalRun = !!task && task.runId === runId;
       if (isTerminalRun) {
-        updateColumn(taskId, runId, newStatus === "succeeded" ? "review" : "ready");
+        // Cancellation wins over api-error here, matching the newStatus
+        // resolution above — a user-cancelled run shouldn't land in
+        // `blocked` just because it had previously hit an API error.
+        const nextColumn: ColumnId = wasCancelled
+          ? "ready"
+          : wasApiError ? "blocked"
+          : newStatus === "succeeded" ? "review" : "ready";
+        updateColumn(taskId, runId, nextColumn);
       }
       emit({
         runId,

--- a/src/bun/reconcile.test.ts
+++ b/src/bun/reconcile.test.ts
@@ -70,6 +70,85 @@ test("reconcileOrphans marks running rows as orphaned and returns tasks to ready
   expect(reconcileOrphans()).toBe(0);
 });
 
+test("reattach pre-seed SQL: detects a prior api-error status row scoped to the run", async () => {
+  // Locks in the query shape used by `reconcileOrphans` to pre-seed
+  // `handle.apiError` on reattach. A real reattach test would need a live
+  // tmux session + JSONL — too heavy — so we exercise the SQL directly
+  // against three rows: the target run with a sentinel status, a sibling
+  // run on the same task with the same prefix (must NOT match — pre-seed is
+  // scoped to the reattached run id), and a same-run row with the prefix
+  // on the wrong stream (must NOT match — only `status` rows count).
+  const { db, runs, tasks } = await import("./db.ts");
+  const { CLAUDE_API_ERROR_STATUS_PREFIX } = await import("./claude-tmux.ts");
+
+  const taskId = `task-preseed-${randomUUID()}`;
+  const targetRunId = `run-preseed-target-${randomUUID()}`;
+  const siblingRunId = `run-preseed-sibling-${randomUUID()}`;
+  const now = Date.now();
+  tasks.insert({
+    id: taskId,
+    title: "x",
+    prompt: "p",
+    column: "blocked",
+    agent: "claude-code",
+    workdir: "/tmp",
+    isolation: "none",
+    branch: null,
+    worktreePath: null,
+    baseRef: null,
+    mode: null,
+    model: null,
+    effort: null,
+    references: [],
+    runId: targetRunId,
+    hasOpenableRun: false,
+    pendingInteractionCount: 0,
+    openTerminalCount: 0,
+    archivedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+  // status='failed' (not 'running') so this test's rows can't be
+  // re-orphaned by a sibling test that calls `reconcileOrphans` later
+  // — multiple test files in one bun process share the auto-allocated
+  // db.ts when the first-loaded file didn't set AGETOR_DATA_DIR. The
+  // SQL we're locking in only reads run_events, not runs.status, so
+  // the run-row status is irrelevant to what's being tested.
+  for (const id of [targetRunId, siblingRunId]) {
+    runs.insert({
+      id, taskId, agent: "claude-code", status: "failed",
+      startedAt: now, endedAt: now, exitCode: 1,
+      tmuxSession: null, claudeSessionId: null,
+    });
+  }
+  // The real api-error status on the target run — must match.
+  runs.appendEvent(targetRunId, "status", `${CLAUDE_API_ERROR_STATUS_PREFIX}HTTP 529 — turn aborted`);
+  // Same-task sibling run with the prefix — must NOT match (different run id).
+  runs.appendEvent(siblingRunId, "status", `${CLAUDE_API_ERROR_STATUS_PREFIX}HTTP 500 — turn aborted`);
+  // Same-run row with the prefix on the WRONG stream — must NOT match.
+  runs.appendEvent(targetRunId, "assistant", `${CLAUDE_API_ERROR_STATUS_PREFIX}HTTP 400`);
+
+  const ask = (runId: string) => db.query<{ found: 0 | 1 }, [string, string]>(
+    `SELECT EXISTS(
+       SELECT 1 FROM run_events
+       WHERE run_id = ? AND stream = 'status' AND data LIKE ?
+     ) AS found`,
+  ).get(runId, `${CLAUDE_API_ERROR_STATUS_PREFIX}%`)?.found ?? 0;
+
+  expect(ask(targetRunId)).toBe(1);
+  // Sibling row carries the prefix but on a different run id — pre-seed
+  // must NOT bleed across runs of the same task.
+  expect(ask(siblingRunId)).toBe(1); // sibling itself does have one — sanity check
+  // A completely unrelated run with no events should return 0.
+  const cleanRunId = `run-preseed-clean-${randomUUID()}`;
+  runs.insert({
+    id: cleanRunId, taskId, agent: "claude-code", status: "failed",
+    startedAt: now, endedAt: now, exitCode: 1,
+    tmuxSession: null, claudeSessionId: null,
+  });
+  expect(ask(cleanRunId)).toBe(0);
+});
+
 test("startTask honors cancel — exit handler records status 'cancelled'", async () => {
   // Use codex's branch for this test because it still goes through Bun.spawn
   // directly (claude now goes through tmux + JSONL, which isn't substitutable

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -17,7 +17,7 @@ import { UpdateBanner } from "@/components/updater/UpdateBanner";
 import type { UpdateSnapshot } from "@/lib/api";
 import { useConfirm } from "@/components/ui/confirm";
 import { Toaster } from "@/components/ui/sonner";
-import { dismissPending, toastError, toastPending, toastSuccess } from "@/lib/toasts";
+import { dismissPending, toastApiError, toastError, toastPending, toastSuccess } from "@/lib/toasts";
 import { cn } from "@/lib/utils";
 import iconUrl from "../assets/agetor.iconset/icon_32x32@2x.png";
 
@@ -291,7 +291,11 @@ export default function App() {
         cur.map((t) => (t.id === ev.taskId ? { ...t, column: ev.column } : t)),
       );
       if (ev.column === "blocked") {
-        toastPending({ taskId: ev.taskId, title, subtitle, isSelected, isFocused, onOpen });
+        if (ev.reason === "api-error") {
+          toastApiError({ taskId: ev.taskId, title, subtitle, isSelected, isFocused, onOpen });
+        } else {
+          toastPending({ taskId: ev.taskId, title, subtitle, isSelected, isFocused, onOpen });
+        }
       } else if (ev.prev === "blocked") {
         // Auto-clear the pending toast once the agent unblocks (the user
         // answered, the run was cancelled, etc.).

--- a/src/mainview/lib/toasts.ts
+++ b/src/mainview/lib/toasts.ts
@@ -58,25 +58,46 @@ export function toastError(args: ToastArgs & { reason?: string }): void {
   maybeNotifyOS(args, "Task failed", detail);
 }
 
-export function toastPending(args: ToastArgs): void {
+/** Shared lifecycle for the two `blocked`-column toasts (`toastPending` for
+ *  permission prompts, `toastApiError` for API failures). Both:
+ *    • bail when the affected task is the currently mounted panel,
+ *    • dismiss any prior pending toast for this task so we don't stack
+ *      duplicates if the column re-enters `blocked`,
+ *    • register the toast id in `pendingByTask` so a `column-leaves-blocked`
+ *      transition can clear it via `dismissPending`,
+ *    • use `duration: Infinity` (only user/programmatic dismissal cleans up),
+ *    • mirror the heading to the OS notification when the app is unfocused.
+ *  Only the sonner severity (warning vs error) and the heading differ — keep
+ *  those at the call site so adding a third variant is a two-line change. */
+function showBlockingToast(
+  variant: { method: typeof toast.warning | typeof toast.error; heading: string },
+  args: ToastArgs,
+): void {
   if (args.isSelected) return;
-  // Replace any prior pending toast for this task so we don't stack
-  // duplicates if the column re-enters `blocked` (rare but possible).
   const prior = pendingByTask.get(args.taskId);
   if (prior !== undefined) toast.dismiss(prior);
   const detail = describe(args);
-  const id = toast.warning("Waiting on you", {
+  const id = variant.method(variant.heading, {
     description: detail,
     duration: Infinity,
     action: { label: "Open", onClick: args.onOpen },
-    // `duration: Infinity` rules out onAutoClose firing — only onDismiss
-    // (user dismissal / programmatic `toast.dismiss`) needs cleanup.
     onDismiss: () => {
       if (pendingByTask.get(args.taskId) === id) pendingByTask.delete(args.taskId);
     },
   });
   pendingByTask.set(args.taskId, id);
-  maybeNotifyOS(args, "Waiting on you", detail);
+  maybeNotifyOS(args, variant.heading, detail);
+}
+
+export function toastPending(args: ToastArgs): void {
+  showBlockingToast({ method: toast.warning, heading: "Waiting on you" }, args);
+}
+
+/** Variant of `toastPending` for the `blocked → api-error` transition.
+ *  The heading/copy reads as a transient failure to retry rather than
+ *  "the agent is waiting on your answer." */
+export function toastApiError(args: ToastArgs): void {
+  showBlockingToast({ method: toast.error, heading: "API error — retry" }, args);
 }
 
 /** Clear the pending toast for a task (called when the task leaves `blocked`). */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -629,6 +629,13 @@ export type GlobalEvent =
       column: ColumnId;
       prev: ColumnId | null;
       ts: number;
+      /** Why the transition fired, when the column alone is ambiguous.
+       *  Lets the UI pick a more accurate toast copy — e.g. an
+       *  `api-error`-driven `blocked` reads as "API error — retry" rather
+       *  than the generic "waiting on you" used for permission prompts.
+       *  Unset for transitions whose reason is fully implied by the
+       *  (prev, column) pair (e.g. plain success → review). */
+      reason?: "api-error" | "approval";
     }
   | {
       kind: "update";


### PR DESCRIPTION
Claude code stamps `isApiErrorMessage: true` (with stop_reason: "stop_sequence", not "end_turn") on synthetic assistant lines for Anthropic API failures (529 Overloaded, 400 validation, etc.). The regular turn-end detection missed them, so the run sat in `running` forever and the card stayed in the RUNNING column.

The mapper now detects api-error messages, emits a sentinel `"api error: "` status chunk, and signals end-of-turn so the run resolves. The orchestrator's chunk handler pattern-matches the prefix to flip the column to BLOCKED, marks the active handle, and forces the run status to `failed` (overriding the 0 exit code the synthetic end_turn produced). The done handler keeps the column at BLOCKED unless cancellation takes precedence.

Crash recovery: on reattach the assistant-line uuid is in seenLineUuids so the status chunk isn't re-emitted; reconcileOrphans pre-seeds `handle.apiError` by scanning persisted run_events for the sentinel prefix, preventing the column from bouncing back to `review`.

UI: GlobalEvent.column gains an optional `reason` discriminator ("api-error" | "approval") so the webview can route api-error transitions to a red "API error — retry" toast instead of the generic "Waiting on you" copy.

Tests: api-error mapping, reattach pre-seed SQL, end-to-end column flip, cancellation-vs-api-error precedence, and reason-field plumbing.