### PR TITLE
fix(runpanel): stop duplicating user messages on long-running tasks

### DIFF
--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -29,6 +29,7 @@ import {
   type TaskReference,
 } from "../../../shared/types.ts";
 import { appendReferences } from "../../../shared/refs.ts";
+import { createEventDeduper } from "@/lib/event-dedup";
 import { AgentIcon } from "./AgentIcon";
 import {
   ReferencesPicker,
@@ -321,28 +322,13 @@ function RunPanelBody({
   // panel shows the whole conversation as a single scrollback.
   useEffect(() => {
     setEvents([]);
-    // Dedup by composite key (ts|runId|stream|first-200-chars-of-data) —
-    // the polling fallback in claude-tmux flushes many JSONL events per
-    // tick, all stamped with the same Date.now() ms.
-    //
-    // Exception for `user` events: each user message is emitted twice —
-    // once live (orchestrator's onChunk in startTask/sendInput, ts=wall
-    // clock) and once from the JSONL parser when claude transcribes it
-    // (ts=Date.now() at flush time, or synthetic baseTs+i during a
-    // rebuild). Drop ts from the key for user events so the two paths
-    // collapse to one bubble per message. Also normalize CR/LF in the
-    // key: tmux's paste-buffer delivers our `\n`-separated prompt to
-    // claude as `\r`, and the JSONL stores those `\r`s verbatim — so
-    // without normalization the live (`\n`) and JSONL (`\r`) copies
-    // differ byte-for-byte in the first 200 chars and slip past dedup.
-    // The bun side normalizes too (claude-tmux.ts); this is belt-and-
-    // suspenders for any other path that might leak a CR through.
-    const seen = new Set<string>();
-    const normalizeForKey = (s: string) => s.replace(/\r\n?/g, "\n");
-    const keyFor = (e: RunEvent) =>
-      e.stream === "user"
-        ? `user|${e.runId}|${normalizeForKey(e.data ?? "").slice(0, 200)}`
-        : `${e.ts}|${e.runId}|${e.stream}|${(e.data ?? "").slice(0, 200)}`;
+    // Collapse the dual-emit + replay duplicates the server stream carries
+    // (live echo + JSONL twin per user message; full-history replay on every
+    // reconnect). The deduper keeps `user` keys in a never-trimmed set so a
+    // follow-up folded into a long in-flight turn — whose live echo and JSONL
+    // twin are separated by thousands of intervening events — still collapses
+    // to a single bubble. See `event-dedup.ts`.
+    const dedupe = createEventDeduper();
     // Coalesce the open-time replay burst into one state update per animation
     // frame. On connect the server streams the whole history as one SSE frame
     // per event; each `onmessage` is its own event-loop task, so React can't
@@ -359,17 +345,7 @@ function RunPanelBody({
       setEvents((cur) => [...cur, ...batch]);
     };
     const unsub = api.subscribeTask(task.id, (e) => {
-      const key = keyFor(e);
-      if (seen.has(key)) return;
-      seen.add(key);
-      if (seen.size > 5000) {
-        const drop = seen.size - 4000;
-        let i = 0;
-        for (const k of seen) {
-          if (i++ >= drop) break;
-          seen.delete(k);
-        }
-      }
+      if (!dedupe.accept(e)) return;
       if (e.stream === "interaction") {
         try {
           const req = JSON.parse(e.data) as PendingInteraction;

--- a/src/mainview/lib/event-dedup.test.ts
+++ b/src/mainview/lib/event-dedup.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { createEventDeduper, eventDedupKey } from "./event-dedup.ts";
+import type { RunEvent } from "../../shared/types.ts";
+
+const ev = (e: Partial<RunEvent>): RunEvent => ({
+  runId: "run-1",
+  taskId: "task-1",
+  stream: "stdout",
+  data: "",
+  ts: 0,
+  ...e,
+});
+
+describe("eventDedupKey", () => {
+  test("user key drops ts and normalizes newlines", () => {
+    const live = ev({ stream: "user", data: "hello\r\nworld", ts: 100 });
+    const jsonl = ev({ stream: "user", data: "hello\nworld", ts: 999 });
+    expect(eventDedupKey(live)).toBe(eventDedupKey(jsonl));
+  });
+
+  test("non-user key keeps ts so same-tick distinct events stay apart", () => {
+    const a = ev({ stream: "assistant", data: "chunk", ts: 100 });
+    const b = ev({ stream: "assistant", data: "chunk", ts: 101 });
+    expect(eventDedupKey(a)).not.toBe(eventDedupKey(b));
+  });
+
+  test("same user text on different runs stays distinct", () => {
+    const a = ev({ stream: "user", data: "yes", runId: "run-1" });
+    const b = ev({ stream: "user", data: "yes", runId: "run-2" });
+    expect(eventDedupKey(a)).not.toBe(eventDedupKey(b));
+  });
+});
+
+describe("createEventDeduper", () => {
+  test("collapses the live echo + JSONL twin of a user message", () => {
+    const d = createEventDeduper();
+    expect(d.accept(ev({ stream: "user", data: "hi", ts: 1 }))).toBe(true);
+    expect(d.accept(ev({ stream: "user", data: "hi", ts: 50 }))).toBe(false);
+  });
+
+  test("keeps genuinely distinct high-volume events", () => {
+    const d = createEventDeduper();
+    expect(d.accept(ev({ stream: "assistant", data: "a", ts: 1 }))).toBe(true);
+    expect(d.accept(ev({ stream: "assistant", data: "b", ts: 1 }))).toBe(true);
+    expect(d.accept(ev({ stream: "assistant", data: "a", ts: 1 }))).toBe(false);
+  });
+
+  // The regression: a follow-up folded into a long in-flight turn. The live
+  // echo lands immediately; the JSONL twin only arrives after claude finishes
+  // the (long) current response — thousands of events later. With a single
+  // capped+evicted set the live echo's key would be gone by then and the twin
+  // would render as a duplicate. The durable `user` set must survive it.
+  test("user dedup survives eviction of thousands of intervening events", () => {
+    const d = createEventDeduper({ cap: 50, keep: 40 });
+    // Live echo of the folded user message.
+    expect(d.accept(ev({ stream: "user", data: "do the thing", ts: 1 }))).toBe(true);
+    // A long response streams in — far more than `cap` volatile events.
+    for (let i = 0; i < 5000; i++) {
+      d.accept(ev({ stream: "assistant", data: `chunk-${i}`, ts: 1000 + i }));
+    }
+    // The JSONL twin finally arrives (different ts). It must still be a dup.
+    expect(d.accept(ev({ stream: "user", data: "do the thing", ts: 9999 }))).toBe(false);
+  });
+
+  test("volatile set is trimmed (oldest evicted) past the cap", () => {
+    const d = createEventDeduper({ cap: 10, keep: 5 });
+    for (let i = 0; i < 20; i++) {
+      d.accept(ev({ stream: "stdout", data: `line-${i}`, ts: i }));
+    }
+    // An early, since-evicted key re-appears as "new" after trimming.
+    expect(d.accept(ev({ stream: "stdout", data: "line-0", ts: 0 }))).toBe(true);
+  });
+
+  test("high-volume volatile events never evict user keys (separate sets)", () => {
+    // userCap below the volatile count proves the two sets are independent:
+    // 5000 stdout events must not touch the durable user set.
+    const d = createEventDeduper({ cap: 50, keep: 40, userCap: 100, userKeep: 80 });
+    expect(d.accept(ev({ stream: "user", data: "keep me", ts: 1 }))).toBe(true);
+    for (let i = 0; i < 5000; i++) {
+      d.accept(ev({ stream: "stdout", data: `line-${i}`, ts: 1000 + i }));
+    }
+    expect(d.accept(ev({ stream: "user", data: "keep me", ts: 9999 }))).toBe(false);
+  });
+
+  test("durable user set is bounded by userCap (belt-and-suspenders)", () => {
+    const d = createEventDeduper({ userCap: 10, userKeep: 5 });
+    for (let i = 0; i < 20; i++) {
+      // Distinct runs so each user message gets a distinct key.
+      d.accept(ev({ stream: "user", data: "msg", runId: `run-${i}`, ts: i }));
+    }
+    // The oldest user key has been evicted past the cap, so it re-accepts.
+    expect(d.accept(ev({ stream: "user", data: "msg", runId: "run-0", ts: 0 }))).toBe(true);
+  });
+});

--- a/src/mainview/lib/event-dedup.ts
+++ b/src/mainview/lib/event-dedup.ts
@@ -1,0 +1,109 @@
+// Dedup for the unified task-level event stream the run panel renders.
+//
+// Every user message is emitted TWICE on the wire: once live (the
+// orchestrator's `onChunk`/`appendEvent` the instant the message is sent,
+// stamped with the wall clock) and once from the JSONL parser when claude
+// transcribes it into its session file (a different `ts`). The server also
+// replays the full persisted history on every (re)connection. So the panel
+// must collapse duplicates client-side — this is that collapse, extracted as a
+// pure helper so it can be unit-tested apart from the React effect.
+import type { RunEvent } from "../../shared/types.ts";
+
+/** Normalize CR-only / CRLF newlines to `\n`. tmux's paste-buffer delivers our
+ *  `\n`-separated prompt to claude as `\r`, and the JSONL stores those `\r`s
+ *  verbatim — so without this the live (`\n`) and JSONL (`\r`) copies of a user
+ *  message differ byte-for-byte in the first 200 chars and slip past dedup. */
+const normalizeForKey = (s: string) => s.replace(/\r\n?/g, "\n");
+
+/**
+ * Composite dedup key for a stream event.
+ *
+ * `user` events drop `ts` (the live + JSONL copies carry different
+ * timestamps) and normalize newlines, keying on `user|runId|first-200-chars`
+ * so the two paths collapse to one bubble. Everything else keeps `ts` because
+ * the polling fallback in claude-tmux flushes many JSONL events per tick, all
+ * stamped with the same `Date.now()` ms — `ts` is what keeps genuinely
+ * distinct same-tick events apart.
+ *
+ * Consequence of the ts-less `user` key: two genuinely-identical user sends in
+ * the SAME run (e.g. folding `"continue"` twice into one in-flight turn) share
+ * a key and render as a single bubble. This is intentional — there is no
+ * disambiguator that survives the live-echo↔JSONL-twin collapse — and harmless:
+ * both sends are still delivered to claude (the tmux paste is independent of UI
+ * dedup). Distinct runs get distinct keys via `runId`, so repeated idle
+ * follow-ups still each show.
+ */
+export function eventDedupKey(e: RunEvent): string {
+  return e.stream === "user"
+    ? `user|${e.runId}|${normalizeForKey(e.data ?? "").slice(0, 200)}`
+    : `${e.ts}|${e.runId}|${e.stream}|${(e.data ?? "").slice(0, 200)}`;
+}
+
+/** Evict oldest keys (Sets iterate in insertion order) once `set` exceeds
+ *  `cap`, trimming back down to `keep`. No-op while under the cap. */
+function trimOldest(set: Set<string>, cap: number, keep: number): void {
+  if (set.size <= cap) return;
+  const drop = set.size - keep;
+  let i = 0;
+  for (const k of set) {
+    if (i++ >= drop) break;
+    set.delete(k);
+  }
+}
+
+export interface EventDeduper {
+  /** @returns true the first time this event is seen (caller keeps it),
+   *  false on a repeat (caller drops it). */
+  accept(e: RunEvent): boolean;
+}
+
+/**
+ * Build a stateful deduper backed by two sets:
+ *
+ *  - `volatile` — high-volume non-`user` events (stdout / assistant / tool /
+ *    status / …). Capped at `cap` keys and trimmed back to `keep` (oldest
+ *    evicted) so a multi-thousand-event turn can't grow the set unbounded.
+ *
+ *  - `durable` — `user` events ONLY. A user message's two copies (live echo +
+ *    JSONL twin) can be separated by thousands of intervening events: when a
+ *    follow-up is folded into an in-flight turn on a long-running task, the live
+ *    echo lands immediately but claude doesn't transcribe the JSONL twin until
+ *    it finishes the current (long) response. If the live echo's key lived in
+ *    the evictable `volatile` set it would be gone by the time the twin arrives,
+ *    and the twin would render as a duplicate bubble — the exact "duplicated
+ *    user message on long-running tasks" bug. So `user` keys get their own set,
+ *    trimmed only at a far higher threshold (`userCap`). Crucially the fold gap
+ *    is measured in *volatile* events, not user messages, so eviction here only
+ *    ever drops user keys old enough that their twin landed long ago — the
+ *    high cap is pure belt-and-suspenders against an unbounded session, not
+ *    load-bearing for correctness. User events are rare (one per turn), so the
+ *    default cap is reached only by genuinely enormous conversations.
+ */
+export function createEventDeduper(opts?: {
+  cap?: number;
+  keep?: number;
+  userCap?: number;
+  userKeep?: number;
+}): EventDeduper {
+  const cap = opts?.cap ?? 5000;
+  const keep = opts?.keep ?? 4000;
+  const userCap = opts?.userCap ?? 50_000;
+  const userKeep = opts?.userKeep ?? 40_000;
+  const volatile = new Set<string>();
+  const durable = new Set<string>();
+  return {
+    accept(e: RunEvent): boolean {
+      const key = eventDedupKey(e);
+      if (e.stream === "user") {
+        if (durable.has(key)) return false;
+        durable.add(key);
+        trimOldest(durable, userCap, userKeep);
+        return true;
+      }
+      if (volatile.has(key)) return false;
+      volatile.add(key);
+      trimOldest(volatile, cap, keep);
+      return true;
+    },
+  };
+}


### PR DESCRIPTION
User messages are emitted twice on the unified task stream — a live echo the instant the message is sent, and the JSONL twin when claude transcribes it — and the panel collapses them client-side. That dedup used a single Set capped at 5000 keys with oldest-first eviction. When a follow-up is folded into a long in-flight turn, the live echo and its JSONL twin are separated by thousands of intervening events, so the live echo's key was evicted before the twin arrived and the message rendered twice.

Extract the dedup into a pure, testable helper (event-dedup.ts) backed by two sets: a capped `volatile` set for high-volume non-user events and a `durable` set for user events with a far higher cap, so user keys survive the fold gap. RunPanel now delegates to createEventDeduper().

Add event-dedup.test.ts (9 cases) covering the fold-gap regression, set independence, and cap eviction.