### PR TITLE
fix(claude-questions): stop AskUserQuestion preview panels bleeding i…

### DIFF
--- a/src/bun/claude-questions.test.ts
+++ b/src/bun/claude-questions.test.ts
@@ -8,6 +8,7 @@ import {
   parseAskModal,
   parseModalPane,
   planAskAnswers,
+  stripPreviewColumn,
   type AskAnswer,
   type AskQuestionSpec,
 } from "./claude-questions.ts";
@@ -80,6 +81,40 @@ describe("parseAskModal", () => {
   });
 });
 
+describe("stripPreviewColumn — removes the side-by-side preview box from a row", () => {
+  test("cuts the box off an option row at the gutter", () => {
+    expect(stripPreviewColumn("❯ 1. One combined line            ┌──────────────┐"))
+      .toBe("❯ 1. One combined line");
+    expect(stripPreviewColumn("  2. Separate name + flag         │ Cancelled by: X │"))
+      .toBe("  2. Separate name + flag");
+  });
+
+  test("blanks an indented box continuation row entirely", () => {
+    expect(stripPreviewColumn("                                  │ — or — │")).toBe("");
+    expect(stripPreviewColumn("                                  ├─── ✂ ─── 2 lines hidden ───┤")).toBe("");
+    expect(stripPreviewColumn("                                  └──────────────┘")).toBe("");
+  });
+
+  test("preserves a full-width separator row (horizontals at column 0)", () => {
+    const sep = "─".repeat(60);
+    expect(stripPreviewColumn(sep)).toBe(sep);
+  });
+
+  test("leaves a label that merely contains a lone box char after a gap (≥2 box-char guard)", () => {
+    // A real panel row has both borders; a label with a single stray `│` does not.
+    expect(stripPreviewColumn("  1. Use A  │ B layout")).toBe("  1. Use A  │ B layout");
+    // …but two box chars after the gutter still strip (defends the real case).
+    expect(stripPreviewColumn("  1. Use A  │ B │")).toBe("  1. Use A");
+  });
+
+  test("rows with no preview box are returned unchanged", () => {
+    expect(stripPreviewColumn("❯ 1. Red")).toBe("❯ 1. Red");
+    expect(stripPreviewColumn("  One main model with others as failover/cost backups.")).toBe(
+      "  One main model with others as failover/cost backups.",
+    );
+  });
+});
+
 describe("parseModalPane — reads the visible question off the pane", () => {
   test("flat single-select (Color): question + options, no tab bar, not multiSelect", () => {
     const p = parseModalPane(fx("single_select"))!;
@@ -138,6 +173,28 @@ describe("parseModalPane — reads the visible question off the pane", () => {
     expect(p.options.map((o) => o.label)).toEqual(["Plugins + curated built-ins", "Plugins only"]);
     expect(p.options[0]!.description).toBe("Enumerate plugins and a curated list.");
     expect(p.options[1]!.description).toBe("Enumerate enabled-plugin items only.");
+  });
+
+  test("side-by-side `preview` panel: the example box never bleeds into option labels/descriptions", () => {
+    // capture-pane flattens claude's side-by-side preview layout so the
+    // box-drawn example panel lands on the SAME rows as the options (to the
+    // right). Before the fix, option 2 rendered as
+    // "Full-width row below shift  │ Supervisor block (240px), 2 stacked lines: │".
+    const p = parseModalPane(fx("multi_preview_panel"))!;
+    expect(p.tabbed).toBe(true);
+    expect(p.tabHeaders).toEqual(["Layout", "Display", "Extras"]);
+    expect(p.questionText).toBe("Where should the new cancellation detail row go?");
+    expect(p.multiSelect).toBe(false);
+    expect(p.options.map((o) => o.label)).toEqual([
+      "Inside the merged cell", "Full-width row below shift",
+    ]);
+    // No preview text, box-drawing chars, or collapse markers anywhere.
+    for (const o of p.options) {
+      expect(o.description ?? "").not.toContain("Supervisor block");
+      expect(`${o.label} ${o.description ?? ""}`).not.toMatch(/[┌┐└┘├┤┬┴┼│✂]/);
+      expect(`${o.label} ${o.description ?? ""}`).not.toContain("lines hidden");
+    }
+    expect(p.options.every((o) => o.description === undefined)).toBe(true);
   });
 
   test("tabbed multiSelect (Toppings): tab headers, checkbox options, multiSelect=true", () => {

--- a/src/bun/claude-questions.ts
+++ b/src/bun/claude-questions.ts
@@ -192,6 +192,47 @@ export interface ParsedQuestionPane {
 /** A numbered option row: optional `❯`/`›` cursor, number, optional `[ ]`/`[✔]`
  *  checkbox, then the label. */
 const OPTION_RE = /^\s*([›❯])?\s*(\d+)\.\s+(?:\[([ xX✔])\]\s*)?(.+?)\s*$/;
+
+/**
+ * When an AskUserQuestion option carries a `preview` example panel, claude
+ * renders a **side-by-side** layout: the option list on the left, a
+ * box-drawn preview panel on the right of the focused option. tmux
+ * `capture-pane` flattens that into text, so the preview box ends up on the
+ * SAME rows as the option labels — e.g.
+ *
+ *     ❯ 1. One combined line            ┌────────────────────────────┐
+ *       2. Separate name + flag         │ Name on one line, role tag  │
+ *                                       │ — or —                      │
+ *                                       ├─── ✂ ─── 2 lines hidden ────┤
+ *                                       └─────────────────────────────┘
+ *                                       Notes: press n to add notes
+ *
+ * Left as-is, `OPTION_RE` swallows the box content into the label and the
+ * description-gather loop scoops up the box rows — so option 2 above renders
+ * as `Separate name + flag | Name on one line, role tag …`. Strip the right-hand
+ * preview column from every captured row before parsing: cut a trailing
+ * `<≥2 spaces gutter><box-corner/border char>…` segment off each line.
+ *
+ * Two guards keep this from eating real text:
+ *  - the trigger char must be a corner/vertical/scissor char, NOT a bare
+ *    `─`/`━`, so full-width separator rows (which start at column 0 with
+ *    horizontals) are preserved; and
+ *  - the candidate segment must contain at least TWO box-drawing chars — a
+ *    genuine panel row always has them (both borders `│ … │`, a `┌──┐`/`└──┘`
+ *    edge, or `├── ✂ ──┤`), whereas a label that merely happens to contain a
+ *    lone `│` after a double space (e.g. `Use A  │ B`) is left intact.
+ *
+ * The JSONL tool_use (which has the real per-option `preview`) is the
+ * authoritative source when available; this only keeps the lossy pane fallback
+ * from garbling labels when it isn't. */
+const PREVIEW_COLUMN_RE = /\s{2,}[┌┐└┘├┤┬┴┼│╭╮╰╯✂].*$/u;
+const BOX_DRAWING_CHAR = /[┌┐└┘├┤┬┴┼│╭╮╰╯✂─━]/gu;
+export function stripPreviewColumn(line: string): string {
+  const m = PREVIEW_COLUMN_RE.exec(line);
+  if (!m) return line;
+  const boxChars = m[0].match(BOX_DRAWING_CHAR)?.length ?? 0;
+  return boxChars >= 2 ? line.slice(0, m.index) : line;
+}
 /** Rows that look like options but are the modal's built-in actions, not real
  *  answers. */
 const EXCLUDED_OPTION = /^(Type something\.?|Chat about this)$/;
@@ -203,7 +244,10 @@ const EXCLUDED_OPTION = /^(Type something\.?|Chat about this)$/;
  */
 export function parseModalPane(tail: string): ParsedQuestionPane | null {
   if (!QUESTION_SIGNATURE.test(tail) || !FOOTER_SIGNATURE.test(tail)) return null;
-  const lines = tail.split("\n").map((l) => l.replace(/\s+$/, ""));
+  // Trim trailing whitespace, then strip any right-hand `preview` panel column
+  // (see PREVIEW_COLUMN_RE) so an option's example box never bleeds into the
+  // label or description of an adjacent option.
+  const lines = tail.split("\n").map((l) => stripPreviewColumn(l.replace(/\s+$/, "")));
 
   // Tab bar (multi-question only): `←  ☐ Toppings  ☒ Size  ✔ Submit  →`.
   const tabLine = lines.find((l) => /✔\s*Submit/.test(l) && /[☐☒]/.test(l));

--- a/src/bun/fixtures/askuserquestion/multi_preview_panel.txt
+++ b/src/bun/fixtures/askuserquestion/multi_preview_panel.txt
@@ -1,0 +1,24 @@
+
+  Some prior assistant output scrolls above the modal here. It is not part of
+  the question and the parser stops at the separator line below it.
+
+  A few decisions will shape the implementation:
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+←  ☐ Layout  ☐ Display  ☐ Extras  ✔ Submit  →
+
+Where should the new cancellation detail row go?
+
+❯ 1. Inside the merged cell       ┌──────────────────────────────────────────────────────────────────────────┐
+ 2. Full-width row below shift    │ Supervisor block (240px), 2 stacked lines:                               │
+                                  │                                                                          │
+                                  │ ┌───────────────────────────────────────┐                                │
+                                  ├─── ✂ ─── 5 lines hidden ─────────────────────────────────────────────────┤
+                                  └──────────────────────────────────────────────────────────────────────────┘
+
+                                  Notes: press n to add notes
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  Chat about this
+
+Enter to select · ↑/↓ to navigate · n to add notes · Tab to switch questions · Esc to cancel


### PR DESCRIPTION
…nto option labels

When an AskUserQuestion option carries a `preview` example panel, claude renders a side-by-side TUI layout (option list left, box-drawn preview right). tmux capture-pane flattens that onto the same rows as the option labels, so parseModalPane's OPTION_RE swallowed the box into the label and the description-gather loop scooped up the box rows — e.g. option 2 rendered as "Separate name + flag | Cancelled by: XYZ …".

Strip the right-hand preview column from every captured row before parsing (stripPreviewColumn): cut a trailing "<>=2-space gutter><box char>…" segment, anchored on corner/vertical/scissor chars (not bare ─/━ so full-width separators survive) and guarded to require >=2 box-drawing chars so a stray "|" in a real label isn't truncated. This both trims the box off option rows and blanks the indented continuation rows, which the existing isNoise() boundary logic then handles for free.

This only affects the lossy pane-scrape fallback; full per-option previews still come from the JSONL tool_use (mapJsonlAskInput) and render in RunPanel.

Adds a multi_preview_panel.txt fixture, a parseModalPane preview test, and direct stripPreviewColumn unit tests. Full suite 508/0.