### PR TITLE
feat(claude-code): add Claude Sonnet 5 to the model picker

### DIFF
--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -160,6 +160,16 @@ test("claude-code 'fable-5' maps to --model claude-fable-5", () => {
   ]);
 });
 
+test("claude-code 'sonnet-5' maps to --model claude-sonnet-5", () => {
+  const { cmd } = buildCommand(builtin("claude-code"), "do thing", { ...claudeDefaults, model: "sonnet-5", mode: "auto" });
+  expect(cmd).toEqual([
+    "claude",
+    "--model", "claude-sonnet-5",
+    "--permission-mode", "auto",
+    "--", "do thing",
+  ]);
+});
+
 test("claude-code prefixes the prompt with `--` so a leading-dash prompt isn't parsed as a flag", () => {
   // Regression: a prompt like a markdown checklist item starts with `-`.
   // Without the `--` terminator claude's CLI errors `unknown option` and

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -64,6 +64,7 @@ const CLAUDE_MODEL_FLAG: Record<string, string> = {
   "opus-4.8": "claude-opus-4-8",
   "opus-4.7": "claude-opus-4-7",
   "opus-4.6": "claude-opus-4-6",
+  "sonnet-5": "claude-sonnet-5",
   "sonnet-4.6": "claude-sonnet-4-6",
   "haiku-4.5": "claude-haiku-4-5",
 };

--- a/src/bun/effort-support.test.ts
+++ b/src/bun/effort-support.test.ts
@@ -28,6 +28,15 @@ test("claude sonnet-4.6 supports max but not xhigh (per API docs)", () => {
   expect(ids).not.toContain("xhigh");
 });
 
+test("claude sonnet-5 supports xhigh + max (first Sonnet tier with xhigh)", () => {
+  const ids = supportedEfforts("claude-code", "sonnet-5").map((o) => o.id);
+  expect(ids).toContain("max");
+  expect(ids).toContain("xhigh");
+  expect(ids).toContain("high");
+  expect(ids).toContain("medium");
+  expect(ids).toContain("low");
+});
+
 test("claude haiku-4.5 exposes no effort options (CLI doesn't accept the flag)", () => {
   const ids = supportedEfforts("claude-code", "haiku-4.5").map((o) => o.id);
   expect(ids).toEqual([]);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -427,7 +427,7 @@ export const CODE_PLAN_MODE: Record<AgentKind, { code: string; plan: string }> =
  */
 export const EFFORT_OPTIONS: AgentOption[] = [
   { id: "max", label: "Max", hint: "Absolute maximum effort. Slowest, most thorough." },
-  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Fable 5 / Opus 4.8 / 4.7 / 4.6 / codex only." },
+  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Fable 5 / Opus 4.8 / 4.7 / 4.6 / Sonnet 5 / codex." },
   { id: "high", label: "High", hint: "Deep reasoning. The API default where supported." },
   { id: "medium", label: "Medium", hint: "Balanced speed vs. capability." },
   { id: "low", label: "Low", hint: "Most efficient. Best for simple tasks." },
@@ -453,8 +453,9 @@ export const EFFORT_OPTIONS: AgentOption[] = [
 export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> = {
   // Per https://platform.claude.com/docs/en/build-with-claude/effort the
   // effort parameter is API-supported on Fable 5 / Opus 4.8 / 4.7 / 4.6 /
-  // Sonnet 4.6 / Opus 4.5 (xhigh is Fable-5- and Opus-only; Sonnet 4.6 has no
-  // xhigh; Haiku 4.5 doesn't support effort at all). The `/effort` CLI command accepts more
+  // Sonnet 5 / Sonnet 4.6 / Opus 4.5 (xhigh is Fable-5-, Opus-, and Sonnet-5-only;
+  // Sonnet 4.6 has no xhigh; Haiku 4.5 doesn't support effort at all). The
+  // `/effort` CLI command accepts more
   // levels but the underlying API request would fail for unsupported pairs,
   // so we filter at the picker rather than letting the user fire bad runs.
   "claude-code": {
@@ -463,6 +464,8 @@ export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> =
     "opus-4.8": ["max", "xhigh", "high", "medium", "low"],
     "opus-4.7": ["max", "xhigh", "high", "medium", "low"],
     "opus-4.6": ["max", "xhigh", "high", "medium", "low"],
+    // Sonnet 5 is the first Sonnet-tier model with xhigh (full low→max range).
+    "sonnet-5": ["max", "xhigh", "high", "medium", "low"],
     "sonnet-4.6": ["max", "high", "medium", "low"],
     // Haiku 4.5 doesn't support the effort parameter — `supportedEfforts`
     // returns `[]` and the picker disables itself.
@@ -508,6 +511,7 @@ const MODEL_MODE_DENY: Record<AgentKind, Record<string, string[]>> = {
     "opus-4.8": [],
     "opus-4.7": [],
     "opus-4.6": [],
+    "sonnet-5": [],
     "sonnet-4.6": [],
     "haiku-4.5": [],
   },
@@ -531,7 +535,8 @@ export const AGENT_OPTIONS: Record<AgentKind, AgentOptions> = {
       { id: "opus-4.8", label: "Opus 4.8", hint: "Most capable Opus; slower." },
       { id: "opus-4.7", label: "Opus 4.7", hint: "Prior flagship; same effort range as 4.8." },
       { id: "opus-4.6", label: "Opus 4.6", hint: "Earlier Opus generation." },
-      { id: "sonnet-4.6", label: "Sonnet 4.6", hint: "Balanced." },
+      { id: "sonnet-5", label: "Sonnet 5", hint: "Near-Opus quality on coding/agentic work at Sonnet cost." },
+      { id: "sonnet-4.6", label: "Sonnet 4.6", hint: "Prior Sonnet generation." },
       { id: "haiku-4.5", label: "Haiku 4.5", hint: "Fast and cheap." },
     ],
     modes: [


### PR DESCRIPTION
Add the just-announced Claude Sonnet 5 (claude-sonnet-5) as a selectable claude-code model. It supports the full effort range including xhigh — the first Sonnet-tier model to do so.

Touches the documented sync points:
- AGENT_OPTIONS["claude-code"].models (placed newest-first, above Sonnet 4.6)
- MODEL_EFFORT_SUPPORT (low→max incl. xhigh) + the xhigh effort hint
- MODEL_MODE_DENY (no denied modes)
- CLAUDE_MODEL_FLAG (sonnet-5 → claude-sonnet-5)

DEFAULT_MODEL stays on opus-4.8 — this is purely additive. Adds matching assertions in agents.test.ts and effort-support.test.ts.