### PR TITLE
fix(claude-tmux): pin classic renderer so global fullscreen TUI can't…

### DIFF
--- a/src/bun/claude-tmux.test.ts
+++ b/src/bun/claude-tmux.test.ts
@@ -8,6 +8,7 @@ import { homedir } from "node:os";
 process.env.AGETOR_TMUX_BIN = "/bin/echo";
 
 import {
+  buildClaudeSessionEnv,
   CLAUDE_API_ERROR_STATUS_PREFIX,
   CLAUDE_MODE_ACCEPT_EDITS,
   CLAUDE_MODE_AUTO,
@@ -53,6 +54,30 @@ test("encodeProjectPath turns every slash and dot into a dash", () => {
 
 test("sessionNameFor uses the first 12 chars of the task id", () => {
   expect(sessionNameFor("abcdef0123456789-rest")).toBe("agetor-abcdef012345");
+});
+
+test("buildClaudeSessionEnv pins the classic renderer and re-injects PATH", () => {
+  const env = buildClaudeSessionEnv({ CLAUDE_CODE_EFFORT_LEVEL: "low" });
+  // Caller env is preserved…
+  expect(env.CLAUDE_CODE_EFFORT_LEVEL).toBe("low");
+  // …and the classic-renderer pin is forced so a user's global `tui`
+  // fullscreen setting can't flip agetor's session into the alternate
+  // screen buffer (which would break the pane scraper's scrollback reads).
+  expect(env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN).toBe("1");
+  // PATH is re-injected from the current process.
+  expect(env.PATH).toBe(process.env.PATH ?? "");
+});
+
+test("buildClaudeSessionEnv's classic-renderer pin is not overridable by caller env", () => {
+  // A harness-level env that tried to enable fullscreen must lose: agetor's
+  // pin is layered last. CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN takes precedence
+  // over CLAUDE_CODE_NO_FLICKER per the docs, so the scraper stays safe even
+  // when both are present.
+  const env = buildClaudeSessionEnv({
+    CLAUDE_CODE_NO_FLICKER: "1",
+    CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN: "0",
+  });
+  expect(env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN).toBe("1");
 });
 
 interface Record { stream: string; data: string }

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -188,6 +188,46 @@ export function sessionNameFor(taskId: string): string {
   return `agetor-${taskId.slice(0, 12)}`;
 }
 
+/**
+ * Build the env every spawned claude session runs with: the caller-supplied
+ * env (model / effort / CLAUDE_CONFIG_DIR vars from `buildCommand`) with two
+ * agetor pins layered on top.
+ *
+ *   - **PATH** is re-injected from the current process because the tmux
+ *     *server* captures env at its first launch and reuses it for every
+ *     subsequent session — passing it per-session via `-e` guarantees the
+ *     spawned claude sees the freshly-rehydrated PATH even if the long-running
+ *     bundled tmux server captured a stale copy (e.g. agetor restarted with a
+ *     different login-shell PATH).
+ *   - **CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1** forces claude's classic
+ *     (inline) renderer regardless of the user's saved `tui` setting. Claude
+ *     Code v2.1.89+ added an opt-in "Fullscreen rendering" mode (`/tui
+ *     fullscreen` / `CLAUDE_CODE_NO_FLICKER=1`) that draws the TUI on the
+ *     terminal's ALTERNATE screen buffer. The spawned claude reads the user's
+ *     global `~/.claude/settings.json`, so a user who enabled fullscreen in
+ *     their own everyday claude usage would flip agetor's sessions into it too
+ *     — which breaks the pane scraper (`scrapeTimer` → `capture-pane`) we rely
+ *     on to catch the permission / AskUserQuestion modals the hook system
+ *     bypasses: the alt screen has NO scrollback, so the AskUserQuestion
+ *     collector's `capture-pane -p -S -200` comes back truncated, and the modal
+ *     geometry the fingerprinting is tuned to changes. agetor never shows the
+ *     tmux pane (its own UI renders the JSONL stream), so fullscreen's
+ *     flicker / memory / mouse wins are irrelevant here. Per the docs this var
+ *     takes precedence over `CLAUDE_CODE_NO_FLICKER` and the `tui` setting.
+ *     Docs: https://code.claude.com/docs/en/fullscreen
+ *
+ * Both pins come AFTER the caller spread on purpose: agetor's classic-renderer
+ * guarantee must not be silently overridable by a harness-level env that set
+ * `CLAUDE_CODE_NO_FLICKER`.
+ */
+export function buildClaudeSessionEnv(callerEnv: Record<string, string>): Record<string, string> {
+  return {
+    ...callerEnv,
+    PATH: process.env.PATH ?? "",
+    CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN: "1",
+  };
+}
+
 interface ContentBlock {
   type: string;
   text?: string;
@@ -2186,23 +2226,15 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
 
   // Build the tmux command. `-e KEY=VAL` injects env vars into the new
   // session (so the spawned claude inherits them); `--` separates the tmux
-  // flags from the command to run.
-  //
-  // PATH is injected explicitly because the tmux *server* captures env at
-  // its first launch and reuses it for every subsequent session — passing
-  // it per-session via `-e` guarantees the spawned claude sees the
-  // currently-rehydrated PATH even if the server's captured copy is stale
-  // (e.g. agetor restarted with a different login-shell PATH but the
-  // long-running bundled tmux server is still around).
+  // flags from the command to run. `buildClaudeSessionEnv` layers agetor's
+  // forced pins (PATH re-injection, classic-renderer) over the caller env —
+  // see that helper for the full rationale.
   //
   // We no longer inject AGETOR_API_PORT/TOKEN/TASK_ID: with the PreToolUse hook
   // and the ask_user MCP both gone, nothing in the spawned claude reads them,
   // and AGETOR_API_TOKEN gates every orchestration route — no reason to expose
   // it to the agent's environment.
-  const fullEnv: Record<string, string> = {
-    ...opts.env,
-    PATH: process.env.PATH ?? "",
-  };
+  const fullEnv = buildClaudeSessionEnv(opts.env);
   const tmuxArgs: string[] = ["new-session", "-d", "-s", sessionName, "-c", opts.cwd];
   for (const [k, v] of Object.entries(fullEnv)) tmuxArgs.push("-e", `${k}=${v}`);
   tmuxArgs.push("--", ...opts.argv);


### PR DESCRIPTION
… break the pane scraper

Claude Code v2.1.89+ added an opt-in "Fullscreen rendering" mode (/tui fullscreen, CLAUDE_CODE_NO_FLICKER=1) that draws the TUI on the terminal's alternate screen buffer and persists to ~/.claude/settings.json. Agetor's spawned claude reads that global setting, so a user who enabled fullscreen in their everyday usage would flip agetor's sessions into it too — breaking the tmux pane scraper that catches permission / AskUserQuestion modals: the alt screen has no scrollback, so the collector's `capture-pane -p -S -200` truncates, and the modal geometry the fingerprinting expects changes.

Force the classic renderer by injecting CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 (which takes precedence over CLAUDE_CODE_NO_FLICKER and the tui setting) into every spawned session. Agetor never shows the tmux pane — its own UI renders the JSONL stream — so fullscreen's flicker/memory/mouse wins are irrelevant.

Extract the env build into an exported pure helper buildClaudeSessionEnv so the pin is testable and can't drift from the call site, and add unit tests covering the pin, PATH re-injection, and that the pin isn't overridable by caller env.