### PR TITLE
feat(new-task): add Git Pull button + behind-remote indicator to the …

### DIFF
--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -42,7 +42,7 @@ import {
   sessionNameFor,
 } from "./claude-tmux.ts";
 import { planAskAnswers } from "./claude-questions.ts";
-import { getTaskDiff, gitFetch, hasUncommittedChanges, listBranches } from "./worktree.ts";
+import { getTaskDiff, gitFetch, gitPull, hasUncommittedChanges, listBranches } from "./worktree.ts";
 import {
   attachSocket,
   closeTerminal,
@@ -296,6 +296,23 @@ export function startApiServer() {
           const result = await gitFetch(p);
           if (!result.ok) {
             return json({ error: result.error ?? "git fetch failed" }, { status: 400, headers: corsHeaders(req) });
+          }
+          return json({ ok: true }, { headers: corsHeaders(req) });
+        }),
+      },
+
+      // Fast-forward a single local branch to its upstream (the branch picker's
+      // Git Pull button). Network-bound like /projects/fetch. `branch` is the
+      // selected branch's short name; the helper picks `git pull --ff-only` for
+      // the checked-out branch and a checkout-free fast-forward otherwise.
+      "/projects/pull": {
+        POST: authed(async (req) => {
+          const { path: p, branch } = (await req.json().catch(() => ({}))) as { path?: string; branch?: string };
+          if (!p) return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
+          if (!branch) return json({ error: "branch required" }, { status: 400, headers: corsHeaders(req) });
+          const result = await gitPull(p, branch);
+          if (!result.ok) {
+            return json({ error: result.error ?? "git pull failed" }, { status: 400, headers: corsHeaders(req) });
           }
           return json({ ok: true }, { headers: corsHeaders(req) });
         }),

--- a/src/bun/worktree.test.ts
+++ b/src/bun/worktree.test.ts
@@ -409,3 +409,167 @@ test("gitFetch --prune drops a remote-tracking branch deleted on origin", async 
   const pruned = await listBranches(clone);
   expect(pruned.some((b) => b.name.endsWith("feature/short-lived"))).toBe(false);
 });
+
+test("listBranches reports behind/ahead/upstream once origin moves ahead + fetch", async () => {
+  const { gitFetch, listBranches } = await import("./worktree.ts");
+  const origin = await makeRepo();
+  const clone = mkdtempSync(path.join(tmpdir(), "agetor-wt-behind-"));
+  await git(["clone", origin, clone], path.dirname(clone));
+
+  // A fresh clone is in sync with its upstream.
+  const fresh = (await listBranches(clone)).find((b) => b.name === "main");
+  expect(fresh?.upstream).toBe("origin/main");
+  expect(fresh?.behind).toBe(0);
+  expect(fresh?.ahead).toBe(0);
+
+  // Advance origin/main, then fetch so the clone's tracking ref sees it.
+  writeFileSync(path.join(origin, "more.txt"), "x\n");
+  await git(["add", "."], origin);
+  await git(["commit", "-m", "second"], origin);
+  await gitFetch(clone);
+
+  const list = await listBranches(clone);
+  const after = list.find((b) => b.name === "main");
+  expect(after?.behind).toBe(1);
+  expect(after?.ahead).toBe(0);
+  // Regression guard: with the local `main` behind, `origin/main` has a newer
+  // commit date and sorts ahead of it. The dedup must still keep the LOCAL row
+  // (not collapse to the remote-tracking ref), or the picker would lose the
+  // current/behind/upstream signal for the branch the user actually pulls.
+  expect(after?.remote).toBe(false);
+  expect(list.some((b) => b.name === "origin/main")).toBe(false);
+});
+
+test("gitPull fast-forwards the checked-out branch and clears the behind count", async () => {
+  const { gitPull, listBranches } = await import("./worktree.ts");
+  const origin = await makeRepo();
+  const clone = mkdtempSync(path.join(tmpdir(), "agetor-wt-pull-current-"));
+  await git(["clone", origin, clone], path.dirname(clone));
+
+  writeFileSync(path.join(origin, "more.txt"), "x\n");
+  await git(["add", "."], origin);
+  await git(["commit", "-m", "second"], origin);
+
+  const r = await gitPull(clone, "main");
+  expect(r.ok).toBe(true);
+  // The fast-forwarded file is now present in the clone's working tree.
+  expect(existsSync(path.join(clone, "more.txt"))).toBe(true);
+  const after = (await listBranches(clone)).find((b) => b.name === "main");
+  expect(after?.behind).toBe(0);
+});
+
+test("gitPull fast-forwards a non-checked-out local branch without a checkout", async () => {
+  const { gitFetch, gitPull, listBranches } = await import("./worktree.ts");
+  const origin = await makeRepo();
+  // Create a feature branch on origin so the clone can track it.
+  await git(["checkout", "-b", "feature"], origin);
+  writeFileSync(path.join(origin, "feat.txt"), "f1\n");
+  await git(["add", "."], origin);
+  await git(["commit", "-m", "feat1"], origin);
+  await git(["checkout", "main"], origin);
+
+  const clone = mkdtempSync(path.join(tmpdir(), "agetor-wt-pull-other-"));
+  await git(["clone", origin, clone], path.dirname(clone));
+  // Materialize a local `feature` tracking origin/feature, then switch back to
+  // main so `feature` is NOT the checked-out branch.
+  await git(["checkout", "feature"], clone);
+  await git(["checkout", "main"], clone);
+
+  // Advance origin/feature.
+  await git(["checkout", "feature"], origin);
+  writeFileSync(path.join(origin, "feat.txt"), "f2\n");
+  await git(["add", "."], origin);
+  await git(["commit", "-m", "feat2"], origin);
+  await git(["checkout", "main"], origin);
+
+  await gitFetch(clone);
+  expect((await listBranches(clone)).find((b) => b.name === "feature")?.behind).toBe(1);
+
+  const r = await gitPull(clone, "feature");
+  expect(r.ok).toBe(true);
+  expect((await listBranches(clone)).find((b) => b.name === "feature")?.behind).toBe(0);
+  // main is still the checked-out branch — the pull didn't switch worktrees.
+  expect((await listBranches(clone)).find((b) => b.current)?.name).toBe("main");
+});
+
+test("gitPull refuses to fast-forward a diverged branch", async () => {
+  const { gitFetch, gitPull } = await import("./worktree.ts");
+  const origin = await makeRepo();
+  const clone = mkdtempSync(path.join(tmpdir(), "agetor-wt-pull-diverged-"));
+  await git(["clone", origin, clone], path.dirname(clone));
+
+  // A local commit on the clone…
+  writeFileSync(path.join(clone, "local.txt"), "L\n");
+  await git(["add", "."], clone);
+  await git(["commit", "-m", "local"], clone);
+  // …and a different commit on origin → divergence.
+  writeFileSync(path.join(origin, "remote.txt"), "R\n");
+  await git(["add", "."], origin);
+  await git(["commit", "-m", "remote"], origin);
+  await gitFetch(clone);
+
+  const r = await gitPull(clone, "main");
+  expect(r.ok).toBe(false);
+  expect(r.error).toBeTruthy();
+});
+
+test("gitPull refuses a non-checked-out branch that has diverged from its upstream", async () => {
+  const { gitFetch, gitPull } = await import("./worktree.ts");
+  // Exercises the `git fetch . <tracking>:<branch>` path's fast-forward-only
+  // guard (distinct from the checked-out `git pull --ff-only` path above).
+  const origin = await makeRepo();
+  await git(["checkout", "-b", "feature"], origin);
+  writeFileSync(path.join(origin, "feat.txt"), "f1\n");
+  await git(["add", "."], origin);
+  await git(["commit", "-m", "feat1"], origin);
+  await git(["checkout", "main"], origin);
+
+  const clone = mkdtempSync(path.join(tmpdir(), "agetor-wt-pull-other-diverged-"));
+  await git(["clone", origin, clone], path.dirname(clone));
+  // Materialize a local `feature`, give it a local-only commit, then switch back
+  // to main so `feature` is the non-checked-out branch we pull.
+  await git(["checkout", "feature"], clone);
+  writeFileSync(path.join(clone, "local.txt"), "L\n");
+  await git(["add", "."], clone);
+  await git(["commit", "-m", "local feat"], clone);
+  await git(["checkout", "main"], clone);
+
+  // A different commit on origin/feature → divergence.
+  await git(["checkout", "feature"], origin);
+  writeFileSync(path.join(origin, "feat.txt"), "f2\n");
+  await git(["add", "."], origin);
+  await git(["commit", "-m", "feat2"], origin);
+  await git(["checkout", "main"], origin);
+
+  await gitFetch(clone);
+  const r = await gitPull(clone, "feature");
+  expect(r.ok).toBe(false);
+  expect(r.error).toBeTruthy();
+});
+
+test("gitPull returns an error when the dir isn't a git repo", async () => {
+  const { gitPull } = await import("./worktree.ts");
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-wt-pull-nongit-"));
+  const r = await gitPull(dir, "main");
+  expect(r.ok).toBe(false);
+  expect(r.error).toContain("not a git repository");
+});
+
+test("gitPull errors when the selected branch has no upstream", async () => {
+  const { gitPull } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  // A second local branch with no upstream, while `main` stays checked out so
+  // we exercise the non-checked-out path's upstream lookup.
+  await git(["branch", "other"], repo);
+  const r = await gitPull(repo, "other");
+  expect(r.ok).toBe(false);
+  expect(r.error).toContain("no upstream");
+});
+
+test("gitPull rejects a branch name that could be read as a git flag", async () => {
+  const { gitPull } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  const r = await gitPull(repo, "--upload-pack=evil");
+  expect(r.ok).toBe(false);
+  expect(r.error).toContain("invalid branch name");
+});

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -1,7 +1,9 @@
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 import { dataDir } from "./db.ts";
-import type { DiffFile, Task, TaskDiff } from "../shared/types.ts";
+import type { BranchInfo, DiffFile, Task, TaskDiff } from "../shared/types.ts";
+
+export type { BranchInfo };
 
 const WORKTREES_DIR = path.join(dataDir, "worktrees");
 
@@ -95,17 +97,6 @@ export async function resolveRef(dir: string, ref: string): Promise<string | nul
   return /^[0-9a-f]{40}$/.test(res.stdout) ? res.stdout : null;
 }
 
-export interface BranchInfo {
-  /** Short ref name, e.g. "main", "feature/x", or "origin/feature/x". */
-  name: string;
-  /** Unix-ms timestamp of the tip commit, used to sort recents first. */
-  committedAt: number;
-  /** True for the branch currently checked out at `dir`. */
-  current: boolean;
-  /** True for remote-tracking refs (`refs/remotes/<remote>/<name>`). */
-  remote: boolean;
-}
-
 /**
  * List branches at `dir`, sorted by most recent commit first. Includes both
  * local branches (`refs/heads/…`) and remote-tracking branches (`refs/remotes/<remote>/…`),
@@ -130,12 +121,15 @@ export async function listBranches(dir: string): Promise<BranchInfo[]> {
   const currentName = head.ok ? head.stdout : null;
   // Tab-separated to keep parsing simple — branch names can't contain tabs.
   // `%(HEAD)` marks the current branch with `*`. Querying both heads and
-  // remotes in one pass keeps the sort stable.
+  // remotes in one pass keeps the sort stable. `%(upstream:short)` /
+  // `%(upstream:track)` give the configured upstream + a "[ahead N, behind M]"
+  // string, computed locally against the remote-tracking ref (no network), so
+  // the behind/ahead counts reflect the last fetch.
   const res = await git(
     [
       "for-each-ref",
       "--sort=-committerdate",
-      "--format=%(refname)\t%(refname:short)\t%(committerdate:unix)",
+      "--format=%(refname)\t%(refname:short)\t%(committerdate:unix)\t%(upstream:short)\t%(upstream:track)",
       "refs/heads/",
       "refs/remotes/",
     ],
@@ -143,7 +137,23 @@ export async function listBranches(dir: string): Promise<BranchInfo[]> {
   );
   if (!res.ok) return [];
 
-  const seen = new Set<string>();
+  // First pass: collect the local head short-names. A remote-tracking ref is
+  // only surfaced when it has no local counterpart — and we decide that up front
+  // rather than via first-seen dedup because `--sort=-committerdate` can place a
+  // remote ref AHEAD of its own local branch when the local branch is behind.
+  // First-seen dedup would then keep `origin/main` and drop local `main`,
+  // mislabeling the row as remote (losing its `current`/`behind`/`upstream`).
+  const localNames = new Set<string>();
+  for (const line of res.stdout.split("\n")) {
+    if (!line) continue;
+    const parts = line.split("\t");
+    if (parts.length < 3) continue;
+    if (parts[0]!.startsWith("refs/heads/") && !parts[1]!.startsWith("agetor/")) {
+      localNames.add(parts[1]!);
+    }
+  }
+
+  const seenRemote = new Set<string>();
   const branches: BranchInfo[] = [];
   for (const line of res.stdout.split("\n")) {
     if (!line) continue;
@@ -152,22 +162,47 @@ export async function listBranches(dir: string): Promise<BranchInfo[]> {
     const fullRef = parts[0]!;
     const shortName = parts[1]!;
     const ts = Number(parts[2]) * 1000;
+    // `for-each-ref` emits all 4 trailing tabs, so these fields are always
+    // present (possibly empty). split("\t") keeps trailing empties.
+    const upstreamShort = parts[3] ?? "";
+    const track = parts[4] ?? "";
     const isRemote = fullRef.startsWith("refs/remotes/");
-    // `origin/HEAD -> origin/main` shows up as an empty timestamp on the
-    // pointer line; the actual `origin/main` row already covers it.
-    if (isRemote && shortName.endsWith("/HEAD")) continue;
-    // The remote's short name keeps the `<remote>/` prefix so a local `main`
-    // and a tracking `origin/main` don't collide; for the dedup key, strip
-    // that prefix so we can prefer the local one.
-    const dedupKey = isRemote ? shortName.replace(/^[^/]+\//, "") : shortName;
-    if (!isRemote && shortName.startsWith("agetor/")) continue;
-    if (seen.has(dedupKey)) continue;
-    seen.add(dedupKey);
+    if (isRemote) {
+      // `origin/HEAD -> origin/main` shows up as a pointer alias; the real
+      // `origin/main` row already covers it.
+      if (shortName.endsWith("/HEAD")) continue;
+      // Strip the `<remote>/` prefix to compare against local names + other
+      // remotes (so `origin/main` and a local `main` don't both show).
+      const bare = shortName.replace(/^[^/]+\//, "");
+      if (localNames.has(bare)) continue; // a local branch with this name wins
+      if (seenRemote.has(bare)) continue; // first remote-tracking ref wins among remotes
+      seenRemote.add(bare);
+    } else {
+      // Branches agetor manages itself aren't the user's own — hide them. Local
+      // short-names are unique, so no further dedup is needed for heads.
+      if (shortName.startsWith("agetor/")) continue;
+    }
+    // Upstream tracking. Only meaningful for local branches with a configured
+    // upstream that still exists. `track` looks like "[ahead 2, behind 3]",
+    // "[behind 1]", "[gone]", or "" (in sync). An empty `upstreamShort` means
+    // no upstream is set; "[gone]" means the upstream ref was deleted — both
+    // leave the counts null ("can't compare") rather than 0 ("up to date").
+    let upstream: string | null = null;
+    let ahead: number | null = null;
+    let behind: number | null = null;
+    if (!isRemote && upstreamShort && track !== "[gone]") {
+      upstream = upstreamShort;
+      ahead = Number(/ahead (\d+)/.exec(track)?.[1] ?? 0);
+      behind = Number(/behind (\d+)/.exec(track)?.[1] ?? 0);
+    }
     branches.push({
       name: shortName,
       committedAt: Number.isFinite(ts) ? ts : 0,
       current: !isRemote && shortName === currentName,
       remote: isRemote,
+      upstream,
+      ahead,
+      behind,
     });
   }
   return branches;
@@ -188,6 +223,72 @@ export async function gitFetch(dir: string): Promise<{ ok: boolean; error?: stri
   if (!root) return { ok: false, error: "not a git repository" };
   const res = await git(["fetch", "--all", "--prune"], root, 120_000);
   if (!res.ok) return { ok: false, error: res.stderr || `git fetch failed (exit ${res.exitCode})` };
+  return { ok: true };
+}
+
+/**
+ * Fast-forward a single local `branch` in the repo containing `dir` to its
+ * upstream. Always fast-forward-only, so a pull never creates a merge commit or
+ * leaves conflicts in the user's repo — a diverged branch fails with a clear
+ * message instead.
+ *
+ * Two cases:
+ *  - `branch` is the branch checked out at the repo root → `git pull --ff-only`
+ *    (fetches its upstream and fast-forwards in place, updating tracking refs).
+ *  - `branch` is any other local branch → refresh its remote-tracking ref over
+ *    the network, then fast-forward the local ref from it *without* a checkout.
+ *
+ * Network-bound, so it gets the same longer budget as `gitFetch`. Returns
+ * `{ ok: false, error }` when `dir` isn't a git repo, the branch has no
+ * upstream, the fetch failed, or the branch has diverged (non-ff). The stderr
+ * (where git writes auth/network/ff errors) is surfaced for the UI.
+ */
+export async function gitPull(dir: string, branch: string): Promise<{ ok: boolean; error?: string }> {
+  // Defense-in-depth: branch names from listBranches can never start with "-"
+  // (git's ref-format rules forbid it), but guard anyway so a "-"-leading value
+  // can't be read as a flag by the git invocations below. (We avoid git's
+  // `--end-of-options` here because `git rev-parse` echoes it back into stdout
+  // rather than consuming it, which would corrupt the upstream parse.)
+  if (branch.startsWith("-")) return { ok: false, error: `invalid branch name: ${branch}` };
+  const root = await repoRoot(dir);
+  if (!root) return { ok: false, error: "not a git repository" };
+
+  const head = await git(["symbolic-ref", "--quiet", "--short", "HEAD"], root, 5_000);
+  const current = head.ok ? head.stdout : null;
+
+  if (branch === current) {
+    // Checked-out branch: fetch + fast-forward in place (also updates tracking refs).
+    const res = await git(["pull", "--ff-only"], root, 120_000);
+    if (!res.ok) return { ok: false, error: res.stderr || res.stdout || `git pull failed (exit ${res.exitCode})` };
+    return { ok: true };
+  }
+
+  // Non-checked-out local branch: resolve its upstream, refresh the tracking ref
+  // from the network, then fast-forward the local ref from the tracking ref.
+  const up = await git(["rev-parse", "--abbrev-ref", `${branch}@{upstream}`], root, 5_000);
+  if (!up.ok) return { ok: false, error: `"${branch}" has no upstream to pull from` };
+  const upstream = up.stdout; // e.g. "origin/main"
+  const slash = upstream.indexOf("/");
+  if (slash < 0) return { ok: false, error: `"${branch}" has an unexpected upstream "${upstream}"` };
+  const remote = upstream.slice(0, slash);
+  const remoteBranch = upstream.slice(slash + 1);
+
+  // Update refs/remotes/<remote>/<remoteBranch> from the network.
+  const fetched = await git(["fetch", remote, remoteBranch], root, 120_000);
+  if (!fetched.ok) return { ok: false, error: fetched.stderr || `git fetch failed (exit ${fetched.exitCode})` };
+
+  // `git fetch .` from the local repo is fast-forward-only — it refuses a non-ff
+  // update, which is exactly the divergence guard we want. Fast-forwarding from
+  // the freshly-updated tracking ref keeps the behind indicator honest afterwards
+  // (a direct `<remoteBranch>:<branch>` fetch would leave the tracking ref stale).
+  const ff = await git(
+    ["fetch", ".", `refs/remotes/${remote}/${remoteBranch}:refs/heads/${branch}`],
+    root,
+    10_000,
+  );
+  if (!ff.ok) {
+    return { ok: false, error: ff.stderr || `"${branch}" has diverged from ${upstream}; fast-forward not possible` };
+  }
   return { ok: true };
 }
 

--- a/src/mainview/components/kanban/BranchPicker.tsx
+++ b/src/mainview/components/kanban/BranchPicker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { GitBranch, RefreshCw } from "lucide-react";
+import { ArrowDownToLine, ArrowDownUp, GitBranch, RefreshCw } from "lucide-react";
 import { api, type BranchInfo } from "@/lib/api";
 import { SearchSelect } from "@/components/ui/search-select";
 import { cn } from "@/lib/utils";
@@ -56,20 +56,26 @@ export function BranchPicker({ workdir, value, onChange, className, label, title
   const [error, setError] = useState<string | null>(null);
   // `git fetch` failure, surfaced on the Fetch button only.
   const [fetchError, setFetchError] = useState<string | null>(null);
-  // Bumped by the Git Fetch button to re-run the listing effect after a
-  // `git fetch` lands new remote branches, without touching `workdir`.
+  // `git pull` failure, surfaced on the Pull button only (kept separate from
+  // `fetchError` for the same reason: don't mislabel a pull failure as a fetch).
+  const [pullError, setPullError] = useState<string | null>(null);
+  // Bumped by the Git Fetch/Pull buttons to re-run the listing effect after a
+  // `git fetch`/`git pull` changes refs, without touching `workdir`.
   const [refreshKey, setRefreshKey] = useState(0);
   const [fetching, setFetching] = useState(false);
+  const [pulling, setPulling] = useState(false);
   const lastWorkdirRef = useRef(workdir);
 
   useEffect(() => {
     let cancelled = false;
     setError(null);
-    // A workdir/refresh change abandons any in-flight fetch's UI: clear its
+    // A workdir/refresh change abandons any in-flight fetch/pull UI: clear its
     // spinner and error so they don't linger against the new project (the
-    // fetch promise itself is also guarded below).
+    // fetch/pull promises themselves are also guarded below).
     setFetching(false);
     setFetchError(null);
+    setPulling(false);
+    setPullError(null);
     // Reset eagerly so the picker never shows the previous project's branches
     // while the new fetch is in flight.
     setSnap({ workdir, list: [] });
@@ -96,13 +102,21 @@ export function BranchPicker({ workdir, value, onChange, className, label, title
     return () => { cancelled = true; };
   }, [workdir, refreshKey]);
 
+  // A pull failure is branch-specific ("can't fast-forward <branch>"), so clear
+  // it when the selection changes — otherwise its tooltip lingers on the Pull
+  // button against a different branch and reads as that branch's failure.
+  useEffect(() => { setPullError(null); }, [value]);
+
   // Pull all remotes, then re-list branches so freshly pushed `origin/*`
   // branches appear in the picker. Network-bound, so the trigger spins while
   // it runs; failures surface on the Fetch button via `fetchError`. The fetch
   // is tagged with the workdir it started against so a project switch mid-fetch
   // can't apply a stale result/spinner/error to the new project.
   const handleFetch = async () => {
-    if (!workdir || fetching) return;
+    // Don't fetch while a pull is mid-flight: two concurrent git network ops on
+    // the same repo race on git's ref/FETCH_HEAD locks. The Fetch button is also
+    // disabled while `pulling` for the same reason.
+    if (!workdir || fetching || pulling) return;
     const dir = workdir;
     setFetching(true);
     setFetchError(null);
@@ -116,10 +130,42 @@ export function BranchPicker({ workdir, value, onChange, className, label, title
     }
   };
 
+  // Fast-forward the selected local branch to its upstream, then re-list so the
+  // behind indicator clears. Network-bound like fetch; same workdir-tagging so a
+  // project switch mid-pull can't apply a stale spinner/error/result. Guarded by
+  // `canPull` below — only enabled for a local branch that has an upstream.
+  const handlePull = async () => {
+    if (!workdir || pulling || fetching || !canPull) return;
+    const dir = workdir;
+    const branch = value;
+    setPulling(true);
+    setPullError(null);
+    try {
+      await api.gitPull(dir, branch);
+      if (dir === lastWorkdirRef.current) setRefreshKey((k) => k + 1);
+    } catch (e) {
+      if (dir === lastWorkdirRef.current) setPullError(e instanceof Error ? e.message : String(e));
+    } finally {
+      if (dir === lastWorkdirRef.current) setPulling(false);
+    }
+  };
+
   // Only trust `branches` when its workdir matches the current one; otherwise
   // the data is stale from the prior project and would mislead both the
   // dropdown and the auto-select effect below.
   const branches = snap.workdir === workdir ? snap.list : [];
+
+  // The selected branch's tracking info drives the Pull button + behind badge.
+  // Pull only makes sense for a real local branch with an upstream — not the
+  // synthetic HEAD row, a remote-only `origin/*`, or a custom sha.
+  const selected = branches.find((b) => b.name === value);
+  const canPull = !!selected && !selected.remote && !!selected.upstream;
+  const behind = selected?.behind ?? 0;
+  const ahead = selected?.ahead ?? 0;
+  // Diverged = behind AND ahead → a fast-forward pull will be refused. We still
+  // let the user click Pull (the server returns the explicit ff error), but the
+  // badge/tooltip say "diverged" instead of steering them to "pull to ff".
+  const diverged = behind > 0 && ahead > 0;
 
   // When branches arrive and no explicit value is set, pre-select the current
   // branch so the trigger doesn't show a misleading "HEAD" while a real ref is
@@ -147,10 +193,11 @@ export function BranchPicker({ workdir, value, onChange, className, label, title
     });
   }
   for (const b of branches) {
+    const age = b.current ? `current · ${formatAge(b.committedAt)}` : formatAge(b.committedAt);
     items.push({
       value: b.name,
       label: b.name,
-      hint: b.current ? `current · ${formatAge(b.committedAt)}` : formatAge(b.committedAt),
+      hint: b.behind ? `${age} · ↓${b.behind} behind` : age,
       pinned: b.current,
     });
   }
@@ -166,22 +213,65 @@ export function BranchPicker({ workdir, value, onChange, className, label, title
 
   return (
     <div className={cn("min-w-0 space-y-1", className)}>
-      {/* Label + Git Fetch share one row so the picker below stays full-width.
-          The button sits flush-right (ml-auto) even when no label is given. */}
+      {/* Label + behind badge + Git Pull/Fetch share one row so the picker below
+          stays full-width. The controls sit flush-right (ml-auto) even with no label. */}
       <div className="flex items-center gap-2">
         {label && <label className="text-muted-foreground">{label}</label>}
+        {behind > 0 && (
+          diverged ? (
+            <span
+              className="ml-auto inline-flex items-center gap-0.5 text-xs font-medium text-amber-500"
+              title={`${selected?.name} has diverged from ${selected?.upstream ?? "the remote"} (${ahead} ahead, ${behind} behind) — fast-forward not possible`}
+            >
+              <ArrowDownUp className="size-3" aria-hidden />
+              diverged
+            </span>
+          ) : (
+            <span
+              className="ml-auto inline-flex items-center gap-0.5 text-xs font-medium text-amber-500"
+              title={`${behind} commit${behind === 1 ? "" : "s"} behind ${selected?.upstream ?? "the remote"} — pull to fast-forward`}
+            >
+              <ArrowDownToLine className="size-3" aria-hidden />
+              {behind} behind
+            </span>
+          )
+        )}
+        <button
+          type="button"
+          onClick={handlePull}
+          disabled={disabled || !workdir || pulling || fetching || !canPull}
+          title={
+            pullError
+              ? `Git pull failed: ${pullError}`
+              : !selected || selected.remote
+                ? "Select a local branch to pull"
+                : !selected.upstream
+                  ? `No upstream configured for ${selected.name}`
+                  : diverged
+                    ? `${selected.name} has diverged from ${selected.upstream} — fast-forward will fail; reconcile it manually`
+                    : `Fast-forward ${selected.name} to ${selected.upstream} (git pull --ff-only)`
+          }
+          className={cn(
+            "inline-flex items-center gap-1 rounded text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            behind > 0 ? "" : "ml-auto",
+            (disabled || !workdir || pulling || fetching || !canPull) && "cursor-not-allowed opacity-50",
+          )}
+        >
+          <ArrowDownToLine className={cn("size-3", pulling && "animate-pulse")} aria-hidden />
+          {pulling ? "Pulling…" : "Pull"}
+        </button>
         <button
           type="button"
           onClick={handleFetch}
-          disabled={disabled || !workdir || fetching}
+          disabled={disabled || !workdir || fetching || pulling}
           title={
             fetchError
               ? `Git fetch failed: ${fetchError}`
               : "Fetch all branches from remote (git fetch --all --prune)"
           }
           className={cn(
-            "ml-auto inline-flex items-center gap-1 rounded text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-            (disabled || !workdir || fetching) && "cursor-not-allowed opacity-50",
+            "inline-flex items-center gap-1 rounded text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            (disabled || !workdir || fetching || pulling) && "cursor-not-allowed opacity-50",
           )}
         >
           <RefreshCw className={cn("size-3", fetching && "animate-spin")} aria-hidden />

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   AgentKind,
   AgentStatus,
   AppEvent,
+  BranchInfo,
   ColumnId,
   GlobalEvent,
   Harness,
@@ -26,7 +27,10 @@ export interface UpdateSnapshot {
   lastCheckedAt: number | null;
 }
 
-export interface BranchInfo { name: string; committedAt: number; current: boolean }
+// Re-exported from shared so existing `import { type BranchInfo } from "@/lib/api"`
+// callers (BranchPicker) keep working while the single definition lives in
+// src/shared/types.ts (server + webview share one wire shape).
+export type { BranchInfo };
 
 /** Where a command/extension comes from. `plugin` entries are contributed by an
  *  enabled Claude Code plugin and are namespaced `<plugin>:<name>`; `builtin`
@@ -240,6 +244,15 @@ export const api = {
     j<{ ok: true }>("/projects/fetch", {
       method: "POST",
       body: JSON.stringify({ path: dir }),
+    }),
+  /** Fast-forward a single local `branch` to its upstream (the picker's Git Pull
+   *  button). The caller re-lists branches afterwards so the behind indicator
+   *  refreshes. Rejects (ApiError) on divergence, missing upstream, or network
+   *  failure — the git stderr rides along as the error message. */
+  gitPull: (dir: string, branch: string) =>
+    j<{ ok: true }>("/projects/pull", {
+      method: "POST",
+      body: JSON.stringify({ path: dir, branch }),
     }),
   getTmuxSource: () =>
     j<{

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -808,6 +808,33 @@ export interface Project {
 }
 
 /**
+ * A branch surfaced by the new-task base-ref picker. Shared so the server
+ * (`listBranches` in src/bun/worktree.ts) and the webview (`api.ts` /
+ * `BranchPicker`) agree on a single wire shape — the previous per-side copies
+ * had already silently drifted (the client one omitted `remote`).
+ */
+export interface BranchInfo {
+  /** Short ref name, e.g. "main", "feature/x", or "origin/feature/x". */
+  name: string;
+  /** Unix-ms timestamp of the tip commit, used to sort recents first. */
+  committedAt: number;
+  /** True for the branch currently checked out at the repo. */
+  current: boolean;
+  /** True for remote-tracking refs (`refs/remotes/<remote>/<name>`). */
+  remote: boolean;
+  /** Short name of the upstream tracking ref (e.g. "origin/main"), or null when
+   *  the branch has no configured upstream or is itself a remote-tracking ref. */
+  upstream: string | null;
+  /** Commits the upstream has that this branch lacks ("behind" count). 0 when up
+   *  to date; null when there's no upstream. Reflects the last fetch (compared
+   *  against the local remote-tracking ref, not the network). */
+  behind: number | null;
+  /** Commits this branch has that the upstream lacks ("ahead" count). Used to
+   *  detect divergence (ahead > 0 && behind > 0). Null when there's no upstream. */
+  ahead: number | null;
+}
+
+/**
  * @deprecated Use {@link HarnessStatus} instead. Kept as a type alias so the
  * webview code that already imported `AgentStatus` doesn't need to rename;
  * the shape is now per-harness (multiple rows can share a `kind`).


### PR DESCRIPTION
…branch picker

Adds a Git Pull action next to the existing Fetch button that fast-forwards the selected branch to its upstream, plus a "behind remote" indicator on the selected branch and per dropdown row.

- worktree.ts: new gitPull(dir, branch) — fast-forward only; `git pull --ff-only` for the checked-out branch, a checkout-free fetch + fast-forward for any other local branch; rejects "-"-leading names. listBranches now reports upstream/ahead/behind via the same for-each-ref pass (no extra git spawns, no network).
- Fix a pre-existing dedup bug: a local branch that was behind its remote was dropped from the picker (committerdate sort + first-seen dedup collapsing it to the remote-tracking ref). Replaced with a two-pass dedup that deterministically prefers local heads.
- server.ts: POST /projects/pull.
- Consolidate BranchInfo into src/shared/types.ts (was duplicated across the bun and webview sides and had silently drifted).
- BranchPicker: Pull button + behind/diverged badge; mutually disabled with Fetch so two git network ops can't race; clears the branch-specific pull error when the selection changes.

Tests: gitPull (checked-out/non-checked-out fast-forward, diverged refusal, no-upstream, non-repo, dash guard) and the behind/dedup regression. 575 pass.