### PR TITLE
fix(notifications): alert when background-workflow prompts need input

### DIFF
--- a/src/bun/global-events.test.ts
+++ b/src/bun/global-events.test.ts
@@ -68,6 +68,51 @@ test("startTask emits column → running and run-status → succeeded", async ()
   tasks.delete(created.task.id);
 });
 
+test("registering and resolving an interaction emits global interaction events", async () => {
+  // Importing the orchestrator installs the interactions broadcaster bridges
+  // (setBroadcaster / setResolvedBroadcaster) that also fan interactions onto
+  // the app-level global bus — the channel the notification hook listens on.
+  const { subscribeGlobal, wireInteractionBroadcast } = await import("./orchestrator.ts");
+  const { registerTmuxPrompt, cancelPendingForTask } = await import("./interactions.ts");
+
+  // The interactions broadcaster is a single process-wide callback; a sibling
+  // test (interactions.test.ts) may have overridden it to capture raw
+  // broadcasts. Re-establish the real wiring so this test is order-independent.
+  wireInteractionBroadcast();
+
+  const taskId = "int-evt-task";
+  const runId = "int-evt-run";
+
+  const events: GlobalEvent[] = [];
+  const unsub = subscribeGlobal((e) => {
+    if (e.kind === "interaction" && e.taskId === taskId) events.push(e);
+  });
+
+  const { id } = registerTmuxPrompt({
+    taskId,
+    runId,
+    paneText: "Proceed?",
+    choices: [{ key: "1", label: "Yes" }],
+    fingerprint: "fp-int-evt",
+  });
+
+  cancelPendingForTask(taskId, "test");
+  unsub();
+
+  const pending = events.find((e) => e.kind === "interaction" && e.state === "pending");
+  expect(pending).toBeDefined();
+  if (pending?.kind === "interaction") {
+    expect(pending.interactionId).toBe(id);
+    expect(pending.runId).toBe(runId);
+  }
+
+  const resolved = events.find((e) => e.kind === "interaction" && e.state === "resolved");
+  expect(resolved).toBeDefined();
+  if (resolved?.kind === "interaction") {
+    expect(resolved.interactionId).toBe(id);
+  }
+});
+
 test("reconcileOrphans emits run-status → orphaned + column → ready", async () => {
   const { createTask, subscribeGlobal, reconcileOrphans } = await import("./orchestrator.ts");
   const { tasks, runs, db } = await import("./db.ts");

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -166,34 +166,67 @@ export function __emitGlobalForTest(e: GlobalEvent): void {
   emitGlobal(e);
 }
 
-// Bridge: interactions.ts publishes new pending entries here so they ride
-// the same SSE stream the UI is already subscribed to. The UI distinguishes
-// them from regular log events via `stream === "interaction"`.
-setBroadcaster((req: AnyRequest) => {
-  emit({
-    runId: req.runId,
-    taskId: req.taskId,
-    stream: "interaction",
-    data: JSON.stringify(req),
-    ts: req.createdAt,
+/**
+ * Bridge: interactions.ts publishes new/resolved entries here so they ride the
+ * same SSE stream the UI is already subscribed to (the UI distinguishes them
+ * from regular log events via `stream === "interaction"`) AND the app-level
+ * global bus so the notification hook can alert the user.
+ *
+ * Exported and idempotent because `setBroadcaster`/`setResolvedBroadcaster`
+ * install a single process-wide callback: any code that overrides it (e.g. a
+ * test capturing raw broadcasts) would otherwise permanently detach the global
+ * emit. Tests that need the real wiring can re-call this to restore it.
+ */
+export function wireInteractionBroadcast(): void {
+  setBroadcaster((req: AnyRequest) => {
+    emit({
+      runId: req.runId,
+      taskId: req.taskId,
+      stream: "interaction",
+      data: JSON.stringify(req),
+      ts: req.createdAt,
+    });
+    // Also ride the app-level bus so the notification hook can alert the user
+    // even when no panel for this task is open (or it's open but the window is
+    // backgrounded and can't repaint the card). The per-task `interaction`
+    // event above only reaches the RunPanel subscribed to this task.
+    emitGlobal({
+      kind: "interaction",
+      taskId: req.taskId,
+      runId: req.runId,
+      state: "pending",
+      interactionId: req.id,
+      ts: req.createdAt,
+    });
   });
-});
 
-// Companion bridge for the *removal* side. Every answer*/cancel* path
-// in interactions.ts calls into this, so the run panel can drop the
-// card immediately instead of waiting for a refresh poll. Without
-// this, scraper auto-cancel and run-cancellation leave stale cards in
-// the panel (the existing additions-only SSE plumbing has no way to
-// signal "this is gone").
-setResolvedBroadcaster((res: InteractionResolved) => {
-  emit({
-    runId: res.runId,
-    taskId: res.taskId,
-    stream: "interaction_resolved",
-    data: JSON.stringify({ id: res.id, kind: res.kind }),
-    ts: Date.now(),
+  // Companion bridge for the *removal* side. Every answer*/cancel* path in
+  // interactions.ts calls into this, so the run panel can drop the card
+  // immediately instead of waiting for a refresh poll. Without this, scraper
+  // auto-cancel and run-cancellation leave stale cards in the panel (the
+  // existing additions-only SSE plumbing has no way to signal "this is gone").
+  setResolvedBroadcaster((res: InteractionResolved) => {
+    emit({
+      runId: res.runId,
+      taskId: res.taskId,
+      stream: "interaction_resolved",
+      data: JSON.stringify({ id: res.id, kind: res.kind }),
+      ts: Date.now(),
+    });
+    // App-level companion to the pending emit above — lets the notification
+    // hook clear its "Waiting on you" alert once the last prompt is gone.
+    emitGlobal({
+      kind: "interaction",
+      taskId: res.taskId,
+      runId: res.runId,
+      state: "resolved",
+      interactionId: res.id,
+      ts: Date.now(),
+    });
   });
-});
+}
+
+wireInteractionBroadcast();
 
 /**
  * Decide what to do with runs left in `status='running'` from a previous

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -17,7 +17,8 @@ import { UpdateBanner } from "@/components/updater/UpdateBanner";
 import type { UpdateSnapshot } from "@/lib/api";
 import { useConfirm } from "@/components/ui/confirm";
 import { Toaster } from "@/components/ui/sonner";
-import { dismissPending, toastApiError, toastError, toastPending, toastSuccess } from "@/lib/toasts";
+import { dismissPending, notifyWaitingInput, toastApiError, toastError, toastPending, toastSuccess } from "@/lib/toasts";
+import { PendingInputTracker } from "@/lib/pending-input-tracker";
 import { cn } from "@/lib/utils";
 import iconUrl from "../assets/agetor.iconset/icon_32x32@2x.png";
 
@@ -194,6 +195,10 @@ export default function App() {
   // current state without re-subscribing on every render.
   const tasksRef = useRef<Task[]>(tasks);
   const selectedIdRef = useRef<string | null>(selected?.id ?? null);
+  // Tracks interaction ids awaiting an answer, keyed by task. Lets the
+  // notification hook alert only on the FIRST prompt for a task (not once per
+  // stacked prompt) and clear the alert only when the LAST one resolves.
+  const pendingInputRef = useRef<PendingInputTracker>(new PendingInputTracker());
   useEffect(() => { tasksRef.current = tasks; }, [tasks]);
   useEffect(() => { selectedIdRef.current = selected?.id ?? null; }, [selected]);
 
@@ -261,11 +266,43 @@ export default function App() {
         // many browsers but works inside WKWebView.
         window.focus();
       };
+      if (ev.kind === "interaction") {
+        // A question / permission prompt opened or closed. The tracker raises
+        // the alert only on the first prompt for a task and clears it only when
+        // the last one resolves — stacked prompts don't re-alert.
+        const tracker = pendingInputRef.current;
+        if (ev.state === "pending") {
+          if (tracker.add(ev.taskId, ev.interactionId)) {
+            notifyWaitingInput({ taskId: ev.taskId, title, subtitle, isSelected, isFocused, onOpen });
+          }
+        } else if (tracker.remove(ev.taskId, ev.interactionId)) {
+          dismissPending(ev.taskId);
+        }
+        // Optimistically reflect the change in the card's pending count so the
+        // "needs input" amber-pulse flag (TaskCard, gated on
+        // pendingInteractionCount) appears the instant the prompt lands rather
+        // than waiting up to 2s for the next /tasks poll, which then reconciles
+        // the true count.
+        setTasks((cur) =>
+          cur.map((t) => {
+            if (t.id !== ev.taskId) return t;
+            const next = ev.state === "pending"
+              ? t.pendingInteractionCount + 1
+              : Math.max(0, t.pendingInteractionCount - 1);
+            return { ...t, pendingInteractionCount: next };
+          }),
+        );
+        return;
+      }
       if (ev.kind === "run-status") {
         // Any terminal run state supersedes a pending-input prompt — clear the
         // "Waiting on you" toast so it doesn't linger next to the success/
-        // failure toast (or silently after a cancel).
+        // failure toast (or silently after a cancel). Also drop the tracker's
+        // entry: a run that ends with a modal still on the pane may never emit
+        // a resolved interaction, and a stale id would otherwise suppress the
+        // first-prompt alert for this task's next run.
         dismissPending(ev.taskId);
+        pendingInputRef.current.clearTask(ev.taskId);
         if (ev.status === "succeeded") {
           toastSuccess({ taskId: ev.taskId, title, subtitle, isSelected, isFocused, onOpen });
         } else if (ev.status === "failed" || ev.status === "orphaned") {

--- a/src/mainview/lib/pending-input-tracker.test.ts
+++ b/src/mainview/lib/pending-input-tracker.test.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "bun:test";
+import { PendingInputTracker } from "./pending-input-tracker.ts";
+
+test("add signals only on the first prompt per task", () => {
+  const t = new PendingInputTracker();
+  expect(t.add("task-1", "a")).toBe(true);   // first → alert
+  expect(t.add("task-1", "b")).toBe(false);  // stacked → no re-alert
+  expect(t.add("task-2", "c")).toBe(true);   // different task → alert
+});
+
+test("add is idempotent for a repeated id", () => {
+  const t = new PendingInputTracker();
+  expect(t.add("task-1", "a")).toBe(true);
+  // Re-delivery of the same pending id must not re-signal (set already non-empty).
+  expect(t.add("task-1", "a")).toBe(false);
+});
+
+test("remove signals only when the last prompt resolves", () => {
+  const t = new PendingInputTracker();
+  t.add("task-1", "a");
+  t.add("task-1", "b");
+  expect(t.remove("task-1", "a")).toBe(false); // one still pending
+  expect(t.remove("task-1", "b")).toBe(true);  // last gone → clear alert
+});
+
+test("remove of an unknown task or id is a no-op", () => {
+  const t = new PendingInputTracker();
+  expect(t.remove("nope", "x")).toBe(false);
+  t.add("task-1", "a");
+  expect(t.remove("task-1", "ghost")).toBe(false); // id never tracked
+});
+
+test("clearTask drops all tracking so the next prompt re-signals", () => {
+  const t = new PendingInputTracker();
+  t.add("task-1", "a");
+  t.add("task-1", "b");
+  t.clearTask("task-1");
+  // After a terminal run cleared the task, a fresh prompt must alert again.
+  expect(t.add("task-1", "c")).toBe(true);
+});
+
+test("clearTask is scoped to one task", () => {
+  const t = new PendingInputTracker();
+  t.add("task-1", "a");
+  t.add("task-2", "b");
+  t.clearTask("task-1");
+  expect(t.add("task-1", "c")).toBe(true);   // cleared → re-signals
+  expect(t.add("task-2", "d")).toBe(false);  // untouched → still tracked
+});

--- a/src/mainview/lib/pending-input-tracker.ts
+++ b/src/mainview/lib/pending-input-tracker.ts
@@ -1,0 +1,53 @@
+/**
+ * Tracks which interaction ids are awaiting an answer, keyed by task, so the
+ * app-level notification hook fires "Waiting on you" exactly ONCE per task (not
+ * once per stacked prompt) and clears it only when the LAST prompt resolves.
+ *
+ * Pure and DOM-free on purpose: the toast/notification side effects live in the
+ * caller (App.tsx), and this bookkeeping is unit-tested in isolation.
+ */
+export class PendingInputTracker {
+  private byTask = new Map<string, Set<string>>();
+
+  /**
+   * Record a newly-pending prompt. Returns `true` when it is the FIRST live
+   * prompt for the task — the caller's signal to raise the alert. A repeat of
+   * an id already tracked never re-signals.
+   */
+  add(taskId: string, interactionId: string): boolean {
+    let set = this.byTask.get(taskId);
+    if (!set) {
+      set = new Set();
+      this.byTask.set(taskId, set);
+    }
+    const wasEmpty = set.size === 0;
+    set.add(interactionId);
+    return wasEmpty;
+  }
+
+  /**
+   * Drop a resolved prompt. Returns `true` when the task now has NO live
+   * prompts left — the caller's signal to clear the alert. Unknown task/id
+   * pairs are a no-op returning `false`.
+   */
+  remove(taskId: string, interactionId: string): boolean {
+    const set = this.byTask.get(taskId);
+    if (!set) return false;
+    set.delete(interactionId);
+    if (set.size === 0) {
+      this.byTask.delete(taskId);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Forget all tracking for a task — used when its run reaches a terminal state
+   * without every prompt emitting a resolved event (e.g. the agent process
+   * exits with a modal still on the pane). Without this, a stale id would sit
+   * in the set and suppress the FIRST-prompt alert for the task's next run.
+   */
+  clearTask(taskId: string): void {
+    this.byTask.delete(taskId);
+  }
+}

--- a/src/mainview/lib/toasts.ts
+++ b/src/mainview/lib/toasts.ts
@@ -23,6 +23,12 @@ export interface ToastArgs {
 
 // Track active pending toasts so a column-leaves-blocked transition can
 // dismiss the matching toast without the caller carrying the id around.
+// Single-slot per task, SHARED by every "needs attention" helper here
+// (`toastPending`, `toastApiError`, `notifyWaitingInput`) and cleared by
+// `dismissPending`. Only one such toast shows per task at a time — a second
+// writer dismisses the first. That's fine while these states don't realistically
+// co-occur (an api-error means the turn died, so there's no live modal); if a
+// future caller can overlap them, key this by `(taskId, kind)` instead.
 const pendingByTask = new Map<string, string | number>();
 
 function describe(args: ToastArgs): string {
@@ -98,6 +104,34 @@ export function toastPending(args: ToastArgs): void {
  *  "the agent is waiting on your answer." */
 export function toastApiError(args: ToastArgs): void {
   showBlockingToast({ method: toast.error, heading: "API error — retry" }, args);
+}
+
+/**
+ * Alert the user that a question / permission prompt is waiting on them.
+ * Distinct from `toastPending` (the `blocked`-column path) in one crucial way:
+ * it fires the native OS notification when the window is unfocused **even if
+ * the prompted task is the currently-open panel**. That case — panel open but
+ * the agetor window backgrounded behind a long workflow — is exactly when the
+ * occluded webview can't repaint the question card, so the notification is the
+ * only thing that pulls the user back. The in-app sonner toast is still
+ * suppressed for the open panel (the card is already there, or will be the
+ * instant the window repaints on focus).
+ */
+export function notifyWaitingInput(args: ToastArgs): void {
+  maybeNotifyOS(args, "Waiting on you", describe(args));
+  if (args.isSelected) return;
+  const prior = pendingByTask.get(args.taskId);
+  if (prior !== undefined) toast.dismiss(prior);
+  const detail = describe(args);
+  const id = toast.warning("Waiting on you", {
+    description: detail,
+    duration: Infinity,
+    action: { label: "Open", onClick: args.onOpen },
+    onDismiss: () => {
+      if (pendingByTask.get(args.taskId) === id) pendingByTask.delete(args.taskId);
+    },
+  });
+  pendingByTask.set(args.taskId, id);
 }
 
 /** Clear the pending toast for a task (called when the task leaves `blocked`). */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -720,6 +720,25 @@ export type GlobalEvent =
       /** Human-readable detail (error message, etc). */
       message: string | null;
       ts: number;
+    }
+  | {
+      /**
+       * A question / permission prompt was registered (`pending`) or cleared
+       * (`resolved`). Distinct from the per-task `interaction` SSE event (which
+       * only reaches the open RunPanel): this rides the app-level bus so the
+       * notification hook can alert the user — with a native OS notification
+       * and a "Waiting on you" toast — even when the agetor window is
+       * backgrounded mid-workflow and the panel can't repaint the card.
+       */
+      kind: "interaction";
+      taskId: string;
+      runId: string;
+      state: "pending" | "resolved";
+      /** Stable id of the interaction, so the UI can track which prompts are
+       *  live per task (several can stack) and clear the alert only once the
+       *  last one resolves. */
+      interactionId: string;
+      ts: number;
     };
 
 /**


### PR DESCRIPTION
Pending question/permission prompts were published only on the per-task SSE stream, which reaches just the open RunPanel. When a background workflow raised a prompt after the visible turn completed and the agetor window was backgrounded, the occluded webview couldn't repaint the card and nothing pulled the user back — the question looked "missing" until they refocused.

Emit an app-level `interaction` GlobalEvent (pending/resolved) alongside the per-task SSE event so the notification hook can alert the user, and surface it three ways:

- toasts: notifyWaitingInput() fires the native OS notification when the window is unfocused even if the prompted task's panel is already open (the backgrounded-but-open case), plus a "Waiting on you" toast when a different task is selected.
- App: optimistically bump pendingInteractionCount so the kanban amber-pulse flag appears instantly instead of after the 2s poll; track live prompts via a new PendingInputTracker so the alert fires once per task and clears on the last resolve (and on terminal run-status, in case a run ends with a modal still on the pane).
- orchestrator: extract the broadcaster wiring into an idempotent, exported wireInteractionBroadcast() that emits the global event from both bridges.

Adds the GlobalEvent "interaction" kind, a unit-tested PendingInputTracker, and a global-events test for the new emit. typecheck clean; 556 tests pass.