### PR TITLE
feat(tasks): add task type filter to the kanban board

### DIFF
--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -3,7 +3,7 @@ import { DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors } f
 import { AlertTriangle, Settings, X } from "lucide-react";
 import { api, type AgentModelMap } from "@/lib/api";
 import { Button } from "@/components/ui/button";
-import { COLUMNS, type AgentStatus, type ColumnId, type GlobalEvent, type Harness, type Project, type Task } from "../shared/types.ts";
+import { COLUMNS, type AgentStatus, type ColumnId, type GlobalEvent, type Harness, type Project, type Task, type TaskType } from "../shared/types.ts";
 import { AgentIcon } from "@/components/kanban/AgentIcon";
 import { Column } from "@/components/kanban/Column";
 import { DiffDialog } from "@/components/kanban/DiffDialog";
@@ -81,6 +81,7 @@ export default function App() {
   const [statusFilter, setStatusFilter] = useState<ColumnId[]>([]);
   const [archivedView, setArchivedView] = useState<"active" | "all" | "archived">("active");
   const [harnessFilter, setHarnessFilter] = useState<string[]>([]);
+  const [typeFilter, setTypeFilter] = useState<TaskType[]>([]);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [tmuxDialogOpen, setTmuxDialogOpen] = useState(false);
   const [updateSnapshot, setUpdateSnapshot] = useState<UpdateSnapshot | null>(null);
@@ -318,11 +319,12 @@ export default function App() {
       }
       if (repoFilter.length > 0 && !repoFilter.includes(t.workdir)) return false;
       if (harnessFilter.length > 0 && !harnessFilter.includes(t.agent)) return false;
+      if (typeFilter.length > 0 && !typeFilter.includes(t.taskType)) return false;
       if (archivedView === "active" && t.archivedAt != null) return false;
       if (archivedView === "archived" && t.archivedAt == null) return false;
       return true;
     });
-  }, [tasks, textQuery, repoFilter, harnessFilter, archivedView]);
+  }, [tasks, textQuery, repoFilter, harnessFilter, typeFilter, archivedView]);
 
   const visibleColumns = useMemo(
     () => (statusFilter.length === 0 ? COLUMNS : COLUMNS.filter((c) => statusFilter.includes(c.id))),
@@ -560,6 +562,8 @@ export default function App() {
             onArchivedViewChange={setArchivedView}
             harnessFilter={harnessFilter}
             onHarnessFilterChange={setHarnessFilter}
+            typeFilter={typeFilter}
+            onTypeFilterChange={setTypeFilter}
             projects={projects}
             harnesses={harnesses}
             taskAgentIds={taskAgentIds}

--- a/src/mainview/components/kanban/KanbanFilters.tsx
+++ b/src/mainview/components/kanban/KanbanFilters.tsx
@@ -1,10 +1,12 @@
-import { Cpu, Folder, Search, Tag } from "lucide-react";
+import { Cpu, Folder, Search, Shapes, Tag } from "lucide-react";
 import { AgentIcon } from "@/components/kanban/AgentIcon";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { MultiSearchSelect } from "@/components/ui/multi-search-select";
 import { Select } from "@/components/ui/select";
-import { COLUMNS, type ColumnId, type Harness, type Project } from "../../../shared/types.ts";
+import { cn } from "@/lib/utils";
+import { taskTypeIcon } from "@/lib/task-type-icon";
+import { COLUMNS, TASK_TYPES, type ColumnId, type Harness, type Project, type TaskType } from "../../../shared/types.ts";
 
 export type ArchivedView = "active" | "all" | "archived";
 
@@ -19,6 +21,8 @@ interface Props {
   onArchivedViewChange: (v: ArchivedView) => void;
   harnessFilter: string[];
   onHarnessFilterChange: (v: string[]) => void;
+  typeFilter: TaskType[];
+  onTypeFilterChange: (v: TaskType[]) => void;
   projects: Project[];
   harnesses: Harness[];
   /** Distinct harness ids referenced by any current task. Used to surface
@@ -45,6 +49,8 @@ export function KanbanFilters({
   onArchivedViewChange,
   harnessFilter,
   onHarnessFilterChange,
+  typeFilter,
+  onTypeFilterChange,
   projects,
   harnesses,
   taskAgentIds,
@@ -74,12 +80,21 @@ export function KanbanFilters({
     .filter((id) => !known.has(id))
     .map((id) => ({ value: id, label: id, hint: "removed" }));
   const harnessItems = [...enabledItems, ...disabledItems, ...orphanItems];
+  const typeItems = TASK_TYPES.map((t) => {
+    const Icon = taskTypeIcon(t.icon);
+    return {
+      value: t.id,
+      label: t.label,
+      icon: <Icon className={cn("size-3.5", t.iconClass)} />,
+    };
+  });
   const anyActive =
     textQuery !== ""
     || repoFilter.length > 0
     || statusFilter.length > 0
     || archivedView !== "active"
-    || harnessFilter.length > 0;
+    || harnessFilter.length > 0
+    || typeFilter.length > 0;
 
   return (
     <div className="flex shrink-0 items-center gap-2 border-b border-border/60 px-4 py-2">
@@ -119,6 +134,15 @@ export function KanbanFilters({
         leadingIcon={<Tag className="size-3.5" />}
         className="w-48"
       />
+      <MultiSearchSelect
+        values={typeFilter}
+        onChange={onTypeFilterChange}
+        items={typeItems}
+        emptyLabel="All types"
+        placeholder="Search types…"
+        leadingIcon={<Shapes className="size-3.5" />}
+        className="w-44"
+      />
       <Select
         value={archivedView}
         onChange={(e) => onArchivedViewChange(e.target.value as ArchivedView)}
@@ -139,6 +163,7 @@ export function KanbanFilters({
             onStatusFilterChange([]);
             onArchivedViewChange("active");
             onHarnessFilterChange([]);
+            onTypeFilterChange([]);
           }}
         >
           Clear

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Bug, ClipboardList, Code2, FlaskConical, GitBranch, Inbox } from "lucide-react";
+import { ClipboardList, Code2, GitBranch } from "lucide-react";
 import { api, type AgentModelMap, type AvailableCommand } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { taskTypeIcon } from "@/lib/task-type-icon";
 import {
   AGENT_OPTIONS,
   CODE_PLAN_MODE,
@@ -35,14 +36,6 @@ import { SlashAutocomplete } from "./SlashAutocomplete";
 import { spliceAtSelection, readCaret, restoreCaret } from "@/lib/textarea-insert";
 
 const initialMode = (kind: AgentKind) => AGENT_OPTIONS[kind].modes[0]?.id ?? "auto";
-
-// Map the `TaskTypeMeta.icon` string ids to actual lucide components.
-// Defined module-scope so the lookup doesn't re-allocate per render.
-const TASK_TYPE_ICONS = {
-  Inbox,
-  Bug,
-  FlaskConical,
-} as const;
 
 interface Props {
   onSubmit: (
@@ -414,7 +407,7 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
           <label className="text-muted-foreground">Type</label>
           <div className="grid grid-cols-3 gap-1">
             {TASK_TYPES.map((t) => {
-              const Icon = TASK_TYPE_ICONS[t.icon];
+              const Icon = taskTypeIcon(t.icon);
               const selected = taskType === t.id;
               return (
                 <Button

--- a/src/mainview/components/kanban/TaskCard.tsx
+++ b/src/mainview/components/kanban/TaskCard.tsx
@@ -1,19 +1,13 @@
 import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
-import { Archive, ArchiveRestore, ArrowRight, Bug, CheckCircle2, FlaskConical, FolderOpen, GitBranch, GitCompare, Inbox, MessageCircleQuestion, Play, Square, Terminal, Trash2 } from "lucide-react";
+import { Archive, ArchiveRestore, ArrowRight, CheckCircle2, FolderOpen, GitBranch, GitCompare, MessageCircleQuestion, Play, Square, Terminal, Trash2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { abbreviateHome, cn } from "@/lib/utils";
+import { taskTypeIcon } from "@/lib/task-type-icon";
 import { taskTypeMeta, type Task } from "../../../shared/types.ts";
 import { AgentIcon } from "./AgentIcon";
-
-// Resolve TaskTypeMeta.icon strings to actual lucide components.
-const TASK_TYPE_ICONS = {
-  Inbox,
-  Bug,
-  FlaskConical,
-} as const;
 
 interface Props {
   task: Task;
@@ -67,7 +61,7 @@ export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen, o
     : "Review";
 
   const type = taskTypeMeta(task.taskType);
-  const TypeIcon = TASK_TYPE_ICONS[type.icon];
+  const TypeIcon = taskTypeIcon(type.icon);
 
   return (
     <Card

--- a/src/mainview/lib/task-type-icon.ts
+++ b/src/mainview/lib/task-type-icon.ts
@@ -1,0 +1,14 @@
+import { Bug, FlaskConical, Inbox } from "lucide-react";
+import type { TaskTypeMeta } from "../../shared/types.ts";
+
+// Resolve a TaskTypeMeta.icon string to its lucide component. The mapping can't
+// live in shared/types.ts (it must stay free of runtime/React imports), so this
+// is the single webview-side source of truth — keyed on the icon union so it
+// stays exhaustive at compile time.
+const ICONS = {
+  Inbox,
+  Bug,
+  FlaskConical,
+} as const satisfies Record<TaskTypeMeta["icon"], unknown>;
+
+export const taskTypeIcon = (icon: TaskTypeMeta["icon"]) => ICONS[icon];


### PR DESCRIPTION
Add a Task/Bug/Spike type filter to the kanban filter bar, alongside the existing harness, repo, and status filters. Options derive from the TASK_TYPES enum so they stay aligned with the new-task type picker, and the predicate is wired into the visibleTasks memo plus the Clear handler.

Also consolidate the duplicated TaskTypeMeta.icon -> lucide-component mapping (previously copied in TaskCard, NewTaskForm, and the new filter) into a single src/mainview/lib/task-type-icon.ts helper, typed to stay exhaustive against the icon union.