### PR TITLE
feat(settings): add "Open in Terminal" button to every harness

### DIFF
--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -1,5 +1,10 @@
 import { test, expect, beforeEach } from "bun:test";
-import { buildCommand } from "./agents.ts";
+import {
+  buildCommand,
+  buildHarnessTerminalCommand,
+  isValidEnvKey,
+  toTerminalAppleScript,
+} from "./agents.ts";
 import { AGENT_OPTIONS, type AgentKind, type Harness } from "../shared/types.ts";
 
 beforeEach(() => {
@@ -378,4 +383,76 @@ test.each(AGENTS)("AGENT_OPTIONS[%s] has unique ids and no 'default' placeholder
   expect(effortIds.length).toBeGreaterThan(0);
   expect(new Set(effortIds).size).toBe(effortIds.length);
   expect(effortIds).not.toContain("default");
+});
+
+// --- isValidEnvKey -----------------------------------------------------------
+
+test("isValidEnvKey accepts POSIX identifiers and rejects everything else", () => {
+  for (const ok of ["FOO", "_x", "A1_B2", "CLAUDE_CONFIG_DIR"]) {
+    expect(isValidEnvKey(ok)).toBe(true);
+  }
+  for (const bad of ["1FOO", "FOO BAR", "FOO=BAR", "X; rm -rf ~", "FOO-BAR", "", "a.b"]) {
+    expect(isValidEnvKey(bad)).toBe(false);
+  }
+});
+
+// --- buildHarnessTerminalCommand ---------------------------------------------
+
+test("terminal command for a built-in claude-code: no config/PATH exports, banner present", () => {
+  const cmd = buildHarnessTerminalCommand(builtin("claude-code"), "/home/u");
+  expect(cmd.startsWith("clear; ")).toBe(true);
+  expect(cmd).toContain("cd '/home/u'");
+  expect(cmd).not.toContain("export PATH=");
+  expect(cmd).not.toContain("export CLAUDE_CONFIG_DIR=");
+  expect(cmd).not.toContain("export HOME=");
+  expect(cmd).toContain("Agetor harness");
+  expect(cmd).toContain('Run "claude"');
+});
+
+test("claude-code alias exports CLAUDE_CONFIG_DIR but never HOME (keychain stays put)", () => {
+  const cmd = buildHarnessTerminalCommand(alias("claude-code", { home: "/cfg" }), "/cfg");
+  expect(cmd).toContain("export CLAUDE_CONFIG_DIR='/cfg'");
+  expect(cmd).not.toContain("export HOME=");
+});
+
+test("codex alias re-homes via HOME + CODEX_HOME", () => {
+  const cmd = buildHarnessTerminalCommand(alias("codex", { home: "/cfg" }), "/cfg");
+  expect(cmd).toContain("export HOME='/cfg'");
+  expect(cmd).toContain("export CODEX_HOME='/cfg/.codex'");
+});
+
+test("an absolute bin puts its dir first on PATH; a bare name does not", () => {
+  const withBin = buildHarnessTerminalCommand(alias("claude-code", { bin: "/opt/bin/claude" }), "/home/u");
+  expect(withBin).toContain("export PATH='/opt/bin':$PATH");
+  expect(withBin).toContain('Run "claude"');
+
+  const bareName = buildHarnessTerminalCommand(builtin("claude-code"), "/home/u");
+  expect(bareName).not.toContain("export PATH=");
+});
+
+test("env values with shell metacharacters are single-quote-escaped", () => {
+  const cmd = buildHarnessTerminalCommand(
+    alias("claude-code", { env: { TOKEN: "pa$$'w", SPACED: 'a b "c"' } }),
+    "/home/u",
+  );
+  // ' is closed-escaped-reopened; $ and " stay literal inside single quotes.
+  expect(cmd).toContain("export TOKEN='pa$$'\\''w'");
+  expect(cmd).toContain(`export SPACED='a b "c"'`);
+});
+
+test("non-identifier env keys are dropped, neutralizing injection from legacy rows", () => {
+  const cmd = buildHarnessTerminalCommand(
+    alias("claude-code", { env: { GOOD: "1", "EVIL; touch /tmp/pwned": "2" } }),
+    "/home/u",
+  );
+  expect(cmd).toContain("export GOOD='1'");
+  expect(cmd).not.toContain("touch /tmp/pwned");
+});
+
+// --- toTerminalAppleScript ---------------------------------------------------
+
+test("toTerminalAppleScript escapes quotes/backslashes and wraps in do script + activate", () => {
+  const script = toTerminalAppleScript('echo "hi"; cd /x\\y');
+  expect(script).toContain('do script "echo \\"hi\\"; cd /x\\\\y"');
+  expect(script).toContain('activate application "Terminal"');
 });

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -145,6 +145,72 @@ export function harnessEnv(harness: Harness): Record<string, string> {
 }
 
 /**
+ * A POSIX-valid environment variable name: a letter or underscore followed
+ * by letters, digits, or underscores. Used to gate what the harness `env`
+ * map may contain, both at write time (the harness POST/PATCH routes) and at
+ * shell-emit time (`buildHarnessTerminalCommand` below). Anything outside
+ * this set can't be a real `export NAME=…` target and — left unquoted — would
+ * let a crafted key (`X; rm -rf ~`) break out of the generated command.
+ */
+const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function isValidEnvKey(key: string): boolean {
+  return ENV_KEY_RE.test(key);
+}
+
+/**
+ * Build the interactive-shell command that loads a harness's env into a new
+ * Terminal window. Pure and deterministic — no spawning — so the escaping is
+ * unit-testable in isolation (see agents.test.ts). The caller wraps the
+ * result with `toTerminalAppleScript` and hands it to `osascript`.
+ *
+ * Every interpolated value is POSIX single-quoted (`sq`), which neutralizes
+ * `$`, backtick, spaces, and backslashes; the lone special case is `'`
+ * itself, closed-escaped-reopened. Env *keys* are filtered through
+ * `ENV_KEY_RE` rather than quoted — a non-identifier key can't be a valid
+ * `export` target anyway, and skipping it closes the injection vector even
+ * for legacy DB rows written before the route-level validation existed.
+ */
+export function buildHarnessTerminalCommand(harness: Harness, cwd: string): string {
+  const bin = resolveBin(harness);
+  const env = harnessEnv(harness);
+  const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
+  const launch = path.basename(bin);
+
+  const cmds: string[] = ["clear"];
+  for (const [k, v] of Object.entries(env)) {
+    if (!ENV_KEY_RE.test(k)) continue;
+    cmds.push(`export ${k}=${sq(v)}`);
+  }
+  // Put the harness binary's directory first on PATH so a bare `claude` /
+  // `codex` in this shell resolves to exactly the binary agetor would spawn
+  // (matters for `bin` overrides / aliases). Skipped when `bin` is a bare
+  // name we couldn't resolve to an absolute path — there's no dir to add.
+  if (path.isAbsolute(bin)) cmds.push(`export PATH=${sq(path.dirname(bin))}:$PATH`);
+  cmds.push(`cd ${sq(cwd)}`);
+  cmds.push(
+    `printf '%s\\n' ${sq(`▸ Agetor harness "${harness.label}" (${harness.id}) — env loaded.`)} ` +
+      `${sq(`  Run "${launch}" to start it, or "${launch} /login" to authenticate this account.`)}`,
+  );
+  return cmds.join("; ");
+}
+
+/**
+ * Wrap a shell command in the AppleScript that opens it in a new Terminal.app
+ * window and brings Terminal to the front. `do script` feeds the string to a
+ * fresh interactive login shell and leaves the window at a prompt afterward,
+ * so exported vars persist for the user's session. Backslash and double-quote
+ * are escaped for the AppleScript double-quoted string literal.
+ */
+export function toTerminalAppleScript(shellCmd: string): string {
+  const asEscape = (s: string) => s.replace(/(["\\])/g, "\\$1");
+  return (
+    `tell application "Terminal" to do script "${asEscape(shellCmd)}"\n` +
+    `activate application "Terminal"`
+  );
+}
+
+/**
  * Build the launch argv for a harness. For claude-code this is the
  * interactive REPL — no `--print`. The driver (tmux) drops these args after
  * `tmux new-session ... -- <argv>`. For codex this is `codex exec ...`,

--- a/src/bun/server-auth.test.ts
+++ b/src/bun/server-auth.test.ts
@@ -60,6 +60,35 @@ test("/agent-commands requires a known agent kind", async () => {
   expect(res.status).toBe(400);
 });
 
+test("POST /harnesses/:id/open-terminal requires auth", async () => {
+  const res = await fetch(url("/harnesses/claude-code/open-terminal"), {
+    method: "POST",
+  });
+  expect(res.status).toBe(401);
+});
+
+test("POST /harnesses/:id/open-terminal 404s for an unknown harness", async () => {
+  const res = await fetch(url("/harnesses/nope-not-a-harness/open-terminal"), {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  expect(res.status).toBe(404);
+});
+
+test("POST /harnesses rejects an invalid env var name", async () => {
+  const res = await fetch(url("/harnesses"), {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      id: "claude-badenv",
+      kind: "claude-code",
+      label: "Bad Env",
+      env: { "X; rm -rf ~": "1" },
+    }),
+  });
+  expect(res.status).toBe(400);
+});
+
 test("/approvals rejects unauthenticated POSTs", async () => {
   const res = await fetch(url("/approvals?taskId=any"), {
     method: "POST",

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -17,6 +17,11 @@ import {
 } from "./db.ts";
 import { archiveTask, createTask, deleteTask, startTask, cancelRun, reconcileTaskSession, sendInput, subscribe, subscribeGlobal, unarchiveTask } from "./orchestrator.ts";
 import { checkAllHarnesses } from "./agent-status.ts";
+import {
+  buildHarnessTerminalCommand,
+  isValidEnvKey,
+  toTerminalAppleScript,
+} from "./agents.ts";
 import { applyUpdate, checkForUpdate, getUpdateSnapshot } from "./updater.ts";
 import {
   bundledTmuxAvailable,
@@ -524,7 +529,14 @@ export function startApiServer() {
           const env: Record<string, string> = {};
           if (body.env && typeof body.env === "object" && !Array.isArray(body.env)) {
             for (const [k, v] of Object.entries(body.env)) {
-              if (typeof v === "string") env[k] = v;
+              if (typeof v !== "string") continue;
+              if (!isValidEnvKey(k)) {
+                return json(
+                  { error: `invalid env var name "${k}" — names must match [A-Za-z_][A-Za-z0-9_]*` },
+                  { status: 400, headers: corsHeaders(req) },
+                );
+              }
+              env[k] = v;
             }
           }
           if (harnesses.get(body.id)) {
@@ -602,7 +614,14 @@ export function startApiServer() {
           if (body.env && typeof body.env === "object" && !Array.isArray(body.env)) {
             const env: Record<string, string> = {};
             for (const [k, v] of Object.entries(body.env)) {
-              if (typeof v === "string") env[k] = v;
+              if (typeof v !== "string") continue;
+              if (!isValidEnvKey(k)) {
+                return json(
+                  { error: `invalid env var name "${k}" — names must match [A-Za-z_][A-Za-z0-9_]*` },
+                  { status: 400, headers: corsHeaders(req) },
+                );
+              }
+              env[k] = v;
             }
             patch.env = env;
           }
@@ -645,6 +664,62 @@ export function startApiServer() {
             return json({ error: "not found" }, { status: 404, headers: corsHeaders(req) });
           }
           return json(harnesses.usage(req.params.id), { headers: corsHeaders(req) });
+        }),
+      },
+
+      // Open a configured shell for this harness in a new Terminal.app window.
+      // The harness's home-derived vars (CLAUDE_CONFIG_DIR for claude-code,
+      // HOME + CODEX_HOME for codex), its custom env, and its binary's
+      // directory on PATH are all exported, then the window is left at an
+      // interactive prompt. This is the supported way to authenticate or
+      // inspect a multi-account alias: `claude /login` run in this shell
+      // writes credentials against the alias's own config dir, exactly as a
+      // real run would. macOS-only (osascript + Terminal.app), same as
+      // `/tasks/:id/open-tmux`.
+      "/harnesses/:id/open-terminal": {
+        POST: authed(async (req) => {
+          const harness = harnesses.getByIdOrKind(req.params.id);
+          if (!harness) {
+            return json({ error: "harness not found" }, { status: 404, headers: corsHeaders(req) });
+          }
+          // cwd: the harness home if it's a real directory, else the user's
+          // home. A configured-but-missing home shouldn't fail the launch.
+          const cwd = harness.home && existsSync(harness.home) ? harness.home : homedir();
+          const script = toTerminalAppleScript(buildHarnessTerminalCommand(harness, cwd));
+          const proc = Bun.spawn(["osascript", "-e", script], {
+            stdout: "ignore",
+            stderr: "pipe",
+          });
+          // Await the launch so the UI gets real feedback. `do script` returns
+          // as soon as Terminal accepts the command (it does NOT wait for the
+          // shell command to finish), so this resolves in well under a second
+          // on success and fails fast when Automation permission is denied.
+          // A 5s ceiling guards against a wedged osascript holding the
+          // response open.
+          const exit = await Promise.race([
+            proc.exited,
+            Bun.sleep(5000).then(() => "timeout" as const),
+          ]);
+          if (exit === "timeout") {
+            // Assume it's still coming up rather than reporting a false error.
+            return json({ ok: true }, { headers: corsHeaders(req) });
+          }
+          if (exit !== 0) {
+            const detail = (await new Response(proc.stderr).text()).trim();
+            console.warn(
+              `[agetor] osascript exited ${exit} while opening a terminal for harness "${harness.id}": ${detail}`,
+            );
+            return json(
+              {
+                error:
+                  `Couldn't open Terminal (osascript exited ${exit}).` +
+                  (detail ? ` ${detail}` : "") +
+                  " Check System Settings → Privacy & Security → Automation.",
+              },
+              { status: 502, headers: corsHeaders(req) },
+            );
+          }
+          return json({ ok: true }, { headers: corsHeaders(req) });
         }),
       },
 

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { ChevronLeft, Plus, Trash2, X } from "lucide-react";
+import { ChevronLeft, Plus, Terminal, Trash2, X } from "lucide-react";
 import { toast } from "sonner";
 import { ApiError, api, type HarnessesPayload, type HarnessInput } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -227,6 +227,18 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
     }
   };
 
+  const onOpenTerminal = async (h: Harness) => {
+    try {
+      await api.openHarnessTerminal(h.id);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      toast.error(`Couldn't open a terminal for "${h.label}"`, {
+        description: message,
+        duration: Infinity,
+      });
+    }
+  };
+
   const clearPending = (id: string) =>
     setPendingToggle((m) => {
       if (!(id in m)) return m;
@@ -351,6 +363,7 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
           }
           onDelete={onDeleteHarness}
           onToggleEnabled={onToggleEnabled}
+          onOpenTerminal={onOpenTerminal}
           pendingToggle={pendingToggle}
         />
       )}
@@ -420,6 +433,7 @@ function ListView({
   onEdit,
   onDelete,
   onToggleEnabled,
+  onOpenTerminal,
   pendingToggle,
 }: {
   payload: HarnessesPayload;
@@ -438,6 +452,9 @@ function ListView({
   onEdit: (h: Harness) => void;
   onDelete: (h: Harness) => void;
   onToggleEnabled: (h: Harness) => void;
+  /** Open a new Terminal.app window with this harness's env loaded so the
+   *  user can authenticate or inspect it (e.g. `claude /login`). */
+  onOpenTerminal: (h: Harness) => void;
   /** Optimistic toggle state — keyed by harness id, value is what the user
    *  clicked toward. Lets the Switch animate before the confirm/round-trip
    *  resolves. Missing keys mean "use the server's `h.enabled`". */
@@ -552,6 +569,15 @@ function ListView({
                     aria-label={h.enabled ? `Disable ${h.label}` : `Enable ${h.label}`}
                   />
                 )}
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => onOpenTerminal(h)}
+                  aria-label={`Open ${h.label} in Terminal`}
+                  title="Open in Terminal — load this harness's env to log in or inspect it"
+                >
+                  <Terminal className="size-4" />
+                </Button>
                 {!h.isBuiltin && (
                   <>
                     <Button size="sm" variant="ghost" onClick={() => onEdit(h)}>

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -220,6 +220,10 @@ export const api = {
     }),
   getHarnessUsage: (id: string) =>
     j<HarnessUsage>(`/harnesses/${encodeURIComponent(id)}/usage`),
+  openHarnessTerminal: (id: string) =>
+    j<{ ok: true }>(`/harnesses/${encodeURIComponent(id)}/open-terminal`, {
+      method: "POST",
+    }),
   listAgentModels: () => j<AgentModelMap>("/agent-models"),
   refreshAgentModels: () => j<AgentModelMap>("/agent-models", { method: "POST" }),
   listProjects: () => j<Project[]>("/projects"),


### PR DESCRIPTION
Each harness row in Settings gets a Terminal button that opens a new Terminal.app window with that harness's environment loaded (CLAUDE_CONFIG_DIR / HOME+CODEX_HOME, custom env, and the harness bin on PATH), leaving the window at an interactive prompt. This is the supported way to authenticate or inspect a multi-account alias — e.g. `claude /login` runs against the alias's own config dir. claude-code exports only CLAUDE_CONFIG_DIR (not HOME) so the macOS keychain still resolves.

- New POST /harnesses/:id/open-terminal route; awaits osascript (5s ceiling) and returns 502 with a hint when Automation permission is denied, so the UI surfaces the failure instead of silently no-opping.
- Extract pure, unit-tested helpers buildHarnessTerminalCommand / toTerminalAppleScript; values are POSIX single-quoted and the AppleScript literal is escaped.
- Validate harness env var names ([A-Za-z_][A-Za-z0-9_]*) on POST/PATCH, and skip non-identifier keys at shell-emit time, closing a command-injection vector from crafted/legacy env keys.