### PR TITLE
feat(new-task): add Git Fetch button to the branch picker

### DIFF
--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -42,7 +42,7 @@ import {
   sessionNameFor,
 } from "./claude-tmux.ts";
 import { planAskAnswers } from "./claude-questions.ts";
-import { getTaskDiff, hasUncommittedChanges, listBranches } from "./worktree.ts";
+import { getTaskDiff, gitFetch, hasUncommittedChanges, listBranches } from "./worktree.ts";
 import {
   attachSocket,
   closeTerminal,
@@ -283,6 +283,21 @@ export function startApiServer() {
           const dir = url.searchParams.get("path");
           if (!dir) return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
           return json(await listBranches(dir), { headers: corsHeaders(req) });
+        }),
+      },
+
+      // Fetch all remotes for a project so the branch picker can surface newly
+      // pushed branches without leaving agetor. Network-bound — the helper uses
+      // a longer git timeout than the read-only routes above.
+      "/projects/fetch": {
+        POST: authed(async (req) => {
+          const { path: p } = (await req.json().catch(() => ({}))) as { path?: string };
+          if (!p) return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
+          const result = await gitFetch(p);
+          if (!result.ok) {
+            return json({ error: result.error ?? "git fetch failed" }, { status: 400, headers: corsHeaders(req) });
+          }
+          return json({ ok: true }, { headers: corsHeaders(req) });
         }),
       },
 

--- a/src/bun/worktree.test.ts
+++ b/src/bun/worktree.test.ts
@@ -341,3 +341,71 @@ test("hasUncommittedChanges returns true for a modified tracked file", async () 
   writeFileSync(path.join(repo, "README"), "changed\n");
   expect(await hasUncommittedChanges(repo)).toBe(true);
 });
+
+test("gitFetch returns an error when the dir isn't a git repo", async () => {
+  const { gitFetch } = await import("./worktree.ts");
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-wt-fetch-nongit-"));
+  const r = await gitFetch(dir);
+  expect(r.ok).toBe(false);
+  expect(r.error).toContain("not a git repository");
+});
+
+test("gitFetch succeeds (no-op) for a repo with no remotes", async () => {
+  const { gitFetch } = await import("./worktree.ts");
+  // `git fetch --all` with nothing to fetch exits 0 — the picker just sees the
+  // existing local branches, so the button shouldn't surface a spurious error.
+  const repo = await makeRepo();
+  const r = await gitFetch(repo);
+  expect(r.ok).toBe(true);
+  expect(r.error).toBeUndefined();
+});
+
+test("gitFetch pulls a newly pushed branch so listBranches surfaces it", async () => {
+  const { gitFetch, listBranches } = await import("./worktree.ts");
+  // `origin` is a normal repo we point the clone at; a new branch pushed here
+  // after the clone is invisible to the clone until a fetch runs.
+  const origin = await makeRepo();
+  const clone = mkdtempSync(path.join(tmpdir(), "agetor-wt-fetch-clone-"));
+  await git(["clone", origin, clone], path.dirname(clone));
+
+  // The clone starts unaware of a branch created on origin post-clone.
+  await git(["checkout", "-b", "feature/new-remote-branch"], origin);
+  writeFileSync(path.join(origin, "feature.txt"), "remote work\n");
+  await git(["add", "."], origin);
+  await git(["commit", "-m", "feature commit"], origin);
+
+  const before = await listBranches(clone);
+  expect(before.some((b) => b.name.endsWith("feature/new-remote-branch"))).toBe(false);
+
+  const r = await gitFetch(clone);
+  expect(r.ok).toBe(true);
+
+  const after = await listBranches(clone);
+  expect(after.some((b) => b.name.endsWith("feature/new-remote-branch"))).toBe(true);
+});
+
+test("gitFetch --prune drops a remote-tracking branch deleted on origin", async () => {
+  const { gitFetch, listBranches } = await import("./worktree.ts");
+  // Prove the `--prune` flag really mirrors the remote: a branch that exists at
+  // clone time but is later deleted on origin must disappear from the picker.
+  const origin = await makeRepo();
+  await git(["checkout", "-b", "feature/short-lived"], origin);
+  writeFileSync(path.join(origin, "tmp.txt"), "x\n");
+  await git(["add", "."], origin);
+  await git(["commit", "-m", "short lived"], origin);
+  // Leave origin checked out on main so the branch can be deleted later.
+  await git(["checkout", "main"], origin);
+
+  const clone = mkdtempSync(path.join(tmpdir(), "agetor-wt-fetch-prune-"));
+  await git(["clone", origin, clone], path.dirname(clone));
+  const cloned = await listBranches(clone);
+  expect(cloned.some((b) => b.name.endsWith("feature/short-lived"))).toBe(true);
+
+  // Delete the branch on origin, then fetch+prune from the clone.
+  await git(["branch", "-D", "feature/short-lived"], origin);
+  const r = await gitFetch(clone);
+  expect(r.ok).toBe(true);
+
+  const pruned = await listBranches(clone);
+  expect(pruned.some((b) => b.name.endsWith("feature/short-lived"))).toBe(false);
+});

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -173,6 +173,24 @@ export async function listBranches(dir: string): Promise<BranchInfo[]> {
   return branches;
 }
 
+/**
+ * Fetch every remote for the repo containing `dir`, pruning deleted
+ * remote-tracking refs so the branch picker mirrors the remote exactly. After
+ * this resolves, `listBranches` surfaces any newly-fetched `origin/*` branches.
+ *
+ * Network-bound, so it gets a longer budget than the default 30 s git()
+ * timeout. A repo with no remotes succeeds with no output. Returns
+ * `{ ok: false, error }` when `dir` isn't a git repo or the fetch failed — the
+ * stderr (where git writes auth/network errors) is surfaced for the UI.
+ */
+export async function gitFetch(dir: string): Promise<{ ok: boolean; error?: string }> {
+  const root = await repoRoot(dir);
+  if (!root) return { ok: false, error: "not a git repository" };
+  const res = await git(["fetch", "--all", "--prune"], root, 120_000);
+  if (!res.ok) return { ok: false, error: res.stderr || `git fetch failed (exit ${res.exitCode})` };
+  return { ok: true };
+}
+
 function slugify(s: string): string {
   return s
     .toLowerCase()

--- a/src/mainview/components/kanban/BranchPicker.tsx
+++ b/src/mainview/components/kanban/BranchPicker.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { GitBranch } from "lucide-react";
+import { GitBranch, RefreshCw } from "lucide-react";
 import { api, type BranchInfo } from "@/lib/api";
 import { SearchSelect } from "@/components/ui/search-select";
+import { cn } from "@/lib/utils";
 
 interface Props {
   /** Workdir whose branches to list. Empty = no project picked yet. */
@@ -9,6 +10,12 @@ interface Props {
   value: string;
   onChange: (next: string) => void;
   className?: string;
+  /**
+   * Field label rendered above the picker. Sharing the label row with the
+   * Git Fetch button keeps the picker trigger itself full-width, so long
+   * branch names aren't clipped inside the narrow new-task sidebar.
+   */
+  label?: string;
   /** Tooltip on the trigger. */
   title?: string;
   placement?: "top" | "bottom";
@@ -36,25 +43,40 @@ const formatAge = (ms: number): string => {
  * covers the "use what's checked out" intent without the extra entry. Empty
  * value still means "use HEAD" downstream so the picker can sit unselected.
  */
-export function BranchPicker({ workdir, value, onChange, className, title, placement, disabled }: Props) {
+export function BranchPicker({ workdir, value, onChange, className, label, title, placement, disabled }: Props) {
   // Branches are tagged with the workdir they were fetched for. Without the
   // tag, switching projects would let the auto-select effect below see the
   // previous repo's `branches` array (state updates from `setBranches([])`
   // don't apply until the next render) and re-pick its "current" branch into
   // a freshly-cleared `value`.
   const [snap, setSnap] = useState<{ workdir: string; list: BranchInfo[] }>({ workdir: "", list: [] });
+  // Listing failure (git for-each-ref / API). Kept separate from `fetchError`
+  // so the picker tooltip never mislabels a `git fetch` failure as "couldn't
+  // list branches".
   const [error, setError] = useState<string | null>(null);
+  // `git fetch` failure, surfaced on the Fetch button only.
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  // Bumped by the Git Fetch button to re-run the listing effect after a
+  // `git fetch` lands new remote branches, without touching `workdir`.
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [fetching, setFetching] = useState(false);
   const lastWorkdirRef = useRef(workdir);
 
   useEffect(() => {
     let cancelled = false;
     setError(null);
+    // A workdir/refresh change abandons any in-flight fetch's UI: clear its
+    // spinner and error so they don't linger against the new project (the
+    // fetch promise itself is also guarded below).
+    setFetching(false);
+    setFetchError(null);
     // Reset eagerly so the picker never shows the previous project's branches
     // while the new fetch is in flight.
     setSnap({ workdir, list: [] });
     // Workdir changed since last run — drop the previously selected ref so a
     // branch from the prior repo doesn't linger (and won't get rendered as a
-    // "custom ref" entry against a repo that doesn't have it).
+    // "custom ref" entry against a repo that doesn't have it). Guarded so a
+    // manual refresh (same workdir, bumped refreshKey) leaves the selection be.
     if (lastWorkdirRef.current !== workdir) {
       lastWorkdirRef.current = workdir;
       if (value) onChange("");
@@ -72,7 +94,27 @@ export function BranchPicker({ workdir, value, onChange, className, title, place
       }
     })();
     return () => { cancelled = true; };
-  }, [workdir]);
+  }, [workdir, refreshKey]);
+
+  // Pull all remotes, then re-list branches so freshly pushed `origin/*`
+  // branches appear in the picker. Network-bound, so the trigger spins while
+  // it runs; failures surface on the Fetch button via `fetchError`. The fetch
+  // is tagged with the workdir it started against so a project switch mid-fetch
+  // can't apply a stale result/spinner/error to the new project.
+  const handleFetch = async () => {
+    if (!workdir || fetching) return;
+    const dir = workdir;
+    setFetching(true);
+    setFetchError(null);
+    try {
+      await api.gitFetch(dir);
+      if (dir === lastWorkdirRef.current) setRefreshKey((k) => k + 1);
+    } catch (e) {
+      if (dir === lastWorkdirRef.current) setFetchError(e instanceof Error ? e.message : String(e));
+    } finally {
+      if (dir === lastWorkdirRef.current) setFetching(false);
+    }
+  };
 
   // Only trust `branches` when its workdir matches the current one; otherwise
   // the data is stale from the prior project and would mislead both the
@@ -123,18 +165,42 @@ export function BranchPicker({ workdir, value, onChange, className, title, place
   }
 
   return (
-    <SearchSelect
-      value={effective}
-      onChange={(next) => onChange(next === HEAD_VALUE ? "" : next)}
-      items={items}
-      className={className}
-      placement={placement}
-      disabled={disabled}
-      title={title ?? (error ? `Couldn't list branches: ${error}` : undefined)}
-      placeholder="Search branches…"
-      emptyLabel="HEAD"
-      leadingIcon={<GitBranch className="size-3.5" />}
-      displayValue={(v) => (v === HEAD_VALUE ? "HEAD" : v)}
-    />
+    <div className={cn("min-w-0 space-y-1", className)}>
+      {/* Label + Git Fetch share one row so the picker below stays full-width.
+          The button sits flush-right (ml-auto) even when no label is given. */}
+      <div className="flex items-center gap-2">
+        {label && <label className="text-muted-foreground">{label}</label>}
+        <button
+          type="button"
+          onClick={handleFetch}
+          disabled={disabled || !workdir || fetching}
+          title={
+            fetchError
+              ? `Git fetch failed: ${fetchError}`
+              : "Fetch all branches from remote (git fetch --all --prune)"
+          }
+          className={cn(
+            "ml-auto inline-flex items-center gap-1 rounded text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            (disabled || !workdir || fetching) && "cursor-not-allowed opacity-50",
+          )}
+        >
+          <RefreshCw className={cn("size-3", fetching && "animate-spin")} aria-hidden />
+          {fetching ? "Fetching…" : "Fetch"}
+        </button>
+      </div>
+      <SearchSelect
+        value={effective}
+        onChange={(next) => onChange(next === HEAD_VALUE ? "" : next)}
+        items={items}
+        className="w-full"
+        placement={placement}
+        disabled={disabled}
+        title={title ?? (error ? `Couldn't list branches: ${error}` : undefined)}
+        placeholder="Search branches…"
+        emptyLabel="HEAD"
+        leadingIcon={<GitBranch className="size-3.5" />}
+        displayValue={(v) => (v === HEAD_VALUE ? "HEAD" : v)}
+      />
+    </div>
   );
 }

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -503,20 +503,18 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
             title="Pick the working directory the agent runs in. Add new ones with the folder picker at the bottom of the list."
           />
         </div>
-        <div className="min-w-0 space-y-1">
-          <label className="text-muted-foreground">Branch</label>
-          <BranchPicker
-            workdir={workdir}
-            value={baseRef}
-            onChange={setBaseRef}
-            placement="bottom"
-            title={
-              isolate
-                ? "Base ref the worktree branches from. Pick the current branch row to use what's checked out at task start."
-                : "Isolation is off — the value is recorded but the agent will run directly in the project workdir."
-            }
-          />
-        </div>
+        <BranchPicker
+          label="Branch"
+          workdir={workdir}
+          value={baseRef}
+          onChange={setBaseRef}
+          placement="bottom"
+          title={
+            isolate
+              ? "Base ref the worktree branches from. Pick the current branch row to use what's checked out at task start."
+              : "Isolation is off — the value is recorded but the agent will run directly in the project workdir."
+          }
+        />
 
         <label
           className="flex cursor-pointer items-center gap-1.5"

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -233,6 +233,14 @@ export const api = {
     }).then((r) => r.refs),
   listBranches: (dir: string) =>
     j<BranchInfo[]>(`/projects/branches?path=${encodeURIComponent(dir)}`),
+  /** `git fetch --all --prune` on the project so newly pushed remote branches
+   *  show up in the branch picker. Resolves once the fetch completes; the
+   *  caller re-lists branches afterwards. */
+  gitFetch: (dir: string) =>
+    j<{ ok: true }>("/projects/fetch", {
+      method: "POST",
+      body: JSON.stringify({ path: dir }),
+    }),
   getTmuxSource: () =>
     j<{
       source: "system" | "bundled";


### PR DESCRIPTION
Adds a "Fetch" button on the Branch label row of the new-task side panel that runs `git fetch --all --prune` on the selected project, then re-lists branches so newly pushed (and pruned) remote branches show up in the picker without leaving agetor.

- worktree.ts: new `gitFetch(dir)` helper — resolves repo root then fetches all remotes with a 120s timeout (network-bound, longer than the default git budget); returns { ok, error? } and surfaces git stderr on failure.
- server.ts: new `POST /projects/fetch` route (authed) delegating to gitFetch.
- api.ts: `api.gitFetch(dir)` client method.
- BranchPicker.tsx: a `refreshKey` re-list after fetch (no workdir poke, so the user's selection is preserved); the Fetch button lives on the label row so the picker trigger stays full-width and long branch names aren't clipped. Fetch failures use a dedicated `fetchError` state, and an in-flight fetch is tagged with its workdir so switching project mid-fetch can't strand the spinner or apply a stale result/error.
- Tests: gitFetch non-repo error, new-branch surfaces, no-remote no-op, and --prune drops a branch deleted on origin.