### PR TITLE
feat(terminal): support VS Code-style macOS Opt/Cmd word & line editi…

### DIFF
--- a/src/mainview/components/kanban/TerminalView.tsx
+++ b/src/mainview/components/kanban/TerminalView.tsx
@@ -6,6 +6,7 @@ import { Plus, X, TerminalSquare } from "lucide-react";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { macEditSequence } from "./terminal-keys.ts";
 import type { TerminalTab } from "../../../shared/types.ts";
 
 /** xterm theme tuned to the app's dark zinc palette. */
@@ -116,6 +117,18 @@ function TerminalPane({
 
     const dataSub = term.onData((d) => {
       if (ws && ws.readyState === WebSocket.OPEN) ws.send(enc.encode(d));
+    });
+
+    // macOS word/line editing shortcuts (⌥/⌘ + arrows/backspace/delete),
+    // matching VS Code's terminal. See macEditSequence for the mapping + why
+    // xterm's defaults don't work here.
+    term.attachCustomKeyEventHandler((e) => {
+      if (e.type !== "keydown") return true;
+      const seq = macEditSequence(e);
+      if (!seq) return true;
+      e.preventDefault(); // keep the webview from also acting on the combo
+      if (ws && ws.readyState === WebSocket.OPEN) ws.send(enc.encode(seq));
+      return false; // handled — don't let xterm emit its own variant
     });
 
     const ro = new ResizeObserver(() => {

--- a/src/mainview/components/kanban/terminal-keys.test.ts
+++ b/src/mainview/components/kanban/terminal-keys.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { macEditSequence } from "./terminal-keys.ts";
+
+/** Build a minimal key-event shape; all modifiers default off. */
+const key = (
+  k: string,
+  mods: Partial<{ metaKey: boolean; altKey: boolean; ctrlKey: boolean; shiftKey: boolean }> = {},
+) => ({ metaKey: false, altKey: false, ctrlKey: false, shiftKey: false, key: k, ...mods });
+
+describe("macEditSequence", () => {
+  test("⌘ line navigation / deletion", () => {
+    expect(macEditSequence(key("ArrowLeft", { metaKey: true }))).toBe("\x01"); // Ctrl-A
+    expect(macEditSequence(key("ArrowRight", { metaKey: true }))).toBe("\x05"); // Ctrl-E
+    expect(macEditSequence(key("Backspace", { metaKey: true }))).toBe("\x15"); // Ctrl-U
+    expect(macEditSequence(key("Delete", { metaKey: true }))).toBe("\x0b"); // Ctrl-K
+  });
+
+  test("⌥ word navigation / deletion", () => {
+    expect(macEditSequence(key("ArrowLeft", { altKey: true }))).toBe("\x1bb");
+    expect(macEditSequence(key("ArrowRight", { altKey: true }))).toBe("\x1bf");
+    expect(macEditSequence(key("Backspace", { altKey: true }))).toBe("\x1b\x7f");
+    expect(macEditSequence(key("Delete", { altKey: true }))).toBe("\x1bd");
+  });
+
+  test("Shift-modified combos fall through to xterm (selection gestures)", () => {
+    expect(macEditSequence(key("ArrowLeft", { metaKey: true, shiftKey: true }))).toBeNull();
+    expect(macEditSequence(key("ArrowRight", { altKey: true, shiftKey: true }))).toBeNull();
+  });
+
+  test("extra modifiers disqualify the combo", () => {
+    // ⌘+⌥ together → not a recognized combo
+    expect(macEditSequence(key("ArrowLeft", { metaKey: true, altKey: true }))).toBeNull();
+    // ⌃+⌥ together → not a recognized combo
+    expect(macEditSequence(key("ArrowLeft", { altKey: true, ctrlKey: true }))).toBeNull();
+  });
+
+  test("unmodified and unhandled keys pass through", () => {
+    expect(macEditSequence(key("ArrowLeft"))).toBeNull(); // bare arrow → xterm default
+    expect(macEditSequence(key("a", { altKey: true }))).toBeNull(); // Opt+letter → macOptionIsMeta
+    expect(macEditSequence(key("Home", { metaKey: true }))).toBeNull(); // unhandled key
+  });
+});

--- a/src/mainview/components/kanban/terminal-keys.ts
+++ b/src/mainview/components/kanban/terminal-keys.ts
@@ -1,0 +1,50 @@
+/**
+ * macOS word/line editing shortcuts for the task-details terminal, matching
+ * VS Code's integrated terminal. xterm's `macOptionIsMeta` only rewrites
+ * *printable* Opt+letter keys (Opt+B/Opt+F → Meta); it doesn't touch the
+ * arrows, and ⌘ combos never reach the shell at all. For these, xterm's
+ * default is either a CSI-modified arrow (\x1b[1;3D) that the default
+ * zsh/readline keymap doesn't bind to word/line movement, or nothing — so we
+ * translate each into the byte sequence zsh's default emacs keymap expects and
+ * send it ourselves. Shell-config agnostic, the same way VS Code wires these up.
+ *
+ * Returns the bytes to write to the PTY, or null if the combo isn't one we
+ * handle (in which case the caller should let xterm process the key normally).
+ *
+ * Pure + dependency-free on purpose so it can be unit-tested without xterm,
+ * React, or a real KeyboardEvent — see terminal-keys.test.ts.
+ */
+type EditKeyEvent = Pick<KeyboardEvent, "metaKey" | "altKey" | "ctrlKey" | "shiftKey" | "key">;
+
+export function macEditSequence(e: EditKeyEvent): string | null {
+  // Shifted combos (⇧ + ⌘/⌥ + arrow) are selection gestures elsewhere — leave
+  // them to xterm's default path rather than swallowing a whole key class.
+  if (e.shiftKey) return null;
+
+  // ⌘ — whole-line navigation / deletion.
+  if (e.metaKey && !e.altKey && !e.ctrlKey) {
+    switch (e.key) {
+      case "ArrowLeft": return "\x01"; // ⌘← → line start (Ctrl-A)
+      case "ArrowRight": return "\x05"; // ⌘→ → line end (Ctrl-E)
+      // ⌘⌫ → Ctrl-U. NB: in zsh's default emacs keymap ^U is kill-whole-line
+      // (deletes the entire line, not just to the left of the cursor); in
+      // bash/readline it's unix-line-discard (cursor→start). Same byte VS Code
+      // sends; behavior is shell-dependent.
+      case "Backspace": return "\x15";
+      case "Delete": return "\x0b"; // ⌘⌦ → delete to line end (Ctrl-K)
+    }
+    return null;
+  }
+
+  // ⌥ — word navigation / deletion.
+  if (e.altKey && !e.metaKey && !e.ctrlKey) {
+    switch (e.key) {
+      case "ArrowLeft": return "\x1bb"; // ⌥← → word left
+      case "ArrowRight": return "\x1bf"; // ⌥→ → word right
+      case "Backspace": return "\x1b\x7f"; // ⌥⌫ → delete word back
+      case "Delete": return "\x1bd"; // ⌥⌦ → delete word forward
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
…ng keys

The task-details xterm.js terminal only honored printable Opt+letter bindings (via macOptionIsMeta); Opt/Cmd + arrows, backspace, and delete did nothing because xterm emits CSI-modified arrows (\x1b[1;3D) that default zsh/readline doesn't bind, and Cmd combos never reach the shell at all.

Add a custom keydown handler that translates the macOS editing combos into the byte sequences zsh's default emacs keymap expects, mirroring VS Code's terminal:

  Opt+Left/Right   -> word left/right        (\x1bb / \x1bf)
  Opt+Backspace    -> delete word back       (\x1b\x7f)
  Opt+Delete       -> delete word forward    (\x1bd)
  Cmd+Left/Right   -> line start/end         (Ctrl-A / Ctrl-E)
  Cmd+Backspace    -> kill line              (Ctrl-U)
  Cmd+Delete       -> delete to line end     (Ctrl-K)

The mapping lives in a pure, dependency-free helper (terminal-keys.ts) with unit tests (terminal-keys.test.ts). Shift-modified combos fall through to xterm so selection gestures aren't swallowed.