### PR TITLE
fix(tasks): move "Commit & push" to the right of the extensions picker

### DIFF
--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -886,20 +886,10 @@ function RunPanelBody({
               startingFolder={task.worktreePath ?? task.workdir}
             />
           )}
-          {canSend && latestRun?.status === "succeeded" && hasChanges && !sending && (
-            <div>
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={() => void sendCommitPush()}
-                title="Ask the agent to commit the working-tree changes and push the current branch to origin."
-              >
-                <GitCommit className="mr-1 size-3" /> Commit &amp; push
-              </Button>
-            </div>
-          )}
           {canSend && (
-            <div className="flex items-center">
+            // Picker on the left; "Commit & push" (when offered) pushed to the
+            // right so it isn't stacked directly on top of the picker.
+            <div className="flex items-center justify-between gap-2">
               <ExtensionPicker
                 extensions={sendExtensions}
                 value={input}
@@ -910,6 +900,16 @@ function RunPanelBody({
                 // in-flight send needs to disable the trigger here.
                 disabled={sending}
               />
+              {latestRun?.status === "succeeded" && hasChanges && !sending && (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => void sendCommitPush()}
+                  title="Ask the agent to commit the working-tree changes and push the current branch to origin."
+                >
+                  <GitCommit className="mr-1 size-3" /> Commit &amp; push
+                </Button>
+              )}
             </div>
           )}
           <div className="flex items-stretch gap-2">


### PR DESCRIPTION
In the task-details message dock, "Commit & push" sat stacked directly above the MCP/Skills/Plugins picker, crowding it. Merge the two into one row — picker on the left, "Commit & push" pushed to the right via justify-between — so they sit side by side. When the commit button isn't offered, the picker stays left-aligned on its own.