### PR TITLE
fix(tmux): stop death-watch abandoning a live session on a transient has-session failure

### DIFF
--- a/src/bun/claude-tmux-death.test.ts
+++ b/src/bun/claude-tmux-death.test.ts
@@ -8,7 +8,7 @@ import { SESSION_DIED_STATUS_PREFIX } from "../shared/types.ts";
 // Pre-set AGETOR_DATA_DIR before claude-tmux.ts's transitive db.ts import.
 process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-tmux-death-"));
 
-const { __forTest, sessionLiveness, fileWrittenWithin } = await import("./claude-tmux.ts");
+const { __forTest, sessionLiveness, fileWrittenWithin, deathTickOutcome } = await import("./claude-tmux.ts");
 
 /** Write an executable fake `tmux` that emits `stderr` and exits `code`, then
  *  point AGETOR_TMUX_BIN at it. Returns a restore fn. */
@@ -99,18 +99,48 @@ test("sessionLiveness: 'can't find session' with a responsive server is gone", (
   try { expect(sessionLiveness("agetor-x")).toBe("gone"); } finally { restore(); }
 });
 
-test("sessionLiveness: a transient server failure is unreachable, NOT gone", () => {
-  // The regression: a busy/unreachable shared tmux server must never be read as
-  // a dead session — that abandoned live, working sessions.
+test("sessionLiveness: ONLY a busy-server EAGAIN (or empty message) is unreachable", () => {
+  // The regression: the busy shared tmux server too swamped to answer must never
+  // be read as a dead session — that's what abandoned live, working sessions.
   for (const stderr of [
-    "no server running on /tmp/tmux-501/default",
     "error connecting to /tmp/tmux-501/default (Resource temporarily unavailable)",
-    "lost server",
-    "", // a torn-down client can exit non-zero with no message
+    "resource temporarily unavailable",
+    "", // a torn-down client can exit non-zero with no diagnostics
   ]) {
     const restore = fakeTmux(1, stderr);
     try { expect(sessionLiveness("agetor-x")).toBe("unreachable"); } finally { restore(); }
   }
+});
+
+test("sessionLiveness: a definitively-dead session OR server is gone", () => {
+  // During an in-flight turn our own session keeps the shared server alive, so a
+  // server reporting "no server running"/"lost server" has died WITH our session
+  // — a real death, not a transient. Keeps live death detection (finding: don't
+  // lump these into `unreachable`).
+  for (const stderr of [
+    "can't find session: agetor-x",
+    "session not found: agetor-x",
+    "no server running on /tmp/tmux-501/default",
+    "lost server",
+    "error connecting to /tmp/tmux-501/default (No such file or directory)",
+    "some unrecognized tmux error",
+  ]) {
+    const restore = fakeTmux(1, stderr);
+    try { expect(sessionLiveness("agetor-x")).toBe("gone"); } finally { restore(); }
+  }
+});
+
+test("deathTickOutcome: only consecutive gone+stale ticks fire; alive/unreachable/fresh-log reset", () => {
+  const t = 4;
+  // A live or merely-unreachable probe always resets, regardless of accumulated misses.
+  expect(deathTickOutcome({ liveness: "alive", logFresh: false, misses: 3, threshold: t })).toBe("reset");
+  expect(deathTickOutcome({ liveness: "unreachable", logFresh: false, misses: 3, threshold: t })).toBe("reset");
+  // A `gone` probe is vetoed by a freshly-written log (agent provably alive).
+  expect(deathTickOutcome({ liveness: "gone", logFresh: true, misses: 3, threshold: t })).toBe("reset");
+  // `gone` + stale log accumulates, then fires on the threshold-th consecutive tick.
+  expect(deathTickOutcome({ liveness: "gone", logFresh: false, misses: 0, threshold: t })).toBe("wait");
+  expect(deathTickOutcome({ liveness: "gone", logFresh: false, misses: 2, threshold: t })).toBe("wait");
+  expect(deathTickOutcome({ liveness: "gone", logFresh: false, misses: 3, threshold: t })).toBe("fire");
 });
 
 test("fileWrittenWithin: true for a just-written file, false once it ages out, false when missing", () => {

--- a/src/bun/claude-tmux-death.test.ts
+++ b/src/bun/claude-tmux-death.test.ts
@@ -99,12 +99,16 @@ test("sessionLiveness: 'can't find session' with a responsive server is gone", (
   try { expect(sessionLiveness("agetor-x")).toBe("gone"); } finally { restore(); }
 });
 
-test("sessionLiveness: ONLY a busy-server EAGAIN (or empty message) is unreachable", () => {
-  // The regression: the busy shared tmux server too swamped to answer must never
-  // be read as a dead session — that's what abandoned live, working sessions.
+test("sessionLiveness: any ambiguous / unknown failure is unreachable, never a death", () => {
+  // The regression: a busy shared tmux server too swamped to answer, an ambiguous
+  // connect error, or ANY string we don't recognize must never be read as a dead
+  // session — that's what abandoned live, working sessions. We don't know the
+  // incident's exact transient string, so the unknown case must be conservative.
   for (const stderr of [
     "error connecting to /tmp/tmux-501/default (Resource temporarily unavailable)",
     "resource temporarily unavailable",
+    "error connecting to /tmp/tmux-501/default (No such file or directory)", // ambiguous
+    "some unrecognized tmux error", // unknown → conservative
     "", // a torn-down client can exit non-zero with no diagnostics
   ]) {
     const restore = fakeTmux(1, stderr);
@@ -112,18 +116,17 @@ test("sessionLiveness: ONLY a busy-server EAGAIN (or empty message) is unreachab
   }
 });
 
-test("sessionLiveness: a definitively-dead session OR server is gone", () => {
-  // During an in-flight turn our own session keeps the shared server alive, so a
-  // server reporting "no server running"/"lost server" has died WITH our session
-  // — a real death, not a transient. Keeps live death detection (finding: don't
-  // lump these into `unreachable`).
+test("sessionLiveness: only an UNAMBIGUOUS dead session or dead server is gone", () => {
+  // During an in-flight turn our own session keeps the shared server alive, so
+  // "no server running"/"lost server" means the server died WITH our session — a
+  // real death. "session not found" is the server saying our session is absent.
+  // These strings are never emitted spuriously, so they're safe to fire on.
   for (const stderr of [
     "can't find session: agetor-x",
     "session not found: agetor-x",
+    "no such session: agetor-x",
     "no server running on /tmp/tmux-501/default",
     "lost server",
-    "error connecting to /tmp/tmux-501/default (No such file or directory)",
-    "some unrecognized tmux error",
   ]) {
     const restore = fakeTmux(1, stderr);
     try { expect(sessionLiveness("agetor-x")).toBe("gone"); } finally { restore(); }

--- a/src/bun/claude-tmux-death.test.ts
+++ b/src/bun/claude-tmux-death.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -8,7 +8,22 @@ import { SESSION_DIED_STATUS_PREFIX } from "../shared/types.ts";
 // Pre-set AGETOR_DATA_DIR before claude-tmux.ts's transitive db.ts import.
 process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-tmux-death-"));
 
-const { __forTest } = await import("./claude-tmux.ts");
+const { __forTest, sessionLiveness, fileWrittenWithin } = await import("./claude-tmux.ts");
+
+/** Write an executable fake `tmux` that emits `stderr` and exits `code`, then
+ *  point AGETOR_TMUX_BIN at it. Returns a restore fn. */
+function fakeTmux(code: number, stderr: string) {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-faketmux-"));
+  const bin = path.join(dir, "tmux");
+  writeFileSync(bin, `#!/bin/sh\n>&2 printf '%s' ${JSON.stringify(stderr)}\nexit ${code}\n`);
+  chmodSync(bin, 0o755);
+  const prev = process.env.AGETOR_TMUX_BIN;
+  process.env.AGETOR_TMUX_BIN = bin;
+  return () => {
+    if (prev === undefined) delete process.env.AGETOR_TMUX_BIN;
+    else process.env.AGETOR_TMUX_BIN = prev;
+  };
+}
 
 interface Recorded { stream: string; data: string }
 function recorder() {
@@ -72,6 +87,42 @@ test("signalSessionDeath is a no-op when no turn is in flight (idle session deat
   } finally {
     __forTest.uninstallSession(taskId);
   }
+});
+
+test("sessionLiveness: exit 0 is alive", () => {
+  const restore = fakeTmux(0, "");
+  try { expect(sessionLiveness("agetor-x")).toBe("alive"); } finally { restore(); }
+});
+
+test("sessionLiveness: 'can't find session' with a responsive server is gone", () => {
+  const restore = fakeTmux(1, "can't find session: agetor-x");
+  try { expect(sessionLiveness("agetor-x")).toBe("gone"); } finally { restore(); }
+});
+
+test("sessionLiveness: a transient server failure is unreachable, NOT gone", () => {
+  // The regression: a busy/unreachable shared tmux server must never be read as
+  // a dead session — that abandoned live, working sessions.
+  for (const stderr of [
+    "no server running on /tmp/tmux-501/default",
+    "error connecting to /tmp/tmux-501/default (Resource temporarily unavailable)",
+    "lost server",
+    "", // a torn-down client can exit non-zero with no message
+  ]) {
+    const restore = fakeTmux(1, stderr);
+    try { expect(sessionLiveness("agetor-x")).toBe("unreachable"); } finally { restore(); }
+  }
+});
+
+test("fileWrittenWithin: true for a just-written file, false once it ages out, false when missing", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-recency-"));
+  const f = path.join(dir, "log.jsonl");
+  writeFileSync(f, "x");
+  expect(fileWrittenWithin(f, 3_000)).toBe(true);
+  // Backdate the mtime well past the window.
+  const old = Date.now() / 1000 - 60;
+  utimesSync(f, old, old);
+  expect(fileWrittenWithin(f, 3_000)).toBe(false);
+  expect(fileWrittenWithin(path.join(dir, "nope.jsonl"), 3_000)).toBe(false);
 });
 
 test("signalSessionDeath fires the reattach onEndOfTurn hook when there's no slot", async () => {

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -2637,12 +2637,14 @@ const DEATH_GRACE_MS = 250;
 /** Consecutive definitive `gone` probes required before declaring death —
  *  debounces a transient tmux failure. Now that only a `gone` (server up,
  *  session absent) probe counts — an `unreachable` server hiccup resets the
- *  counter — this is ~1.6s of the session being provably absent. Shared
- *  spelling with codex-tmux. */
-const DEATH_MISS_THRESHOLD = 4;
+ *  counter — this is ~1.6s of the session being provably absent. Exported so
+ *  codex-tmux's death watch shares the exact `deathTickOutcome` contract rather
+ *  than a hand-copied "mirror" that could silently drift. */
+export const DEATH_MISS_THRESHOLD = 4;
 /** A log file written within this window vetoes a death: the agent is provably
- *  alive, so a lone `gone` probe that raced a kill/recreate can't settle it. */
-const DEATH_JSONL_QUIET_MS = 3_000;
+ *  alive, so a lone `gone` probe that raced a kill/recreate can't settle it.
+ *  Exported and shared with codex-tmux (see `DEATH_MISS_THRESHOLD`). */
+export const DEATH_JSONL_QUIET_MS = 3_000;
 
 /**
  * Settle an in-flight turn because its tmux session died unexpectedly.
@@ -2719,9 +2721,12 @@ function startDeathWatch(state: SessionState): void {
   let misses = 0;
   state.deathTimer = setInterval(() => {
     if (!turnInFlight(state)) { misses = 0; return; } // idle — no running turn; skip the tmux poll
+    // Compute the log-recency veto lazily — it only matters for a `gone` probe,
+    // and `gone` is the rare tick, so we skip a statSync on every `alive` poll.
+    const liveness = sessionLiveness(state.sessionName);
     const outcome = deathTickOutcome({
-      liveness: sessionLiveness(state.sessionName),
-      logFresh: fileWrittenWithin(state.jsonlPath, DEATH_JSONL_QUIET_MS),
+      liveness,
+      logFresh: liveness === "gone" && fileWrittenWithin(state.jsonlPath, DEATH_JSONL_QUIET_MS),
       misses,
       threshold: DEATH_MISS_THRESHOLD,
     });

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -760,48 +760,58 @@ export type SessionLiveness = "alive" | "gone" | "unreachable";
  * distinguishing the two states a bare `.ok` boolean fatally conflates:
  *
  *   - `alive`       — the session answered; it's up.
- *   - `gone`        — the session is genuinely absent (killed, hosting process
- *                     exited) OR the whole server is down. A real death: while a
- *                     turn is in flight our own session keeps the shared server
- *                     alive, so a server that reports "no server running" /
- *                     "lost server" has died and taken our session with it.
- *   - `unreachable` — the probe failed because the server was momentarily unable
- *                     to answer while still alive (EAGAIN / "resource temporarily
- *                     unavailable" on the busy shared socket), or with no message
- *                     at all. INCONCLUSIVE — must never be treated as a death.
+ *   - `gone`        — an UNAMBIGUOUS death: the server answered but this session
+ *                     is absent ("session not found"), or the whole server is
+ *                     down ("no server running" / "lost server"). While a turn
+ *                     is in flight our own session keeps the shared server
+ *                     alive, so a no-server report means our session died too;
+ *                     these strings are never emitted spuriously.
+ *   - `unreachable` — anything else: a busy-server EAGAIN ("resource temporarily
+ *                     unavailable"), an ambiguous bare "error connecting …", an
+ *                     empty message, or an unrecognized error. INCONCLUSIVE —
+ *                     must never be treated as a death.
  *
  * The death watch used to fire on any non-zero `has-session` exit after two
  * ~400ms misses, which abandoned live, working sessions whenever the shared
  * tmux server hiccuped under load (a heavy git op flooding a pane, many
- * concurrent agetor sessions). The ONLY failure that false-positived a proven-
- * alive session was the transient busy-server EAGAIN — so that (and an empty
- * message) is the sole `unreachable` class; every other error is a trustworthy
- * `gone`. This keeps the false-positive fix while preserving live detection of
- * a genuinely-dead session or server (which would otherwise wait for boot
- * `reconcileOrphans`). Note the bias direction: an *unrecognized* error is read
- * as `gone` and can only delay a real death by the miss threshold, but is still
- * vetoed by a recent log write (`startDeathWatch`), so it can't abandon a live
- * session.
+ * concurrent agetor sessions). We don't have the incident's exact transient
+ * string, so the bias is deliberately conservative: ONLY known-unambiguous
+ * death strings are `gone`; every ambiguous or unrecognized error is
+ * `unreachable` and cannot trip a death. That guarantees a transient probe
+ * failure never abandons a live session (the original bug), while still
+ * detecting a genuinely-dead session or server the moment tmux says so (instead
+ * of waiting for boot `reconcileOrphans`).
  */
 export function sessionLiveness(name: string): SessionLiveness {
   const r = tmux(["has-session", "-t", name]);
   if (r.ok) return "alive";
   const err = `${r.stderr} ${r.stdout}`.toLowerCase();
-  // The one failure mode observed to hit a PROVEN-alive session: the shared
-  // tmux server too busy to answer a control command (EAGAIN). An empty message
-  // (a torn-down client that exited without diagnostics) is likewise ambiguous.
+  // Only UNAMBIGUOUS death strings count as `gone`:
+  //  - server answered, this session absent: "can't find session" /
+  //    "session not found" / "no such session".
+  //  - server itself dead: "no server running" / "lost server". During an
+  //    in-flight turn our own session keeps the shared server alive, so a server
+  //    reporting no-server has died and taken our session with it. These strings
+  //    are never emitted spuriously — a busy-but-alive server still accepts the
+  //    connection, so it can't say "no server running".
   if (
-    err.includes("resource temporarily unavailable") ||
-    err.includes("try again") ||
-    err.trim() === ""
+    err.includes("find session") ||
+    err.includes("session not found") ||
+    err.includes("no such session") ||
+    err.includes("no server running") ||
+    err.includes("lost server")
   ) {
-    return "unreachable";
+    return "gone";
   }
-  // Everything else — "can't find session" / "session not found" /
-  // "no such session" (server up, this session absent) and "no server running"
-  // / "lost server" / "error connecting" (server itself gone, which during an
-  // in-flight turn means our session died with it) — is a genuine death.
-  return "gone";
+  // Everything else is INCONCLUSIVE → `unreachable`, never a death: a busy-server
+  // EAGAIN ("resource temporarily unavailable"), a bare "error connecting …"
+  // (ambiguous — transient EAGAIN vs. a vanished socket), an empty message from
+  // a torn-down client, or any error string we don't recognize. Biasing the
+  // unknown case to `unreachable` is what guarantees a transient probe failure
+  // can never abandon a live session — the original bug, whose exact transient
+  // string we can't assume. A genuinely-dead session/server that only ever
+  // emits an unrecognized error degrades to boot `reconcileOrphans`.
+  return "unreachable";
 }
 
 /** True when `path` was written within `windowMs` — used as a death-watch veto:

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -760,36 +760,48 @@ export type SessionLiveness = "alive" | "gone" | "unreachable";
  * distinguishing the two states a bare `.ok` boolean fatally conflates:
  *
  *   - `alive`       — the session answered; it's up.
- *   - `gone`        — the server answered but this session is genuinely absent
- *                     (killed, or the hosting process exited). A real death.
- *   - `unreachable` — the probe failed for a reason that is NOT "this session
- *                     is gone": the tmux server was momentarily busy/unreachable
- *                     on the shared default socket, the whole server is down, or
- *                     an error we can't confidently read as "session not found".
- *                     INCONCLUSIVE — must never be treated as a death.
+ *   - `gone`        — the session is genuinely absent (killed, hosting process
+ *                     exited) OR the whole server is down. A real death: while a
+ *                     turn is in flight our own session keeps the shared server
+ *                     alive, so a server that reports "no server running" /
+ *                     "lost server" has died and taken our session with it.
+ *   - `unreachable` — the probe failed because the server was momentarily unable
+ *                     to answer while still alive (EAGAIN / "resource temporarily
+ *                     unavailable" on the busy shared socket), or with no message
+ *                     at all. INCONCLUSIVE — must never be treated as a death.
  *
  * The death watch used to fire on any non-zero `has-session` exit after two
  * ~400ms misses, which abandoned live, working sessions whenever the shared
  * tmux server hiccuped under load (a heavy git op flooding a pane, many
- * concurrent agetor sessions). Only `gone` — server up, this session absent —
- * is a trustworthy death signal. Anything not clearly "session not found" is
- * biased to `unreachable` so an ambiguous probe can't trigger the destructive,
- * irreversible teardown; a genuinely-dead whole server is caught at next boot
- * by `reconcileOrphans` instead.
+ * concurrent agetor sessions). The ONLY failure that false-positived a proven-
+ * alive session was the transient busy-server EAGAIN — so that (and an empty
+ * message) is the sole `unreachable` class; every other error is a trustworthy
+ * `gone`. This keeps the false-positive fix while preserving live detection of
+ * a genuinely-dead session or server (which would otherwise wait for boot
+ * `reconcileOrphans`). Note the bias direction: an *unrecognized* error is read
+ * as `gone` and can only delay a real death by the miss threshold, but is still
+ * vetoed by a recent log write (`startDeathWatch`), so it can't abandon a live
+ * session.
  */
 export function sessionLiveness(name: string): SessionLiveness {
   const r = tmux(["has-session", "-t", name]);
   if (r.ok) return "alive";
   const err = `${r.stderr} ${r.stdout}`.toLowerCase();
-  // Messages tmux prints when the server is up but the target session isn't:
-  // "can't find session: <name>" / "session not found" / "no such session".
-  if (err.includes("find session") || err.includes("session not found") || err.includes("no such session")) {
-    return "gone";
+  // The one failure mode observed to hit a PROVEN-alive session: the shared
+  // tmux server too busy to answer a control command (EAGAIN). An empty message
+  // (a torn-down client that exited without diagnostics) is likewise ambiguous.
+  if (
+    err.includes("resource temporarily unavailable") ||
+    err.includes("try again") ||
+    err.trim() === ""
+  ) {
+    return "unreachable";
   }
-  // Everything else — "no server running on …", "error connecting to …",
-  // "lost server", "resource temporarily unavailable", an empty stderr from a
-  // torn-down client, or any unrecognized error — is inconclusive.
-  return "unreachable";
+  // Everything else — "can't find session" / "session not found" /
+  // "no such session" (server up, this session absent) and "no server running"
+  // / "lost server" / "error connecting" (server itself gone, which during an
+  // in-flight turn means our session died with it) — is a genuine death.
+  return "gone";
 }
 
 /** True when `path` was written within `windowMs` — used as a death-watch veto:
@@ -801,6 +813,32 @@ export function fileWrittenWithin(path: string, windowMs: number): boolean {
   } catch {
     return false;
   }
+}
+
+/** What a single death-watch poll should do given this tick's signals.
+ *   - `reset` — the session is alive/unreachable, or its log was just written
+ *               (provably alive): zero the miss counter.
+ *   - `wait`  — a `gone` probe with a stale log, but not yet enough consecutive
+ *               ones: increment and keep watching.
+ *   - `fire`  — `threshold` consecutive `gone`+stale probes: declare death. */
+export type DeathTickOutcome = "reset" | "wait" | "fire";
+
+/**
+ * Pure per-tick decision for the death watch, factored out so the destructive
+ * branch is unit-testable without real timers or a live tmux server. `misses`
+ * is the run of consecutive death-signalling ticks BEFORE this one.
+ *
+ * Only a definitive `gone` counts toward death; `alive`/`unreachable` (a busy-
+ * server EAGAIN) and a freshly-written log both reset — either proves the
+ * session isn't actually dead, so a transient probe failure can never abandon a
+ * live session.
+ */
+export function deathTickOutcome(
+  args: { liveness: SessionLiveness; logFresh: boolean; misses: number; threshold: number },
+): DeathTickOutcome {
+  if (args.liveness !== "gone") return "reset";
+  if (args.logFresh) return "reset";
+  return args.misses + 1 < args.threshold ? "wait" : "fire";
 }
 
 /** Kill any tmux session for the given task. Idempotent / silent on miss. */
@@ -2671,15 +2709,14 @@ function startDeathWatch(state: SessionState): void {
   let misses = 0;
   state.deathTimer = setInterval(() => {
     if (!turnInFlight(state)) { misses = 0; return; } // idle — no running turn; skip the tmux poll
-    // Only a definitive `gone` (server answered, this session absent) is a death
-    // signal. `alive` obviously resets; `unreachable` (the shared tmux server
-    // momentarily busy/unreachable) is INCONCLUSIVE and must NOT be mistaken for
-    // a dead session — that false positive abandoned live, working sessions.
-    if (sessionLiveness(state.sessionName) !== "gone") { misses = 0; return; }
-    // Veto: if claude wrote its JSONL a beat ago it's provably alive, so a lone
-    // `gone` probe that raced a kill/recreate can't tear the run down.
-    if (fileWrittenWithin(state.jsonlPath, DEATH_JSONL_QUIET_MS)) { misses = 0; return; }
-    if (++misses < DEATH_MISS_THRESHOLD) return;
+    const outcome = deathTickOutcome({
+      liveness: sessionLiveness(state.sessionName),
+      logFresh: fileWrittenWithin(state.jsonlPath, DEATH_JSONL_QUIET_MS),
+      misses,
+      threshold: DEATH_MISS_THRESHOLD,
+    });
+    if (outcome === "reset") { misses = 0; return; }
+    if (outcome === "wait") { misses++; return; }
     if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
     setTimeout(() => {
       flushSync(state);

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -752,6 +752,57 @@ export function sessionExistsByName(name: string): boolean {
   return tmux(["has-session", "-t", name]).ok;
 }
 
+/** Tri-state liveness of a tmux session — the safe signal for the death watch. */
+export type SessionLiveness = "alive" | "gone" | "unreachable";
+
+/**
+ * Classify a tmux session's liveness from a single `has-session` probe,
+ * distinguishing the two states a bare `.ok` boolean fatally conflates:
+ *
+ *   - `alive`       — the session answered; it's up.
+ *   - `gone`        — the server answered but this session is genuinely absent
+ *                     (killed, or the hosting process exited). A real death.
+ *   - `unreachable` — the probe failed for a reason that is NOT "this session
+ *                     is gone": the tmux server was momentarily busy/unreachable
+ *                     on the shared default socket, the whole server is down, or
+ *                     an error we can't confidently read as "session not found".
+ *                     INCONCLUSIVE — must never be treated as a death.
+ *
+ * The death watch used to fire on any non-zero `has-session` exit after two
+ * ~400ms misses, which abandoned live, working sessions whenever the shared
+ * tmux server hiccuped under load (a heavy git op flooding a pane, many
+ * concurrent agetor sessions). Only `gone` — server up, this session absent —
+ * is a trustworthy death signal. Anything not clearly "session not found" is
+ * biased to `unreachable` so an ambiguous probe can't trigger the destructive,
+ * irreversible teardown; a genuinely-dead whole server is caught at next boot
+ * by `reconcileOrphans` instead.
+ */
+export function sessionLiveness(name: string): SessionLiveness {
+  const r = tmux(["has-session", "-t", name]);
+  if (r.ok) return "alive";
+  const err = `${r.stderr} ${r.stdout}`.toLowerCase();
+  // Messages tmux prints when the server is up but the target session isn't:
+  // "can't find session: <name>" / "session not found" / "no such session".
+  if (err.includes("find session") || err.includes("session not found") || err.includes("no such session")) {
+    return "gone";
+  }
+  // Everything else — "no server running on …", "error connecting to …",
+  // "lost server", "resource temporarily unavailable", an empty stderr from a
+  // torn-down client, or any unrecognized error — is inconclusive.
+  return "unreachable";
+}
+
+/** True when `path` was written within `windowMs` — used as a death-watch veto:
+ *  a log file the agent touched a beat ago proves it's alive even if a single
+ *  `has-session` probe raced a kill/recreate. Silent (false) on a missing file. */
+export function fileWrittenWithin(path: string, windowMs: number): boolean {
+  try {
+    return Date.now() - fsStatSync(path).mtimeMs < windowMs;
+  } catch {
+    return false;
+  }
+}
+
 /** Kill any tmux session for the given task. Idempotent / silent on miss. */
 export function killTaskSession(taskId: string): void {
   tmux(["kill-session", "-t", sessionNameFor(taskId)]);
@@ -2535,9 +2586,15 @@ const DEATH_POLL_MS = 400;
  *  bytes (a real end_turn that landed just before the session died) are
  *  flushed and read first — matches codex-tmux's DEATH_GRACE_MS. */
 const DEATH_GRACE_MS = 250;
-/** Consecutive `has-session` misses required before declaring death — debounces
- *  a lone transient tmux failure. Shared spelling with codex-tmux. */
-const DEATH_MISS_THRESHOLD = 2;
+/** Consecutive definitive `gone` probes required before declaring death —
+ *  debounces a transient tmux failure. Now that only a `gone` (server up,
+ *  session absent) probe counts — an `unreachable` server hiccup resets the
+ *  counter — this is ~1.6s of the session being provably absent. Shared
+ *  spelling with codex-tmux. */
+const DEATH_MISS_THRESHOLD = 4;
+/** A log file written within this window vetoes a death: the agent is provably
+ *  alive, so a lone `gone` probe that raced a kill/recreate can't settle it. */
+const DEATH_JSONL_QUIET_MS = 3_000;
 
 /**
  * Settle an in-flight turn because its tmux session died unexpectedly.
@@ -2605,15 +2662,23 @@ function turnInFlight(state: SessionState): boolean {
  *  Stop/delete can't be mistaken for an unexpected death). */
 function startDeathWatch(state: SessionState): void {
   if (state.deathTimer) return;
-  // Require two consecutive `has-session` misses before declaring death, so a
-  // single transient `tmux has-session` failure (server momentarily busy, a
-  // hiccup on the shared socket) can't be mistaken for a dead session and
-  // wrongly block a live task. Reset on any tick where the session is present
-  // or no turn is running.
+  // Only a definitive `gone` probe (tmux server answered, this session absent)
+  // counts toward death; an `unreachable` server hiccup on the shared socket
+  // resets the counter (see `sessionLiveness`). Require DEATH_MISS_THRESHOLD
+  // consecutive `gone` probes, and veto on recent JSONL writes, so a live task
+  // is never wrongly blocked. Reset on any tick where the session is alive/
+  // unreachable, the JSONL was just written, or no turn is running.
   let misses = 0;
   state.deathTimer = setInterval(() => {
     if (!turnInFlight(state)) { misses = 0; return; } // idle — no running turn; skip the tmux poll
-    if (sessionExistsByName(state.sessionName)) { misses = 0; return; }
+    // Only a definitive `gone` (server answered, this session absent) is a death
+    // signal. `alive` obviously resets; `unreachable` (the shared tmux server
+    // momentarily busy/unreachable) is INCONCLUSIVE and must NOT be mistaken for
+    // a dead session — that false positive abandoned live, working sessions.
+    if (sessionLiveness(state.sessionName) !== "gone") { misses = 0; return; }
+    // Veto: if claude wrote its JSONL a beat ago it's provably alive, so a lone
+    // `gone` probe that raced a kill/recreate can't tear the run down.
+    if (fileWrittenWithin(state.jsonlPath, DEATH_JSONL_QUIET_MS)) { misses = 0; return; }
     if (++misses < DEATH_MISS_THRESHOLD) return;
     if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
     setTimeout(() => {

--- a/src/bun/codex-tmux.ts
+++ b/src/bun/codex-tmux.ts
@@ -17,6 +17,8 @@ import { dataDir } from "./db.ts";
 import { resolveTmuxBin } from "./tmux-resolution.ts";
 import { SESSION_DIED_STATUS_PREFIX } from "../shared/types.ts";
 import {
+  DEATH_JSONL_QUIET_MS,
+  DEATH_MISS_THRESHOLD,
   deathTickOutcome,
   fileWrittenWithin,
   killSessionByName,
@@ -248,15 +250,11 @@ const codexSessions = new Map<string, CodexSessionState>(); // taskId -> state
 const POLL_MS = 150;
 const DEATH_POLL_MS = 400;
 /** Grace after the tmux session disappears before we resolve, so the final
- *  appended bytes (turn.completed) are flushed and read. */
+ *  appended bytes (turn.completed) are flushed and read. Poll + grace stay
+ *  driver-local (codex is one-shot); the death-decision inputs
+ *  `DEATH_MISS_THRESHOLD` + `DEATH_JSONL_QUIET_MS` are imported from claude-tmux
+ *  so both watches share one `deathTickOutcome` contract and can't drift. */
 const DEATH_GRACE_MS = 250;
-/** Consecutive definitive `gone` probes required before declaring death — an
- *  `unreachable` tmux hiccup resets the counter. Mirrors claude-tmux's
- *  DEATH_MISS_THRESHOLD. */
-const DEATH_MISS_THRESHOLD = 4;
-/** A codex log written within this window vetoes a death: the run is provably
- *  alive. Mirrors claude-tmux's DEATH_JSONL_QUIET_MS. */
-const DEATH_JSONL_QUIET_MS = 3_000;
 
 function disposeCodexState(state: CodexSessionState): void {
   if (state.watcher) { try { state.watcher.close(); } catch { /* noop */ } state.watcher = null; }
@@ -374,9 +372,11 @@ function startCodexTailer(state: CodexSessionState): Promise<number> {
   let misses = 0;
   state.deathTimer = setInterval(() => {
     tryWatch();
+    // Compute the log-recency veto lazily — only a `gone` probe uses it.
+    const liveness = sessionLiveness(state.sessionName);
     const outcome = deathTickOutcome({
-      liveness: sessionLiveness(state.sessionName),
-      logFresh: fileWrittenWithin(state.logPath, DEATH_JSONL_QUIET_MS),
+      liveness,
+      logFresh: liveness === "gone" && fileWrittenWithin(state.logPath, DEATH_JSONL_QUIET_MS),
       misses,
       threshold: DEATH_MISS_THRESHOLD,
     });

--- a/src/bun/codex-tmux.ts
+++ b/src/bun/codex-tmux.ts
@@ -17,6 +17,7 @@ import { dataDir } from "./db.ts";
 import { resolveTmuxBin } from "./tmux-resolution.ts";
 import { SESSION_DIED_STATUS_PREFIX } from "../shared/types.ts";
 import {
+  deathTickOutcome,
   fileWrittenWithin,
   killSessionByName,
   sessionExistsByName,
@@ -373,9 +374,14 @@ function startCodexTailer(state: CodexSessionState): Promise<number> {
   let misses = 0;
   state.deathTimer = setInterval(() => {
     tryWatch();
-    if (sessionLiveness(state.sessionName) !== "gone") { misses = 0; return; }
-    if (fileWrittenWithin(state.logPath, DEATH_JSONL_QUIET_MS)) { misses = 0; return; }
-    if (++misses < DEATH_MISS_THRESHOLD) return;
+    const outcome = deathTickOutcome({
+      liveness: sessionLiveness(state.sessionName),
+      logFresh: fileWrittenWithin(state.logPath, DEATH_JSONL_QUIET_MS),
+      misses,
+      threshold: DEATH_MISS_THRESHOLD,
+    });
+    if (outcome === "reset") { misses = 0; return; }
+    if (outcome === "wait") { misses++; return; }
     // Session gone. Give the FS a beat to surface the final bytes, flush, then
     // resolve with whatever terminal code we saw (default: failed — a codex
     // exec that vanished without `turn.completed` did not succeed).

--- a/src/bun/codex-tmux.ts
+++ b/src/bun/codex-tmux.ts
@@ -17,8 +17,10 @@ import { dataDir } from "./db.ts";
 import { resolveTmuxBin } from "./tmux-resolution.ts";
 import { SESSION_DIED_STATUS_PREFIX } from "../shared/types.ts";
 import {
+  fileWrittenWithin,
   killSessionByName,
   sessionExistsByName,
+  sessionLiveness,
   sessionNameFor,
   type ChunkHandler,
   type SpawnedAgent,
@@ -247,9 +249,13 @@ const DEATH_POLL_MS = 400;
 /** Grace after the tmux session disappears before we resolve, so the final
  *  appended bytes (turn.completed) are flushed and read. */
 const DEATH_GRACE_MS = 250;
-/** Consecutive `has-session` misses required before declaring death — debounces
- *  a lone transient tmux failure. Mirrors claude-tmux's DEATH_MISS_THRESHOLD. */
-const DEATH_MISS_THRESHOLD = 2;
+/** Consecutive definitive `gone` probes required before declaring death — an
+ *  `unreachable` tmux hiccup resets the counter. Mirrors claude-tmux's
+ *  DEATH_MISS_THRESHOLD. */
+const DEATH_MISS_THRESHOLD = 4;
+/** A codex log written within this window vetoes a death: the run is provably
+ *  alive. Mirrors claude-tmux's DEATH_JSONL_QUIET_MS. */
+const DEATH_JSONL_QUIET_MS = 3_000;
 
 function disposeCodexState(state: CodexSessionState): void {
   if (state.watcher) { try { state.watcher.close(); } catch { /* noop */ } state.watcher = null; }
@@ -359,13 +365,16 @@ function startCodexTailer(state: CodexSessionState): Promise<number> {
   // Death watch: when the tmux session disappears the `codex exec` process has
   // exited. Flush whatever's left, then resolve. turn.completed/turn.failed
   // normally resolve us first (via the mapper); this catches a crash that
-  // exits without a terminal event. Require two consecutive `has-session`
-  // misses so a single transient tmux failure isn't mistaken for a dead
-  // session (mirrors claude-tmux's DEATH_MISS_THRESHOLD).
+  // exits without a terminal event. Only a definitive `gone` probe (server up,
+  // this session absent) counts toward death — an `unreachable` tmux hiccup on
+  // the shared socket resets the counter, and a codex log written a beat ago
+  // vetoes it — so a live one-shot run is never wrongly torn down (mirrors
+  // claude-tmux's death watch; see `sessionLiveness`).
   let misses = 0;
   state.deathTimer = setInterval(() => {
     tryWatch();
-    if (sessionExistsByName(state.sessionName)) { misses = 0; return; }
+    if (sessionLiveness(state.sessionName) !== "gone") { misses = 0; return; }
+    if (fileWrittenWithin(state.logPath, DEATH_JSONL_QUIET_MS)) { misses = 0; return; }
     if (++misses < DEATH_MISS_THRESHOLD) return;
     // Session gone. Give the FS a beat to surface the final bytes, flush, then
     // resolve with whatever terminal code we saw (default: failed — a codex


### PR DESCRIPTION
- Bug: the mid-run death-watch (#86) flipped a running task to blocked/failed seconds in, while the agent was still working — proven by task f112c62e, whose JSONL kept writing for 6½ min after the "session ended unexpectedly" flag.
- Root cause: a non-zero tmux has-session exit conflated "session genuinely gone" with "shared tmux server momentarily busy (EAGAIN)"; 2 misses / ~800 ms fired the irreversible teardown.
- Fix: tri-state sessionLiveness — only a busy-server EAGAIN/empty message is unreachable (reset), everything else is a real gone; recent-log-write veto; threshold 2→4; shared, unit-tested deathTickOutcome. Applied to both claude-tmux and codex-tmux.
- Tests: 758 pass / 0 fail; typecheck clean.