### PR TITLE
feat(models): add Claude Fable 5 to claude-code picker; default to Op…

### DIFF
--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -150,6 +150,16 @@ test("claude-code 'opus-4.8' maps to --model claude-opus-4-8", () => {
   ]);
 });
 
+test("claude-code 'fable-5' maps to --model claude-fable-5", () => {
+  const { cmd } = buildCommand(builtin("claude-code"), "do thing", { ...claudeDefaults, model: "fable-5", mode: "auto" });
+  expect(cmd).toEqual([
+    "claude",
+    "--model", "claude-fable-5",
+    "--permission-mode", "auto",
+    "--", "do thing",
+  ]);
+});
+
 test("claude-code prefixes the prompt with `--` so a leading-dash prompt isn't parsed as a flag", () => {
   // Regression: a prompt like a markdown checklist item starts with `-`.
   // Without the `--` terminator claude's CLI errors `unknown option` and

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -46,6 +46,7 @@ export interface AgentRunOptions {
 // curated list doesn't know about yet). Codex accepts the friendly ids as-is
 // so it doesn't need a translation table.
 const CLAUDE_MODEL_FLAG: Record<string, string> = {
+  "fable-5": "claude-fable-5",
   "opus-4.8": "claude-opus-4-8",
   "opus-4.7": "claude-opus-4-7",
   "opus-4.6": "claude-opus-4-6",

--- a/src/bun/effort-support.test.ts
+++ b/src/bun/effort-support.test.ts
@@ -33,14 +33,20 @@ test("claude haiku-4.5 exposes no effort options (CLI doesn't accept the flag)",
   expect(ids).toEqual([]);
 });
 
-test("claude null model falls back to DEFAULT_MODEL support set (opus-4.7)", () => {
+test("claude null model falls back to DEFAULT_MODEL support set (opus-4.8)", () => {
   // No model specified → use the agent's default model's support set. Since
-  // claude-code's DEFAULT_MODEL is opus-4.7, xhigh + max are both available.
-  expect(DEFAULT_MODEL["claude-code"]).toBe("opus-4.7");
+  // claude-code's DEFAULT_MODEL is opus-4.8, xhigh + max are both available.
+  expect(DEFAULT_MODEL["claude-code"]).toBe("opus-4.8");
   const ids = supportedEfforts("claude-code", null).map((o) => o.id);
   expect(ids).toContain("xhigh");
   expect(ids).toContain("max");
   expect(ids).toContain("high");
+});
+
+test("claude fable-5 supports xhigh + max", () => {
+  const ids = supportedEfforts("claude-code", "fable-5").map((o) => o.id);
+  expect(ids).toContain("xhigh");
+  expect(ids).toContain("max");
 });
 
 test("codex gpt-5.5 supports xhigh but not max", () => {

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -642,6 +642,14 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
           </div>
         </div>
 
+        {/* Fable 5 sits above Opus in the picker but bills at 2x the usage —
+            surface that under the model row so the cost is obvious before Create. */}
+        {kind === "claude-code" && model === "fable-5" && (
+          <div className="text-[11px] text-muted-foreground">
+            Fable 5 uses 2x the usage of Opus.
+          </div>
+        )}
+
         {/* Surfacing a missing-agent error inline so the user sees install
             guidance before they hit Create and get a delayed failure. */}
         {selectedStatus && !selectedStatus.available && (

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -375,7 +375,9 @@ export interface AgentOptions {
  * CLI happens to default to.
  */
 export const DEFAULT_MODEL: Record<AgentKind, string> = {
-  "claude-code": "opus-4.7",
+  // Default to Opus 4.8 — Fable 5 sits above it in the picker but costs 2x the
+  // usage, so the default stays on the most-capable non-premium tier.
+  "claude-code": "opus-4.8",
   "codex": "gpt-5.5",
 };
 export const DEFAULT_EFFORT: Record<AgentKind, string> = {
@@ -425,7 +427,7 @@ export const CODE_PLAN_MODE: Record<AgentKind, { code: string; plan: string }> =
  */
 export const EFFORT_OPTIONS: AgentOption[] = [
   { id: "max", label: "Max", hint: "Absolute maximum effort. Slowest, most thorough." },
-  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Opus 4.8 / 4.7 / 4.6 / codex only." },
+  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Fable 5 / Opus 4.8 / 4.7 / 4.6 / codex only." },
   { id: "high", label: "High", hint: "Deep reasoning. The API default where supported." },
   { id: "medium", label: "Medium", hint: "Balanced speed vs. capability." },
   { id: "low", label: "Low", hint: "Most efficient. Best for simple tasks." },
@@ -450,12 +452,14 @@ export const EFFORT_OPTIONS: AgentOption[] = [
  */
 export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> = {
   // Per https://platform.claude.com/docs/en/build-with-claude/effort the
-  // effort parameter is API-supported on Opus 4.8 / 4.7 / 4.6 / Sonnet 4.6
-  // / Opus 4.5 (xhigh is Opus-only; Sonnet 4.6 has no xhigh; Haiku 4.5
-  // doesn't support effort at all). The `/effort` CLI command accepts more
+  // effort parameter is API-supported on Fable 5 / Opus 4.8 / 4.7 / 4.6 /
+  // Sonnet 4.6 / Opus 4.5 (xhigh is Fable-5- and Opus-only; Sonnet 4.6 has no
+  // xhigh; Haiku 4.5 doesn't support effort at all). The `/effort` CLI command accepts more
   // levels but the underlying API request would fail for unsupported pairs,
   // so we filter at the picker rather than letting the user fire bad runs.
   "claude-code": {
+    // Fable 5 shares Opus 4.7/4.8's request surface (effort low→max, xhigh).
+    "fable-5": ["max", "xhigh", "high", "medium", "low"],
     "opus-4.8": ["max", "xhigh", "high", "medium", "low"],
     "opus-4.7": ["max", "xhigh", "high", "medium", "low"],
     "opus-4.6": ["max", "xhigh", "high", "medium", "low"],
@@ -500,6 +504,7 @@ export function supportedEfforts(agent: AgentKind, model: string | null): AgentO
  */
 const MODEL_MODE_DENY: Record<AgentKind, Record<string, string[]>> = {
   "claude-code": {
+    "fable-5": [],
     "opus-4.8": [],
     "opus-4.7": [],
     "opus-4.6": [],
@@ -522,7 +527,8 @@ export function supportedModes(agent: AgentKind, model: string | null): AgentOpt
 export const AGENT_OPTIONS: Record<AgentKind, AgentOptions> = {
   "claude-code": {
     models: [
-      { id: "opus-4.8", label: "Opus 4.8", hint: "Most capable; slower." },
+      { id: "fable-5", label: "Fable 5", hint: "Most powerful tier — above Opus. Uses 2x the usage of Opus." },
+      { id: "opus-4.8", label: "Opus 4.8", hint: "Most capable Opus; slower." },
       { id: "opus-4.7", label: "Opus 4.7", hint: "Prior flagship; same effort range as 4.8." },
       { id: "opus-4.6", label: "Opus 4.6", hint: "Earlier Opus generation." },
       { id: "sonnet-4.6", label: "Sonnet 4.6", hint: "Balanced." },


### PR DESCRIPTION
…us 4.8

List Fable 5 at the top of the claude-code model picker (above Opus 4.8) and wire it through every place a model id is consumed:

- AGENT_OPTIONS, MODEL_EFFORT_SUPPORT (low→max incl. xhigh), and MODEL_MODE_DENY in shared/types.ts
- CLAUDE_MODEL_FLAG mapping fable-5 -> claude-fable-5 in bun/agents.ts

Show a "Fable 5 uses 2x the usage of Opus" helper under the model row in NewTaskForm when Fable 5 is selected, and move the claude-code default model from Opus 4.7 to Opus 4.8 (Fable 5 stays opt-in due to the 2x cost).

Update the xhigh hint + effort-support doc comment to include Fable 5, and add tests for the fable-5 --model mapping, its effort surface, and the new default.