### PR TITLE
fix(claude-tmux): wait for image attach before pressing Enter

### DIFF
--- a/src/bun/claude-tmux-queue.test.ts
+++ b/src/bun/claude-tmux-queue.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, writeFileSync, appendFileSync, openSync, writeSync, closeSync } from "node:fs";
+import { mkdtempSync, writeFileSync, appendFileSync, openSync, writeSync, closeSync, chmodSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -260,7 +260,7 @@ test("partial trailing line is left for the next flush", async () => {
 
 /**
  * Snapshot + restore the `AGETOR_TMUX_BIN` env var around a test body.
- * The chain calls `pastePromptSync` → `tmux()` → `Bun.spawnSync(bin, …)`;
+ * The chain calls `pastePrompt` → `tmux()` → `Bun.spawnSync(bin, …)`;
  * pointing the bin at a no-op `true` lets the chain advance without
  * needing a real tmux. Restoring on exit keeps the env clean for later
  * tests in the same process (tmux probes elsewhere read this var).
@@ -526,6 +526,262 @@ test("queueTmuxOp: skips its body if the session was disposed between scheduling
     } finally {
       __forTest.uninstallSession(taskId);
       __forTest.setSlashCommandSettleMs(prev);
+    }
+  });
+});
+
+// ─── pasteContainsImagePath / countImagePaths detection rules ──────────
+// The slow path (post-paste settle, scaled by image count) inside
+// `pastePrompt` only fires when these helpers signal an image. Get the
+// rule wrong in either direction and either every paste pays 600 ms of
+// latency for nothing, or the image-attach race re-opens.
+test("pasteContainsImagePath: matches absolute file paths with image extensions", () => {
+  // Real prompt shape — `appendReferences` writes `- /abs/path` bullets.
+  const prompt =
+    "fix the bug\n\nReferenced files/folders:\n- /Users/me/.agetor/screenshots/screenshot-2026-06-02_17-47-49-b51759d7.png";
+  expect(__forTest.pasteContainsImagePath(prompt)).toBe(true);
+});
+
+test("pasteContainsImagePath: matches each supported extension", () => {
+  for (const ext of ["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico", "avif", "heic"]) {
+    expect(__forTest.pasteContainsImagePath(`see /tmp/foo.${ext}`)).toBe(true);
+  }
+});
+
+test("pasteContainsImagePath: case-insensitive on the extension", () => {
+  expect(__forTest.pasteContainsImagePath("attached: /tmp/Foo.PNG")).toBe(true);
+  expect(__forTest.pasteContainsImagePath("attached: /tmp/bar.JPEG")).toBe(true);
+});
+
+test("pasteContainsImagePath: a bare `.png` token (no word before the dot) does NOT match", () => {
+  // The regex requires a `\w` immediately before the extension dot so
+  // prose mentioning the extension doesn't trip the slow path. Likewise
+  // edge inputs like `..png` (consecutive dots) and `,png` (non-word
+  // prefix) are rejected.
+  expect(__forTest.pasteContainsImagePath(".png")).toBe(false);
+  expect(__forTest.pasteContainsImagePath("save as .png next")).toBe(false);
+  expect(__forTest.pasteContainsImagePath("see ..png file")).toBe(false);
+});
+
+test("pasteContainsImagePath: non-image extensions do not match", () => {
+  expect(__forTest.pasteContainsImagePath("see /tmp/foo.ts")).toBe(false);
+  expect(__forTest.pasteContainsImagePath("/Users/me/notes.md")).toBe(false);
+  expect(__forTest.pasteContainsImagePath("hello world")).toBe(false);
+});
+
+test("pasteContainsImagePath: is stateless across repeated calls (global regex regression)", () => {
+  // `IMAGE_PATH_RE` carries the /g flag so `.match()` can count occurrences
+  // for the scaled settle. Without an explicit `lastIndex = 0` reset, a
+  // repeat `.test()` on the same string alternates true/false — a footgun
+  // worth pinning so a future refactor doesn't quietly re-introduce it.
+  const s = "/tmp/foo.png";
+  expect(__forTest.pasteContainsImagePath(s)).toBe(true);
+  expect(__forTest.pasteContainsImagePath(s)).toBe(true);
+  expect(__forTest.pasteContainsImagePath(s)).toBe(true);
+});
+
+test("countImagePaths: counts each image reference for settle-window scaling", () => {
+  expect(__forTest.countImagePaths("no images here")).toBe(0);
+  expect(__forTest.countImagePaths("- /tmp/a.png")).toBe(1);
+  expect(__forTest.countImagePaths("- /tmp/a.png\n- /tmp/b.jpg\n- /tmp/c.webp")).toBe(3);
+  // Mixed image + non-image refs only counts images.
+  expect(__forTest.countImagePaths("- /tmp/a.png\n- /tmp/notes.md\n- /tmp/b.jpeg")).toBe(2);
+});
+
+// ─── pastePrompt slow path: image-bearing paste delays before Enter ────
+// Regression for "Image #1 stuck in input, message never sent" — the
+// trailing Enter we used to send immediately after the bracketed paste
+// landed mid-flight in claude's image-attach flow and was consumed
+// instead of submitting the message. The fix is a settle delay scaled by
+// the number of image paths; the Enter count is unchanged (one per
+// paste, image or not) so we can't accidentally cause a stray empty
+// submit or interrupt an idle pane.
+
+/**
+ * Drop-in tmux binary that records every argv it was called with to a
+ * file. Lets tests assert the exact sequence of `send-keys`, `paste-
+ * buffer`, etc. — the `/usr/bin/true` shim used elsewhere only signals
+ * exit-code success, which is enough for ordering tests but not for
+ * "did we send Enter once or twice?" assertions.
+ *
+ * `$@` in /bin/sh is whitespace-joined verbatim. We can't faithfully
+ * recover an argv with embedded whitespace from that, but tmux argv here
+ * is always single-token flags + session names — no whitespace inside any
+ * single arg — so a per-line `echo "$@"` is unambiguous.
+ */
+function withRecordingTmuxBin<T>(fn: (readCalls: () => string[]) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-tmux-rec-"));
+  const binPath = path.join(dir, "tmux-recorder.sh");
+  const logPath = path.join(dir, "calls.log");
+  writeFileSync(binPath, `#!/bin/sh\necho "$@" >> "${logPath}"\nexit 0\n`);
+  // Recorder must be executable for spawnSync to invoke it. 0o755 is the
+  // standard "owner all, others read+exec" mode for a script.
+  chmodSync(binPath, 0o755);
+  // Pre-create the log so a 0-call test can readFileSync without ENOENT.
+  writeFileSync(logPath, "");
+  const prevBin = process.env.AGETOR_TMUX_BIN;
+  process.env.AGETOR_TMUX_BIN = binPath;
+  const readCalls = () => readFileSync(logPath, "utf8").split("\n").filter((l) => l.length > 0);
+  return fn(readCalls).finally(() => {
+    if (prevBin === undefined) delete process.env.AGETOR_TMUX_BIN;
+    else process.env.AGETOR_TMUX_BIN = prevBin;
+  });
+}
+
+test("queuePaste: image-bearing bracketed paste waits for the attach-settle window", async () => {
+  await withFakeTmuxBin(async () => {
+    const SETTLE = 80; // shrunk for the test; production default is 600 ms / image
+    const prevSettle = __forTest.setImageAttachSettleMs(SETTLE);
+    const prevSlash = __forTest.setSlashCommandSettleMs(0);
+    try {
+      const taskId = randomUUID();
+      const promptWithImage =
+        "fix this\n\nReferenced files/folders:\n- /tmp/screenshot.png";
+      const t0 = performance.now();
+      await __forTest.queuePaste(
+        taskId,
+        "sess-img",
+        promptWithImage,
+        0,
+        undefined,
+        { bracketed: true },
+      );
+      const elapsed = performance.now() - t0;
+      // 1 image × SETTLE per image. Tolerance covers scheduler jitter on
+      // a loaded CI box.
+      expect(elapsed).toBeGreaterThanOrEqual(SETTLE - 20);
+    } finally {
+      __forTest.setImageAttachSettleMs(prevSettle);
+      __forTest.setSlashCommandSettleMs(prevSlash);
+    }
+  });
+});
+
+test("queuePaste: settle scales with the number of image paths", async () => {
+  await withFakeTmuxBin(async () => {
+    const SETTLE = 80; // per image
+    const prevSettle = __forTest.setImageAttachSettleMs(SETTLE);
+    const prevSlash = __forTest.setSlashCommandSettleMs(0);
+    try {
+      const taskId = randomUUID();
+      const promptWithThreeImages =
+        "compare these\n\nReferenced files/folders:\n- /tmp/a.png\n- /tmp/b.jpg\n- /tmp/c.webp";
+      const t0 = performance.now();
+      await __forTest.queuePaste(
+        taskId,
+        "sess-multi",
+        promptWithThreeImages,
+        0,
+        undefined,
+        { bracketed: true },
+      );
+      const elapsed = performance.now() - t0;
+      // 3 images × SETTLE. Generous lower bound (≥ 2.5 × SETTLE) accounts
+      // for sub-ms scheduler slop without making the test trivial.
+      expect(elapsed).toBeGreaterThanOrEqual(SETTLE * 2.5);
+    } finally {
+      __forTest.setImageAttachSettleMs(prevSettle);
+      __forTest.setSlashCommandSettleMs(prevSlash);
+    }
+  });
+});
+
+test("queuePaste: text-only bracketed paste skips the slow path (resolves promptly)", async () => {
+  await withFakeTmuxBin(async () => {
+    // Slow path is set to a *very* long delay so a failure to detect
+    // "no image" would blow this test's wall clock budget visibly.
+    const prevSettle = __forTest.setImageAttachSettleMs(5_000);
+    const prevSlash = __forTest.setSlashCommandSettleMs(0);
+    try {
+      const taskId = randomUUID();
+      const t0 = performance.now();
+      await __forTest.queuePaste(
+        taskId,
+        "sess-txt",
+        "no images here, just a follow-up\n\nReferenced files/folders:\n- /tmp/notes.md",
+        0,
+        undefined,
+        { bracketed: true },
+      );
+      const elapsed = performance.now() - t0;
+      // No image extension in the paste → fast path. Should finish well
+      // under the (intentionally bloated) image-settle window. 500 ms is
+      // generous against CI scheduler noise while still being orders of
+      // magnitude below the 5_000 ms slow-path bound.
+      expect(elapsed).toBeLessThan(500);
+    } finally {
+      __forTest.setImageAttachSettleMs(prevSettle);
+      __forTest.setSlashCommandSettleMs(prevSlash);
+    }
+  });
+});
+
+test("queuePaste: image-bearing paste sends exactly ONE Enter (no stray empty submit)", async () => {
+  // Earlier iterations of this fix sent two Enters on image paths; the
+  // second was a guess at dismissing an attach-confirm modal that may
+  // not exist in the bracketed-paste flow. The JSONL repro already
+  // showed a single-Enter image submit succeeding once claude was idle,
+  // so a second Enter would risk a stray empty submit or pane interrupt.
+  // Lock in the contract: exactly one `send-keys Enter` per image paste.
+  await withRecordingTmuxBin(async (readCalls) => {
+    const prevSettle = __forTest.setImageAttachSettleMs(20);
+    const prevSlash = __forTest.setSlashCommandSettleMs(0);
+    try {
+      const taskId = randomUUID();
+      await __forTest.queuePaste(
+        taskId,
+        "sess-once",
+        "fix this\n\nReferenced files/folders:\n- /tmp/screenshot.png",
+        0,
+        undefined,
+        { bracketed: true },
+      );
+      const enterCalls = readCalls().filter((line) =>
+        line.includes("send-keys") && line.endsWith(" Enter"));
+      expect(enterCalls.length).toBe(1);
+    } finally {
+      __forTest.setImageAttachSettleMs(prevSettle);
+      __forTest.setSlashCommandSettleMs(prevSlash);
+    }
+  });
+});
+
+test("queuePaste: image-bearing paste skips the trailing Enter when session disposes during settle", async () => {
+  // Closes the same dispose-during-gap race the modal-dismissal path
+  // protects against (see "dismissTmuxPrompt mid-body re-gate" above).
+  // The image slow path awaits between paste-buffer and Enter; if the
+  // session is uninstalled during the sleep, the trailing Enter must
+  // NOT fire — otherwise it leaks into whatever pane reuses the tmux
+  // session name on a respawn.
+  await withRecordingTmuxBin(async (readCalls) => {
+    const SETTLE = 120;
+    const prevSettle = __forTest.setImageAttachSettleMs(SETTLE);
+    const prevSlash = __forTest.setSlashCommandSettleMs(0);
+    const { taskId, jsonlPath } = freshSession();
+    const state = __forTest.installSession(taskId, jsonlPath);
+    try {
+      const pasted = __forTest.queuePaste(
+        taskId,
+        state.sessionName,
+        "fix this\n\nReferenced files/folders:\n- /tmp/screenshot.png",
+        0,
+        state, // expectedState — gates the re-check on this identity
+        { bracketed: true },
+      );
+      // Dispose mid-sleep so `stillCurrent()` flips to false before the
+      // trailing Enter would fire.
+      await new Promise((r) => setTimeout(r, SETTLE / 2));
+      __forTest.uninstallSession(taskId);
+      await pasted;
+      const enterCalls = readCalls().filter((line) =>
+        line.includes("send-keys") && line.endsWith(" Enter"));
+      // load-buffer + paste-buffer + delete-buffer fire pre-await, so
+      // some tmux calls are recorded — but the Enter must be skipped.
+      expect(enterCalls.length).toBe(0);
+    } finally {
+      // Session already uninstalled above. Restore tunables.
+      __forTest.setImageAttachSettleMs(prevSettle);
+      __forTest.setSlashCommandSettleMs(prevSlash);
     }
   });
 });

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -2307,6 +2307,23 @@ export const __forTest = {
     return prev;
   },
   getSlashCommandSettleMs(): number { return slashCommandSettleMs; },
+  /** Override the image-attach settle window — the delay between the
+   *  bracketed paste and the trailing Enter when the paste contains an
+   *  image file path. Tests shrink it to ~0 to avoid sleeping per
+   *  image-path assertion. Returns the previous value for restore. */
+  setImageAttachSettleMs(ms: number): number {
+    const prev = imageAttachSettleMs;
+    imageAttachSettleMs = ms;
+    return prev;
+  },
+  getImageAttachSettleMs(): number { return imageAttachSettleMs; },
+  /** Image-path detection used by `pastePrompt` to decide whether to
+   *  take the slow (post-paste settle) path. Re-exported for unit tests
+   *  so the rule can be asserted without reaching into the regex literal. */
+  pasteContainsImagePath,
+  /** Count the image paths the regex finds. Used internally to scale the
+   *  settle window by image count; exposed so tests can pin the heuristic. */
+  countImagePaths,
   /** Direct access to the paste queue for assertions. Read-only — tests
    *  inspect ordering by observing tmux side effects, not by mutating
    *  the chain. */
@@ -2316,15 +2333,98 @@ export const __forTest = {
 };
 
 /**
+ * Match a file path whose basename ends in a common image extension. The
+ * pattern requires a word character immediately before the `.ext` so a
+ * bare `.png` token in prose ("save as .png next") or accidental ones
+ * like `..png` / `,.png` don't trigger the image-attach slow path. The
+ * extension list is kept in sync with `IMAGE` in
+ * `src/mainview/lib/file-icons.tsx` — when adding a new extension there,
+ * add it here too.
+ */
+const IMAGE_PATH_RE =
+  /[\w.\-/]*\w\.(png|jpe?g|gif|webp|svg|bmp|ico|avif|heic)\b/gi;
+
+/** True iff `text` carries at least one image-file path. Exported via
+ *  `__forTest` so the unit suite can assert the detection rule without
+ *  reaching into the regex literal. */
+export function pasteContainsImagePath(text: string): boolean {
+  // Reset state on the global regex before .test() — without it, .test()
+  // resumes from lastIndex and a repeat call on the same string returns
+  // alternating true/false.
+  IMAGE_PATH_RE.lastIndex = 0;
+  return IMAGE_PATH_RE.test(text);
+}
+
+/** Number of image-file paths in `text`. Used to scale the settle window
+ *  so multi-image pastes get proportional time for claude's bracketed-
+ *  paste handler to read, encode, and attach each one. */
+export function countImagePaths(text: string): number {
+  return text.match(IMAGE_PATH_RE)?.length ?? 0;
+}
+
+/**
+ * Per-image settle window. Claude's TUI reads the image synchronously on
+ * its input thread when it sees a path in a bracketed paste — it replaces
+ * the path with an `[Image #N]` placeholder, reads the file, and base64-
+ * encodes it. A `send-keys Enter` that arrives mid-flight is consumed by
+ * the attachment flow instead of submitting the message, leaving the
+ * text + placeholder sitting in the input forever. 600 ms comfortably
+ * exceeds the time observed for ~MB-sized screenshots; the cost is paid
+ * only when the heuristic fires, and is scaled by the number of image
+ * paths in the paste (Retina screenshots are routinely 3-5 MB and four
+ * of them in one message would exceed a single 600 ms budget).
+ *
+ * The scaled total is capped at `IMAGE_ATTACH_SETTLE_MAX_MS` so a paste
+ * that accidentally trips the detector many times (e.g. a doc dump that
+ * mentions many `.png` files) doesn't stall the queue for seconds.
+ *
+ * Tests shrink the per-image value to ~0 to keep the queue suite fast.
+ */
+let imageAttachSettleMs = 600;
+
+/** Absolute upper bound on the scaled settle window. Picked at 3 s —
+ *  beyond the slowest observed multi-image attach in practice while still
+ *  bounding the worst-case stall a paste can introduce. */
+const IMAGE_ATTACH_SETTLE_MAX_MS = 3_000;
+
+/**
  * Send `text` as a single user turn to the named tmux session. We pipe via
  * `load-buffer -` to avoid shell-quoting issues (the prompt may contain
  * newlines, dollar signs, quotes, …), paste it into the active window, then
  * press Enter to submit.
  *
- * Sync core — callers go through `queuePaste` so back-to-back pastes for the
- * same task can't interleave at the tmux layer. See `queuePaste` for why.
+ * When the paste contains image file paths, sleep before sending the
+ * trailing Enter so claude's bracketed-paste handler can finish attaching
+ * each image. Without the wait, the single Enter we send arrives mid-
+ * flight in the attachment flow and gets consumed instead of submitting
+ * the message — the symptom is the agetor UI showing the message as sent
+ * while the JSONL has no corresponding user-message row, with the text
+ * stuck in claude's input behind an `[Image #N]` placeholder.
+ *
+ * We send exactly one Enter — the same as the non-image path. Earlier
+ * iterations of this fix sent two Enters (the first to dismiss a
+ * suspected attach-confirm modal, the second to submit) but there is no
+ * direct evidence such a modal exists in the bracketed-paste flow, and
+ * the JSONL repro confirmed at least one image-bearing paste DID submit
+ * with a single Enter — so the second Enter would risk a stray empty
+ * submit / interrupt against an idle pane.
+ *
+ * The `stillCurrent` predicate is consulted before the trailing Enter so
+ * a session dispose that lands during the image-settle sleep can't leak
+ * the keystroke into a respawned pane reusing the same tmux session name.
+ * The non-image fast path stays fully sync so the original `queueTmuxOp`
+ * invariant (no awaits between tmux calls) is preserved for the common
+ * case.
+ *
+ * Callers go through `queuePaste` so back-to-back pastes for the same
+ * task can't interleave at the tmux layer. See `queuePaste` for why.
  */
-function pastePromptSync(sessionName: string, text: string, opts: { bracketed?: boolean } = {}): void {
+async function pastePrompt(
+  sessionName: string,
+  text: string,
+  opts: { bracketed?: boolean } = {},
+  stillCurrent: () => boolean = () => true,
+): Promise<void> {
   // load-buffer reads from stdin; -b names a tmux buffer we can target.
   const buf = `agetor-${sessionName}`;
   const load = tmux(["load-buffer", "-b", buf, "-"], { stdinText: text });
@@ -2341,6 +2441,17 @@ function pastePromptSync(sessionName: string, text: string, opts: { bracketed?: 
   const pasteFlags = opts.bracketed ? ["-p"] : [];
   tmux(["paste-buffer", ...pasteFlags, "-b", buf, "-t", sessionName]);
   tmux(["delete-buffer", "-b", buf]);
+  if (opts.bracketed) {
+    const imageCount = countImagePaths(text);
+    if (imageCount > 0) {
+      // Slow path: claude is reading + attaching one or more images. Wait,
+      // then re-gate before the Enter so a dispose during the sleep can't
+      // leak the keystroke into a respawned pane.
+      const settle = Math.min(imageAttachSettleMs * imageCount, IMAGE_ATTACH_SETTLE_MAX_MS);
+      await Bun.sleep(settle);
+      if (!stillCurrent()) return;
+    }
+  }
   tmux(["send-keys", "-t", sessionName, "Enter"]);
 }
 
@@ -2356,7 +2467,7 @@ function pastePromptSync(sessionName: string, text: string, opts: { bracketed?: 
  * applied before the *next* operation — never before the slash itself.
  *
  * Important caveat about what this delay actually buys: the timer starts
- * when `pastePromptSync` returns (i.e. when tmux's `send-keys Enter`
+ * when `pastePrompt` returns (i.e. when tmux's `send-keys Enter`
  * exits), NOT when claude has finished processing the slash command. On
  * an idle REPL these are close enough that 700ms covers consumption +
  * repaint. When claude is mid-turn, the slash command queues inside
@@ -2465,13 +2576,14 @@ function queuePaste(
   expectedState?: SessionState,
   opts: { bracketed?: boolean } = {},
 ): Promise<void> {
-  // No mid-body re-gate needed: pastePromptSync delivers all four tmux
-  // calls (load-buffer + paste-buffer + delete-buffer + send-keys Enter)
-  // synchronously before the optional settle sleep. The settle is pure
-  // waiting — no tmux calls happen after it within this body — so a
-  // dispose during the sleep can't leak keystrokes.
-  return queueTmuxOp(taskId, async () => {
-    pastePromptSync(sessionName, text, opts);
+  // Forward `stillCurrent` into pastePrompt — its image-attach slow path
+  // awaits between the bracketed paste and the trailing Enter, so it
+  // needs the same dispose-during-gap re-gate that the modal-dismissal
+  // path uses. The fast (non-image) path inside pastePrompt stays fully
+  // synchronous, so the original "no tmux calls after the await"
+  // invariant still holds for the common case.
+  return queueTmuxOp(taskId, async (stillCurrent) => {
+    await pastePrompt(sessionName, text, opts, stillCurrent);
     if (settleMs > 0) await Bun.sleep(settleMs);
   }, expectedState);
 }


### PR DESCRIPTION
Image-bearing pastes were getting stuck in claude's input box with an `[Image #N]` placeholder, never submitting. Root cause: claude's bracketed-paste handler reads the image asynchronously to attach it, and the trailing `send-keys Enter` we fired immediately after `paste-buffer` landed mid-flight in that flow and was consumed instead of submitting the message. The agetor UI showed the message as sent while the JSONL had no corresponding user-message row.

Fix:
- Detect image file paths in the paste via a path-stem regex over the same extension set as `file-icons.tsx`.
- When present, sleep for `imageAttachSettleMs` (default 600ms, scaled by image count up to a 3s cap) before sending Enter so claude can finish attaching each image first.
- Forward `stillCurrent` from the queue into `pastePrompt` so a dispose during the settle sleep can't leak the trailing Enter into a respawned pane reusing the same tmux session name.
- Send exactly one Enter per paste (image or not) — the JSONL repro showed a single Enter already works once attach completes, and a second Enter risks a stray empty submit / pane interrupt.

Renamed `pastePromptSync` to `pastePrompt` since it's now async.

Tests: `pasteContainsImagePath` / `countImagePaths` rule coverage across all extensions + negatives; image-paste timing scales with image count; text-only paste skips the slow path; a recorder-based test pins "exactly one Enter per image paste"; a dispose-during- settle test mirrors the existing modal re-gate pattern.