### PR TITLE
Fix/trust dialog and prompt display

### DIFF
--- a/src/bun/claude-tmux-scraper.test.ts
+++ b/src/bun/claude-tmux-scraper.test.ts
@@ -138,23 +138,32 @@ test("matchStartupConsentDialog — bypass-permissions warning, accept is option
   expect(m!.acceptIndex).toBe(1); // must move off the default "No, exit"
 });
 
-test("matchStartupConsentDialog — trust-folder dialog (HYPOTHESIZED shape, not yet observed), accept is the cursor default", () => {
-  // NOTE: this asserts the matcher's contract against an *assumed* trust-prompt
-  // shape — claude's real trust dialog wording/options have not been reproduced
-  // against the live TUI (bypass mode suppresses it; auto-mode worktree launches
-  // haven't triggered it). The entry is safe-by-omission (a wrong guess no-ops),
-  // so this test guards the parser, NOT that claude actually draws this.
-  const pane = `Do you trust the files in this folder?
+test("matchStartupConsentDialog — workspace-trust dialog (real observed text), accept is the cursor default", () => {
+  // The real first-run workspace-trust prompt (claude 2.1.x). NOT suppressed by
+  // --dangerously-skip-permissions, so agetor's fresh worktrees hit it; left
+  // unanswered it blocks JSONL creation until the 30s boot timeout kills the run.
+  const pane = `────────────────────────────────────────────────────────────────────────────────
+ Accessing workspace:
 
-  /Users/me/.agetor/worktrees/abc
+ /Users/alamosaravali/.agetor/worktrees/49e737a1-091d-4a1b-9522-0c7a3578562f
 
-❯ 1. Yes, proceed
-  2. No, exit`;
+ Quick safety check: Is this a project you created or one you trust? (Like your
+ own code, a well-known open source project, or work from your team). If not,
+ take a moment to review what's in this folder first.
+
+ Claude Code'll be able to read, edit, and execute files here.
+
+ Security guide
+
+ ❯ 1. Yes, I trust this folder
+   2. No, exit
+
+ Enter to confirm · Esc to cancel`;
   const m = matchStartupConsentDialog(pane);
   expect(m).not.toBeNull();
   expect(m!.name).toBe("trust-folder");
   expect(m!.cursorIndex).toBe(0);
-  expect(m!.acceptIndex).toBe(0); // already on the affirmative → Enter alone
+  expect(m!.acceptIndex).toBe(0); // already on "Yes, I trust this folder" → Enter alone
 });
 
 test("matchStartupConsentDialog — a normal per-tool permission modal is NOT auto-confirmed", () => {
@@ -176,7 +185,7 @@ test("matchStartupConsentDialog — bypass marker without a parseable choice lis
 
 test("matchStartupConsentDialog — distinct dialogs get distinct fingerprints", () => {
   const bypass = matchStartupConsentDialog(`Bypass Permissions mode\n❯ 1. No, exit\n  2. Yes, I accept`)!;
-  const trust = matchStartupConsentDialog(`trust the files in this folder\n❯ 1. Yes, proceed\n  2. No, exit`)!;
+  const trust = matchStartupConsentDialog(`Quick safety check\n❯ 1. Yes, I trust this folder\n  2. No, exit`)!;
   expect(bypass).not.toBeNull();
   expect(trust).not.toBeNull();
   expect(bypass.fingerprint).not.toBe(trust.fingerprint);

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -1749,20 +1749,25 @@ const STARTUP_CONSENT_DIALOGS: Array<{ name: string; marker: RegExp; affirmative
   //   ❯ 1. No, exit
   //     2. Yes, I accept
   { name: "bypass-permissions", marker: /bypass permissions mode/i, affirmative: /\baccept\b/i },
-  // BEST-EFFORT / UNVERIFIED: the first-run trust prompt claude shows for a
-  // never-before-opened directory:
-  //   Do you trust the files in this folder?
-  //   ❯ 1. Yes, proceed
+  // Workspace-trust prompt: claude shows this the first time it opens a
+  // directory not already trusted in ~/.claude.json. It is NOT suppressed by
+  // `--dangerously-skip-permissions` (workspace trust is a separate layer from
+  // permissions), so agetor's fresh per-task worktrees reliably trigger it —
+  // and it blocks claude from ever writing its JSONL until answered (otherwise
+  // the run dies at the 30s boot timeout with the dialog on the pane). Observed
+  // text (claude 2.1.x):
+  //   Quick safety check: Is this a project you created or one you trust? …
+  //   ❯ 1. Yes, I trust this folder
   //     2. No, exit
-  // The exact wording/options here are assumed, not observed — `bypass` mode
-  // suppresses this prompt entirely, and auto-mode launches in agetor's
-  // worktrees have not been seen to trigger it. Kept as safe defence: the
-  // `affirmative` is deliberately the narrow `/\bproceed\b/i` (NOT `/trust/`,
-  // which a "No, don't trust" option would also match → wrong keypress). If
-  // claude's real affirmative isn't "…proceed", this entry simply no-ops and
-  // we fall back to the boot-timeout path — never a wrong action. Confirm the
-  // real TUI text before relying on it.
-  { name: "trust-folder", marker: /trust the files in this (folder|directory)/i, affirmative: /\bproceed\b/i },
+  // `affirmative` is anchored on "Yes …trust this folder", so it can only ever
+  // land on the trust option — never a "No, …trust" variant (the original
+  // safety concern). The marker also keeps the older "trust the files in this
+  // folder" wording as a fallback in case an earlier build phrased it that way.
+  {
+    name: "trust-folder",
+    marker: /Quick safety check|trust this folder|trust the files in this (folder|directory)/i,
+    affirmative: /Yes\b.*\btrust this folder\b/i,
+  },
 ];
 
 export interface StartupDialogMatch {

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -2769,6 +2769,28 @@ function AskQuestionsCard({
  * background) so the user recognises that they're looking at what's
  * actually on the tmux screen, not an agetor-synthesised question.
  */
+/** claude's TUI keyboard-shortcut footers — meaningless when answering through
+ *  agetor's buttons, and they bury the actual prompt. Stripped from the scraped
+ *  pane before display. Display-only; the parsed choices are unaffected. */
+const PROMPT_NOISE_RE = [
+  /^esc to cancel\b/i,
+  /^enter to (confirm|select|continue)\b/i,
+  /^↑\/↓/,
+  /^tab to amend\b/i,
+  /\bctrl\+e to explain\b/i,
+  /\(ctrl\+b ctrl\+b/i,
+  /to run in background\)/i,
+];
+function cleanPromptPane(text: string): string {
+  const out: string[] = [];
+  for (const line of text.split("\n")) {
+    if (PROMPT_NOISE_RE.some((re) => re.test(line.trim()))) continue;
+    if (out.length > 0 && out[out.length - 1] === line) continue; // repaint dup row
+    out.push(line);
+  }
+  return out.join("\n").replace(/^\n+|\n+$/g, "");
+}
+
 function TmuxPromptCard({
   req,
   onResolved,
@@ -2868,8 +2890,8 @@ function TmuxPromptCard({
           <Terminal className="size-3.5" aria-hidden /> Claude is paused on a prompt
         </span>
       </div>
-      <pre className="max-h-96 overflow-auto whitespace-pre rounded-md border border-border/40 bg-muted/40 p-2 font-mono text-[11px] leading-snug">
-        {req.paneText}
+      <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/40 bg-muted/40 p-2 font-mono text-[11px] leading-snug">
+        {cleanPromptPane(req.paneText)}
       </pre>
       <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
         {req.choices.map((c) => {


### PR DESCRIPTION
## Summary

Two fixes for the native-modal flow, surfaced by a fresh-worktree run.

### 1. Workspace-trust dialog hung boot
The first time claude opens a not-yet-trusted directory it shows a workspace-trust
prompt — and `--dangerously-skip-permissions` does **not** suppress it (separate
layer). agetor's fresh per-task worktrees always trigger it, and it blocks claude
from writing its JSONL, so the run died at the 30s boot timeout. agetor's
auto-confirm matcher was written against an unverified guess that didn't match
the real text (*"Quick safety check… Yes, I trust this folder"*). Updated the
matcher to the observed text (affirmative anchored on `Yes …trust this folder`
so it can never select "No"); the boot poller then auto-confirms it.

### 2. "Claude is paused on a prompt" card clipped the message
`TmuxPromptCard` used `whitespace-pre` (no wrap), so long wrapped pane rows (a
Bash dangerous-glob confirm with a long path) were clipped at the card edge.
Switched to `whitespace-pre-wrap break-words` and strip claude's TUI
keyboard-shortcut footers + duplicate repaint rows. Display-only — the parsed
Yes/No buttons are unaffected.

## Testing
Updated the trust-dialog test to the real pane text. Suite **478/0**, typecheck
clean, webview bundles.