### PR TITLE
feat(claude-code): track background agents as read-only stream tabs

### DIFF
--- a/src/bun/claude-subagents.integration.test.ts
+++ b/src/bun/claude-subagents.integration.test.ts
@@ -1,0 +1,163 @@
+/**
+ * End-to-end verification of the background-agent tracking feature against the
+ * REAL Claude Code transcript layout — using genuine `subagents/agent-*.jsonl`
+ * files (not synthetic fixtures) when they're present on this machine, exercised
+ * through the actual HTTP server routes the webview uses.
+ *
+ * Flow under test (production code paths, nothing stubbed except the tmux spawn
+ * — `attachSubagentWatcher` is invoked exactly as `attachTailer` does it):
+ *   real agent-*.jsonl  →  watcher  →  mapJsonlEventToChunks  →  run_events
+ *   (tagged subagent_id) + `subagents` registry  →  GET /tasks/:id/subagents
+ *   and the GET /tasks/:id/events SSE replay (subagentId threaded through).
+ *
+ * Safe: its own temp DATA_DIR + dedicated port, no tmux, no claude spawn, never
+ * touches a running agetor instance. Skips cleanly on a machine/CI without the
+ * sample transcripts.
+ */
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, mkdirSync, copyFileSync, existsSync, readdirSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import path from "node:path";
+
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-subagents-itest-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+process.env.AGETOR_API_PORT = "4402";
+
+// The sample transcripts produced by this repo's own session. Present on the
+// dev machine; absent elsewhere → the test self-skips.
+const REAL_SUBAGENTS_DIR = path.join(
+  homedir(),
+  ".claude/projects/-Users-alamosaravali--agetor-worktrees-e803837b-7b8b-4d34-9830-15677d9bd9df",
+  "2122c7f4-4813-4eb7-9889-77793afc6a92",
+  "subagents",
+);
+const HAVE_REAL = existsSync(REAL_SUBAGENTS_DIR)
+  && readdirSync(REAL_SUBAGENTS_DIR).some((f) => /^agent-.+\.jsonl$/.test(f));
+
+let server: { stop: () => void; port: number };
+let token: string;
+
+beforeAll(async () => {
+  await import("./db.ts");
+  const { startApiServer, API_TOKEN } = await import("./server.ts");
+  server = startApiServer() as unknown as { stop: () => void; port: number };
+  token = API_TOKEN;
+});
+
+afterAll(() => { server?.stop?.(); });
+
+const url = (p: string) => `http://127.0.0.1:4402${p}`;
+const authed = (p: string) => fetch(url(p), { headers: { authorization: `Bearer ${token}` } });
+
+/** Read an SSE endpoint for `ms`, returning the parsed `data:` frames. */
+async function readSse(p: string, ms: number): Promise<any[]> {
+  const ctrl = new AbortController();
+  const res = await fetch(url(`${p}?token=${encodeURIComponent(token)}`), { signal: ctrl.signal });
+  const reader = res.body!.getReader();
+  const dec = new TextDecoder();
+  const out: any[] = [];
+  const deadline = Date.now() + ms;
+  let buf = "";
+  try {
+    while (Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      const r = await Promise.race([
+        reader.read(),
+        new Promise<{ value: undefined; done: true }>((res2) => setTimeout(() => res2({ value: undefined, done: true }), Math.max(1, remaining))),
+      ]);
+      if (r.done) break;
+      buf += dec.decode(r.value, { stream: true });
+      let i: number;
+      while ((i = buf.indexOf("\n\n")) >= 0) {
+        const frame = buf.slice(0, i);
+        buf = buf.slice(i + 2);
+        const line = frame.split("\n").find((l) => l.startsWith("data:"));
+        if (!line) continue;
+        try { out.push(JSON.parse(line.slice(5).trim())); } catch { /* ping / partial */ }
+      }
+    }
+  } finally {
+    ctrl.abort();
+  }
+  return out;
+}
+
+test.skipIf(!HAVE_REAL)(
+  "real claude subagent transcripts surface via /tasks/:id/subagents and the events SSE",
+  async () => {
+    const { tasks, runs, subagents } = await import("./db.ts");
+    const { attachSubagentWatcher } = await import("./claude-subagents.ts");
+
+    // Seed a task + (terminal) run — terminal so it doesn't perturb the shared
+    // reconcileOrphans scan (see the bun-test shared-db note).
+    const taskId = `task-itest-${randomUUID()}`;
+    const runId = `run-itest-${randomUUID()}`;
+    const now = Date.now();
+    tasks.insert({
+      id: taskId, title: "t", prompt: "p", column: "running", agent: "claude-code",
+      workdir: "/tmp", isolation: "none", taskType: "task", branch: null, worktreePath: null,
+      baseRef: null, mode: null, model: null, effort: null, references: [], runId,
+      hasOpenableRun: false, pendingInteractionCount: 0, openTerminalCount: 0,
+      archivedAt: null, createdAt: now, updatedAt: now,
+    });
+    runs.insert({
+      id: runId, taskId, agent: "claude-code", status: "succeeded", startedAt: now,
+      endedAt: now, exitCode: 0, tmuxSession: null, claudeSessionId: null, codexSessionId: null,
+    });
+
+    // Lay out a real `<sessionId>/subagents/` tree by copying the genuine
+    // transcripts, then point the watcher at the derived main jsonlPath.
+    const sessionId = randomUUID();
+    const proj = path.join(DATA_DIR, "projects", "encoded");
+    const subDir = path.join(proj, sessionId, "subagents");
+    mkdirSync(subDir, { recursive: true });
+    const copied: string[] = [];
+    for (const f of readdirSync(REAL_SUBAGENTS_DIR)) {
+      if (/^agent-.+\.(jsonl|meta\.json)$/.test(f)) {
+        copyFileSync(path.join(REAL_SUBAGENTS_DIR, f), path.join(subDir, f));
+        const m = /^agent-(.+)\.jsonl$/.exec(f);
+        if (m) copied.push(m[1]!);
+      }
+    }
+    expect(copied.length).toBeGreaterThanOrEqual(1);
+    const jsonlPath = path.join(proj, `${sessionId}.jsonl`);
+
+    // Drive the real watcher exactly as attachTailer does, then settle it.
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    w.pump(Date.now());            // discover + tail real transcripts
+    w.pump(Date.now() + 60_000);   // idle past the done threshold → completed
+
+    // 1) HTTP snapshot route returns every real subagent with its meta label.
+    const snap = await authed(`/tasks/${taskId}/subagents`);
+    expect(snap.status).toBe(200);
+    const list = (await snap.json()) as Array<{ id: string; agentType: string | null; status: string }>;
+    expect(list.map((s) => s.id).sort()).toEqual([...copied].sort());
+    // These genuine transcripts were spawned as Explore / claude-code-guide.
+    expect(list.every((s) => typeof s.agentType === "string" && s.agentType.length > 0)).toBe(true);
+    expect(list.every((s) => s.status === "completed")).toBe(true);
+
+    // 2) The events SSE replay carries the subagents' transcript content,
+    //    tagged with the right subagentId and parsed into real event kinds.
+    const events = await readSse(`/tasks/${taskId}/events`, 1500);
+    const tagged = events.filter((e) => e.subagentId && copied.includes(e.subagentId));
+    expect(tagged.length).toBeGreaterThan(0);
+    // Real subagent work includes assistant text and tool calls.
+    const kinds = new Set(tagged.map((e) => e.stream));
+    expect([...kinds].some((k) => k === "assistant" || k === "tool_use" || k === "user")).toBe(true);
+    // Every tagged event names a real subagent and the right task.
+    expect(tagged.every((e) => e.taskId === taskId)).toBe(true);
+
+    w.detach();
+  },
+);
+
+test("integration harness is wired even when sample transcripts are absent", () => {
+  // Guards against the whole file silently skipping (e.g. a broken path) by
+  // always asserting the server booted. The real assertions run on the dev box.
+  expect(typeof token).toBe("string");
+  expect(token.length).toBeGreaterThan(0);
+  if (!HAVE_REAL) {
+    console.log("[itest] sample claude subagent transcripts not present — real-transcript case skipped");
+  }
+});

--- a/src/bun/claude-subagents.test.ts
+++ b/src/bun/claude-subagents.test.ts
@@ -142,6 +142,54 @@ test("marks a subagent completed after end_turn + idle, without double-emitting 
   setSubagentEmitter(null);
 });
 
+test("a resumed (re-running) subagent is not re-completed until its new turn ends", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+  setSubagentEmitter(() => { /* drain */ });
+
+  const agentId = "resume0a1b2c3";
+  const file = path.join(subagentsDir, `agent-${agentId}.jsonl`);
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "Explore", description: "resumable", spawnDepth: 1 }));
+  // First turn: ends with end_turn → completes.
+  writeFileSync(file,
+    JSON.stringify({ type: "user", isSidechain: true, uuid: "ru", message: { role: "user", content: "go" } }) + "\n" +
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: "rA", message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "done turn 1" }] } }) + "\n");
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0);
+  w.pump(t0 + 10_000);
+  expect(subagents.get(agentId)!.status).toBe("completed");
+
+  // Resume: append a NEW turn that has NOT ended yet (a tool_use, stop_reason
+  // "tool_use"). Re-tail via a fresh watcher (reattach path re-reads from 0;
+  // the DB-seeded dedup skips the old lines, and the unfinished new line flips
+  // the agent back to running).
+  appendFileSync(file,
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: "rB", message: { role: "assistant", stop_reason: "tool_use", content: [{ type: "tool_use", id: "t9", name: "Bash", input: { command: "ls" } }] } }) + "\n");
+  w.detach();
+
+  const w2 = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  w2.pump(t0 + 10_001);
+  expect(subagents.get(agentId)!.status).toBe("running");
+  // Idle WITHOUT a fresh end_turn: the reset `sawEndOfTurn` must keep it
+  // running (the bug this guards against would re-complete it here).
+  w2.pump(t0 + 40_000);
+  expect(subagents.get(agentId)!.status).toBe("running");
+
+  // The resumed turn finally ends → completes again.
+  appendFileSync(file,
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: "rC", message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "done turn 2" }] } }) + "\n");
+  w2.pump(t0 + 40_001);
+  w2.pump(t0 + 80_000);
+  expect(subagents.get(agentId)!.status).toBe("completed");
+
+  w2.detach();
+  setSubagentEmitter(null);
+});
+
 test("AGETOR_TRACK_SUBAGENTS=0 yields an inert no-op watcher", async () => {
   const prev = process.env.AGETOR_TRACK_SUBAGENTS;
   process.env.AGETOR_TRACK_SUBAGENTS = "0";

--- a/src/bun/claude-subagents.test.ts
+++ b/src/bun/claude-subagents.test.ts
@@ -1,0 +1,160 @@
+import { test, expect, beforeAll } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { RunEvent } from "../shared/types.ts";
+
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-subagents-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+
+beforeAll(async () => {
+  await import("./db.ts");
+});
+
+/** Build a temp `<sessionId>/subagents/` layout + a seeded task/run, returning
+ *  the jsonlPath the watcher derives the subagents dir from. */
+async function seed() {
+  const { tasks, runs } = await import("./db.ts");
+  const taskId = `task-sub-${randomUUID()}`;
+  const runId = `run-sub-${randomUUID()}`;
+  const now = Date.now();
+  tasks.insert({
+    id: taskId, title: "t", prompt: "p", column: "running", agent: "claude-code",
+    workdir: "/tmp", isolation: "none", taskType: "task", branch: null, worktreePath: null,
+    baseRef: null, mode: null, model: null, effort: null, references: [], runId,
+    hasOpenableRun: false, pendingInteractionCount: 0, openTerminalCount: 0,
+    archivedAt: null, createdAt: now, updatedAt: now,
+  });
+  // Insert the run as already-terminal: bun test shares one SQLite db across
+  // files, and reconcileOrphans() scans every `running` run globally — a
+  // lingering `running` row here would pollute reconcile.test.ts. The watcher
+  // attaches subagent events by task.runId regardless of the run's status, so
+  // this doesn't affect what we're testing.
+  runs.insert({
+    id: runId, taskId, agent: "claude-code", status: "succeeded", startedAt: now,
+    endedAt: now, exitCode: 0, tmuxSession: null, claudeSessionId: null, codexSessionId: null,
+  });
+
+  const sessionId = randomUUID();
+  const proj = path.join(DATA_DIR, "projects", "encoded");
+  const subagentsDir = path.join(proj, sessionId, "subagents");
+  mkdirSync(subagentsDir, { recursive: true });
+  const jsonlPath = path.join(proj, `${sessionId}.jsonl`);
+  return { taskId, runId, jsonlPath, subagentsDir };
+}
+
+function sidechainLines(): string {
+  return [
+    JSON.stringify({ type: "user", isSidechain: true, uuid: "u1", message: { role: "user", content: "do the thing" } }),
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: "a1", message: { role: "assistant", stop_reason: "tool_use", content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "ls" } }] } }),
+  ].join("\n") + "\n";
+}
+
+test("discovers a subagent file, tags its events, and emits lifecycle", async () => {
+  const { subagents, db } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+  const { taskId, runId, jsonlPath, subagentsDir } = await seed();
+
+  const captured: RunEvent[] = [];
+  setSubagentEmitter((e) => captured.push(e));
+
+  const agentId = "a1b2c3d4e5f6";
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "Explore", description: "Map the thing", toolUseId: "toolu_x", spawnDepth: 1 }));
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`), sidechainLines());
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  w.pump(Date.now());
+
+  // Registry row created from the meta sidecar, still running.
+  const list = subagents.listForTask(taskId);
+  expect(list.length).toBe(1);
+  expect(list[0]!.id).toBe(agentId);
+  expect(list[0]!.agentType).toBe("Explore");
+  expect(list[0]!.description).toBe("Map the thing");
+  expect(list[0]!.status).toBe("running");
+  expect(list[0]!.runId).toBe(runId);
+
+  // Content events persisted under the parent run, tagged with subagent_id.
+  const rows = db.query<{ stream: string; subagent_id: string | null }, [string]>(
+    `SELECT stream, subagent_id FROM run_events WHERE run_id = ? AND subagent_id IS NOT NULL ORDER BY id`,
+  ).all(runId);
+  expect(rows.map((r) => r.stream)).toEqual(["user", "tool_use"]);
+  expect(rows.every((r) => r.subagent_id === agentId)).toBe(true);
+
+  // Live emits: one 'subagent' started lifecycle + the tagged content events.
+  const started = captured.filter((e) => e.stream === "subagent");
+  expect(started.length).toBe(1);
+  expect(JSON.parse(started[0]!.data).phase).toBe("started");
+  expect(captured.filter((e) => e.stream === "user" || e.stream === "tool_use").every((e) => e.subagentId === agentId)).toBe(true);
+
+  w.detach();
+  setSubagentEmitter(null);
+});
+
+test("marks a subagent completed after end_turn + idle, without double-emitting on reattach", async () => {
+  const { subagents, db } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+  const { taskId, runId, jsonlPath, subagentsDir } = await seed();
+
+  const captured: RunEvent[] = [];
+  setSubagentEmitter((e) => captured.push(e));
+
+  const agentId = "f6e5d4c3b2a1";
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "general-purpose", description: "work", spawnDepth: 1 }));
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`), sidechainLines());
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0);
+  expect(subagents.get(agentId)!.status).toBe("running");
+
+  // Append the terminal end_turn line, then pump again far enough in the
+  // future that the idle threshold elapses → completed.
+  appendFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`),
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: "a2", message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "done" }] } }) + "\n");
+  w.pump(t0 + 1);          // reads the end_turn (sawEndOfTurn=true), still running (not idle yet)
+  expect(subagents.get(agentId)!.status).toBe("running");
+  w.pump(t0 + 10_000);     // now idle past DONE_IDLE_MS → completed
+  const done = subagents.get(agentId)!;
+  expect(done.status).toBe("completed");
+  expect(done.endedAt).not.toBeNull();
+  expect(captured.some((e) => e.stream === "subagent" && JSON.parse(e.data).phase === "finished")).toBe(true);
+
+  const countBefore = db.query<{ c: number }, [string]>(
+    `SELECT COUNT(*) c FROM run_events WHERE subagent_id = ?`,
+  ).get(agentId)!.c;
+  expect(countBefore).toBe(3); // user + tool_use + assistant(text)
+
+  w.detach();
+
+  // Reattach: a fresh watcher re-tails the same file from offset 0, seeded from
+  // the DB dedup set — it must NOT re-insert the already-persisted events.
+  const w2 = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  w2.pump(Date.now());
+  const countAfter = db.query<{ c: number }, [string]>(
+    `SELECT COUNT(*) c FROM run_events WHERE subagent_id = ?`,
+  ).get(agentId)!.c;
+  expect(countAfter).toBe(countBefore);
+  w2.detach();
+  setSubagentEmitter(null);
+});
+
+test("AGETOR_TRACK_SUBAGENTS=0 yields an inert no-op watcher", async () => {
+  const prev = process.env.AGETOR_TRACK_SUBAGENTS;
+  process.env.AGETOR_TRACK_SUBAGENTS = "0";
+  // Re-import fresh so the module-level ENABLED flag re-reads the env.
+  const mod = await import(`./claude-subagents.ts?gate=${randomUUID()}`);
+  const { subagents } = await import("./db.ts");
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+  writeFileSync(path.join(subagentsDir, `agent-zzz.meta.json`), JSON.stringify({ agentType: "Explore", description: "x", spawnDepth: 1 }));
+  writeFileSync(path.join(subagentsDir, `agent-zzz.jsonl`), sidechainLines());
+  const w = mod.attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  w.pump(Date.now());
+  expect(subagents.listForTask(taskId).length).toBe(0);
+  w.detach();
+  if (prev === undefined) delete process.env.AGETOR_TRACK_SUBAGENTS;
+  else process.env.AGETOR_TRACK_SUBAGENTS = prev;
+});

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -191,6 +191,12 @@ export function attachSubagentWatcher(opts: {
   let timer: ReturnType<typeof setTimeout> | null = null;
   let dirWatcher: FSWatcher | null = null;
   let detached = false;
+  // The first cycle tails EVERY known file (including ones the DB says are
+  // already `completed`) so a reattach picks up any bytes appended while agetor
+  // was down — e.g. a background agent resumed during the gap. Steady-state
+  // polling then only re-reads `running` files; resumes of a finished agent
+  // after that are caught by the dir watcher's append notification.
+  let firstCycle = true;
 
   // Reattach: rehydrate subagents this task already had so we resume their
   // tails from offset 0 (the DB-seeded `seen` set suppresses re-emission of
@@ -290,9 +296,13 @@ export function attachSubagentWatcher(opts: {
       }
       // A previously-finished subagent that started writing again (resumed
       // background agent) flips back to running before we emit its new turn.
+      // Reset the end-of-turn latch so the new turn must produce its OWN
+      // end_turn before `checkDone` can complete it again — otherwise the stale
+      // `sawEndOfTurn` from the prior turn would mark it done mid-resume.
       if (fs.status !== "running") {
         fs.status = "running";
         fs.endedAt = null;
+        fs.sawEndOfTurn = false;
         subagentsDb.setStatus(fs.subagentId, "running", null);
         emitLifecycle(fs, "started");
       }
@@ -334,7 +344,16 @@ export function attachSubagentWatcher(opts: {
     try {
       armDirWatcher();
       discover();
-      for (const fs of files.values()) tailFile(fs);
+      // Steady-state: only re-stat/re-read `running` files. Completed ones keep
+      // no per-tick cost; a resume (rare) re-opens them via the dir watcher's
+      // append notification (see `armDirWatcher`, which tails ALL files). The
+      // first cycle is the exception — it tails everything to drain a reattach
+      // backlog.
+      const tailAll = firstCycle;
+      firstCycle = false;
+      for (const fs of files.values()) {
+        if (tailAll || fs.status === "running") tailFile(fs);
+      }
       checkDone(now);
     } catch { /* swallow — never crash the timer */ }
   }

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -1,0 +1,368 @@
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Background / sub-agent tracking.
+ *
+ * When a claude task spawns a sub-agent (the Agent/Task tool — Explore,
+ * general-purpose, …, whether synchronous or run-in-background), claude writes
+ * that agent's FULL transcript to its own sidechain file, a sibling of the main
+ * session JSONL we already tail:
+ *
+ *   ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl            ← main stream
+ *   ~/.claude/projects/<encoded-cwd>/<sessionId>/subagents/
+ *         agent-<agentId>.jsonl      ← per-subagent transcript (isSidechain:true)
+ *         agent-<agentId>.meta.json  ← { agentType, description, toolUseId, spawnDepth }
+ *
+ * The `<sessionId>/subagents/` dir is created lazily — it only exists once a
+ * sub-agent has run. We watch it, tail each `agent-*.jsonl` with the SAME
+ * mapper the main stream uses (`mapJsonlEventToChunks`), and persist/emit each
+ * event tagged with the subagent's id so the run panel can render a read-only
+ * per-subagent tab. The main session JSONL still shows the launching `Agent`
+ * tool-use card; the tab is the drill-in.
+ *
+ * This module is READ-ONLY w.r.t. the agent: it watches files and tails them.
+ * It never spawns, signals, or tears down a tmux session — `detach()` only
+ * closes fs watchers + the poll timer.
+ *
+ * The format is internal to claude and the docs warn it can change between
+ * versions, so everything here is defensive (missing dir / meta / fields all
+ * degrade gracefully) and gated behind AGETOR_TRACK_SUBAGENTS (default on).
+ * A parse error on one subagent file can never affect the main stream — it is
+ * isolated to that file's tail.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+import {
+  existsSync,
+  statSync,
+  openSync,
+  readSync,
+  closeSync,
+  readdirSync,
+  readFileSync,
+  watch as fsWatch,
+  type FSWatcher,
+} from "node:fs";
+import path from "node:path";
+import { runs, subagents as subagentsDb, tasks } from "./db.ts";
+import { mapJsonlEventToChunks } from "./claude-tmux.ts";
+import type { RunEvent, Subagent, SubagentEvent, SubagentStatus } from "../shared/types.ts";
+
+/** Off only when explicitly disabled. The watcher is cheap when idle, but the
+ *  flag lets us kill it entirely if a future claude layout change breaks the
+ *  on-disk assumptions, without shipping a new build. */
+const ENABLED = process.env.AGETOR_TRACK_SUBAGENTS !== "0";
+
+/** Poll cadence while at least one subagent is still running — fast enough to
+ *  feel live in the panel, cheap enough (a stat per file) to run per task. */
+const FAST_POLL_MS = 600;
+/** Cadence when nothing is running (or the dir doesn't exist yet). A board of
+ *  completed-but-undeleted tasks shouldn't burn CPU; mirrors the main scraper's
+ *  idle-throttle lesson. */
+const SLOW_POLL_MS = 4000;
+/** After a subagent's transcript shows an end_turn and then goes quiet for this
+ *  long, treat it as finished. A later append (a resumed background agent)
+ *  flips it back to running. */
+const DONE_IDLE_MS = 1500;
+
+/**
+ * SSE sink, injected once by the orchestrator at startup (which owns the
+ * subscriber fan-out via `emit`). Kept as an injected dependency rather than a
+ * direct import to avoid a hard cycle and to leave the watcher unit-testable
+ * (DB-only) when no emitter is registered.
+ */
+let emitFn: ((e: RunEvent) => void) | null = null;
+export function setSubagentEmitter(fn: ((e: RunEvent) => void) | null): void {
+  emitFn = fn;
+}
+
+interface SubagentMeta {
+  agentType: string | null;
+  description: string | null;
+  spawnDepth: number;
+}
+
+/** Read & parse `agent-<id>.meta.json`. Tolerates absence / malformed JSON —
+ *  the transcript is the source of truth; the sidecar is just a nicer label. */
+function readMeta(subagentsDir: string, id: string): SubagentMeta {
+  try {
+    const raw = readFileSync(path.join(subagentsDir, `agent-${id}.meta.json`), "utf8");
+    const o = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      agentType: typeof o.agentType === "string" ? o.agentType : null,
+      description: typeof o.description === "string" ? o.description : null,
+      spawnDepth: typeof o.spawnDepth === "number" ? o.spawnDepth : 1,
+    };
+  } catch {
+    return { agentType: null, description: null, spawnDepth: 1 };
+  }
+}
+
+/** Read bytes appended to a file since `offset`. Sync (like the main stream's
+ *  `flushSync`) — keeps the per-tick body simple and ordered. */
+function readAppendedSync(filePath: string, offset: number): { text: string; next: number } {
+  let st;
+  try { st = statSync(filePath); } catch { return { text: "", next: offset }; }
+  if (st.size <= offset) return { text: "", next: offset };
+  const len = st.size - offset;
+  const buf = Buffer.alloc(len);
+  let fd;
+  try { fd = openSync(filePath, "r"); } catch { return { text: "", next: offset }; }
+  try {
+    readSync(fd, buf, 0, len, offset);
+  } finally {
+    closeSync(fd);
+  }
+  return { text: buf.toString("utf8"), next: st.size };
+}
+
+interface FileState {
+  subagentId: string;
+  /** Parent run the events attach to — captured at discovery, then stable. */
+  runId: string;
+  /** Byte cursor into the subagent JSONL. */
+  offset: number;
+  /** Line uuids already dispatched (dedup; seeded from DB on reattach). */
+  seen: Set<string>;
+  /** Whether we've observed an assistant end_turn — gate for done-detection. */
+  sawEndOfTurn: boolean;
+  /** `Date.now()` of the last byte we read — the idle clock for done-detection. */
+  lastAppendAt: number;
+  status: SubagentStatus;
+  sourcePath: string;
+  agentType: string | null;
+  description: string | null;
+  spawnDepth: number;
+  startedAt: number;
+  endedAt: number | null;
+}
+
+export interface SubagentWatcherHandle {
+  detach(): void;
+  /** Run a single discover → tail → done-check cycle synchronously, without
+   *  touching the poll schedule. Production never calls this (the timer drives
+   *  it); tests use it with an injected `now` to exercise the watcher
+   *  deterministically instead of waiting on real timers. */
+  pump(now?: number): void;
+}
+
+/** The run a newly-discovered subagent should attach its events to: the task's
+ *  current run if one is live, else its most recent run. `task.runId` survives
+ *  the resolve-to-`review` transition, so this is reliably set while the
+ *  session is alive — but fall back defensively. */
+function resolveRunId(taskId: string): string | null {
+  const t = tasks.get(taskId);
+  if (t?.runId) return t.runId;
+  return runs.listForTask(taskId)[0]?.id ?? null;
+}
+
+function toSubagentShape(fs: FileState, taskId: string): Subagent {
+  return {
+    id: fs.subagentId,
+    taskId,
+    runId: fs.runId,
+    parentKind: "subagent",
+    agentType: fs.agentType,
+    description: fs.description,
+    spawnDepth: fs.spawnDepth,
+    sourcePath: fs.sourcePath,
+    status: fs.status,
+    startedAt: fs.startedAt,
+    endedAt: fs.endedAt,
+  };
+}
+
+/**
+ * Start watching `<sessionId>/subagents/` for the given task. The directory is
+ * derived from the main session's `jsonlPath` so it tracks whatever layout
+ * (fresh vs legacy configDir) that path resolved to. Returns a handle whose
+ * `detach()` releases all timers/watchers — and nothing else.
+ */
+export function attachSubagentWatcher(opts: {
+  taskId: string;
+  jsonlPath: string;
+  /** Test-only: suppress the self-scheduling poll timer so a test drives the
+   *  watcher via `pump()` instead of real timers. */
+  manual?: boolean;
+}): SubagentWatcherHandle {
+  if (!ENABLED) return { detach() { /* disabled */ }, pump() { /* disabled */ } };
+
+  const { taskId } = opts;
+  const sessionId = path.basename(opts.jsonlPath, ".jsonl");
+  const subagentsDir = path.join(path.dirname(opts.jsonlPath), sessionId, "subagents");
+  const files = new Map<string, FileState>();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let dirWatcher: FSWatcher | null = null;
+  let detached = false;
+
+  // Reattach: rehydrate subagents this task already had so we resume their
+  // tails from offset 0 (the DB-seeded `seen` set suppresses re-emission of
+  // already-persisted lines). A row left `running` whose transcript is actually
+  // finished gets reconciled by the normal done-check on the next tick.
+  for (const row of subagentsDb.listForTask(taskId)) {
+    files.set(row.id, {
+      subagentId: row.id,
+      runId: row.runId ?? resolveRunId(taskId) ?? row.id,
+      offset: 0,
+      seen: runs.seenLineUuidsForSubagent(row.id),
+      sawEndOfTurn: false,
+      lastAppendAt: 0,
+      status: row.status,
+      sourcePath: row.sourcePath,
+      agentType: row.agentType,
+      description: row.description,
+      spawnDepth: row.spawnDepth,
+      startedAt: row.startedAt,
+      endedAt: row.endedAt,
+    });
+  }
+
+  function emitLifecycle(fs: FileState, phase: "started" | "finished"): void {
+    const payload: SubagentEvent = { phase, subagent: toSubagentShape(fs, taskId) };
+    emitFn?.({
+      runId: fs.runId,
+      taskId,
+      stream: "subagent",
+      data: JSON.stringify(payload),
+      ts: Date.now(),
+      subagentId: fs.subagentId,
+    });
+  }
+
+  /** Pick up newly-created `agent-*.jsonl` files. */
+  function discover(): void {
+    let entries: string[];
+    try { entries = readdirSync(subagentsDir); } catch { return; }
+    for (const name of entries) {
+      const m = /^agent-(.+)\.jsonl$/.exec(name);
+      if (!m) continue;
+      const id = m[1]!;
+      if (files.has(id)) continue;
+      const runId = resolveRunId(taskId);
+      // Without a run to attach to we can't persist (run_events.run_id is NOT
+      // NULL). In practice a live session always has a run; skip defensively
+      // and retry on a later tick if that ever isn't true.
+      if (!runId) continue;
+      const meta = readMeta(subagentsDir, id);
+      const startedAt = Date.now();
+      const fs: FileState = {
+        subagentId: id,
+        runId,
+        offset: 0,
+        seen: new Set(),
+        sawEndOfTurn: false,
+        lastAppendAt: startedAt,
+        status: "running",
+        sourcePath: path.join(subagentsDir, name),
+        agentType: meta.agentType,
+        description: meta.description,
+        spawnDepth: meta.spawnDepth,
+        startedAt,
+        endedAt: null,
+      };
+      files.set(id, fs);
+      subagentsDb.insertIfAbsent(toSubagentShape(fs, taskId));
+      emitLifecycle(fs, "started");
+    }
+  }
+
+  /** Tail one subagent file: dispatch newly-appended lines through the shared
+   *  mapper, persisting + emitting each chunk tagged with the subagent id. */
+  function tailFile(fs: FileState): void {
+    const { text, next } = readAppendedSync(fs.sourcePath, fs.offset);
+    if (!text) return;
+    const lines = text.split("\n");
+    const tail = lines.pop() ?? ""; // partial trailing line — re-read next tick
+    fs.offset = next - Buffer.byteLength(tail, "utf8");
+    for (const line of lines) {
+      if (!line) continue;
+      // Line-level dedup (the mapper can fire onChunk several times per line —
+      // one per content block — all sharing the line uuid, so we must gate on
+      // the line, not per onChunk call). Peek the uuid + end_turn first.
+      let uuid: string | undefined;
+      let endTurnHint = false;
+      try {
+        const o = JSON.parse(line) as { uuid?: unknown; type?: unknown; message?: { stop_reason?: unknown } };
+        uuid = typeof o.uuid === "string" ? o.uuid : undefined;
+        endTurnHint = o.type === "assistant" && o.message?.stop_reason === "end_turn";
+      } catch { /* fall through; mapper will surface the parse error */ }
+
+      if (uuid && fs.seen.has(uuid)) {
+        if (endTurnHint) fs.sawEndOfTurn = true;
+        continue;
+      }
+      // A previously-finished subagent that started writing again (resumed
+      // background agent) flips back to running before we emit its new turn.
+      if (fs.status !== "running") {
+        fs.status = "running";
+        fs.endedAt = null;
+        subagentsDb.setStatus(fs.subagentId, "running", null);
+        emitLifecycle(fs, "started");
+      }
+      const { endOfTurn } = mapJsonlEventToChunks(line, (stream, data, lineUuid) => {
+        runs.appendEvent(fs.runId, stream, data, lineUuid ?? null, fs.subagentId);
+        emitFn?.({ runId: fs.runId, taskId, stream, data, ts: Date.now(), subagentId: fs.subagentId });
+      });
+      if (uuid) fs.seen.add(uuid);
+      if (endOfTurn) fs.sawEndOfTurn = true;
+      fs.lastAppendAt = Date.now();
+    }
+  }
+
+  /** Flip subagents to `completed` once their transcript ends + goes quiet. */
+  function checkDone(now: number): void {
+    for (const fs of files.values()) {
+      if (fs.status === "running" && fs.sawEndOfTurn && now - fs.lastAppendAt > DONE_IDLE_MS) {
+        fs.status = "completed";
+        fs.endedAt = now;
+        subagentsDb.setStatus(fs.subagentId, "completed", now);
+        emitLifecycle(fs, "finished");
+      }
+    }
+  }
+
+  function armDirWatcher(): void {
+    if (dirWatcher || !existsSync(subagentsDir)) return;
+    try {
+      dirWatcher = fsWatch(subagentsDir, { persistent: false }, () => {
+        if (detached) return;
+        try { discover(); for (const fs of files.values()) tailFile(fs); } catch { /* never crash the watcher */ }
+      });
+    } catch { /* fs.watch unsupported on this FS — the poll backstop covers it */ }
+  }
+
+  /** One discover → tail → done-check pass, with no scheduling side effects. */
+  function cycle(now: number): void {
+    if (detached) return;
+    try {
+      armDirWatcher();
+      discover();
+      for (const fs of files.values()) tailFile(fs);
+      checkDone(now);
+    } catch { /* swallow — never crash the timer */ }
+  }
+
+  function tick(): void {
+    if (detached) return;
+    cycle(Date.now());
+    const anyRunning = [...files.values()].some((f) => f.status === "running");
+    timer = setTimeout(tick, anyRunning ? FAST_POLL_MS : SLOW_POLL_MS);
+  }
+
+  // Kick off on the next tick (give the spawn path a beat to settle). Tests
+  // pass `manual` and drive `pump()` themselves.
+  if (!opts.manual) timer = setTimeout(tick, FAST_POLL_MS);
+
+  return {
+    detach(): void {
+      detached = true;
+      if (timer) clearTimeout(timer);
+      timer = null;
+      dirWatcher?.close();
+      dirWatcher = null;
+      // NB: intentionally does NOT touch tmux. Tearing down the watcher must
+      // never stop the agent — other tasks (and the user's own session) share
+      // the tmux server.
+    },
+    pump(now?: number): void {
+      cycle(now ?? Date.now());
+    },
+  };
+}

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -12,6 +12,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { tasks } from "./db.ts";
+import { attachSubagentWatcher, type SubagentWatcherHandle } from "./claude-subagents.ts";
 import { ensureInstalledForCwd } from "./hook-installer.ts";
 import {
   activeTmuxPromptsForTask,
@@ -1060,6 +1061,13 @@ interface SessionState {
    *  been quiet for `END_TURN_IDLE_FIRE_MS`. Cleared in `popEndOfTurn` when the
    *  slot finally pops (the whole busy period is over). */
   holdUntilIdle: boolean;
+  /** Watches `<sessionId>/subagents/` for background/sub agents this session
+   *  spawns, tailing each into the task's event stream (tagged by subagent id)
+   *  for the run panel's read-only tabs. Armed in `attachTailer`, released in
+   *  `disposeSessionState`. Read-only — never touches tmux. Null until armed
+   *  (and when AGETOR_TRACK_SUBAGENTS=0, `attachSubagentWatcher` returns a
+   *  no-op handle). */
+  subagentWatcher: SubagentWatcherHandle | null;
 }
 
 interface TurnSlot {
@@ -1154,6 +1162,7 @@ function makeSessionState(o: MakeSessionStateOpts): SessionState {
     askFirstSeenAt: null,
     pendingEndTurn: null,
     holdUntilIdle: false,
+    subagentWatcher: null,
   };
 }
 
@@ -2520,6 +2529,11 @@ function attachTailer(state: SessionState): void {
   // cheap (one stat + read-if-grew) and bulletproof.
   state.pollTimer = setInterval(() => { void flush(state); }, 400);
   startScraper(state);
+  // Track any background/sub agents this session spawns. Idempotent re-arm:
+  // dispose a prior handle first so a re-attach (reconcileOrphans defensive
+  // overwrite) can't leave two watchers polling the same dir.
+  state.subagentWatcher?.detach();
+  state.subagentWatcher = attachSubagentWatcher({ taskId: state.taskId, jsonlPath: state.jsonlPath });
 }
 
 /* ────────────────────────────────────────────────────────────────────────── *
@@ -3289,6 +3303,10 @@ function disposeSessionState(state: SessionState | undefined): void {
   if (state.scrapeTimer) clearInterval(state.scrapeTimer);
   state.scrapeTimer = null;
   state.scrapeLastFingerprint = null;
+  // Release the subagent watcher's fs.watch + poll timer. Read-only teardown:
+  // this stops us TAILING the subagent files, never the agent itself.
+  state.subagentWatcher?.detach();
+  state.subagentWatcher = null;
   state.onEndOfTurn = null;
   state.pendingEndTurn = null;
   const err = new Error("session killed");

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { homedir, tmpdir } from "node:os";
 import { mkdirSync, mkdtempSync } from "node:fs";
 import path from "node:path";
-import type { AgentKind, Harness, HarnessUsage, Project, Task, TaskReference, TaskType, Run, RunEventStream } from "../shared/types.ts";
+import type { AgentKind, Harness, HarnessUsage, Project, Task, TaskReference, TaskType, Run, RunEventStream, Subagent, SubagentStatus } from "../shared/types.ts";
 import { migrate } from "./migrate.ts";
 import { migrations } from "./migrations/index.ts";
 // Interactions live in-memory in `interactions.ts`. The import creates a
@@ -526,10 +526,10 @@ export const runs = {
    *  caller that just wants `{ runId, stream, data, ts }`. */
   events(runId: string) {
     return db.query<
-      { runId: string; stream: string; data: string; ts: number },
+      { runId: string; stream: string; data: string; ts: number; subagentId: string | null },
       [string]
     >(
-      `SELECT run_id as runId, stream, data, ts
+      `SELECT run_id as runId, stream, data, ts, subagent_id as subagentId
        FROM run_events
        WHERE run_id = ?
        ORDER BY id ASC`,
@@ -542,17 +542,23 @@ export const runs = {
    *  scrollback instead of per-run silos. */
   eventsForTask(taskId: string) {
     return db.query<
-      { runId: string; stream: string; data: string; ts: number },
+      { runId: string; stream: string; data: string; ts: number; subagentId: string | null },
       [string]
     >(
-      `SELECT run_events.run_id as runId, stream, data, ts
+      `SELECT run_events.run_id as runId, stream, data, ts, run_events.subagent_id as subagentId
        FROM run_events
        JOIN runs ON runs.id = run_events.run_id
        WHERE runs.task_id = ?
        ORDER BY run_events.id ASC`,
     ).all(taskId);
   },
-  appendEvent(runId: string, stream: RunEventStream, data: string, lineUuid?: string | null) {
+  appendEvent(
+    runId: string,
+    stream: RunEventStream,
+    data: string,
+    lineUuid?: string | null,
+    subagentId?: string | null,
+  ) {
     // INSERT OR IGNORE only when a dedup key is provided. With NULL keys the
     // partial unique index (`WHERE line_uuid IS NOT NULL`) doesn't apply, so
     // non-JSONL events still insert unconditionally and we don't accidentally
@@ -560,13 +566,13 @@ export const runs = {
     // (runId, NULL).
     if (lineUuid) {
       db.run(
-        `INSERT OR IGNORE INTO run_events (run_id, stream, data, ts, line_uuid) VALUES (?, ?, ?, ?, ?)`,
-        [runId, stream, data, Date.now(), lineUuid],
+        `INSERT OR IGNORE INTO run_events (run_id, stream, data, ts, line_uuid, subagent_id) VALUES (?, ?, ?, ?, ?, ?)`,
+        [runId, stream, data, Date.now(), lineUuid, subagentId ?? null],
       );
     } else {
       db.run(
-        `INSERT INTO run_events (run_id, stream, data, ts) VALUES (?, ?, ?, ?)`,
-        [runId, stream, data, Date.now()],
+        `INSERT INTO run_events (run_id, stream, data, ts, subagent_id) VALUES (?, ?, ?, ?, ?)`,
+        [runId, stream, data, Date.now(), subagentId ?? null],
       );
     }
   },
@@ -591,5 +597,75 @@ export const runs = {
        WHERE r.task_id = ? AND e.line_uuid IS NOT NULL`,
     ).all(taskId);
     return new Set(rows.map((r) => r.line_uuid));
+  },
+  /** Line uuids already persisted for a single subagent's stream. Seeds the
+   *  subagent tailer's in-memory dedup set on reattach so re-reading
+   *  `agent-<id>.jsonl` from offset 0 doesn't double-insert/emit events the
+   *  previous process already streamed. Scoped by subagent_id (independent of
+   *  run_id), mirroring `seenLineUuidsForTask` for the main stream. */
+  seenLineUuidsForSubagent(subagentId: string): Set<string> {
+    const rows = db.query<{ line_uuid: string }, [string]>(
+      `SELECT line_uuid FROM run_events
+       WHERE subagent_id = ? AND line_uuid IS NOT NULL`,
+    ).all(subagentId);
+    return new Set(rows.map((r) => r.line_uuid));
+  },
+};
+
+interface SubagentRow {
+  id: string;
+  task_id: string;
+  run_id: string | null;
+  parent_kind: string;
+  agent_type: string | null;
+  description: string | null;
+  spawn_depth: number;
+  source_path: string;
+  status: string;
+  started_at: number;
+  ended_at: number | null;
+}
+
+function toSubagent(r: SubagentRow): Subagent {
+  return {
+    id: r.id,
+    taskId: r.task_id,
+    runId: r.run_id,
+    parentKind: r.parent_kind === "bg_session" ? "bg_session" : "subagent",
+    agentType: r.agent_type,
+    description: r.description,
+    spawnDepth: r.spawn_depth,
+    sourcePath: r.source_path,
+    status: r.status as SubagentStatus,
+    startedAt: r.started_at,
+    endedAt: r.ended_at,
+  };
+}
+
+export const subagents = {
+  /** Every tracked subagent for a task, oldest first (spawn order — that's how
+   *  the tab strip lays them out left-to-right after the pinned Main tab). */
+  listForTask(taskId: string): Subagent[] {
+    return db.query<SubagentRow, [string]>(
+      `SELECT * FROM subagents WHERE task_id = ? ORDER BY started_at ASC, id ASC`,
+    ).all(taskId).map(toSubagent);
+  },
+  get(id: string): Subagent | null {
+    const row = db.query<SubagentRow, [string]>(`SELECT * FROM subagents WHERE id = ?`).get(id);
+    return row ? toSubagent(row) : null;
+  },
+  /** Register a freshly-discovered subagent. Idempotent: re-discovering an
+   *  existing id (e.g. the watcher restarts) is a no-op rather than resetting
+   *  its status/timing. */
+  insertIfAbsent(s: Subagent): void {
+    db.run(
+      `INSERT OR IGNORE INTO subagents
+         (id, task_id, run_id, parent_kind, agent_type, description, spawn_depth, source_path, status, started_at, ended_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [s.id, s.taskId, s.runId, s.parentKind, s.agentType, s.description, s.spawnDepth, s.sourcePath, s.status, s.startedAt, s.endedAt],
+    );
+  },
+  setStatus(id: string, status: SubagentStatus, endedAt: number | null): void {
+    db.run(`UPDATE subagents SET status = ?, ended_at = ? WHERE id = ?`, [status, endedAt, id]);
   },
 };

--- a/src/bun/migrations/022_subagents.sql
+++ b/src/bun/migrations/022_subagents.sql
@@ -1,0 +1,40 @@
+-- Track Claude Code background / sub agents the main agent spawns. Each one is
+-- a separate sidechain transcript that claude writes at
+-- `<encoded-cwd>/<sessionId>/subagents/agent-<agentId>.jsonl` (with a
+-- `agent-<agentId>.meta.json` sidecar), a sibling of the main session JSONL we
+-- already tail. We tail those files too and store their events in the SAME
+-- run_events table, tagged with `subagent_id` (NULL = the main agent's own
+-- stream). The `subagents` table is the per-stream registry that drives the
+-- read-only tab strip in the run panel.
+--
+-- `parent_kind` generalises the registry so a future `claude --bg` independent
+-- background session (its own top-level JSONL, enumerated via
+-- `claude agents --json`) can be a second kind of agent stream without a schema
+-- change — only the tailer/discovery differs.
+ALTER TABLE run_events ADD COLUMN subagent_id TEXT;
+
+-- Rebuild the dedup index to be subagent-aware. A subagent line carries its own
+-- claude `uuid`, unique per file; keying on (run_id, subagent_id, line_uuid)
+-- guarantees a subagent event and a main-stream event can never collide under
+-- the same run, and keeps a per-file replay-from-offset-0 on reattach
+-- idempotent (same role the original (run_id, line_uuid) index played for the
+-- main stream). Existing rows have subagent_id NULL → IFNULL(...,'') so they
+-- keep exactly their prior uniqueness semantics.
+DROP INDEX IF EXISTS run_events_run_line_uuid;
+CREATE UNIQUE INDEX run_events_run_sub_line_uuid
+  ON run_events(run_id, IFNULL(subagent_id, ''), line_uuid) WHERE line_uuid IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS subagents (
+  id          TEXT PRIMARY KEY,                       -- claude agentId (basename of agent-<id>.jsonl)
+  task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  run_id      TEXT REFERENCES runs(id) ON DELETE CASCADE, -- parent run active when the subagent was spawned
+  parent_kind TEXT NOT NULL DEFAULT 'subagent',       -- 'subagent' | 'bg_session' (future)
+  agent_type  TEXT,                                   -- meta.json.agentType (e.g. "Explore")
+  description TEXT,                                   -- meta.json.description
+  spawn_depth INTEGER NOT NULL DEFAULT 1,             -- meta.json.spawnDepth (1 = spawned by the main agent)
+  source_path TEXT NOT NULL,                          -- absolute path to agent-<id>.jsonl
+  status      TEXT NOT NULL DEFAULT 'running',        -- running|completed|failed|cancelled|orphaned
+  started_at  INTEGER NOT NULL,
+  ended_at    INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_subagents_task ON subagents(task_id, started_at);

--- a/src/bun/migrations/index.ts
+++ b/src/bun/migrations/index.ts
@@ -21,6 +21,7 @@ import m018 from "./018_run_events_dedup.sql" with { type: "text" };
 import m019 from "./019_archived_at.sql" with { type: "text" };
 import m020 from "./020_task_type.sql" with { type: "text" };
 import m021 from "./021_codex_session_id.sql" with { type: "text" };
+import m022 from "./022_subagents.sql" with { type: "text" };
 
 import type { Migration } from "../migrate.ts";
 
@@ -46,4 +47,5 @@ export const migrations: Migration[] = [
   { id: "019_archived_at", sql: m019 },
   { id: "020_task_type", sql: m020 },
   { id: "021_codex_session_id", sql: m021 },
+  { id: "022_subagents", sql: m022 },
 ];

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -50,6 +50,7 @@ import {
   dropCodexSession,
   reattachCodexSession,
 } from "./codex-tmux.ts";
+import { setSubagentEmitter } from "./claude-subagents.ts";
 import { prepareWorkdir, removeWorktree, repoRoot, resolveRef, branchName } from "./worktree.ts";
 import { killTerminalsForTask } from "./terminals.ts";
 import { ensureInstalledForCwd } from "./hook-installer.ts";
@@ -97,6 +98,13 @@ export function subscribe(fn: Listener): () => void {
 function emit(e: RunEvent) {
   for (const fn of listeners) fn(e);
 }
+
+// The subagent watcher (armed inside the claude-tmux tailer) persists its
+// tagged events itself but needs the orchestrator's SSE fan-out to reach the
+// run panel. Register `emit` as its sink once, at module load — there's exactly
+// one listener set and the subagent stream rides the same `/tasks/:id/events`
+// channel the UI already subscribes to.
+setSubagentEmitter(emit);
 
 /**
  * Subscribe to the app-wide lifecycle stream — terminal run-status

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -1461,10 +1461,16 @@ export function startApiServer() {
             let buffer: RunEvent[] | null = [];
             const unsubscribe = subscribe((e) => {
               if (e.runId !== runId) return;
+              // This endpoint is the MAIN run's stream. Background/sub-agent
+              // events are stored under the same parent run_id but belong to
+              // their own (read-only) streams — they surface via
+              // /tasks/:id/subagents + the task-level events endpoint, not here.
+              if (e.subagentId) return;
               if (buffer) buffer.push(e);
               else send(e);
             });
             for (const ev of runs.events(runId)) {
+              if (ev.subagentId) continue;
               send({
                 runId,
                 taskId: "",

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -8,6 +8,7 @@ import { API_TOKEN, getApiPort } from "./api-config.ts";
 import {
   tasks,
   runs,
+  subagents,
   projects,
   preferences,
   harnesses,
@@ -940,6 +941,13 @@ export function startApiServer() {
         GET: authed((req) => json(runs.listForTask(req.params.id), { headers: corsHeaders(req) })),
       },
 
+      // Snapshot of the background/sub agents tracked for a task — drives the
+      // run panel's read-only tab strip on open, and is polled (like /runs)
+      // as a backstop to the live `subagent` SSE deltas.
+      "/tasks/:id/subagents": {
+        GET: authed((req) => json(subagents.listForTask(req.params.id), { headers: corsHeaders(req) })),
+      },
+
       // Everything the task's worktree changed vs its pinned base ref. Returns
       // a friendly `note` (empty `files`) when there's no worktree or no diff.
       "/tasks/:id/diff": {
@@ -1652,6 +1660,7 @@ export function startApiServer() {
                 stream: ev.stream as RunEvent["stream"],
                 data: ev.data,
                 ts: ev.ts,
+                subagentId: ev.subagentId,
               });
             }
             const drained = buffer;

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -3,11 +3,12 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
 import {
-  Archive, ArchiveRestore, Bot, Check, ClipboardList, Copy, FolderOpen, FileText, FilePenLine, FilePlus, Folder,
+  Archive, ArchiveRestore, Bot, Check, ClipboardList, Copy, CornerDownRight, Eye, FolderOpen, FileText, FilePenLine, FilePlus, Folder,
   GitCommit, GitCompare, Globe, HelpCircle, ListTodo, Plug, Search, Send, Slash,
   Sparkles, Square, Terminal, Wrench, X,
 } from "lucide-react";
 import { api, type AgentModelMap, type AvailableCommand, type AvailableExtension, type PendingInteraction } from "@/lib/api";
+import { shouldShowSubagentTabs, resolveActiveStream, splitTabsForOverflow } from "@/lib/subagent-tabs";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Select } from "@/components/ui/select";
@@ -25,6 +26,8 @@ import {
   type Harness,
   type Run,
   type RunEvent,
+  type Subagent,
+  type SubagentEvent,
   type Task,
   type TaskReference,
 } from "../../../shared/types.ts";
@@ -242,6 +245,14 @@ function RunPanelBody({
   const [rebuildBusy, setRebuildBusy] = useState(false);
   const [rebuildNote, setRebuildNote] = useState<string | null>(null);
   const [interactions, setInteractions] = useState<PendingInteraction[]>([]);
+  /** Background/sub agents this task's main agent has spawned. Seeded from the
+   *  snapshot endpoint on open + kept live by `stream: "subagent"` SSE deltas
+   *  and a 2s poll backstop. Drives the read-only tab strip. */
+  const [subagentList, setSubagentList] = useState<Subagent[]>([]);
+  /** Which stream the log is showing: "main" (the task's own agent) or a
+   *  subagent id. Background-agent streams are READ-ONLY — the composer is
+   *  hidden while one is active. */
+  const [activeStream, setActiveStream] = useState<string>("main");
   const logRef = useRef<HTMLDivElement>(null);
   // Tracks whether the log was scrolled near the bottom at the last user
   // interaction. Auto-scroll-to-bottom on new events only fires when this is
@@ -258,6 +269,8 @@ function RunPanelBody({
     setRebuilt(null);
     setRebuildNote(null);
     setInteractions([]);
+    setSubagentList([]);
+    setActiveStream("main");
     nearBottomRef.current = true;
   }, [task.id]);
 
@@ -318,6 +331,32 @@ function RunPanelBody({
     return () => { cancelled = true; clearInterval(t); };
   }, [task.id, task.runId]);
 
+  // Snapshot + poll the task's background/sub agents. The SSE `subagent` deltas
+  // keep this fresh live; the poll is a reopen/reconnect backstop (mirrors the
+  // runs poll). Merge rather than replace so an in-flight SSE delta isn't
+  // clobbered by a slightly-stale poll.
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const list = await api.listSubagents(task.id);
+        if (cancelled) return;
+        setSubagentList((cur) => {
+          // Union by id: the poll (DB) is authoritative on status, but keep any
+          // id we only know from a just-arrived SSE delta that the poll query
+          // raced. Sort by spawn order so tabs don't reshuffle.
+          const byId = new Map<string, Subagent>();
+          for (const s of cur) byId.set(s.id, s);
+          for (const s of list) byId.set(s.id, s);
+          return [...byId.values()].sort((a, b) => a.startedAt - b.startedAt || (a.id < b.id ? -1 : 1));
+        });
+      } catch { /* task may have been deleted */ }
+    };
+    void load();
+    const t = setInterval(load, 2000);
+    return () => { cancelled = true; clearInterval(t); };
+  }, [task.id]);
+
   // One unified task-level stream: every event from every run, merged in
   // chronological order. Replaces the old per-run subscription so the
   // panel shows the whole conversation as a single scrollback.
@@ -372,6 +411,23 @@ function RunPanelBody({
         } catch { /* ignore malformed */ }
         return;
       }
+      if (e.stream === "subagent") {
+        // Live lifecycle delta for a background/sub agent — upsert into the tab
+        // list instead of pushing to the log buffer. The agent's actual
+        // transcript rides the normal user/assistant/tool_* streams (tagged
+        // via `subagentId`) and flows through to `buffer.push` below.
+        try {
+          const { subagent } = JSON.parse(e.data) as SubagentEvent;
+          setSubagentList((cur) => {
+            const i = cur.findIndex((s) => s.id === subagent.id);
+            if (i === -1) return [...cur, subagent];
+            const next = cur.slice();
+            next[i] = subagent;
+            return next;
+          });
+        } catch { /* ignore malformed */ }
+        return;
+      }
       if (e.stream === "interaction_resolved") {
         // Server-side resolution (scraper auto-cancel, run cancellation,
         // delete) — drop the matching card so the UI doesn't keep
@@ -407,7 +463,7 @@ function RunPanelBody({
     if (!nearBottomRef.current) return;
     const el = logRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [events, rebuilt, interactions.length]);
+  }, [events, rebuilt, interactions.length, activeStream]);
 
   useEffect(() => {
     let cancelled = false;
@@ -459,15 +515,33 @@ function RunPanelBody({
     return ids;
   }, [rebuilt, runs]);
 
-  /** Splice `rebuilt` into the live stream by dropping events from runs
-   *  that share its sessionId and appending the rebuilt set. Events from
-   *  earlier sessions (different claudeSessionId) stay visible — the bug
-   *  this fixes was the rebuild silently masking them. */
+  /** The task's own (main) agent events — everything not tagged to a subagent.
+   *  The rebuild-from-JSONL path only ever covers the main session transcript,
+   *  so it splices against these. */
+  const mainEvents = useMemo(() => events.filter((e) => !e.subagentId), [events]);
+
+  /** Background/sub-agent events bucketed by subagent id, in arrival order. */
+  const subagentEventsById = useMemo(() => {
+    const m = new Map<string, RunEvent[]>();
+    for (const e of events) {
+      if (!e.subagentId) continue;
+      const arr = m.get(e.subagentId);
+      if (arr) arr.push(e);
+      else m.set(e.subagentId, [e]);
+    }
+    return m;
+  }, [events]);
+
+  /** Events for whichever stream the tab strip has selected. For "main", splice
+   *  `rebuilt` in by dropping events from runs that share its sessionId and
+   *  appending the rebuilt set (earlier sessions stay visible). A subagent tab
+   *  shows that subagent's transcript directly (no rebuild path applies). */
   const displayedEvents = useMemo(() => {
-    if (!rebuilt || !rebuiltRunIds) return events;
-    const others = events.filter((e) => !rebuiltRunIds.has(e.runId));
+    if (activeStream !== "main") return subagentEventsById.get(activeStream) ?? [];
+    if (!rebuilt || !rebuiltRunIds) return mainEvents;
+    const others = mainEvents.filter((e) => !rebuiltRunIds.has(e.runId));
     return [...others, ...rebuilt.events];
-  }, [events, rebuilt, rebuiltRunIds]);
+  }, [activeStream, subagentEventsById, mainEvents, rebuilt, rebuiltRunIds]);
 
   /** Indicator mode for the bottom-pinned heartbeat. A follow-up sent while
    *  the agent is working is folded into the active run (the backend pastes it
@@ -475,9 +549,32 @@ function RunPanelBody({
    *  in-flight run per task: the heartbeat is simply on ("Agent is working…")
    *  or off. Hidden while an interaction card is up. */
   const indicatorMode: RunIndicatorMode = useMemo(() => {
+    // A background-agent tab's heartbeat tracks that subagent's own status,
+    // independent of the main turn (the parent turn may already be in `review`
+    // while a background workflow keeps running).
+    if (activeStream !== "main") {
+      const s = subagentList.find((x) => x.id === activeStream);
+      return s?.status === "running" ? "active" : "off";
+    }
     if (interactions.length > 0) return "off";
     return runs.some((r) => r.status === "running") ? "active" : "off";
-  }, [interactions.length, runs]);
+  }, [activeStream, subagentList, interactions.length, runs]);
+
+  // Tabs are shown only while background agents are active (see
+  // `shouldShowSubagentTabs`). Logic is extracted + unit-tested in
+  // lib/subagent-tabs.ts (the repo has no DOM test harness).
+  const parentRunRunning = useMemo(() => runs.some((r) => r.status === "running"), [runs]);
+  const showSubagentTabs = useMemo(
+    () => shouldShowSubagentTabs(subagentList, parentRunRunning),
+    [subagentList, parentRunRunning],
+  );
+
+  // When the strip collapses (or the active subagent disappears), fall back to
+  // the Main stream so the log + composer can't be stranded on a hidden tab.
+  useEffect(() => {
+    const resolved = resolveActiveStream(activeStream, showSubagentTabs, subagentList);
+    if (resolved !== activeStream) setActiveStream(resolved);
+  }, [showSubagentTabs, subagentList, activeStream]);
 
   // Two separate affordances:
   //   • `canControl` — Stop button is only meaningful when there's an in-flight
@@ -827,6 +924,17 @@ function RunPanelBody({
 
       <TerminalsSection task={task} />
 
+      {showSubagentTabs && (
+        <SubagentTabs
+          subagents={subagentList}
+          active={activeStream}
+          onSelect={(id) => {
+            nearBottomRef.current = true; // pin the new stream to its latest message
+            setActiveStream(id);
+          }}
+        />
+      )}
+
       <div
         ref={logRef}
         onScroll={(e) => {
@@ -847,7 +955,7 @@ function RunPanelBody({
         ) : (
           <>
             <div className="mb-2 flex items-center justify-between gap-2">
-              {latestRun?.claudeSessionId ? (
+              {activeStream === "main" && latestRun?.claudeSessionId ? (
                 <button
                   type="button"
                   onClick={() => void rebuildFromJsonl()}
@@ -888,6 +996,23 @@ function RunPanelBody({
       {archived ? (
         <div className="shrink-0 border-t border-border/60 p-3 text-[11px] text-muted-foreground">
           This task is archived. Unarchive it to send messages.
+        </div>
+      ) : activeStream !== "main" ? (
+        // Background-agent streams are read-only — you can watch them but not
+        // talk to them. Switch back to Main to send a message.
+        <div className="flex shrink-0 items-center gap-2 border-t border-border/60 p-3 text-[11px] text-muted-foreground">
+          <Eye className="size-3 shrink-0" />
+          <span>
+            Viewing a background agent — read-only.{" "}
+            <button
+              type="button"
+              onClick={() => setActiveStream("main")}
+              className="text-foreground underline underline-offset-2 hover:no-underline"
+            >
+              Back to Main
+            </button>{" "}
+            to send a message.
+          </span>
         </div>
       ) : (
         <div
@@ -1070,6 +1195,108 @@ function extractFileMentions(events: RunEvent[]): string[] {
 function basename(p: string): string {
   const i = p.lastIndexOf("/");
   return i >= 0 ? p.slice(i + 1) : p;
+}
+
+/**
+ * Read-only tab strip for switching the log between the task's own (Main)
+ * agent stream and each background/sub agent it has spawned. Shown only while
+ * background agents are active (see `showSubagentTabs`). The Main tab is always
+ * first and visually emphasised — it's the one stream you can actually talk to;
+ * the background tabs are watch-only. A running agent shows a pulsing green dot,
+ * a finished one a check.
+ */
+function SubagentTab({ s, selected, onSelect }: { s: Subagent; selected: boolean; onSelect: (id: string) => void }) {
+  const label = s.agentType ?? "agent";
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={selected}
+      onClick={() => onSelect(s.id)}
+      title={s.description ?? label}
+      className={cn(
+        "flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-[11px] transition-colors",
+        selected
+          ? "bg-accent text-accent-foreground ring-1 ring-border"
+          : "text-muted-foreground hover:bg-muted/40",
+      )}
+    >
+      {/* Nested agents (spawned by another subagent, not the main agent) get a
+          depth marker so the hierarchy is legible in a flat strip. */}
+      {s.spawnDepth > 1 && <CornerDownRight className="size-3 shrink-0 text-muted-foreground/60" />}
+      {s.status === "running" ? (
+        <span className="relative inline-flex size-2 shrink-0">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500/60 opacity-75" />
+          <span className="relative inline-flex size-2 rounded-full bg-emerald-500" />
+        </span>
+      ) : (
+        <Check className="size-3 shrink-0 text-muted-foreground" />
+      )}
+      <span className="max-w-[10rem] truncate">{label}</span>
+      {s.description && (
+        <span className="max-w-[12rem] truncate text-muted-foreground/70">· {s.description}</span>
+      )}
+    </button>
+  );
+}
+
+function SubagentTabs({
+  subagents,
+  active,
+  onSelect,
+}: {
+  subagents: Subagent[];
+  active: string;
+  onSelect: (id: string) => void;
+}) {
+  // Collapse a large fan-out behind a "+N" pill; expanding wraps the strip onto
+  // multiple rows rather than forcing a long horizontal scroll. A running or
+  // currently-active tab is never hidden (see `splitTabsForOverflow`).
+  const [expanded, setExpanded] = useState(false);
+  const { visible, overflow } = splitTabsForOverflow(subagents, active);
+  const shown = expanded ? subagents : visible;
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Agent streams"
+      className={cn(
+        "flex shrink-0 items-center gap-1 border-b border-border/60 bg-card/40 px-2 py-1.5",
+        expanded ? "flex-wrap" : "overflow-x-auto",
+      )}
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active === "main"}
+        onClick={() => onSelect("main")}
+        className={cn(
+          "flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors",
+          // Main is always emphasised (primary accent) so it reads as the
+          // controllable stream even when a background tab is selected.
+          active === "main"
+            ? "bg-primary/15 text-primary ring-1 ring-primary/40"
+            : "text-primary/80 hover:bg-primary/10",
+        )}
+      >
+        <Bot className="size-3" />
+        Main
+      </button>
+      {shown.map((s) => (
+        <SubagentTab key={s.id} s={s} selected={active === s.id} onSelect={onSelect} />
+      ))}
+      {overflow.length > 0 && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="shrink-0 rounded-md px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted/40"
+          title={expanded ? "Collapse background-agent tabs" : `Show ${overflow.length} more background agent${overflow.length === 1 ? "" : "s"}`}
+        >
+          {expanded ? "Show less" : `+${overflow.length}`}
+        </button>
+      )}
+    </div>
+  );
 }
 
 /**

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -560,6 +560,19 @@ function RunPanelBody({
     return runs.some((r) => r.status === "running") ? "active" : "off";
   }, [activeStream, subagentList, interactions.length, runs]);
 
+  // The run-status RunEventList uses to gate its bottom heartbeat. On a
+  // background-agent tab this must reflect THAT subagent's status, not the main
+  // run's — otherwise a subagent still running after the parent turn resolved
+  // to `review` (the core background-workflow case) would have its heartbeat
+  // suppressed because the main run reads `succeeded`. Map the subagent's
+  // status onto the Run["status"] shape the child expects.
+  const activeRunStatus: Run["status"] | null = useMemo(() => {
+    if (activeStream === "main") return latestRun?.status ?? null;
+    return subagentList.find((s) => s.id === activeStream)?.status === "running"
+      ? "running"
+      : "succeeded";
+  }, [activeStream, subagentList, latestRun?.status]);
+
   // Tabs are shown only while background agents are active (see
   // `shouldShowSubagentTabs`). Logic is extracted + unit-tested in
   // lib/subagent-tabs.ts (the repo has no DOM test harness).
@@ -884,7 +897,10 @@ function RunPanelBody({
           >
             <FolderOpen className="mr-1 size-3" /> Open
           </Button>
-          {!archived && canControl && (
+          {/* Stop targets the main run. Hide it while viewing a read-only
+              background-agent tab so the control doesn't read as "stop this
+              agent" — switch back to Main to stop the task. */}
+          {!archived && canControl && activeStream === "main" && (
             <Button size="sm" variant="destructive" onClick={stop}>
               <Square className="mr-1 size-3" /> Stop
             </Button>
@@ -978,7 +994,7 @@ function RunPanelBody({
               events={displayedEvents}
               interactions={interactions}
               onInteractionResolved={dismissInteraction}
-              runStatus={latestRun?.status ?? null}
+              runStatus={activeRunStatus}
               indicatorMode={indicatorMode}
             />
           </>

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   Project,
   Run,
   RunEvent,
+  Subagent,
   Task,
   TaskDiff,
   TaskReference,
@@ -321,6 +322,10 @@ export const api = {
   terminalSocketUrl: (id: string) =>
     `ws://127.0.0.1:${API_PORT}/terminals/${encodeURIComponent(id)}/ws?token=${encodeURIComponent(API_TOKEN)}`,
   listRuns: (taskId: string) => j<Run[]>(`/tasks/${taskId}/runs`),
+  /** Background/sub agents tracked for a task — drives the run panel's
+   *  read-only per-subagent tab strip. Polled like `listRuns`; live deltas
+   *  also arrive on the task SSE as `stream: "subagent"` events. */
+  listSubagents: (taskId: string) => j<Subagent[]>(`/tasks/${taskId}/subagents`),
   /** Everything the task's worktree changed vs its pinned base. Empty `files`
    *  + a `note` when there's no worktree or no diff. */
   getTaskDiff: (taskId: string) => j<TaskDiff>(`/tasks/${taskId}/diff`),

--- a/src/mainview/lib/subagent-tabs.test.ts
+++ b/src/mainview/lib/subagent-tabs.test.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "bun:test";
+import type { Subagent, SubagentStatus } from "../../shared/types.ts";
+import {
+  shouldShowSubagentTabs,
+  resolveActiveStream,
+  splitTabsForOverflow,
+  anySubagentRunning,
+  MAX_VISIBLE_TABS,
+} from "./subagent-tabs.ts";
+
+function sub(id: string, status: SubagentStatus, startedAt = 0): Subagent {
+  return {
+    id, taskId: "t", runId: "r", parentKind: "subagent",
+    agentType: "Explore", description: "x", spawnDepth: 1, sourcePath: `/p/agent-${id}.jsonl`,
+    status, startedAt, endedAt: status === "running" ? null : startedAt + 1,
+  };
+}
+
+test("shouldShowSubagentTabs: hidden with none, shown while a subagent runs", () => {
+  expect(shouldShowSubagentTabs([], true)).toBe(false);
+  expect(shouldShowSubagentTabs([sub("a", "completed")], false)).toBe(false);
+  expect(shouldShowSubagentTabs([sub("a", "running")], false)).toBe(true);
+});
+
+test("shouldShowSubagentTabs: a finished subagent stays visible while the parent turn runs", () => {
+  // The decision: keep a just-finished tab readable until the turn resolves.
+  expect(shouldShowSubagentTabs([sub("a", "completed")], true)).toBe(true);
+  // Parent resolved + nothing running → collapse.
+  expect(shouldShowSubagentTabs([sub("a", "completed")], false)).toBe(false);
+});
+
+test("anySubagentRunning", () => {
+  expect(anySubagentRunning([sub("a", "completed"), sub("b", "running")])).toBe(true);
+  expect(anySubagentRunning([sub("a", "completed")])).toBe(false);
+});
+
+test("resolveActiveStream: collapses to main when hidden, missing, or main", () => {
+  const subs = [sub("a", "running")];
+  expect(resolveActiveStream("main", true, subs)).toBe("main");
+  expect(resolveActiveStream("a", true, subs)).toBe("a");        // valid + shown → keep
+  expect(resolveActiveStream("a", false, subs)).toBe("main");    // strip hidden → reset
+  expect(resolveActiveStream("ghost", true, subs)).toBe("main"); // vanished → reset
+});
+
+test("splitTabsForOverflow: no overflow under the limit", () => {
+  const subs = [sub("a", "completed"), sub("b", "completed")];
+  const { visible, overflow } = splitTabsForOverflow(subs, "main", 6);
+  expect(visible.length).toBe(2);
+  expect(overflow.length).toBe(0);
+});
+
+test("splitTabsForOverflow: overflows past the limit in spawn order", () => {
+  const subs = Array.from({ length: 9 }, (_, i) => sub(`s${i}`, "completed", i));
+  const { visible, overflow } = splitTabsForOverflow(subs, "main", 6);
+  expect(visible.map((s) => s.id)).toEqual(["s0", "s1", "s2", "s3", "s4", "s5"]);
+  expect(overflow.map((s) => s.id)).toEqual(["s6", "s7", "s8"]);
+});
+
+test("splitTabsForOverflow: never hides a running or the active tab", () => {
+  // 8 completed + one running late one (s8) + active is s7 (completed, late).
+  const subs = Array.from({ length: 9 }, (_, i) => sub(`s${i}`, i === 8 ? "running" : "completed", i));
+  const { visible, overflow } = splitTabsForOverflow(subs, "s7", 6);
+  // The running (s8) and the active (s7) must be visible despite being last.
+  expect(visible.map((s) => s.id)).toContain("s8");
+  expect(visible.map((s) => s.id)).toContain("s7");
+  expect(overflow.map((s) => s.id)).not.toContain("s8");
+  expect(overflow.map((s) => s.id)).not.toContain("s7");
+});
+
+test("MAX_VISIBLE_TABS default applies", () => {
+  const subs = Array.from({ length: 8 }, (_, i) => sub(`s${i}`, "completed", i));
+  const { visible } = splitTabsForOverflow(subs, "main");
+  expect(visible.length).toBe(MAX_VISIBLE_TABS);
+});

--- a/src/mainview/lib/subagent-tabs.ts
+++ b/src/mainview/lib/subagent-tabs.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure derivation logic for the run panel's background/sub-agent tab strip.
+ * Kept DOM-free (like event-dedup.ts / event-buffer.ts) so it can be unit
+ * tested with `bun test` — the repo has no jsdom/testing-library, so component
+ * behaviour is validated by testing the logic the component drives.
+ */
+import type { Subagent } from "../../shared/types.ts";
+
+/** Max tabs rendered before the rest collapse behind a "+N" affordance. */
+export const MAX_VISIBLE_TABS = 6;
+
+export function anySubagentRunning(subs: Subagent[]): boolean {
+  return subs.some((s) => s.status === "running");
+}
+
+/**
+ * Tabs are shown only while background agents are *active*: at least one
+ * subagent is running, or the parent turn is still running (so a just-finished
+ * subagent stays readable until the turn resolves). Once nothing is running the
+ * strip collapses back to a plain single-stream log.
+ */
+export function shouldShowSubagentTabs(subs: Subagent[], parentRunRunning: boolean): boolean {
+  return subs.length > 0 && (anySubagentRunning(subs) || parentRunRunning);
+}
+
+/**
+ * Resolve which stream should be active given the current selection. Falls back
+ * to "main" when the strip is hidden or the selected subagent no longer exists,
+ * so the log + composer can never be stranded on a vanished/hidden tab.
+ */
+export function resolveActiveStream(active: string, show: boolean, subs: Subagent[]): string {
+  if (active === "main") return "main";
+  if (!show) return "main";
+  return subs.some((s) => s.id === active) ? active : "main";
+}
+
+/**
+ * Split tabs into an always-visible head + an overflow tail for the "+N" pill.
+ * Spawn order is preserved, and a running agent or the currently-active tab is
+ * never pushed into overflow (you should always see what's live and what you're
+ * looking at) — so `visible` can exceed `limit` when many agents run at once.
+ */
+export function splitTabsForOverflow(
+  subs: Subagent[],
+  active: string,
+  limit: number = MAX_VISIBLE_TABS,
+): { visible: Subagent[]; overflow: Subagent[] } {
+  if (subs.length <= limit) return { visible: [...subs], overflow: [] };
+  const forced = new Set<string>();
+  for (const s of subs) if (s.status === "running") forced.add(s.id);
+  if (active !== "main") forced.add(active);
+
+  const visible: Subagent[] = [];
+  const overflow: Subagent[] = [];
+  for (const s of subs) {
+    if (forced.has(s.id) || visible.length < limit) visible.push(s);
+    else overflow.push(s);
+  }
+  return { visible, overflow };
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -658,6 +658,12 @@ export interface TaskDiff {
  *   thinking     — claude extended-thinking block
  *   tool_use     — claude tool call (data = JSON { id, name, input })
  *   tool_result  — output of a tool call (data = JSON { toolUseId, content })
+ *   subagent     — background/sub-agent lifecycle delta (data = JSON
+ *                  SubagentEvent). Live-only (never persisted to run_events):
+ *                  the `/tasks/:id/subagents` snapshot covers panel reopen, so
+ *                  this stream just keeps the open panel's tab strip in sync.
+ *                  The subagent's actual transcript content rides the normal
+ *                  user/assistant/tool_* streams, tagged via `subagentId`.
  */
 export type RunEventStream =
   | "stdout"
@@ -669,7 +675,8 @@ export type RunEventStream =
   | "assistant"
   | "thinking"
   | "tool_use"
-  | "tool_result";
+  | "tool_result"
+  | "subagent";
 
 export interface RunEvent {
   runId: string;
@@ -677,6 +684,56 @@ export interface RunEvent {
   stream: RunEventStream;
   data: string;
   ts: number;
+  /**
+   * When set, this event belongs to a background/sub agent's stream rather than
+   * the task's main agent stream (NULL/undefined = main). The run panel
+   * partitions the unified event scrollback by this id to drive the read-only
+   * per-subagent tabs. Threaded from `run_events.subagent_id`.
+   */
+  subagentId?: string | null;
+}
+
+/** Lifecycle state of a tracked background/sub agent. Mirrors `RunStatus` plus
+ *  the subagent-specific transitions. */
+export type SubagentStatus =
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "orphaned";
+
+/**
+ * A background / sub agent the main agent spawned, tracked so the run panel can
+ * offer a read-only tab into its live stream. Today every row is a Claude Code
+ * in-session subagent (`parentKind: "subagent"`); `parentKind` leaves room for
+ * future `claude --bg` independent sessions without a schema change.
+ */
+export interface Subagent {
+  /** Claude's agentId — the basename of `subagents/agent-<id>.jsonl`. */
+  id: string;
+  taskId: string;
+  /** Parent run that was in flight when this subagent was spawned. */
+  runId: string | null;
+  parentKind: "subagent" | "bg_session";
+  /** Registered subagent type, e.g. "Explore" / "general-purpose". */
+  agentType: string | null;
+  /** Short human label from the spawning Agent tool call. */
+  description: string | null;
+  /** 1 = spawned by the main agent; >1 = spawned by another subagent. */
+  spawnDepth: number;
+  /** Absolute path to the subagent's JSONL transcript. */
+  sourcePath: string;
+  status: SubagentStatus;
+  startedAt: number;
+  endedAt: number | null;
+}
+
+/** Payload of a `stream: "subagent"` RunEvent (JSON-encoded in `data`). Lets an
+ *  open run panel add/flip a tab the instant a subagent starts or finishes,
+ *  without re-polling the snapshot endpoint. */
+export interface SubagentEvent {
+  phase: "started" | "finished";
+  subagent: Subagent;
 }
 
 /**


### PR DESCRIPTION
When a claude task spawns background/sub agents (the Agent/Task tool), claude writes each one's full transcript to its own sidechain file under <sessionId>/subagents/. agetor never read those, so a background agent's work was invisible. This adds end-to-end tracking.

- Backend: a read-only SubagentWatcher tails each subagents/agent-*.jsonl through the existing JSONL mapper, persists every event tagged with subagent_id (new column), and tracks live status in a new subagents table (migration 022). Detects completion from the transcript's terminal end_turn + idle; reattaches across restarts; gated by AGETOR_TRACK_SUBAGENTS. Never touches tmux — teardown only closes fs-watchers/timers.
- Frontend: RunPanel gains a read-only tab strip. The Main tab is pinned and highlighted (the only stream you can message); each background agent is a watch-only tab with a live status dot. The strip shows only while a background agent is active and collapses afterward; large fan-outs fold behind a +N pill; nested agents get a depth marker. The composer and Stop are hidden on background tabs.
- Data model uses parent_kind so independent claude --bg sessions can become a second stream kind later without a schema change.

Testing: 14 new tests including an end-to-end integration test that drives the real HTTP server + watcher over genuine Claude Code 2.1.196 subagent transcripts. typecheck clean · full suite 619 pass / 0 fail · vite build OK. Includes fixes from a self-review pass (stream-aware heartbeat, resumed-agent completion, per-run stream isolation).