### PR TITLE
fix(tasks): scroll long prompts in the Task details sidebar

### DIFF
--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -2333,7 +2333,7 @@ function TaskDetails({
       <div className="mt-2 space-y-2">
         <div>
           <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Prompt</div>
-          <p className="whitespace-pre-wrap text-[11px] leading-snug">{task.prompt}</p>
+          <p className="max-h-48 overflow-y-auto whitespace-pre-wrap text-[11px] leading-snug">{task.prompt}</p>
         </div>
 
         {!editable && (


### PR DESCRIPTION
Cap the prompt block in the expandable Task details section at ~12 lines (max-h-48) with overflow-y-auto so a large prompt scrolls internally instead of stretching the run panel. Matches the existing max-h-48 convention used by ExpandableBlock.