### PR TITLE
fix(claude-code): show the full hard-wrapped AskUserQuestion text, no…

### DIFF
--- a/src/bun/claude-questions.test.ts
+++ b/src/bun/claude-questions.test.ts
@@ -99,6 +99,24 @@ describe("parseModalPane — reads the visible question off the pane", () => {
     expect(p.multiSelect).toBe(false);
   });
 
+  test("wrapped question + wrapped description: gathers every hard-wrapped row, not just the tail", () => {
+    const p = parseModalPane(fx("single_wrapped_question"))!;
+    // The full question spans two pane rows; the old parser kept only the tail
+    // ("OpenAI). How are they used?").
+    expect(p.questionText).toBe(
+      "There are 5+ AI providers wired up (Vision, Translate, Gemini, Mistral, Groq, OpenAI). How are they used?",
+    );
+    expect(p.options.map((o) => o.label)).toEqual([
+      "Primary + fallbacks", "Task-specialized", "Experimental",
+    ]);
+    expect(p.options[0]!.description).toBe("One main model with others as failover/cost backups.");
+    // option 2's description hard-wraps across two rows → joined into one.
+    expect(p.options[1]!.description).toBe(
+      "Each provider handles a specific job (OCR vs translate vs explain vs chat).",
+    );
+    expect(p.multiSelect).toBe(false);
+  });
+
   test("tabbed multiSelect (Toppings): tab headers, checkbox options, multiSelect=true", () => {
     const p = parseModalPane(fx("multi_initial_toppings"))!;
     expect(p.tabbed).toBe(true);

--- a/src/bun/claude-questions.ts
+++ b/src/bun/claude-questions.ts
@@ -232,23 +232,39 @@ export function parseModalPane(tail: string): ParsedQuestionPane | null {
   const isNoise = (l: string | undefined): boolean =>
     l === undefined || l.trim() === "" || /^[─-]{3,}$/.test(l.trim())
     || /^Next$/.test(l.trim()) || /Esc to cancel/.test(l) || OPTION_RE.test(l);
-  const options = kept.map((r) => ({
-    label: r.label,
-    description: isNoise(lines[r.idx + 1]) ? undefined : lines[r.idx + 1]!.trim(),
-    checked: r.checkbox === "✔" || r.checkbox?.toLowerCase() === "x",
-  }));
+  const options = kept.map((r) => {
+    // A description may hard-wrap across several rows; gather every row between
+    // this option and the next noise boundary (next option / separator / blank
+    // / footer), not just the first.
+    const descLines: string[] = [];
+    for (let i = r.idx + 1; !isNoise(lines[i]); i++) descLines.push(lines[i]!.trim());
+    return {
+      label: r.label,
+      description: descLines.length > 0 ? descLines.join(" ") : undefined,
+      checked: r.checkbox === "✔" || r.checkbox?.toLowerCase() === "x",
+    };
+  });
 
-  // Question text: nearest non-empty line above the first option that isn't the
-  // tab bar, a `☐ <header>` line, an arrow row, or a separator.
+  // Question text: claude hard-wraps a long question across several pane rows,
+  // so gather the whole contiguous block just above the first option — skipping
+  // the blank / tab bar / `☐ <header>` / separator that frame it — and join.
+  // Taking only the nearest row (the old behaviour) dropped everything but the
+  // wrapped tail (e.g. "OpenAI). How are they used?").
   const firstOptIdx = kept[0]!.idx;
-  let questionText = "";
+  const qLines: string[] = [];
   for (let i = firstOptIdx - 1; i >= 0; i--) {
     const l = lines[i]!.trim();
-    if (l === "") continue;
-    if (/^[☐☒←→]/.test(l) || /✔\s*Submit/.test(l) || /^[─-]{3,}$/.test(l)) continue;
-    questionText = l;
-    break;
+    if (/^[☐☒←→]/.test(l) || /✔\s*Submit/.test(l) || /^[─-]{3,}$/.test(l)) {
+      if (qLines.length > 0) break; // a frame row above the gathered block → done
+      continue;                      // frame row below the question → keep scanning up
+    }
+    if (l === "") {
+      if (qLines.length > 0) break; // blank above the question → top boundary
+      continue;                      // blank between question and options → skip
+    }
+    qLines.unshift(l);               // a (possibly wrapped) question row
   }
+  const questionText = qLines.join(" ");
 
   return { tabbed: tabHeaders.length > 0, tabHeaders, questionText, multiSelect, options, cursorIndex };
 }

--- a/src/bun/fixtures/askuserquestion/single_wrapped_question.txt
+++ b/src/bun/fixtures/askuserquestion/single_wrapped_question.txt
@@ -1,0 +1,21 @@
+ ⚠ 1 setup issue: MCP · /doctor
+
+❯ Call AskUserQuestion with one question about AI provider usage and three options.
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ☐ Providers
+
+There are 5+ AI providers wired up (Vision, Translate, Gemini, Mistral, Groq,
+OpenAI). How are they used?
+
+❯ 1. Primary + fallbacks
+  One main model with others as failover/cost backups.
+  2. Task-specialized
+  Each provider handles a specific job
+  (OCR vs translate vs explain vs chat).
+  3. Experimental
+  Several are leftovers/experiments, not all in active use.
+  4. Type something.
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  5. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel


### PR DESCRIPTION
…t just the tail

parseModalPane built the question text by taking only the nearest pane row above the first option, so a long question that agetor's narrower capture-pane wraps across rows lost everything but the last row (e.g. shown as 'OpenAI). How are they used?'). Option descriptions had the same single-row bug. Both the question card and the review-to-submit card render this data, so both truncated.

Gather the whole contiguous wrapped block instead: for the question (walk up, bounded by the tab-bar / separator / blank that frames it) and for each option description (walk down until the next noise row), joined on spaces — Ink word-wraps at spaces, so the join restores the original text. Display-only: the answer-drive path keys off option labels, which are unchanged.

New fixture single_wrapped_question.txt (2-row question + 2-row description) + test. Suite 478/0; typecheck clean.