### PR TITLE
fix(claude-tmux): surface questions raised after a task resolves to r…

### DIFF
--- a/src/bun/claude-tmux-scraper.test.ts
+++ b/src/bun/claude-tmux-scraper.test.ts
@@ -338,3 +338,144 @@ test("dispatchLine updates permissionMode BEFORE the dedup guard (reattach safet
   expect(state.permissionMode).toBe("plan");
   __forTest.uninstallSession("t-pm-reattach");
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Idle scrape throttle — regression for "a question raised after the task went
+// to review never appears in the stream (user has to answer it in tmux)".
+//
+// A native AskUserQuestion / permission modal appears with NO JSONL write
+// (claude doesn't persist the tool_use until it's answered), so once a session
+// is JSONL-idle past SCRAPE_IDLE_AFTER_MS the old hard `return` stopped the
+// scraper forever — `lastJsonlAppendAt` never advanced again, so a modal raised
+// after the turn resolved was never captured. The throttle must keep scraping.
+
+const {
+  decideScrapeTick,
+  SCRAPE_IDLE_AFTER_MS,
+  SCRAPE_IDLE_POLL_MS,
+  SCRAPE_DEEP_IDLE_AFTER_MS,
+  SCRAPE_DEEP_IDLE_POLL_MS,
+} = __forTest;
+
+const NOW = 1_000_000;
+// A session that's been JSONL-quiet long enough to be idle, but not yet
+// "deeply" idle — the common "just resolved to review" window (2s cadence).
+const NEAR_IDLE_APPEND = NOW - (SCRAPE_IDLE_AFTER_MS + 1_000);
+// A session quiet past SCRAPE_DEEP_IDLE_AFTER_MS — the slow 10s cadence.
+const DEEP_IDLE_APPEND = NOW - (SCRAPE_DEEP_IDLE_AFTER_MS + 5_000);
+
+test("decideScrapeTick — busy session (turn in flight) always scrapes at full rate", () => {
+  const d = decideScrapeTick({
+    turnInFlight: true,
+    lastJsonlAppendAt: 0,
+    activePromptCount: 0,
+    askCardLive: false,
+    lastIdleScrapeAt: 0,
+    now: NOW,
+  });
+  expect(d).toEqual({ run: true, stampIdle: false });
+});
+
+test("decideScrapeTick — recently-active session (within idle window) scrapes, no idle stamp", () => {
+  const d = decideScrapeTick({
+    turnInFlight: false,
+    lastJsonlAppendAt: NOW - (SCRAPE_IDLE_AFTER_MS - 1), // still 'recent'
+    activePromptCount: 0,
+    askCardLive: false,
+    lastIdleScrapeAt: 0,
+    now: NOW,
+  });
+  expect(d).toEqual({ run: true, stampIdle: false });
+});
+
+test("decideScrapeTick — near-idle session STILL scrapes once past the 2s throttle (the bug)", () => {
+  // No turn in flight, JSONL silent past SCRAPE_IDLE_AFTER_MS, last idle
+  // capture > SCRAPE_IDLE_POLL_MS ago. The old code returned here and never
+  // looked at the pane again — stranding a modal raised after `review`.
+  const d = decideScrapeTick({
+    turnInFlight: false,
+    lastJsonlAppendAt: NEAR_IDLE_APPEND,
+    activePromptCount: 0,
+    askCardLive: false,
+    lastIdleScrapeAt: NOW - SCRAPE_IDLE_POLL_MS - 1,
+    now: NOW,
+  });
+  expect(d).toEqual({ run: true, stampIdle: true });
+});
+
+test("decideScrapeTick — near-idle but within the 2s throttle skips (keeps idle cost low)", () => {
+  const d = decideScrapeTick({
+    turnInFlight: false,
+    lastJsonlAppendAt: NEAR_IDLE_APPEND,
+    activePromptCount: 0,
+    askCardLive: false,
+    lastIdleScrapeAt: NOW - (SCRAPE_IDLE_POLL_MS - 1), // just scraped
+    now: NOW,
+  });
+  expect(d).toEqual({ run: false, stampIdle: false });
+});
+
+test("decideScrapeTick — deeply-idle session backs off to the 10s cadence", () => {
+  // Quiet > SCRAPE_DEEP_IDLE_AFTER_MS, and the last capture was 3s ago. At the
+  // near-idle 2s rate this would scrape; the deep tier must skip it so long-
+  // dead sessions don't fork tmux every 2s forever.
+  const d = decideScrapeTick({
+    turnInFlight: false,
+    lastJsonlAppendAt: DEEP_IDLE_APPEND,
+    activePromptCount: 0,
+    askCardLive: false,
+    lastIdleScrapeAt: NOW - 3_000, // > SCRAPE_IDLE_POLL_MS but < SCRAPE_DEEP_IDLE_POLL_MS
+    now: NOW,
+  });
+  expect(d).toEqual({ run: false, stampIdle: false });
+});
+
+test("decideScrapeTick — deeply-idle session still scrapes once past the 10s cadence (very-late modal)", () => {
+  const d = decideScrapeTick({
+    turnInFlight: false,
+    lastJsonlAppendAt: DEEP_IDLE_APPEND,
+    activePromptCount: 0,
+    askCardLive: false,
+    lastIdleScrapeAt: NOW - SCRAPE_DEEP_IDLE_POLL_MS - 1,
+    now: NOW,
+  });
+  expect(d).toEqual({ run: true, stampIdle: true });
+});
+
+test("decideScrapeTick — a live ask-card forces full-rate scraping (modal-gone backstop)", () => {
+  const d = decideScrapeTick({
+    turnInFlight: false,
+    lastJsonlAppendAt: DEEP_IDLE_APPEND,
+    activePromptCount: 0,
+    askCardLive: true, // card up → never idle-gated
+    lastIdleScrapeAt: NOW, // would otherwise be inside the throttle window
+    now: NOW,
+  });
+  expect(d).toEqual({ run: true, stampIdle: false });
+});
+
+test("decideScrapeTick — a pending prompt forces full-rate scraping (auto-cancel backstop)", () => {
+  const d = decideScrapeTick({
+    turnInFlight: false,
+    lastJsonlAppendAt: DEEP_IDLE_APPEND,
+    activePromptCount: 1,
+    askCardLive: false,
+    lastIdleScrapeAt: NOW,
+    now: NOW,
+  });
+  expect(d).toEqual({ run: true, stampIdle: false });
+});
+
+test("decideScrapeTick — a session that never appended (lastJsonlAppendAt === 0) is not idle-gated", () => {
+  // Guards the `lastJsonlAppendAt !== 0` clause: a brand-new session shouldn't
+  // be treated as idle before it has produced any output.
+  const d = decideScrapeTick({
+    turnInFlight: false,
+    lastJsonlAppendAt: 0,
+    activePromptCount: 0,
+    askCardLive: false,
+    lastIdleScrapeAt: 0,
+    now: NOW,
+  });
+  expect(d).toEqual({ run: true, stampIdle: false });
+});

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -994,6 +994,15 @@ interface SessionState {
    *  and (b) cheaply detect a truly idle session so the 1s scrape
    *  tick can self-throttle. 0 means "no append observed yet". */
   lastJsonlAppendAt: number;
+  /** `Date.now()` of the last pane capture taken while the session was
+   *  JSONL-idle (no turn in flight, no recent append). A native modal —
+   *  AskUserQuestion or a permission dialog — can appear with NO JSONL
+   *  write (claude doesn't persist the tool_use until it's answered), so
+   *  the idle path can't stop scraping entirely or it would never see a
+   *  question raised after the turn already resolved to `review`. Instead
+   *  it throttles to one capture every `SCRAPE_IDLE_POLL_MS`, stamping the
+   *  time here. 0 means "no idle capture taken yet". */
+  lastIdleScrapeAt: number;
   /** Fingerprint → `Date.now()` of when it was answered. The route
    *  handler stamps an entry here right after `dismissTmuxPrompt`; the
    *  scraper skips re-registering a fingerprint that's still inside
@@ -1138,6 +1147,7 @@ function makeSessionState(o: MakeSessionStateOpts): SessionState {
     scrapeTimer: null,
     scrapeLastFingerprint: null,
     lastJsonlAppendAt: 0,
+    lastIdleScrapeAt: 0,
     recentlyAnsweredFingerprints: new Map(),
     askCardId: null,
     askCollecting: false,
@@ -2275,31 +2285,86 @@ const RECENTLY_ANSWERED_TTL_MS = 3_000;
  *  stable modal awaiting input. */
 const JSONL_RECENT_WRITE_MS = 500;
 
-/** Beyond this idle window with no active turn, the scraper stops
- *  tick'ing entirely — there's no plausible scenario where a brand-
- *  new modal appears on a session that hasn't seen output in a long
- *  time. Idle sessions cost nothing this way. */
+/** Beyond this idle window with no active turn, the scraper drops to a
+ *  reduced cadence (`SCRAPE_IDLE_POLL_MS`) instead of every tick. It can't
+ *  stop entirely: a native modal — an AskUserQuestion or a permission
+ *  dialog raised by a background workflow after the turn already resolved
+ *  to `review` — appears with NO JSONL write, so `lastJsonlAppendAt` would
+ *  stay frozen and a hard stop would never see the question (the user would
+ *  have to answer it in tmux). The throttle keeps idle sessions cheap while
+ *  still catching a late modal within a couple of seconds. */
 const SCRAPE_IDLE_AFTER_MS = 5_000;
+
+/** While JSONL-idle but recently so, capture the pane at most this often (vs
+ *  every `SCRAPE_INTERVAL_MS`). This is the common "task just resolved to
+ *  `review` and a question is about to pop" window — keep it snappy. */
+const SCRAPE_IDLE_POLL_MS = 2_000;
+
+/** Once a session has been JSONL-quiet this long, drop to the much slower
+ *  deep-idle cadence below. The previous code stopped scraping idle sessions
+ *  entirely ("idle costs nothing"); we can't (a modal writes no JSONL), but a
+ *  session that's been silent for minutes is almost certainly parked at the
+ *  REPL with nothing pending, so polling it every 2s forever is wasteful when
+ *  the board holds many completed-but-undeleted tasks (each keeps its tmux
+ *  session for follow-ups). The deep tier keeps long-dead sessions ~cheap
+ *  while still eventually catching a very-late modal. */
+const SCRAPE_DEEP_IDLE_AFTER_MS = 60_000;
+
+/** Pane-capture cadence for a deeply-idle session (quiet > `SCRAPE_DEEP_IDLE_
+ *  AFTER_MS`). 5× cheaper than the near-idle rate. */
+const SCRAPE_DEEP_IDLE_POLL_MS = 10_000;
+
+/** Pure idle-throttle decision for `scrapeOnce`, factored out so the cadence
+ *  logic is unit-testable without tmux. A session is "JSONL-idle" when no turn
+ *  is in flight, nothing has appended to its JSONL for `SCRAPE_IDLE_AFTER_MS`,
+ *  no prompt is already pending, and no ask-card is live. When idle we still
+ *  scrape — a native modal (AskUserQuestion / permission dialog) can appear
+ *  with NO JSONL write, so a hard stop would never see a question raised after
+ *  the turn resolved to `review`. We throttle, fast right after going idle and
+ *  backing off once the session has been quiet a while (`SCRAPE_DEEP_IDLE_*`),
+ *  using `now - lastJsonlAppendAt` as the idle-depth clock — no extra state.
+ *  `run` says whether to capture the pane this tick; `stampIdle` says whether
+ *  the caller should record this as the latest idle capture. */
+function decideScrapeTick(p: {
+  turnInFlight: boolean;
+  lastJsonlAppendAt: number;
+  activePromptCount: number;
+  askCardLive: boolean;
+  lastIdleScrapeAt: number;
+  now: number;
+}): { run: boolean; stampIdle: boolean } {
+  const idleFor = p.now - p.lastJsonlAppendAt;
+  const idle = !p.turnInFlight
+    && p.lastJsonlAppendAt !== 0
+    && idleFor > SCRAPE_IDLE_AFTER_MS
+    && p.activePromptCount === 0
+    && !p.askCardLive;
+  if (!idle) return { run: true, stampIdle: false };
+  const pollInterval = idleFor > SCRAPE_DEEP_IDLE_AFTER_MS
+    ? SCRAPE_DEEP_IDLE_POLL_MS
+    : SCRAPE_IDLE_POLL_MS;
+  if (p.now - p.lastIdleScrapeAt < pollInterval) return { run: false, stampIdle: false };
+  return { run: true, stampIdle: true };
+}
 
 /** Run a single scrape tick. Idempotent: registers at most one new
  *  TmuxPromptRequest per call, auto-cancels any pending one whose
  *  fingerprint no longer matches the pane. */
 function scrapeOnce(state: SessionState): void {
   const now = Date.now();
-  // Idle gate: skip the syscall entirely when nothing is plausibly
-  // happening. A session with no turn in flight that hasn't appended
-  // to its JSONL in 5s is at the REPL prompt; the user isn't waiting
-  // on a modal we missed.
-  if (state.turnQueue.length === 0
-      && state.lastJsonlAppendAt !== 0
-      && now - state.lastJsonlAppendAt > SCRAPE_IDLE_AFTER_MS
-      && activeTmuxPromptsForTask(state.taskId).length === 0
-      // Keep polling while an AskUserQuestion card is live, so the
-      // resolve-on-modal-gone backstop fires if the user answers it via a real
-      // `tmux attach` (external dismissal) rather than the card.
-      && state.askCardId === null) {
-    return;
-  }
+  const tick = decideScrapeTick({
+    turnInFlight: state.turnQueue.length > 0,
+    lastJsonlAppendAt: state.lastJsonlAppendAt,
+    activePromptCount: activeTmuxPromptsForTask(state.taskId).length,
+    // Keep polling at full rate while an AskUserQuestion card is live, so the
+    // resolve-on-modal-gone backstop fires if the user answers it via a real
+    // `tmux attach` (external dismissal) rather than the card.
+    askCardLive: state.askCardId !== null,
+    lastIdleScrapeAt: state.lastIdleScrapeAt,
+    now,
+  });
+  if (tick.stampIdle) state.lastIdleScrapeAt = now;
+  if (!tick.run) return;
 
   const cap = tmux(["capture-pane", "-p", "-t", state.sessionName]);
   if (!cap.ok) {
@@ -2380,7 +2445,12 @@ function scrapeOnce(state: SessionState): void {
   // Stability gate (see `clearedStabilityGate`): a high-confidence match
   // registers on first sighting; everything else waits for the same
   // fingerprint on two consecutive scrapes. Record the fingerprint either way
-  // so the next tick can satisfy the two-tick rule.
+  // so the next tick can satisfy the two-tick rule. Note: while the session is
+  // JSONL-idle the capturing ticks are spaced by the idle cadence
+  // (`SCRAPE_IDLE_POLL_MS`+), not 1s, so a numbered/yes-no modal raised after
+  // the turn resolved to `review` registers in ~two idle ticks rather than ~2s;
+  // the AskUserQuestion path above and any high-confidence match skip the gate
+  // and surface on the first idle capture.
   const cleared = clearedStabilityGate(match, state.scrapeLastFingerprint);
   state.scrapeLastFingerprint = match.fingerprint;
   if (!cleared) return;
@@ -3295,6 +3365,15 @@ export const __forTest = {
   matchYesNoModal,
   matchStartupConsentDialog,
   clearedStabilityGate,
+  /** Pure idle-throttle decision used by `scrapeOnce` — exposed so the
+   *  regression test can assert a JSONL-idle session keeps scraping (at the
+   *  throttled cadence) instead of stopping forever, which would strand a
+   *  modal raised after the turn resolved to `review`. */
+  decideScrapeTick,
+  SCRAPE_IDLE_AFTER_MS,
+  SCRAPE_IDLE_POLL_MS,
+  SCRAPE_DEEP_IDLE_AFTER_MS,
+  SCRAPE_DEEP_IDLE_POLL_MS,
   readPendingAskQuestionsFromJsonl,
   shouldWaitForAskJsonl,
   resumeJsonlOffset,

--- a/src/bun/orchestrator.test.ts
+++ b/src/bun/orchestrator.test.ts
@@ -77,6 +77,40 @@ test("createTask + startTask runs to completion and emits stdout", async () => {
   expect(statuses.some((s) => s.startsWith("exit:"))).toBe(true);
 });
 
+test("task.runId survives the resolve-to-review transition (so a question raised in review can still register)", async () => {
+  // Regression guard for the post-review AskUserQuestion fix: the scraper's
+  // collectAndRegisterAskCard (claude-tmux.ts) bails with `if (!runId) return`,
+  // so if the review transition cleared task.runId, a question raised after the
+  // turn resolved would never register — the exact symptom we just fixed. The
+  // updateColumn path must leave run_id intact (only reconcileOrphans / delete
+  // clear it).
+  const { createTask, startTask } = await import("./orchestrator.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const created = await createTask({
+    title: "runId survives review",
+    prompt: "hello",
+    agent: "claude-code",
+    workdir: process.cwd(),
+    isolation: "none",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const task = created.task;
+
+  const res = await startTask(task.id);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  const runId = res.runId;
+
+  // Let the fake driver resolve the turn (exit 0 → succeeded → review).
+  await new Promise((r) => setTimeout(r, 250));
+
+  const after = tasks.get(task.id);
+  expect(after?.column).toBe("review");
+  expect(after?.runId).toBe(runId);
+
+  db.run(`DELETE FROM tasks WHERE id = ?`, [task.id]);
+});
+
 test("sendInput folds a follow-up into the in-flight run instead of stranding a new one", async () => {
   // Regression for the "queue status never recovers" bug: a message sent
   // while a claude turn is in flight must fold into the active run (same


### PR DESCRIPTION
…eview

A native AskUserQuestion/permission modal writes no JSONL until it is answered, so the scraper's idle gate — which stopped scraping a session that had been JSONL-quiet for 5s — never saw a question raised after the turn already resolved to `review` (the background-workflow "kept running after TURN COMPLETE" case). `lastJsonlAppendAt` stayed frozen, the gate stayed engaged forever, and the card was never registered or broadcast: the user had to answer in tmux.

Replace the hard stop with a two-tier idle throttle. A pure, testable `decideScrapeTick` keeps scraping while idle — every 2s right after the turn resolves, backing off to 10s once the session has been quiet for a minute — so a late modal is caught while long-dead sessions (each keeps a live tmux session for follow-ups) stay cheap. Idle depth is derived from `now - lastJsonlAppendAt`; only `lastIdleScrapeAt` is added to state.

Tests: 8 decideScrapeTick unit tests covering both tiers and the ask-card / pending-prompt / never-appended backstops, plus an orchestrator test locking that task.runId survives the resolve-to-review transition (the assumption collectAndRegisterAskCard's `if (!runId) return` relies on).