### PR TITLE
fix(agents): pass the prompt after a "--" terminator so a leading-dash prompt isn't parsed as a CLI flag

### DIFF
--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -119,7 +119,7 @@ test("claude-code with defaults launches interactive REPL with --model opus-4.7 
     "claude",
     "--model", "claude-opus-4-7",
     "--permission-mode", "auto",
-    "the prompt",
+    "--", "the prompt",
   ]);
   expect(cmd).not.toContain("--print");
   expect(cmd).not.toContain("--dangerously-skip-permissions");
@@ -131,7 +131,7 @@ test("claude-code 'opus-4.7' + 'auto' translates to --model and --permission-mod
     "claude",
     "--model", "claude-opus-4-7",
     "--permission-mode", "auto",
-    "do thing",
+    "--", "do thing",
   ]);
 });
 
@@ -141,8 +141,25 @@ test("claude-code 'opus-4.8' maps to --model claude-opus-4-8", () => {
     "claude",
     "--model", "claude-opus-4-8",
     "--permission-mode", "auto",
-    "do thing",
+    "--", "do thing",
   ]);
+});
+
+test("claude-code prefixes the prompt with `--` so a leading-dash prompt isn't parsed as a flag", () => {
+  // Regression: a prompt like a markdown checklist item starts with `-`.
+  // Without the `--` terminator claude's CLI errors `unknown option` and
+  // exits before writing any JSONL — the tmux driver then only sees a dead
+  // session + empty pane + 30s timeout. The `--` must sit immediately before
+  // the prompt and after every flag.
+  const { cmd } = buildCommand(
+    builtin("claude-code"),
+    "- [ ] Add a button",
+    { ...claudeDefaults, mode: "auto" },
+  );
+  expect(cmd[cmd.length - 2]).toBe("--");
+  expect(cmd[cmd.length - 1]).toBe("- [ ] Add a button");
+  // `--` comes after the permission flag, not before it.
+  expect(cmd.indexOf("--")).toBeGreaterThan(cmd.indexOf("--permission-mode"));
 });
 
 test("claude-code 'bypass' mode emits --dangerously-skip-permissions", () => {
@@ -271,7 +288,7 @@ test("codex with defaults emits --model gpt-5-codex + reasoning effort + --full-
     "--model", "gpt-5-codex",
     "-c", "model_reasoning_effort=high",
     "--full-auto",
-    "hi",
+    "--", "hi",
   ]);
 });
 
@@ -282,7 +299,7 @@ test("codex 'ask' mode drops --full-auto so codex prompts as usual", () => {
     "codex", "exec",
     "--model", "gpt-5-codex",
     "-c", "model_reasoning_effort=high",
-    "hi",
+    "--", "hi",
   ]);
 });
 
@@ -293,7 +310,7 @@ test("codex model 'gpt-5.5' passes through verbatim as --model", () => {
     "--model", "gpt-5.5",
     "-c", "model_reasoning_effort=high",
     "--full-auto",
-    "hi",
+    "--", "hi",
   ]);
 });
 
@@ -304,7 +321,7 @@ test("codex model 'gpt-5' adds --model gpt-5 before the prompt", () => {
     "--model", "gpt-5",
     "-c", "model_reasoning_effort=high",
     "--full-auto",
-    "hi",
+    "--", "hi",
   ]);
 });
 
@@ -346,16 +363,16 @@ test("claude-code unknown effort id is dropped (no env)", () => {
   expect(result.env).toBeUndefined();
 });
 
-test("AGETOR_CLAUDE_ARGS extra args land before the prompt", () => {
+test("AGETOR_CLAUDE_ARGS extra args land before the prompt (and before the `--` terminator)", () => {
   process.env.AGETOR_CLAUDE_ARGS = "--verbose --foo";
   const { cmd } = buildCommand(builtin("claude-code"), "p", { ...claudeDefaults });
-  expect(cmd.slice(-3)).toEqual(["--verbose", "--foo", "p"]);
+  expect(cmd.slice(-4)).toEqual(["--verbose", "--foo", "--", "p"]);
 });
 
-test("AGETOR_CODEX_ARGS extra args still land before the prompt", () => {
+test("AGETOR_CODEX_ARGS extra args still land before the prompt (and before the `--` terminator)", () => {
   process.env.AGETOR_CODEX_ARGS = "--verbose --foo";
   const { cmd } = buildCommand(builtin("codex"), "p", { ...codexDefaults });
-  expect(cmd.slice(-3)).toEqual(["--verbose", "--foo", "p"]);
+  expect(cmd.slice(-4)).toEqual(["--verbose", "--foo", "--", "p"]);
 });
 
 // Invariant test for AGENT_OPTIONS — guards against re-introducing the

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -230,8 +230,16 @@ export function buildCommand(
 
     // Initial prompt as the final argv element — claude's documented form is
     // `claude "query"` to start an interactive session with that prompt
-    // already submitted.
-    if (prompt) args.push(prompt);
+    // already submitted. Prefix it with the `--` option terminator so a
+    // prompt that STARTS WITH `-` (e.g. a markdown checklist item
+    // "- [ ] do the thing", or any "--flag-like" instruction) is treated as a
+    // positional and not misparsed by claude's CLI as an unknown option.
+    // Without `--`, claude errors `unknown option '<prompt>'` and exits
+    // before writing any JSONL — which the tmux driver only observes as a
+    // dead session + empty pane + 30s boot timeout (the run just fails with
+    // no visible cause). `--` is a no-op for prompts that don't lead with a
+    // dash.
+    if (prompt) args.push("--", prompt);
 
     // Effort is required unless the chosen model doesn't accept the flag
     // (Haiku 4.5 today). Unknown effort ids are dropped rather than passed
@@ -267,7 +275,11 @@ export function buildCommand(
   const mode = opts.mode ?? "auto";
   if (mode === "auto") args.push("--full-auto");
 
-  args.push(...extra, prompt);
+  // `--` terminates option parsing so a prompt starting with `-` (markdown
+  // checklist, "--flag-like" text) is taken as the positional prompt rather
+  // than misparsed as an option — same failure class as the claude path
+  // above. Standard in clap-based CLIs like codex.
+  args.push(...extra, "--", prompt);
   return { cmd: args, env: Object.keys(env).length ? env : undefined };
 }
 


### PR DESCRIPTION
A task whose prompt starts with "-" (e.g. a markdown checklist item "- [ ] do the thing", or any "--flag-like" instruction) made buildCommand emit `claude … "- [ ] …"` with the prompt as a bare positional. claude's CLI parses the leading dash as an option and exits with `error: unknown option '<prompt>'` before opening the TUI or writing any JSONL. Because the tmux driver runs claude as the pane's PID 1, that instant exit just leaves a dead session + empty pane, and the run dies at the 30s waitForJsonlAt boot timeout with no visible cause.

Pass the prompt after a "--" option terminator (claude path: args.push("--", prompt); codex path: args.push(...extra, "--", prompt)) so a dash-leading prompt is treated as the positional prompt. No-op for prompts that don't start with a dash. Verified against a real claude 2.1.161 interactive tmux launch: without "--" the pane dies status 1 with no JSONL; with "--" the session stays alive, the JSONL is written, and claude starts the task.

Updates the buildCommand argv assertions and adds a leading-dash regression test.