### PR TITLE
fix(claude-tmux): gap bracketed paste before Enter so follow-up turns submit

### DIFF
--- a/src/bun/claude-tmux-queue.test.ts
+++ b/src/bun/claude-tmux-queue.test.ts
@@ -1,5 +1,14 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, writeFileSync, appendFileSync, openSync, writeSync, closeSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  appendFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  readFileSync,
+  chmodSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -282,6 +291,54 @@ function withFakeTmuxBin<T>(fn: () => Promise<T>): Promise<T> {
   });
 }
 
+/**
+ * Recording variant of `withFakeTmuxBin`: writes a small bun script as the
+ * tmux bin that appends one `{ ns, argv }` JSON line per invocation to a
+ * log file. Lets tests assert both the *order* of tmux calls (load-buffer
+ * → paste-buffer → delete-buffer → send-keys Enter) AND the wall-clock
+ * gap between them (e.g. the bracketed-paste → Enter gap inserted by
+ * `queuePaste`). The shebang points at `process.execPath` — the bun
+ * binary that's running the suite — so the script works without `bun`
+ * being on `PATH`.
+ *
+ * `ms` is `Date.now()` (wall clock) sampled at the start of each
+ * invocation — NOT `Bun.nanoseconds()`, which is process-local and
+ * resets per sub-bun spawn. Subtract two log lines' `ms` for the gap.
+ * Cold-start of the sub-bun process is included in the delta, so use
+ * only for `>= GAP` lower bounds; the cold start can easily widen the
+ * observed delta past any tight upper bound.
+ */
+function withRecordingTmuxBin<T>(fn: (logPath: string) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-tmux-rec-"));
+  const binPath = path.join(dir, "tmux");
+  const logPath = path.join(dir, "log.jsonl");
+  writeFileSync(
+    binPath,
+    `#!${process.execPath}\n` +
+      `import { appendFileSync } from "node:fs";\n` +
+      `appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ ms: Date.now(), argv: process.argv.slice(2) }) + "\\n");\n`,
+  );
+  chmodSync(binPath, 0o755);
+  const prevBin = process.env.AGETOR_TMUX_BIN;
+  process.env.AGETOR_TMUX_BIN = binPath;
+  return fn(logPath).finally(() => {
+    if (prevBin === undefined) delete process.env.AGETOR_TMUX_BIN;
+    else process.env.AGETOR_TMUX_BIN = prevBin;
+  });
+}
+
+function readTmuxLog(logPath: string): Array<{ ms: number; argv: string[] }> {
+  // The log may not exist if no tmux calls ran (e.g. a chain that
+  // short-circuited on stillCurrent before the first invocation).
+  let raw: string;
+  try {
+    raw = readFileSync(logPath, "utf8");
+  } catch {
+    return [];
+  }
+  return raw.split("\n").filter(Boolean).map((l) => JSON.parse(l));
+}
+
 test("queuePaste: chained pastes run in FIFO order", async () => {
   await withFakeTmuxBin(async () => {
     const prev = __forTest.setSlashCommandSettleMs(0);
@@ -526,6 +583,134 @@ test("queueTmuxOp: skips its body if the session was disposed between scheduling
     } finally {
       __forTest.uninstallSession(taskId);
       __forTest.setSlashCommandSettleMs(prev);
+    }
+  });
+});
+
+// ─── bracketed-paste → Enter gap (regression for "[Pasted text +N lines]
+// renders but never submits" — the Enter that follows `paste-buffer -p`
+// gets absorbed as part of the bracketed paste event if it arrives in the
+// same input read). The fix splits the trailing Enter out of
+// `pastePromptSync` and inserts a gap inside `queuePaste`'s bracketed
+// branch, re-gating the Enter through `stillCurrent()` so a dispose during
+// the gap can't leak the keystroke into a respawned pane. ───
+
+test("queuePaste(bracketed): emits load-buffer → paste-buffer -p → delete-buffer → (gap) → send-keys Enter", async () => {
+  // Order proves the bracketed split was wired correctly; the timing
+  // floor on the send-keys Enter proves the gap was honored. Cold-start
+  // of the sub-bun tmux process is additive on top of the gap, so the
+  // delta-ms assertion is a lower bound — tolerance only guards against
+  // a slow timer wake-up, never against the sleep being skipped.
+  const GAP = 60;
+  const TOLERANCE = 30;
+  await withRecordingTmuxBin(async (logPath) => {
+    const prevGap = __forTest.setBracketedEnterGapMs(GAP);
+    const prevSettle = __forTest.setSlashCommandSettleMs(0);
+    try {
+      const taskId = randomUUID();
+      await __forTest.queuePaste(
+        taskId,
+        "sess-x",
+        "hello\nworld",
+        0,
+        undefined,
+        { bracketed: true },
+      );
+      const entries = readTmuxLog(logPath);
+      const cmds = entries.map((e) => e.argv[0]);
+      expect(cmds).toEqual([
+        "load-buffer",
+        "paste-buffer",
+        "delete-buffer",
+        "send-keys",
+      ]);
+      // paste-buffer carries the `-p` (bracketed-paste) flag.
+      const pasteBuffer = entries[1]!;
+      const deleteBuffer = entries[2]!;
+      const sendKeys = entries[3]!;
+      expect(pasteBuffer.argv).toContain("-p");
+      // The trailing send-keys is the Enter, not a stray modal keystroke.
+      expect(sendKeys.argv[sendKeys.argv.length - 1]).toBe("Enter");
+      // Gap floor: delete-buffer → send-keys Enter spans at least
+      // `GAP - TOLERANCE` ms. The actual delta also includes one
+      // sub-bun cold start, which only widens the gap.
+      const deltaMs = sendKeys.ms - deleteBuffer.ms;
+      expect(deltaMs).toBeGreaterThanOrEqual(GAP - TOLERANCE);
+    } finally {
+      __forTest.setBracketedEnterGapMs(prevGap);
+      __forTest.setSlashCommandSettleMs(prevSettle);
+    }
+  });
+});
+
+test("queuePaste(bracketed): trailing Enter is skipped when the session is disposed mid-gap", async () => {
+  // Mid-body re-gate symmetry with the dismissTmuxPrompt test above:
+  // `dropSession` lands during the post-paste sleep, the bracketed
+  // branch's `stillCurrent()` check fires false, and the trailing
+  // send-keys Enter never spawns. Without the re-gate, the new session
+  // installed under the same taskId would inherit a stray Enter.
+  const GAP = 120;
+  await withRecordingTmuxBin(async (logPath) => {
+    const prevGap = __forTest.setBracketedEnterGapMs(GAP);
+    const prevSettle = __forTest.setSlashCommandSettleMs(0);
+    const { taskId, jsonlPath } = freshSession();
+    const state = __forTest.installSession(taskId, jsonlPath);
+    try {
+      const paste = __forTest.queuePaste(
+        taskId,
+        state.sessionName,
+        "msg",
+        0,
+        state,
+        { bracketed: true },
+      );
+      // Land squarely inside the gap — late enough that the paste body's
+      // three sync tmux calls have written, early enough that the Enter
+      // is still pending.
+      await Bun.sleep(GAP / 3);
+      __forTest.uninstallSession(taskId);
+      __forTest.installSession(taskId, jsonlPath);
+      await paste;
+      const cmds = readTmuxLog(logPath).map((e) => e.argv[0]);
+      // Paste body landed; Enter was dropped by the re-gate.
+      expect(cmds).toEqual(["load-buffer", "paste-buffer", "delete-buffer"]);
+      expect(cmds).not.toContain("send-keys");
+    } finally {
+      __forTest.uninstallSession(taskId);
+      __forTest.setBracketedEnterGapMs(prevGap);
+      __forTest.setSlashCommandSettleMs(prevSettle);
+    }
+  });
+});
+
+test("queuePaste(non-bracketed): keeps the original synchronous load-buffer → paste-buffer → delete-buffer → send-keys Enter shape (no gap)", async () => {
+  // Slash-command path must NOT regress to the split-Enter form — the
+  // gap is bracketed-only. This pins the non-bracketed argv ordering
+  // AND confirms paste-buffer has no `-p` flag. A separate timing test
+  // would be brittle here — sub-bun cold start × 4 invocations can
+  // dominate wall-clock and mask any actual gap difference — so the
+  // structural assertion stands on its own.
+  await withRecordingTmuxBin(async (logPath) => {
+    const prevGap = __forTest.setBracketedEnterGapMs(200);
+    const prevSettle = __forTest.setSlashCommandSettleMs(0);
+    try {
+      const taskId = randomUUID();
+      await __forTest.queuePaste(taskId, "sess-x", "/model X", 0);
+      const entries = readTmuxLog(logPath);
+      expect(entries.map((e) => e.argv[0])).toEqual([
+        "load-buffer",
+        "paste-buffer",
+        "delete-buffer",
+        "send-keys",
+      ]);
+      // No `-p`: this is a typed-input slash command, not a paste event.
+      expect(entries[1]!.argv).not.toContain("-p");
+      // The trailing send-keys is the Enter, just as in bracketed mode.
+      const sendKeys = entries[3]!;
+      expect(sendKeys.argv[sendKeys.argv.length - 1]).toBe("Enter");
+    } finally {
+      __forTest.setBracketedEnterGapMs(prevGap);
+      __forTest.setSlashCommandSettleMs(prevSettle);
     }
   });
 });

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -984,7 +984,11 @@ const sessions = new Map<string, SessionState>(); // taskId → state
  * previous one's settle window has elapsed. Modal dismissals
  * (`dismissTmuxPrompt`) share the same chain so a click on a numbered
  * choice can't interleave its `"1"` + Enter keystrokes with an in-flight
- * paste-buffer + Enter from `queuePaste`.
+ * paste from `queuePaste`. (The exact tmux payload is mode-dependent —
+ * non-bracketed slash commands send `load-buffer + paste-buffer +
+ * delete-buffer + send-keys Enter` synchronously, while bracketed user
+ * pastes split the trailing Enter out with a small `bracketedEnterGapMs`
+ * sleep in between. See `queuePaste`.)
  *
  * The map's value is the tail promise of the in-flight chain; new ops
  * append via `queueTmuxOp`. Entries self-evict on completion when no
@@ -2307,6 +2311,15 @@ export const __forTest = {
     return prev;
   },
   getSlashCommandSettleMs(): number { return slashCommandSettleMs; },
+  /** Override the bracketed-paste → Enter gap. Tests shrink it to ~0 to
+   *  avoid sleeping on every paste-queue assertion. Returns the previous
+   *  value so the test can restore it in `afterEach`. */
+  setBracketedEnterGapMs(ms: number): number {
+    const prev = bracketedEnterGapMs;
+    bracketedEnterGapMs = ms;
+    return prev;
+  },
+  getBracketedEnterGapMs(): number { return bracketedEnterGapMs; },
   /** Direct access to the paste queue for assertions. Read-only — tests
    *  inspect ordering by observing tmux side effects, not by mutating
    *  the chain. */
@@ -2324,7 +2337,11 @@ export const __forTest = {
  * Sync core — callers go through `queuePaste` so back-to-back pastes for the
  * same task can't interleave at the tmux layer. See `queuePaste` for why.
  */
-function pastePromptSync(sessionName: string, text: string, opts: { bracketed?: boolean } = {}): void {
+function pastePromptSync(
+  sessionName: string,
+  text: string,
+  opts: { bracketed?: boolean; skipEnter?: boolean } = {},
+): void {
   // load-buffer reads from stdin; -b names a tmux buffer we can target.
   const buf = `agetor-${sessionName}`;
   const load = tmux(["load-buffer", "-b", buf, "-"], { stdinText: text });
@@ -2341,7 +2358,13 @@ function pastePromptSync(sessionName: string, text: string, opts: { bracketed?: 
   const pasteFlags = opts.bracketed ? ["-p"] : [];
   tmux(["paste-buffer", ...pasteFlags, "-b", buf, "-t", sessionName]);
   tmux(["delete-buffer", "-b", buf]);
-  tmux(["send-keys", "-t", sessionName, "Enter"]);
+  // `skipEnter` defers the trailing Enter to the caller so it can sleep
+  // between the bracketed paste and the Enter — see `queuePaste`. Without
+  // that gap, a follow-up turn pasted mid-stream gets rendered as `[Pasted
+  // text +N lines]` in claude's TUI but the immediately-following `\r` is
+  // absorbed as part of the same paste event, so the queued bubble sits
+  // unsubmitted until the user (or a later Enter) commits it.
+  if (!opts.skipEnter) tmux(["send-keys", "-t", sessionName, "Enter"]);
 }
 
 /**
@@ -2369,6 +2392,31 @@ function pastePromptSync(sessionName: string, text: string, opts: { bracketed?: 
  * Tests shrink the value to keep the queue suite fast.
  */
 let slashCommandSettleMs = 700;
+
+/**
+ * Gap between the bracketed-paste body (`paste-buffer -p`) and the trailing
+ * `send-keys Enter` for follow-up turns. Without a gap, claude's Ink TUI
+ * sees the `ESC[201~` end marker and the immediately-following `\r` as part
+ * of the same input read; the `\r` is absorbed as part of the paste event
+ * and the `[Pasted text +N lines]` bubble sits unsubmitted until something
+ * else commits it. 80ms comfortably exceeds the few-ms claude's reader
+ * takes to process the end marker on an idle session; the cost is one
+ * delay per follow-up paste, observable only as a brief queueing window.
+ *
+ * Only applied in bracketed mode — non-bracketed pastes (slash commands)
+ * stream as plain keystrokes and don't have the paste-event coalescing
+ * window. Tests shrink the value to keep the queue suite fast.
+ *
+ * Failure mode is asymmetric: too low silently regresses to the "paste
+ * shown, never submitted" bug with no log signal (the queued bubble
+ * just sits in the TUI input until something else commits it), while
+ * too high only adds perceived latency to follow-up turns. Prefer
+ * raising over lowering when in doubt. A real-world ceiling under load
+ * (e.g. claude paused on a tool call, reader latency higher) has not
+ * been measured — if you observe the regression returning, bump this
+ * first before assuming a structural fix is needed.
+ */
+let bracketedEnterGapMs = 80;
 
 /**
  * Append a tmux operation to the per-task chain. The `fn` thunk runs
@@ -2456,6 +2504,15 @@ function queueTmuxOp(
  * Pass `expectedState` to gate the paste on the session still being
  * the one this paste was scheduled against — see `queueTmuxOp` for the
  * race this closes.
+ *
+ * When `opts.bracketed` is true, the trailing `Enter` is split out of
+ * the synchronous paste body and sent after a small internal gap
+ * (`bracketedEnterGapMs`) so claude's Ink TUI commits the `ESC[200~ …
+ * ESC[201~` paste event before the `\r` arrives — without that gap the
+ * Enter is absorbed as part of the paste event and the queued bubble
+ * sits unsubmitted. The deferred Enter is re-gated through
+ * `stillCurrent()` so a `dropSession` landing during the gap can't
+ * leak the keystroke into a respawned pane.
  */
 function queuePaste(
   taskId: string,
@@ -2465,13 +2522,29 @@ function queuePaste(
   expectedState?: SessionState,
   opts: { bracketed?: boolean } = {},
 ): Promise<void> {
-  // No mid-body re-gate needed: pastePromptSync delivers all four tmux
-  // calls (load-buffer + paste-buffer + delete-buffer + send-keys Enter)
-  // synchronously before the optional settle sleep. The settle is pure
-  // waiting — no tmux calls happen after it within this body — so a
-  // dispose during the sleep can't leak keystrokes.
-  return queueTmuxOp(taskId, async () => {
-    pastePromptSync(sessionName, text, opts);
+  // Non-bracketed path: load-buffer + paste-buffer + delete-buffer +
+  // send-keys Enter all happen synchronously inside pastePromptSync, so
+  // the only await is the optional settle — no tmux calls land after the
+  // sleep, and a dispose during the sleep can't leak keystrokes.
+  //
+  // Bracketed path: we split the trailing Enter out and insert a small
+  // gap so claude's Ink TUI has time to consume `ESC[201~` and commit
+  // the paste before the `\r` arrives. Without the gap the Enter is
+  // absorbed as part of the paste event and the queued bubble sits
+  // unsubmitted (especially when the previous turn is still streaming
+  // or has a background tool in flight — see the "[Pasted text #N +M
+  // lines] never submits" repro). The deferred Enter is re-gated through
+  // `stillCurrent()` so a `dropSession` landing in the gap can't leak the
+  // Enter into a respawned pane.
+  return queueTmuxOp(taskId, async (stillCurrent) => {
+    if (opts.bracketed) {
+      pastePromptSync(sessionName, text, { ...opts, skipEnter: true });
+      if (bracketedEnterGapMs > 0) await Bun.sleep(bracketedEnterGapMs);
+      if (!stillCurrent()) return;
+      tmux(["send-keys", "-t", sessionName, "Enter"]);
+    } else {
+      pastePromptSync(sessionName, text, opts);
+    }
     if (settleMs > 0) await Bun.sleep(settleMs);
   }, expectedState);
 }


### PR DESCRIPTION
Follow-up messages routed through sendTurn / writeInput (the Task Details input path) were being pasted into the tmux session as `[Pasted text +N lines]` but never submitted — the trailing `\r` was absorbed as part of the bracketed-paste event when it arrived in the same input read as the `ESC[201~` end marker.

Split the trailing Enter out of pastePromptSync and insert a small internal sleep (bracketedEnterGapMs, default 80ms) inside queuePaste's bracketed branch so claude's Ink TUI commits the paste before the Enter arrives. The deferred Enter is re-gated through stillCurrent() to keep the disposal-during-gap invariant: a dropSession landing in the gap won't leak the keystroke into a respawned pane.

Non-bracketed pastes (slash commands like /model, /effort, /plan) are unchanged — they stream as plain keystrokes and don't have the paste- event coalescing window.

Tests
- queuePaste(bracketed): pins load-buffer → paste-buffer -p → delete-buffer → (gap) → send-keys Enter ordering AND asserts the wall-clock floor on the delete-buffer → send-keys delta.
- queuePaste(bracketed): mid-gap dropSession skips the trailing Enter.
- queuePaste(non-bracketed): structural assertion that the slash-command path is not routed through the new bracketed split.

Adds a recording fake-tmux helper (withRecordingTmuxBin) that writes a bun-shebang script logging {ms, argv} per invocation, so the new tests can assert both argv order and inter-call timing.