### PR TITLE
fix(runpanel): keep the event stream live when the webview is backgro…

### DIFF
--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -30,6 +30,7 @@ import {
 } from "../../../shared/types.ts";
 import { appendReferences } from "../../../shared/refs.ts";
 import { createEventDeduper } from "@/lib/event-dedup";
+import { createEventBuffer } from "@/lib/event-buffer";
 import { AgentIcon } from "./AgentIcon";
 import {
   ReferencesPicker,
@@ -329,21 +330,39 @@ function RunPanelBody({
     // twin are separated by thousands of intervening events — still collapses
     // to a single bubble. See `event-dedup.ts`.
     const dedupe = createEventDeduper();
-    // Coalesce the open-time replay burst into one state update per animation
-    // frame. On connect the server streams the whole history as one SSE frame
-    // per event; each `onmessage` is its own event-loop task, so React can't
-    // auto-batch them. Appending one-at-a-time meant N renders of the full
-    // list = O(N²) on open. Buffering + a single rAF flush makes it O(N).
-    // Dedup (below) stays synchronous so it's unaffected by the batching.
-    let pending: RunEvent[] = [];
-    let raf = 0;
-    const flush = () => {
-      raf = 0;
-      if (pending.length === 0) return;
-      const batch = pending;
-      pending = [];
-      setEvents((cur) => [...cur, ...batch]);
-    };
+    // Coalesce the open-time replay burst into one state update per batch. On
+    // connect the server streams the whole history as one SSE frame per event;
+    // each `onmessage` is its own event-loop task, so React can't auto-batch
+    // them. Appending one-at-a-time meant N renders of the full list = O(N²) on
+    // open. Buffering + a single flush makes it O(N). Dedup (below) stays
+    // synchronous so it's unaffected by the batching.
+    //
+    // BUT a raw rAF is not a safe *delivery* guarantee: Electrobun runs in a
+    // native macOS WKWebView, which suspends requestAnimationFrame while its
+    // window is occluded / minimized / on another Space. If the user
+    // backgrounds agetor mid-turn, the scheduled rAF never fires, buffered
+    // events pile up, and the stream looks frozen until the window is
+    // re-activated (which is why "open the tmux session" — i.e. clicking back
+    // into agetor — appeared to "refresh" it). So the buffer races the rAF
+    // against a setTimeout fallback (for when the webview isn't painting), and
+    // we also drain on visibility/focus the instant the window returns. The
+    // arm/flush bookkeeping (and the re-arm-after-flush invariant that fixes
+    // the freeze) lives in `createEventBuffer` so it can be unit-tested.
+    const FLUSH_FALLBACK_MS = 250;
+    const buffer = createEventBuffer<RunEvent>(
+      (batch) => setEvents((cur) => [...cur, ...batch]),
+      (flush) => {
+        const raf = requestAnimationFrame(flush);
+        const timer = setTimeout(flush, FLUSH_FALLBACK_MS);
+        return () => { cancelAnimationFrame(raf); clearTimeout(timer); };
+      },
+    );
+    // When the window comes back to the foreground, drain immediately rather
+    // than waiting for a throttled timer/rAF to resume on its own.
+    const onVisible = () => { if (document.visibilityState === "visible") buffer.flushNow(); };
+    const onFocus = () => buffer.flushNow();
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onFocus);
     const unsub = api.subscribeTask(task.id, (e) => {
       if (!dedupe.accept(e)) return;
       if (e.stream === "interaction") {
@@ -365,11 +384,12 @@ function RunPanelBody({
         } catch { /* ignore malformed */ }
         return;
       }
-      pending.push(e);
-      if (raf === 0) raf = requestAnimationFrame(flush);
+      buffer.push(e);
     });
     return () => {
-      if (raf !== 0) cancelAnimationFrame(raf);
+      buffer.dispose();
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onFocus);
       unsub();
     };
   }, [task.id]);

--- a/src/mainview/lib/event-buffer.test.ts
+++ b/src/mainview/lib/event-buffer.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import { createEventBuffer } from "./event-buffer.ts";
+
+/** A manual arm strategy: instead of rAF/timers, capture the flush so the test
+ *  can `fire()` it deterministically and observe arm/disarm bookkeeping. */
+const makeFakeScheduler = () => {
+  let scheduled: (() => void) | null = null;
+  let armCount = 0;
+  let disarmCount = 0;
+  return {
+    arm: (flush: () => void) => {
+      scheduled = flush;
+      armCount++;
+      return () => {
+        scheduled = null;
+        disarmCount++;
+      };
+    },
+    /** Invoke the armed flush. The buffer's flush disarms itself. */
+    fire: () => scheduled?.(),
+    isArmed: () => scheduled !== null,
+    armCount: () => armCount,
+    disarmCount: () => disarmCount,
+  };
+};
+
+describe("createEventBuffer", () => {
+  test("arms once across multiple pushes, then emits the whole batch on fire", () => {
+    const batches: number[][] = [];
+    const s = makeFakeScheduler();
+    const b = createEventBuffer<number>((batch) => batches.push(batch), s.arm);
+
+    b.push(1);
+    b.push(2);
+    b.push(3);
+    expect(s.armCount()).toBe(1); // pushes coalesce — armed only once
+    expect(batches).toEqual([]); // nothing emitted until the flush fires
+
+    s.fire();
+    expect(batches).toEqual([[1, 2, 3]]);
+    expect(s.isArmed()).toBe(false);
+  });
+
+  test("re-arms on the next push after a fire (the freeze-fix invariant)", () => {
+    const batches: number[][] = [];
+    const s = makeFakeScheduler();
+    const b = createEventBuffer<number>((batch) => batches.push(batch), s.arm);
+
+    b.push(1);
+    s.fire();
+    expect(batches).toEqual([[1]]);
+
+    // The handle was reset, so a subsequent event must schedule a fresh flush.
+    b.push(2);
+    expect(s.armCount()).toBe(2);
+    s.fire();
+    expect(batches).toEqual([[1], [2]]);
+  });
+
+  test("flushNow drains immediately, cancels the pending arm, and re-arms next push", () => {
+    const batches: number[][] = [];
+    const s = makeFakeScheduler();
+    const b = createEventBuffer<number>((batch) => batches.push(batch), s.arm);
+
+    b.push(1);
+    b.push(2);
+    expect(s.isArmed()).toBe(true);
+
+    b.flushNow(); // the focus / visibility recovery path
+    expect(batches).toEqual([[1, 2]]);
+    expect(s.disarmCount()).toBe(1); // pending arm was cancelled
+    expect(s.isArmed()).toBe(false);
+
+    b.push(3);
+    expect(s.armCount()).toBe(2); // re-armed
+    s.fire();
+    expect(batches).toEqual([[1, 2], [3]]);
+  });
+
+  test("flushNow with nothing buffered does not emit or arm", () => {
+    const batches: number[][] = [];
+    const s = makeFakeScheduler();
+    const b = createEventBuffer<number>((batch) => batches.push(batch), s.arm);
+
+    b.flushNow();
+    expect(batches).toEqual([]);
+    expect(s.armCount()).toBe(0);
+  });
+
+  test("a fire with nothing buffered is a harmless no-op (idempotent flush)", () => {
+    const batches: number[][] = [];
+    const s = makeFakeScheduler();
+    const b = createEventBuffer<number>((batch) => batches.push(batch), s.arm);
+
+    b.push(1);
+    s.fire(); // emits [1], disarms
+    s.fire(); // already disarmed / empty — must not emit again
+    expect(batches).toEqual([[1]]);
+  });
+
+  test("dispose cancels the pending arm and discards buffered items without emitting", () => {
+    const batches: number[][] = [];
+    const s = makeFakeScheduler();
+    const b = createEventBuffer<number>((batch) => batches.push(batch), s.arm);
+
+    b.push(1);
+    b.push(2);
+    b.dispose();
+    expect(batches).toEqual([]); // dropped, not flushed
+    expect(s.disarmCount()).toBe(1);
+    expect(s.isArmed()).toBe(false);
+
+    // A later flush has nothing to emit (pending was cleared).
+    b.flushNow();
+    expect(batches).toEqual([]);
+  });
+
+  test("each emitted batch is a fresh array — pending resets between flushes", () => {
+    const batches: number[][] = [];
+    const s = makeFakeScheduler();
+    const b = createEventBuffer<number>((batch) => batches.push(batch), s.arm);
+
+    b.push(1);
+    s.fire();
+    b.push(2);
+    s.fire();
+    expect(batches).toEqual([[1], [2]]);
+    expect(batches[0]).not.toBe(batches[1]); // distinct arrays, no shared buffer
+  });
+});

--- a/src/mainview/lib/event-buffer.ts
+++ b/src/mainview/lib/event-buffer.ts
@@ -1,0 +1,82 @@
+// Coalescing buffer for the unified task-level event stream the run panel
+// renders. Incoming SSE events are accumulated and emitted in batches so the
+// open-time replay burst (the server streams the whole history one frame per
+// event) collapses to O(N) renders instead of O(N²) — see the RunPanel SSE
+// effect and the `event-dedup` helper it pairs with.
+//
+// Extracted as a pure, scheduler-agnostic helper (like `event-dedup.ts`) so the
+// load-bearing invariant can be unit-tested apart from the React effect: a
+// flush must *re-arm* on the next push. The original inline version gated
+// arming on `if (raf === 0)` against a raw rAF handle; when the macOS WKWebView
+// suspended an occluded window, WebKit could drop the pending rAF without ever
+// firing it, leaving the handle non-zero so no future event rescheduled — the
+// stream froze until a remount. Routing every arm/flush through this buffer
+// (and resetting the handle inside `flush`) is what guarantees recovery.
+//
+// The buffer knows nothing about rAF, timers, or `visibilitychange`. The caller
+// injects an `arm` strategy (in RunPanel: race a `requestAnimationFrame`
+// against a `setTimeout` fallback) and may call `flushNow()` directly from
+// focus / visibility handlers to drain the instant the window returns.
+
+/** Arms a deferred `flush`. Returns a thunk that cancels the pending
+ *  invocation. The buffer calls this at most once per armed cycle (one arm per
+ *  flush), so the strategy is free to schedule several racing timers and cancel
+ *  them all in the returned thunk. */
+export type ArmStrategy = (flush: () => void) => () => void;
+
+export interface EventBuffer<T> {
+  /** Queue an item and arm a flush if one isn't already pending. */
+  push(item: T): void;
+  /** Drain immediately (cancelling any pending arm). No-op when empty. Safe to
+   *  call repeatedly and from event handlers — this is the focus / visibility
+   *  recovery path. */
+  flushNow(): void;
+  /** Cancel any pending arm and discard buffered items without emitting. */
+  dispose(): void;
+}
+
+/**
+ * Create a coalescing event buffer.
+ *
+ * @param emit  Called with each non-empty batch, in push order. In RunPanel
+ *              this appends to React state.
+ * @param arm   Schedules a deferred flush; see {@link ArmStrategy}.
+ */
+export function createEventBuffer<T>(
+  emit: (batch: T[]) => void,
+  arm: ArmStrategy,
+): EventBuffer<T> {
+  let pending: T[] = [];
+  // The cancel thunk for the in-flight arm, or null when nothing is armed.
+  // Doubles as the "is something scheduled?" flag — resetting it to null inside
+  // `flush` is what lets the next push re-arm (the regression-prone invariant).
+  let disarm: (() => void) | null = null;
+
+  const flush = () => {
+    if (disarm) {
+      disarm();
+      disarm = null;
+    }
+    if (pending.length === 0) return;
+    const batch = pending;
+    pending = [];
+    emit(batch);
+  };
+
+  return {
+    push(item: T) {
+      pending.push(item);
+      if (!disarm) disarm = arm(flush);
+    },
+    flushNow() {
+      flush();
+    },
+    dispose() {
+      if (disarm) {
+        disarm();
+        disarm = null;
+      }
+      pending = [];
+    },
+  };
+}


### PR DESCRIPTION
…unded

The task-details event stream could freeze until the user re-activated the agetor window (e.g. by opening the tmux session). Live SSE delivery was gated solely on requestAnimationFrame, which the macOS WKWebView suspends while its window is occluded / minimized / on another Space: buffered events piled up, and a WebKit-dropped rAF handle left the scheduler permanently armed so no later event ever rescheduled a flush — the stream stayed frozen until a remount. Parsing/broadcast were never at fault (the 400ms JSONL poll runs in the Bun main process), so the "refresh-rate-on-parsing" framing was the wrong layer.

Stop depending solely on rAF: race a setTimeout fallback against it, drain immediately on visibilitychange/focus, and reset the flush handle so the next push re-arms. Extract the arm/flush bookkeeping into a pure, scheduler-agnostic createEventBuffer helper (mirroring event-dedup.ts) and unit-test the re-arm-after-flush invariant that fixes the freeze.