### PR TITLE
Keep a task in `running` while its background agents are still running

### DIFF
--- a/docs/plans/hold-task-running-while-background-agents-run.md
+++ b/docs/plans/hold-task-running-while-background-agents-run.md
@@ -246,9 +246,21 @@ Render a small pill (match the existing badge/pill idiom already in the file —
 
 **Rollback:** the gate is one `if` in `attachDoneHandler`. Reverting T4 restores today's behavior; T1/T2/T3/T5/T6 are additive and inert without it.
 
-## 8. Open questions / assumptions
+## 8. What actually shipped — deviations from this plan
+
+1. **§7 claimed "Stop still works" on a held task. It did not.** `attachDoneHandler` runs `active.delete(runId)` before parking the card, and `cancelRun` begins `if (!h) return false` — so Stop was a silent no-op on exactly the task it was meant to rescue. Fixed by giving `cancelRun` a held-task branch (interrupt by session name, orphan the rows, release to `review`) and adding `interruptTaskSession` to `claude-tmux.ts`, which addresses the session by its deterministic name and so works with no `SessionState` (as after a boot re-arm).
+2. **`disposeSessionState` was parameterized rather than unconditionally orphaning.** T3 verified all three call sites and found `reattachSession`'s defensive pre-dispose may refer to a *live* session that will keep writing. It takes `orphanSubagents = false`; only `spawnClaudeViaTmux` and `dropSession` — both provably preceded by a `killTaskSession` — pass `true`.
+3. **`dropSession` now also releases when there is no `SessionState`.** A task held across a restart has a boot-armed watcher but no session state, so delete/archive would have leaked its poll timer.
+4. **The boot pass releases (rather than skips) a held task whose run has a null `claudeSessionId`.** No watch path can be derived, so nothing would ever observe those agents finishing — treating it like a dead session is the only non-stranding option.
+5. **`setSubagentEmitter` / `setSubagentSettleHook` now return the previous value.** Not in the original plan. `bun test` shares one process; a test that reset them to `null` un-wired the orchestrator for every later file, and the task could never reach `review`. Tests save and restore.
+6. **`db.runningCountForTask`** added so the hold's status message doesn't scan every row via `runningCountsByTask()`.
+
+## 9. Open questions / assumptions
 
 - **Assumed** the `status` chunk emitted when holding (`background agents still running (N) …`) needs no new sentinel constant — it's informational, not pattern-matched by `makeChunkHandler`. If review disagrees, promote it to `shared/types.ts`.
 - **Assumed** `GET /tasks` is the only route the board reads task rows from. T5 must grep for other `tasks.list()` / `tasks.get()` route handlers and cover them.
 - **Deferred:** distinguishing async (`run_in_background`) from sync `Task` subagents. Not needed for this behavior; revisit if the sub-second hold on sync subagents ever proves visible.
 - **Deferred:** surfacing `failed` / `cancelled` subagent statuses (still dead states after this change; we only add `orphaned`).
+- **Deliberate:** the badge renders in *every* column, not just `running`. If a background agent resumes after the card reached `review`, its row flips back to `running` and the badge reappears on a Review card. The count is truthful and surfaces the anomaly rather than hiding it; nothing pulls the card back to `running`. Revisit if it reads as noise.
+- **Known cosmetic:** deleting a held task emits one transient `column → review` GlobalEvent (via `dropSession` → orphan → settle hook) microseconds before the row is deleted.
+- **Not done:** no real-app smoke test (`bun run dev`). Verified by 789 unit/integration tests only.

--- a/docs/plans/hold-task-running-while-background-agents-run.md
+++ b/docs/plans/hold-task-running-while-background-agents-run.md
@@ -1,0 +1,254 @@
+# Plan — Hold a task in `running` while its background agents are still running
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-09 |
+| Source | `/implement` — "if the task has bg tasks running, keep the task in `running`, don't consider it as done moving to review column as is happening today" |
+| Config | AGENTS_CONFIG.yml (balanced; `implementation` overridden to `opus` for T4 per `allow_orchestrator_override`) |
+| Branch | `agetor/d12b32ddc722-bg-tasks-keep-task-running` (already a feature branch — no new branch) |
+| Base SHA | `5df9a2ee26a150ee9ac398d3ac3d7be16b97b742` (tree clean at start) |
+
+## 1. Objective & success criteria
+
+When a claude-code task's main turn ends with `end_turn` but the session still has
+**background/sub agents in flight**, the task card must stay in `running` instead of
+jumping to `review`. It moves to `review` only once the last background agent finishes.
+
+Success criteria:
+
+1. Main turn succeeds + ≥1 `subagents` row for the task has `status='running'` → task stays `column='running'`; the run row is still recorded `succeeded`.
+2. The last background agent completing flips the task `running → review` automatically, emitting the usual `column` GlobalEvent.
+3. Main turn succeeds + no running subagents → unchanged behavior (`review` immediately).
+4. Codex tasks are entirely unaffected.
+5. `cancelled → ready` and `apiError`/`sessionDied → blocked` still win outright, even with subagents running.
+6. A task can never be stranded in `running`: session death, session disposal, and boot reconciliation all release the hold.
+7. The board card shows a "N background agents" badge while any subagent is running.
+
+## 2. Context & constraints (grounded findings)
+
+- **The single choke point** is `attachDoneHandler` (`src/bun/orchestrator.ts:611-665`). Its `.then()` computes
+  `nextColumn = wasCancelled ? "ready" : (wasApiError||wasSessionDied) ? "blocked" : newStatus === "succeeded" ? "review" : "ready"` (`orchestrator.ts:647-650`) and calls `updateColumn` (`orchestrator.ts:158-170`). Both drivers (`claude-tmux.ts` `popEndOfTurn:1395`, `codex-tmux.ts` `resolveCodexDone:329`) feed the same `agent.done` promise. Neither driver knows about columns.
+- **Subagent state already exists.** `claude-subagents.ts` tails `<sessionId>/subagents/agent-<id>.jsonl` and persists rows in the `subagents` table (`migrations/022_subagents.sql`, `db.ts:657-685`). `SubagentStatus` (`shared/types.ts:712-717`) is `running | completed | failed | cancelled | orphaned`, but **only `running` and `completed` are ever written** — the other three are dead states.
+- **Finish detection** is `checkDone` (`claude-subagents.ts:330-339`): `sawEndOfTurn && now - lastAppendAt > DONE_IDLE_MS (1500)` → `completed` + `emitLifecycle(fs, "finished")`.
+- **Codex writes no subagent rows** (`grep subagent src/bun/codex-tmux.ts` → 0 hits). A gate keyed on the `subagents` table is inert for codex by construction — no `kind` special-casing needed.
+- **`claude-subagents.ts` must not import `orchestrator.ts`** (documented cycle avoidance at `claude-subagents.ts:65-70`). The existing escape hatch is the injected `setSubagentEmitter` sink (`claude-subagents.ts:72-74`, registered at `orchestrator.ts:115`). We follow that exact pattern for the release hook.
+- **The watcher is armed on `SessionState`** (`claude-tmux.ts:2774-2775`, inside `attachTailer`) and detached by `disposeSessionState` (`claude-tmux.ts:3592-3593`) and `signalSessionDeath` (`claude-tmux.ts:2705-2706`). `detach()` deliberately touches no tmux and no DB.
+- **Sync vs async subagents are indistinguishable today** — `isAsync` / `run_in_background` / `async_launched` are parsed nowhere in `src/`. Per owner decision we gate on *any* running row (see §3).
+- **Test gotcha (fleet knowledge, verified 2026-06-30):** `bun test` runs every `*.test.ts` in one process sharing one SQLite DB, and `reconcileOrphans` scans `runs WHERE status='running'` **globally**. A new test that leaves a `running` run row passes alone but breaks `reconcile.test.ts` in the full run. **Seed runs as `status:'succeeded'` with `endedAt` set.**
+
+## 3. Approach & key decisions
+
+**Derive the hold from DB state; never from an in-memory map.** A task is "held" iff:
+
+```
+task.column === 'running'
+  && task.runId != null
+  && runs.get(task.runId).status === 'succeeded'
+  && subagents.hasRunning(task.id)
+```
+
+This makes the release check a pure, idempotent function of persisted state — restart-safe, and immune to the settle-vs-completion ordering race (whichever of the gate and the hook runs second observes consistent state and does the right thing).
+
+Owner decisions taken in Phase 2:
+
+| Question | Decision | Consequence |
+| --- | --- | --- |
+| Stuck guard | **Release on session death / detach**, no watchdog timeout | `signalSessionDeath` + `disposeSessionState` + boot reconcile orphan any still-`running` rows. A wedged-but-alive bg agent still holds — accepted. |
+| Which subagents | **Any `status='running'` row** | No new parsing of claude's internal, version-unstable JSONL shape. Sync `Task` subagents block the parent's `end_turn` inline, so they're rarely running at settle time; when the 1500ms-vs-800ms race does bite, the hook releases within ~700ms. |
+| Other outcomes | **Only gate `succeeded → review`** | `cancelled → ready` and `apiError`/`sessionDied → blocked` unchanged — those need attention now and must not hide behind a churning bg agent. |
+| UI scope | **Badge on the card** | `GET /tasks` gains a derived `runningSubagents` count; `TaskCard` renders a pill. |
+
+**Alternatives rejected:**
+- *Reuse `holdUntilIdle` (`claude-tmux.ts:1181-1188`).* Its contract is "wait for the session to go JSONL-idle, then fire" — exactly wrong here, since a background agent can run for minutes while the main session is silent. It also self-clears inside `popEndOfTurn`, the very function we'd be gating.
+- *Gate inside the driver (`popEndOfTurn`).* Would make the turn never resolve, stranding the run row in `running` and breaking follow-up turns. The run genuinely succeeded; only the **column** should wait.
+- *An in-memory `deferredReview` map in the orchestrator.* Lost on restart, and needs careful invalidation. The DB-derived predicate above is strictly simpler.
+- *Parse `run_in_background` to hold only for async agents.* Couples us to an internal format claude's own docs warn is version-unstable, for a race that self-heals in under a second.
+
+**Double-attach hazard.** The boot pass may want to arm a subagent watcher for a task that has no `SessionState` (its run already `succeeded`, so `reattachSession` skips it). Two live watchers on one task would double-emit over SSE (the `(run_id, line_uuid)` partial unique index blocks the DB dupes, but not the emit). Fix: `attachSubagentWatcher` keeps a module-level `Map<taskId, handle>` and detaches any prior handle for the same task before returning a new one. This makes double-attach structurally impossible for *both* callers.
+
+## 4. Work breakdown — implementation tasks
+
+All six tasks own **disjoint files** and run in **one wave**. Contracts below are exact so agents can compile against each other's not-yet-written code.
+
+---
+
+### T1 — Shared types + DB helpers
+**Owns:** `src/shared/types.ts`, `src/bun/db.ts`
+**Goal:** add the derived `Task.runningSubagents` field and the three `subagents` queries the rest of the change needs.
+
+Contract to expose:
+```ts
+// shared/types.ts — on the Task interface. Server-derived, never persisted,
+// never patchable (it is not a column, so PATCH's allow-list is unaffected).
+/** Count of this task's subagents currently `status:"running"`. Derived per
+ *  request by the server; absent on payloads that don't join the subagents table. */
+runningSubagents?: number;
+
+// db.ts — on the exported `subagents` object
+hasRunning(taskId: string): boolean;
+/** Flip every `running` row for this task to `orphaned` (endedAt = now).
+ *  Returns the affected rows so the caller can emit `finished` lifecycle events. */
+orphanRunning(taskId: string, now: number): Subagent[];
+/** taskId → count of `running` rows. One grouped query for the board poll. */
+runningCountsByTask(): Map<string, number>;
+```
+**Acceptance:** `bun run typecheck` clean; `hasRunning` returns `false` for an unknown task id; `orphanRunning` is a no-op returning `[]` when nothing is running.
+
+---
+
+### T2 — Subagent watcher: registry, orphaning, settle hook
+**Owns:** `src/bun/claude-subagents.ts`
+**Goal:** let the orchestrator learn when a task's last subagent finishes, and give session teardown a way to release the hold — without importing `orchestrator.ts`.
+
+1. **Settle hook**, mirroring `setSubagentEmitter` exactly:
+   ```ts
+   let settleFn: ((taskId: string) => void) | null = null;
+   export function setSubagentSettleHook(fn: ((taskId: string) => void) | null): void { settleFn = fn; }
+   ```
+   Call `settleFn?.(taskId)` **after** each `emitLifecycle(fs, "finished")` in `checkDone` (`claude-subagents.ts:330-339`), i.e. after the DB write, so the orchestrator's predicate reads fresh state.
+2. **`orphanRunningSubagents(taskId: string): void`** — new export. Calls `subagentsDb.orphanRunning(taskId, Date.now())`, emits a `finished` lifecycle event per affected row, then `settleFn?.(taskId)`. Must be safe to call for a task with no watcher and no rows. It must **not** touch tmux.
+3. **Module-level watcher registry.** `const watchers = new Map<string, SubagentWatcherHandle>()`. `attachSubagentWatcher` detaches + deletes any existing handle for `taskId` before building the new one, and registers itself. `detach()` removes its own entry. Add `export function detachWatcherFor(taskId: string): void`.
+4. Keep everything defensive: a DB hiccup must never crash the poll timer (existing `cycle()` try/catch).
+
+**Acceptance:** `attachSubagentWatcher` called twice for one task leaves exactly one live timer; `orphanRunningSubagents` on a clean task is a silent no-op; existing `claude-subagents.test.ts` still passes.
+
+---
+
+### T3 — Release the hold on session death / disposal
+**Owns:** `src/bun/claude-tmux.ts`
+**Goal:** honor the owner's "release on session death / detach" rule.
+
+Call `orphanRunningSubagents(state.taskId)` (imported from `./claude-subagents.ts`) from:
+- `signalSessionDeath` (`claude-tmux.ts:2676-2707`), right after `state.subagentWatcher?.detach()` (line 2705).
+- `disposeSessionState` (`claude-tmux.ts:3579-3593`), right after its `detach()` (line 3592).
+
+**Verify each `disposeSessionState` call site before wiring** (`claude-tmux.ts:2877`, `3139`, `3568`): 2877/3139 clear this instance's *own* stale session immediately before `tmux new-session`, so orphaning the previous session's subagent rows is correct; 3568 is `dropSession` (delete/archive/agent-switch), where the rows are about to be cascade-deleted or are genuinely dead. If any call site turns out to run on a *live* session that will keep writing, do **not** orphan there — report it instead of guessing.
+
+**Boundaries:** do not change `popEndOfTurn`, `firePendingEndTurn`, `holdUntilIdle`, or any turn-resolution logic. The turn still resolves normally; only the column waits.
+
+**Acceptance:** typecheck clean; no change to turn-resolution behavior; `claude-tmux.test.ts` + `claude-tmux-queue.test.ts` still pass.
+
+---
+
+### T4 — The gate, the release, and boot reconciliation  *(runner: opus)*
+**Owns:** `src/bun/orchestrator.ts`
+**Goal:** the heart of the change.
+
+1. **Predicate + release**, near `updateColumn`:
+   ```ts
+   /** A task is "held" when its terminal run succeeded but background agents
+    *  are still running. Derived purely from the DB so it survives a restart. */
+   function isHeldByBackgroundAgents(taskId: string): boolean;
+   /** Idempotent: flip a held task to `review` once its last subagent finishes.
+    *  No-ops if the user moved the card, or a newer run is in flight. */
+   function maybeReleaseHeldTask(taskId: string): void;
+   ```
+   `maybeReleaseHeldTask` must bail unless `task.column === "running"`, `task.runId` is set, `runs.get(task.runId)?.status === "succeeded"`, and `!subagents.hasRunning(taskId)`. Then `updateColumn(taskId, task.runId, "review")`.
+2. **Register the hook** next to `setSubagentEmitter(emit)` (`orchestrator.ts:115`):
+   `setSubagentSettleHook(maybeReleaseHeldTask);`
+3. **The gate** in `attachDoneHandler`'s `.then()` (`orchestrator.ts:643-652`). Only the `succeeded` branch changes:
+   ```ts
+   if (isTerminalRun) {
+     const holdForSubagents = !wasCancelled && !wasApiError && !wasSessionDied
+       && newStatus === "succeeded" && subagents.hasRunning(taskId);
+     if (holdForSubagents) {
+       // Leave the card in `running`. `maybeReleaseHeldTask` (fired by the
+       // subagent settle hook) moves it to `review` when the last one finishes.
+       onChunk-equivalent: emit a `status` chunk so the stream explains the wait.
+     } else {
+       const nextColumn: ColumnId = /* unchanged ternary */;
+       updateColumn(taskId, runId, nextColumn);
+     }
+   }
+   ```
+   Ordering matters: `runs.update(runId, { status: newStatus, ... })` (line 632) already ran, so a concurrent hook firing right now sees `succeeded` and can release correctly. Emit an informational `status` event (e.g. `background agents still running (N) — holding in running`) via `emit(...)` so the run stream explains why the card hasn't moved. Still `emitGlobal({kind:"run-status", status:"succeeded"})` — the *run* did succeed.
+   Leave the `.catch()` branch (`orchestrator.ts:666-680`) untouched: it only produces `ready`/`blocked`, neither of which is gated.
+4. **Boot reconciliation**, at the end of `reconcileOrphans` (`orchestrator.ts:269-424`), after the existing `running`-run pass. For every task with `column === 'running'` whose terminal run is **not** `running` and which `subagents.hasRunning(...)`:
+   - If the task's claude tmux session is alive (`sessionExistsByName(sessionNameFor(taskId))`, already imported) → re-arm the watcher so the still-live background agent can finish and release:
+     `attachSubagentWatcher({ taskId, jsonlPath: jsonlPathFor(cwd, run.claudeSessionId, harness?.home ?? null) })`
+     (skip if `claudeSessionId` is null; `attachSubagentWatcher`'s registry from T2 makes this safe against a later reattach).
+   - Else → `orphanRunningSubagents(taskId)`, which fires the settle hook and releases the card to `review`.
+
+   Add the count of released/re-armed tasks to the existing return value's semantics only if trivial; otherwise leave the return value alone and just log.
+
+**Acceptance:** all five behavioral criteria in §1 (1–5) provable by unit test; `orchestrator.test.ts` + `reconcile.test.ts` still pass.
+
+---
+
+### T5 — Expose the count over HTTP
+**Owns:** `src/bun/server.ts`
+**Goal:** the board poll carries the badge data.
+
+In the `GET /tasks` handler (`server.ts:~865`), join the counts once per request:
+```ts
+const counts = subagents.runningCountsByTask();
+return json(tasks.list().map((t) => ({ ...t, runningSubagents: counts.get(t.id) ?? 0 })));
+```
+Do the same for any single-task read route if one exists (search for `tasks.get(` in route handlers). **Do not** add `runningSubagents` to the `PATCH /tasks/:id` allow-list — it is derived, not stored.
+
+**Acceptance:** `GET /tasks` returns `runningSubagents: 0` for every task on a clean DB; typecheck clean.
+
+---
+
+### T6 — Board badge
+**Owns:** `src/mainview/components/kanban/TaskCard.tsx`
+**Goal:** show "N background agents" while any subagent is running.
+
+Render a small pill (match the existing badge/pill idiom already in the file — do not invent new tokens or add a dependency) when `(task.runningSubagents ?? 0) > 0`. Singular/plural the label. It should read naturally next to the existing `running`-column affordances (the card already shows a Stop button when `column === "running" || column === "blocked"`, `TaskCard.tsx:47,148-151`).
+
+**Boundaries:** `TaskCard.tsx` only. Do not touch `App.tsx`, `RunPanel.tsx`, `subagent-tabs.ts`, or `api.ts` — the 2s `/tasks` poll already refreshes the field.
+
+**Acceptance:** badge absent when the count is 0 or undefined; dark-mode styling consistent with the surrounding card.
+
+---
+
+## 5. Work breakdown — test tasks
+
+### TT1 — Orchestrator hold/release (`src/bun/subagent-hold.test.ts`, new file) — covers T1, T4
+- Succeeded run + a `running` subagent row → task stays `running`.
+- Then flip that row `completed` and call the settle hook → task becomes `review`.
+- Succeeded run + no subagent rows → `review` immediately (regression guard).
+- `cancelled` / `apiError` / `sessionDied` with a `running` subagent → `ready` / `blocked` / `blocked` (hold does not apply).
+- Codex task with no subagent rows → `review` (gate inert).
+- `maybeReleaseHeldTask` no-ops when the user has moved the card out of `running`, and when a newer run is in flight.
+
+**Follow `orchestrator.test.ts:1-17`'s module-top env setup** (`AGETOR_DATA_DIR` = `mkdtemp`, `AGETOR_CLAUDE_DRIVER=fake`, `AGETOR_CLAUDE_BIN`/`AGETOR_TMUX_BIN` = `/bin/echo`) and pass `isolation: "none"` on every `createTask`.
+**Critical:** seed run rows as `status:'succeeded'` with `endedAt` set. A leftover `status:'running'` run row passes in isolation but breaks `reconcile.test.ts` in the combined `bun test`, because `reconcileOrphans` scans running runs globally across the shared DB.
+
+### TT2 — Watcher orphaning + settle hook (extend `src/bun/claude-subagents.test.ts`) — covers T2
+- `orphanRunningSubagents` flips `running` → `orphaned`, sets `endedAt`, emits one `finished` lifecycle event per row, and calls the settle hook once.
+- No-op (no events, no hook) when nothing is running.
+- `attachSubagentWatcher` twice for one task → the first handle is detached; only one watcher remains.
+- Existing `manual: true` + `pump(now)` idiom; do not introduce real timers.
+
+### TT3 — Boot reconciliation (extend or sibling of `src/bun/reconcile.test.ts`) — covers T4 §4
+- Task in `running`, terminal run `succeeded`, one `running` subagent row, no live tmux session → after `reconcileOrphans()` the subagent is `orphaned` and the task is `review`.
+- Same but the run row is `running` → untouched by the new pass (the existing orphan path owns it).
+
+## 6. Execution waves
+
+- **Wave 1** — T1, T2, T3, T4, T5, T6 in parallel (six disjoint files, contracts fixed above). Barrier: `bun run typecheck`, then commit.
+- **Wave 2** — code review of the Wave-1 diff (Phase 5, opus).
+- **Wave 3** — TT1, TT2, TT3 in parallel (three disjoint test files). Barrier: `bun test`.
+- **Wave 4** — fixes for review must-fixes + test failures; re-run `bun test` to green.
+
+## 7. Blast radius & risks
+
+| Risk | Mitigation |
+| --- | --- |
+| A wedged-but-alive background agent holds the card indefinitely | Accepted by owner (no watchdog). Session death, disposal, and boot all release. Stop still works — the card keeps its Stop button in `running`. |
+| Sync `Task` subagent still `running` at settle (1500ms `DONE_IDLE_MS` vs 800ms `END_TURN_IDLE_FIRE_MS`) → card briefly held | Self-heals: `checkDone` fires the settle hook ~700ms later and releases to `review`. Covered by TT1. |
+| Two subagent watchers double-emit over SSE | T2's module-level registry makes double-attach structurally impossible. |
+| New test leaves a `running` run row → breaks `reconcile.test.ts` in the combined run only | Called out explicitly in TT1; seed runs terminal. |
+| `runningSubagents` mistaken for a patchable column | It's derived per-request in `server.ts`, never written by `tasks.update`; PATCH allow-list untouched. |
+| Codex regressions | Gate keys off the `subagents` table, which codex never writes. TT1 asserts a codex task resolves to `review`. |
+| Orphaning at a `disposeSessionState` call site that owns a *live* session | T3 requires verifying all three call sites and reporting rather than guessing. |
+
+**Rollback:** the gate is one `if` in `attachDoneHandler`. Reverting T4 restores today's behavior; T1/T2/T3/T5/T6 are additive and inert without it.
+
+## 8. Open questions / assumptions
+
+- **Assumed** the `status` chunk emitted when holding (`background agents still running (N) …`) needs no new sentinel constant — it's informational, not pattern-matched by `makeChunkHandler`. If review disagrees, promote it to `shared/types.ts`.
+- **Assumed** `GET /tasks` is the only route the board reads task rows from. T5 must grep for other `tasks.list()` / `tasks.get()` route handlers and cover them.
+- **Deferred:** distinguishing async (`run_in_background`) from sync `Task` subagents. Not needed for this behavior; revisit if the sub-second hold on sync subagents ever proves visible.
+- **Deferred:** surfacing `failed` / `cancelled` subagent statuses (still dead states after this change; we only add `orphaned`).

--- a/src/bun/claude-subagents.test.ts
+++ b/src/bun/claude-subagents.test.ts
@@ -1,15 +1,64 @@
-import { test, expect, beforeAll } from "bun:test";
+import { test, expect, beforeAll, afterEach } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { RunEvent } from "../shared/types.ts";
+import type { RunEvent, Subagent } from "../shared/types.ts";
 
 const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-subagents-"));
 process.env.AGETOR_DATA_DIR = DATA_DIR;
 
+// Whatever the orchestrator registered at its module load (or `null` if this
+// file runs before it). `bun test` shares one process across every file, so
+// hard-resetting these to `null` in `afterEach` would leave every later file
+// with no SSE sink and no release path — a held task would never reach
+// `review`. Capture by read-modify-restore and put the originals back.
+let originalEmitter: ((e: RunEvent) => void) | null = null;
+let originalSettleHook: ((taskId: string) => void) | null = null;
+
 beforeAll(async () => {
   await import("./db.ts");
+  const { setSubagentEmitter, setSubagentSettleHook } = await import("./claude-subagents.ts");
+  originalEmitter = setSubagentEmitter(null);
+  setSubagentEmitter(originalEmitter);
+  originalSettleHook = setSubagentSettleHook(null);
+  setSubagentSettleHook(originalSettleHook);
+});
+
+// Every task `seed()` creates is tracked here and torn down in the global
+// `afterEach` below. THE TRAP: `seed()` always inserts the task with
+// `column: "running"` and the run as `status: "succeeded"` — exactly the
+// shape `reconcileOrphans`'s held-task sweep (orchestrator.ts) looks for
+// (task.column==='running' && run.status==='succeeded' && a claude-code
+// agent). Combined with a `running` subagent row (which several tests below
+// create), a task left behind here would get silently swept into `review`
+// by any later `reconcileOrphans()` call — including one from
+// reconcile.test.ts, which shares this same process's SQLite db. Deleting
+// the task row (FK ON DELETE CASCADE on runs/subagents/run_events, verified
+// live via `PRAGMA foreign_keys = ON` in db.ts) removes it from every scan.
+const createdTaskIds: string[] = [];
+
+afterEach(async () => {
+  const { detachWatcherFor, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  setSubagentEmitter(originalEmitter);
+  setSubagentSettleHook(originalSettleHook);
+  if (createdTaskIds.length === 0) return;
+  const { tasks } = await import("./db.ts");
+  for (const id of createdTaskIds) {
+    try {
+      detachWatcherFor(id);
+    } catch {
+      /* best-effort */
+    }
+    try {
+      tasks.delete(id);
+    } catch {
+      /* best-effort */
+    }
+  }
+  createdTaskIds.length = 0;
 });
 
 /** Build a temp `<sessionId>/subagents/` layout + a seeded task/run, returning
@@ -18,6 +67,7 @@ async function seed() {
   const { tasks, runs } = await import("./db.ts");
   const taskId = `task-sub-${randomUUID()}`;
   const runId = `run-sub-${randomUUID()}`;
+  createdTaskIds.push(taskId);
   const now = Date.now();
   tasks.insert({
     id: taskId, title: "t", prompt: "p", column: "running", agent: "claude-code",
@@ -205,4 +255,246 @@ test("AGETOR_TRACK_SUBAGENTS=0 yields an inert no-op watcher", async () => {
   w.detach();
   if (prev === undefined) delete process.env.AGETOR_TRACK_SUBAGENTS;
   else process.env.AGETOR_TRACK_SUBAGENTS = prev;
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Settle hook
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("setSubagentSettleHook fires exactly once, after the DB row already reads 'completed'", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+  setSubagentEmitter(() => { /* drain */ });
+
+  const agentId = `settle-${randomUUID()}`;
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "Explore", description: "settle", spawnDepth: 1 }));
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`), sidechainLines());
+
+  const settleCalls: string[] = [];
+  // Collected rather than assigned to a `let`: TS keeps narrowing a
+  // `let x: string | null = null` to `null` across a callback assignment, so
+  // the later `toBe("completed")` wouldn't typecheck.
+  const statusesInsideHook: string[] = [];
+  setSubagentSettleHook((tid) => {
+    settleCalls.push(tid);
+    // Read the DB from INSIDE the hook — this is the ordering guarantee under
+    // test: fireSettle runs after checkDone's `subagentsDb.setStatus(...,
+    // "completed", ...)` write, so a hook reading the row here must already
+    // see the terminal status.
+    statusesInsideHook.push(subagents.get(agentId)!.status);
+  });
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0);
+  expect(settleCalls.length).toBe(0); // mere discovery never settles
+
+  appendFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`),
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: "sA", message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "done" }] } }) + "\n");
+  w.pump(t0 + 1);
+  expect(settleCalls.length).toBe(0); // end_turn observed but not idle yet — not done
+
+  w.pump(t0 + 10_000); // idle past DONE_IDLE_MS → completes → fires settle
+  expect(settleCalls).toEqual([taskId]);
+  expect(statusesInsideHook).toEqual(["completed"]);
+  expect(subagents.get(agentId)!.status).toBe("completed");
+
+  // A further pump with nothing new to complete must not re-fire the hook.
+  w.pump(t0 + 20_000);
+  expect(settleCalls).toEqual([taskId]);
+
+  w.detach();
+});
+
+test("a throwing settle hook does not crash the poll cycle, and the DB write still lands", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+  setSubagentEmitter(() => { /* drain */ });
+
+  const agentId = `throws-${randomUUID()}`;
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "Explore", description: "throws", spawnDepth: 1 }));
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`), sidechainLines());
+
+  let hookCalls = 0;
+  setSubagentSettleHook(() => {
+    hookCalls++;
+    throw new Error("settle hook boom");
+  });
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0);
+  appendFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`),
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: "tB", message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "done" }] } }) + "\n");
+  w.pump(t0 + 1);
+
+  expect(() => w.pump(t0 + 10_000)).not.toThrow();
+  expect(hookCalls).toBe(1);
+  // The hook throwing must not have rolled back (or prevented) the DB write
+  // that happened just before `fireSettle` was called.
+  expect(subagents.get(agentId)!.status).toBe("completed");
+
+  w.detach();
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * orphanRunningSubagents
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("orphanRunningSubagents flips only running rows to orphaned, emits one lifecycle event each, and fires settle once", async () => {
+  const { subagents } = await import("./db.ts");
+  const { orphanRunningSubagents, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, runId } = await seed();
+
+  const now = Date.now();
+  const running1: Subagent = {
+    id: `orph-r1-${randomUUID()}`, taskId, runId, parentKind: "subagent",
+    agentType: "Explore", description: "r1", spawnDepth: 1,
+    sourcePath: "/tmp/r1.jsonl", status: "running", startedAt: now, endedAt: null,
+  };
+  const running2: Subagent = {
+    id: `orph-r2-${randomUUID()}`, taskId, runId, parentKind: "subagent",
+    agentType: "general-purpose", description: "r2", spawnDepth: 1,
+    sourcePath: "/tmp/r2.jsonl", status: "running", startedAt: now, endedAt: null,
+  };
+  const completedEndedAt = now - 5_000;
+  const completed: Subagent = {
+    id: `orph-c1-${randomUUID()}`, taskId, runId, parentKind: "subagent",
+    agentType: "Explore", description: "c1", spawnDepth: 1,
+    sourcePath: "/tmp/c1.jsonl", status: "completed", startedAt: now - 10_000, endedAt: completedEndedAt,
+  };
+  for (const s of [running1, running2, completed]) subagents.insertIfAbsent(s);
+
+  const captured: RunEvent[] = [];
+  setSubagentEmitter((e) => captured.push(e));
+  const settleCalls: string[] = [];
+  setSubagentSettleHook((tid) => settleCalls.push(tid));
+
+  orphanRunningSubagents(taskId);
+
+  const r1 = subagents.get(running1.id)!;
+  const r2 = subagents.get(running2.id)!;
+  const c1 = subagents.get(completed.id)!;
+  expect(r1.status).toBe("orphaned");
+  expect(r1.endedAt).not.toBeNull();
+  expect(r2.status).toBe("orphaned");
+  expect(r2.endedAt).not.toBeNull();
+  // The already-completed row must be left untouched — same status, same endedAt.
+  expect(c1.status).toBe("completed");
+  expect(c1.endedAt).toBe(completedEndedAt);
+
+  const finished = captured.filter((e) => e.stream === "subagent" && JSON.parse(e.data).phase === "finished");
+  expect(finished.length).toBe(2);
+  expect(finished.map((e) => e.subagentId).sort()).toEqual([running1.id, running2.id].sort());
+  expect(finished.every((e) => e.taskId === taskId)).toBe(true);
+
+  // Fired ONCE for the whole batch, not once per orphaned row.
+  expect(settleCalls).toEqual([taskId]);
+});
+
+test("orphanRunningSubagents on a task with no rows is a silent no-op: no events, no settle", async () => {
+  const { orphanRunningSubagents, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId } = await seed(); // fresh task — zero subagent rows ever created
+
+  const captured: RunEvent[] = [];
+  setSubagentEmitter((e) => captured.push(e));
+  const settleCalls: string[] = [];
+  setSubagentSettleHook((tid) => settleCalls.push(tid));
+
+  expect(() => orphanRunningSubagents(taskId)).not.toThrow();
+
+  expect(captured.length).toBe(0);
+  // Real contract (read from the implementation): `orphanRunning` returns []
+  // for a task with no running rows, and the function returns immediately
+  // BEFORE calling `fireSettle` — there's nothing for the orchestrator's
+  // release predicate to usefully re-check, so the hook is not fired at all
+  // (not "fired with zero effect").
+  expect(settleCalls.length).toBe(0);
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Module-level watcher registry
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("attachSubagentWatcher detaches a prior handle for the same taskId; different taskIds stay independent", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher } = await import("./claude-subagents.ts");
+  const { taskId: taskA, jsonlPath: jsonlA, subagentsDir: dirA } = await seed();
+  const { taskId: taskB, jsonlPath: jsonlB, subagentsDir: dirB } = await seed();
+
+  const h1 = attachSubagentWatcher({ taskId: taskA, jsonlPath: jsonlA, manual: true });
+  const hB = attachSubagentWatcher({ taskId: taskB, jsonlPath: jsonlB, manual: true });
+
+  // Re-attach for taskA — must silently detach h1 (structurally impossible to
+  // double-attach the same taskId per the module comment on `watchers`).
+  const h2 = attachSubagentWatcher({ taskId: taskA, jsonlPath: jsonlA, manual: true });
+
+  // h1 is now inert: writing a new subagent file and pumping h1 must NOT
+  // discover it.
+  const idOld = `old-${randomUUID()}`;
+  writeFileSync(path.join(dirA, `agent-${idOld}.meta.json`), JSON.stringify({ agentType: "Explore", description: "x", spawnDepth: 1 }));
+  writeFileSync(path.join(dirA, `agent-${idOld}.jsonl`), sidechainLines());
+  h1.pump(Date.now());
+  expect(subagents.listForTask(taskA).length).toBe(0);
+
+  // h2 — the live, currently-registered handle — DOES discover it.
+  h2.pump(Date.now());
+  expect(subagents.listForTask(taskA).length).toBe(1);
+  expect(subagents.listForTask(taskA)[0]!.id).toBe(idOld);
+
+  // taskB's watcher, untouched by taskA's re-attach, keeps working
+  // independently — attaching for a different taskId must not detach it.
+  const idB = `b-${randomUUID()}`;
+  writeFileSync(path.join(dirB, `agent-${idB}.meta.json`), JSON.stringify({ agentType: "Explore", description: "y", spawnDepth: 1 }));
+  writeFileSync(path.join(dirB, `agent-${idB}.jsonl`), sidechainLines());
+  hB.pump(Date.now());
+  expect(subagents.listForTask(taskB).length).toBe(1);
+
+  h2.detach();
+  hB.detach();
+});
+
+test("a stale handle's detach() cannot evict a newer handle for the same taskId", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, detachWatcherFor } = await import("./claude-subagents.ts");
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+
+  const h1 = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const h2 = attachSubagentWatcher({ taskId, jsonlPath, manual: true }); // auto-detaches h1
+
+  // Calling detach() on the now-stale h1 must be a no-op w.r.t. the registry —
+  // it must NOT evict h2 (identity-compared inside detach()).
+  h1.detach();
+
+  const id1 = `stale-${randomUUID()}`;
+  writeFileSync(path.join(subagentsDir, `agent-${id1}.meta.json`), JSON.stringify({ agentType: "Explore", description: "x", spawnDepth: 1 }));
+  writeFileSync(path.join(subagentsDir, `agent-${id1}.jsonl`), sidechainLines());
+  h2.pump(Date.now()); // h2 must still be live/functional after h1.detach()
+  expect(subagents.listForTask(taskId).length).toBe(1);
+
+  // Now tear down via the registry helper — this SHOULD reach h2, since it's
+  // still the registered handle for taskId.
+  detachWatcherFor(taskId);
+  const id2 = `stale2-${randomUUID()}`;
+  writeFileSync(path.join(subagentsDir, `agent-${id2}.meta.json`), JSON.stringify({ agentType: "Explore", description: "y", spawnDepth: 1 }));
+  writeFileSync(path.join(subagentsDir, `agent-${id2}.jsonl`), sidechainLines());
+  h2.pump(Date.now()); // now inert
+  expect(subagents.listForTask(taskId).length).toBe(1); // unchanged — h2 didn't discover id2
+});
+
+test("detachWatcherFor on an unknown taskId is a silent no-op", async () => {
+  const { detachWatcherFor } = await import("./claude-subagents.ts");
+  expect(() => detachWatcherFor(`no-such-task-${randomUUID()}`)).not.toThrow();
 });

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -69,8 +69,16 @@ const DONE_IDLE_MS = 1500;
  * (DB-only) when no emitter is registered.
  */
 let emitFn: ((e: RunEvent) => void) | null = null;
-export function setSubagentEmitter(fn: ((e: RunEvent) => void) | null): void {
+/** Returns the previously-registered sink. `bun test` shares one process across
+ *  every test file, so a test that installs a spy here must put the real one
+ *  back — otherwise it silently un-wires the orchestrator for every file that
+ *  runs after it. Production ignores the return value. */
+export function setSubagentEmitter(
+  fn: ((e: RunEvent) => void) | null,
+): ((e: RunEvent) => void) | null {
+  const prev = emitFn;
   emitFn = fn;
+  return prev;
 }
 
 /**
@@ -82,8 +90,15 @@ export function setSubagentEmitter(fn: ((e: RunEvent) => void) | null): void {
  * only signals "something changed for taskId," never decides what to do.
  */
 let settleFn: ((taskId: string) => void) | null = null;
-export function setSubagentSettleHook(fn: ((taskId: string) => void) | null): void {
+/** Returns the previously-registered hook, for the same save/restore reason as
+ *  `setSubagentEmitter`: nulling this in a test's `afterEach` strands every
+ *  later test file with no release path, so a held task never reaches `review`. */
+export function setSubagentSettleHook(
+  fn: ((taskId: string) => void) | null,
+): ((taskId: string) => void) | null {
+  const prev = settleFn;
   settleFn = fn;
+  return prev;
 }
 
 /** Call the settle hook, never letting a throwing hook reach the poll timer

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -73,6 +73,30 @@ export function setSubagentEmitter(fn: ((e: RunEvent) => void) | null): void {
   emitFn = fn;
 }
 
+/**
+ * Settle hook, injected once by the orchestrator at startup. Fired whenever a
+ * subagent transitions to a terminal state so the orchestrator can re-check
+ * its "still holding this task in `running`?" predicate without this module
+ * importing orchestrator.ts (same cycle-avoidance rationale as `emitFn`
+ * above). The predicate itself lives on the orchestrator side — this module
+ * only signals "something changed for taskId," never decides what to do.
+ */
+let settleFn: ((taskId: string) => void) | null = null;
+export function setSubagentSettleHook(fn: ((taskId: string) => void) | null): void {
+  settleFn = fn;
+}
+
+/** Call the settle hook, never letting a throwing hook reach the poll timer
+ *  (or any other caller in this file) — the hook runs orchestrator logic we
+ *  don't control, and a bad release predicate must not take the tail down. */
+function fireSettle(taskId: string): void {
+  try {
+    settleFn?.(taskId);
+  } catch (e) {
+    console.error(`[claude-subagents] settle hook threw for task ${taskId}:`, e);
+  }
+}
+
 interface SubagentMeta {
   agentType: string | null;
   description: string | null;
@@ -143,6 +167,21 @@ export interface SubagentWatcherHandle {
   pump(now?: number): void;
 }
 
+/** One live watcher per task, tops — a second `attachSubagentWatcher` for the
+ *  same taskId (e.g. a re-run of `reattachSession` racing a fresh spawn)
+ *  would otherwise leave two timers tailing the same files with independent
+ *  offsets, double-emitting everything. Keyed here instead of trusting every
+ *  call site to remember to detach its previous handle first. */
+const watchers = new Map<string, SubagentWatcherHandle>();
+
+/** Detach whatever watcher is currently registered for a task, if any — a
+ *  no-op when there isn't one (no live watcher, or it already detached
+ *  itself). Exported so a caller can release a task's watcher without
+ *  starting a replacement (e.g. session teardown). */
+export function detachWatcherFor(taskId: string): void {
+  watchers.get(taskId)?.detach();
+}
+
 /** The run a newly-discovered subagent should attach its events to: the task's
  *  current run if one is live, else its most recent run. `task.runId` survives
  *  the resolve-to-`review` transition, so this is reliably set while the
@@ -169,6 +208,49 @@ function toSubagentShape(fs: FileState, taskId: string): Subagent {
   };
 }
 
+/** Same lifecycle-event shape `emitLifecycle` builds from a live `FileState`,
+ *  but built straight off a DB row instead — needed for callers (like
+ *  `orphanRunningSubagents` below) that fire for a task with no attached
+ *  watcher, so there's no `FileState` closure to draw from. */
+function emitLifecycleForRow(sub: Subagent): void {
+  const payload: SubagentEvent = { phase: "finished", subagent: sub };
+  emitFn?.({
+    runId: sub.runId ?? sub.id,
+    taskId: sub.taskId,
+    stream: "subagent",
+    data: JSON.stringify(payload),
+    ts: Date.now(),
+    subagentId: sub.id,
+  });
+}
+
+/**
+ * Orphan every still-`running` subagent row for a task and settle it — the
+ * counterpart to a run's own orphan path (boot reconciliation, a dead tmux
+ * session, …). Called when the thing those subagents were reporting into no
+ * longer exists to hear from them, so their "running" status would otherwise
+ * hold the task hostage forever. Safe to call with no watcher attached, no
+ * rows to orphan, or mid-shutdown — this never touches tmux and never throws.
+ */
+export function orphanRunningSubagents(taskId: string): void {
+  let rows: Subagent[];
+  try {
+    rows = subagentsDb.orphanRunning(taskId, Date.now());
+  } catch (e) {
+    console.error(`[claude-subagents] orphanRunning failed for task ${taskId}:`, e);
+    return;
+  }
+  if (rows.length === 0) return;
+  for (const row of rows) {
+    try {
+      emitLifecycleForRow(row);
+    } catch (e) {
+      console.error(`[claude-subagents] orphan lifecycle emit failed for subagent ${row.id}:`, e);
+    }
+  }
+  fireSettle(taskId);
+}
+
 /**
  * Start watching `<sessionId>/subagents/` for the given task. The directory is
  * derived from the main session's `jsonlPath` so it tracks whatever layout
@@ -182,9 +264,14 @@ export function attachSubagentWatcher(opts: {
    *  watcher via `pump()` instead of real timers. */
   manual?: boolean;
 }): SubagentWatcherHandle {
+  const { taskId } = opts;
+  // Make double-attach for the same task structurally impossible: whatever
+  // was watching this task before (a stale reattach, a leftover from a prior
+  // spawn) gets torn down before we build the new one.
+  detachWatcherFor(taskId);
+
   if (!ENABLED) return { detach() { /* disabled */ }, pump() { /* disabled */ } };
 
-  const { taskId } = opts;
   const sessionId = path.basename(opts.jsonlPath, ".jsonl");
   const subagentsDir = path.join(path.dirname(opts.jsonlPath), sessionId, "subagents");
   const files = new Map<string, FileState>();
@@ -334,6 +421,9 @@ export function attachSubagentWatcher(opts: {
         fs.endedAt = now;
         subagentsDb.setStatus(fs.subagentId, "completed", now);
         emitLifecycle(fs, "finished");
+        // The DB write above must land before the orchestrator's release
+        // predicate (which reads subagentsDb.hasRunning) can see it as done.
+        fireSettle(taskId);
       }
     }
   }
@@ -379,13 +469,17 @@ export function attachSubagentWatcher(opts: {
   // pass `manual` and drive `pump()` themselves.
   if (!opts.manual) timer = setTimeout(tick, FAST_POLL_MS);
 
-  return {
+  const handle: SubagentWatcherHandle = {
     detach(): void {
       detached = true;
       if (timer) clearTimeout(timer);
       timer = null;
       dirWatcher?.close();
       dirWatcher = null;
+      // Only remove ourselves if we're still the registered handle — a newer
+      // attach for this taskId may already have replaced (and detached) us,
+      // and deleting unconditionally would drop that newer entry instead.
+      if (watchers.get(taskId) === handle) watchers.delete(taskId);
       // NB: intentionally does NOT touch tmux. Tearing down the watcher must
       // never stop the agent — other tasks (and the user's own session) share
       // the tmux server.
@@ -394,4 +488,6 @@ export function attachSubagentWatcher(opts: {
       cycle(now ?? Date.now());
     },
   };
+  watchers.set(taskId, handle);
+  return handle;
 }

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -12,7 +12,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { tasks } from "./db.ts";
-import { attachSubagentWatcher, orphanRunningSubagents, type SubagentWatcherHandle } from "./claude-subagents.ts";
+import { attachSubagentWatcher, detachWatcherFor, orphanRunningSubagents, type SubagentWatcherHandle } from "./claude-subagents.ts";
 import { ensureInstalledForCwd } from "./hook-installer.ts";
 import {
   activeTmuxPromptsForTask,
@@ -3578,8 +3578,29 @@ export function dropSession(taskId: string): void {
     // any `running` subagent rows are never getting another transcript line.
     disposeSessionState(state, true);
     sessions.delete(taskId);
+  } else {
+    // A task held in `running` across a restart has a watcher armed by the boot
+    // pass but no SessionState (its run already succeeded, so nothing
+    // reattached). Without this the boot-armed watcher outlives the task it
+    // belongs to, polling a directory that delete/archive is about to remove.
+    detachWatcherFor(taskId);
+    orphanRunningSubagents(taskId);
   }
   killTaskSession(taskId);
+}
+
+/**
+ * Send Ctrl+C to a task's tmux session addressed purely by its deterministic
+ * name — no in-memory `SessionState` required. Stop on a task whose turn has
+ * already resolved (held in `running` while its background agents finish) has
+ * no `active` run handle to route the interrupt through, and after a restart it
+ * has no `SessionState` either. Returns false when the session is already gone.
+ */
+export function interruptTaskSession(taskId: string): boolean {
+  const name = sessionNameFor(taskId);
+  if (!sessionExistsByName(name)) return false;
+  tmux(["send-keys", "-t", name, "C-c"]);
+  return true;
 }
 
 /** Close any watcher / interval timer held by a SessionState and reject any

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -12,7 +12,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { tasks } from "./db.ts";
-import { attachSubagentWatcher, type SubagentWatcherHandle } from "./claude-subagents.ts";
+import { attachSubagentWatcher, orphanRunningSubagents, type SubagentWatcherHandle } from "./claude-subagents.ts";
 import { ensureInstalledForCwd } from "./hook-installer.ts";
 import {
   activeTmuxPromptsForTask,
@@ -2704,6 +2704,12 @@ function signalSessionDeath(state: SessionState): void {
   if (state.scrapeTimer) { clearInterval(state.scrapeTimer); state.scrapeTimer = null; }
   state.subagentWatcher?.detach();
   state.subagentWatcher = null;
+  // The tmux session is provably gone, so nothing will ever write another
+  // subagent transcript line for this task — a still-`running` subagent row
+  // would otherwise hold the task in `running` forever waiting on an agent
+  // that no longer exists. Release it the same way the run itself is
+  // released above.
+  orphanRunningSubagents(state.taskId);
 }
 
 /** Whether a turn is currently in flight on this session — a live head slot
@@ -2873,8 +2879,10 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
   // doesn't leak the old state's watcher + poll/scrape/death timers. Mirrors
   // reattachSession's defensive pre-dispose. Safe on a fresh task (no-op on
   // undefined); on a re-run the old turn is already terminal so no queued slot
-  // is rejected.
-  disposeSessionState(sessions.get(opts.taskId));
+  // is rejected. `orphanSubagents: true` — `killTaskSession` above already
+  // killed the prior session, so any of its rows still `status='running'`
+  // are provably never going to hear from their agent again.
+  disposeSessionState(sessions.get(opts.taskId), true);
   sessions.set(opts.taskId, state);
 
   const done = new Promise<number>((resolve, reject) => {
@@ -3565,7 +3573,10 @@ export function cycleToMode(taskId: string, targetAgetorMode: string): Promise<C
 export function dropSession(taskId: string): void {
   const state = sessions.get(taskId);
   if (state) {
-    disposeSessionState(state);
+    // `orphanSubagents: true` — this task's session is being torn down for
+    // good (delete/archive/agent-switch, `killTaskSession` right below), so
+    // any `running` subagent rows are never getting another transcript line.
+    disposeSessionState(state, true);
     sessions.delete(taskId);
   }
   killTaskSession(taskId);
@@ -3575,8 +3586,18 @@ export function dropSession(taskId: string): void {
  *  queued turn slots so dependent promises settle. Used both by
  *  `dropSession` (intentional teardown) and by `reattachSession` (defensive
  *  cleanup before overwriting an entry in the sessions map). Safe to call
- *  with `undefined` so the caller can pass `sessions.get(taskId)` directly. */
-function disposeSessionState(state: SessionState | undefined): void {
+ *  with `undefined` so the caller can pass `sessions.get(taskId)` directly.
+ *
+ *  `orphanSubagents` gates whether this dispose also flips the task's
+ *  `running` subagent rows to `orphaned`. Only pass `true` when the
+ *  underlying tmux session is provably dead by this point — `dropSession`
+ *  (kills the session right after) and `spawnClaudeViaTmux`'s pre-kill
+ *  (already killed the session before disposing the old state). Leave it
+ *  `false` for `reattachSession`'s defensive re-dispose: a non-null prior
+ *  state there means the SAME tmux session is about to be reattached again,
+ *  which may still be alive and still writing subagent transcripts —
+ *  orphaning there would drop tracking for an agent that's still running. */
+function disposeSessionState(state: SessionState | undefined, orphanSubagents = false): void {
   if (!state) return;
   state.watcher?.close();
   state.watcher = null;
@@ -3591,6 +3612,7 @@ function disposeSessionState(state: SessionState | undefined): void {
   // this stops us TAILING the subagent files, never the agent itself.
   state.subagentWatcher?.detach();
   state.subagentWatcher = null;
+  if (orphanSubagents) orphanRunningSubagents(state.taskId);
   state.onEndOfTurn = null;
   state.pendingEndTurn = null;
   const err = new Error("session killed");

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -689,6 +689,14 @@ export const subagents = {
     ).get(taskId);
     return row !== null;
   },
+  /** How many of this task's subagents are `running`. Distinct from
+   *  `runningCountsByTask` so a single-task caller doesn't scan every row. */
+  runningCountForTask(taskId: string): number {
+    const row = db.query<{ n: number }, [string]>(
+      `SELECT COUNT(*) AS n FROM subagents WHERE task_id = ? AND status = 'running'`,
+    ).get(taskId);
+    return row?.n ?? 0;
+  },
   /** Flip every `running` row for this task to `orphaned` (ended_at = now).
    *  Returns the affected rows (post-update shape) so the caller can emit a
    *  `finished` lifecycle event per row. Returns [] when nothing was running. */

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -682,4 +682,32 @@ export const subagents = {
   setStatus(id: string, status: SubagentStatus, endedAt: number | null): void {
     db.run(`UPDATE subagents SET status = ?, ended_at = ? WHERE id = ?`, [status, endedAt, id]);
   },
+  /** True when at least one subagent row for this task is still `running`. */
+  hasRunning(taskId: string): boolean {
+    const row = db.query<{ 1: number }, [string]>(
+      `SELECT 1 FROM subagents WHERE task_id = ? AND status = 'running' LIMIT 1`,
+    ).get(taskId);
+    return row !== null;
+  },
+  /** Flip every `running` row for this task to `orphaned` (ended_at = now).
+   *  Returns the affected rows (post-update shape) so the caller can emit a
+   *  `finished` lifecycle event per row. Returns [] when nothing was running. */
+  orphanRunning(taskId: string, now: number): Subagent[] {
+    const rows = db.query<SubagentRow, [string]>(
+      `SELECT * FROM subagents WHERE task_id = ? AND status = 'running'`,
+    ).all(taskId);
+    if (rows.length === 0) return [];
+    db.run(
+      `UPDATE subagents SET status = 'orphaned', ended_at = ? WHERE task_id = ? AND status = 'running'`,
+      [now, taskId],
+    );
+    return rows.map((r) => toSubagent({ ...r, status: "orphaned", ended_at: now }));
+  },
+  /** taskId -> count of `running` rows. One grouped query, for the board poll. */
+  runningCountsByTask(): Map<string, number> {
+    const rows = db.query<{ task_id: string; n: number }, []>(
+      `SELECT task_id, COUNT(*) AS n FROM subagents WHERE status = 'running' GROUP BY task_id`,
+    ).all();
+    return new Map(rows.map((r) => [r.task_id, r.n]));
+  },
 };

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { db, tasks, runs, harnesses } from "./db.ts";
+import { db, tasks, runs, harnesses, subagents } from "./db.ts";
 import { spawnAgent, toClaudeModelArg } from "./agents.ts";
 import { checkHarness } from "./agent-status.ts";
 import {
@@ -47,12 +47,18 @@ import {
   sessionExistsByName,
   sessionLiveness,
   sessionNameFor,
+  jsonlPathFor,
 } from "./claude-tmux.ts";
 import {
   dropCodexSession,
   reattachCodexSession,
 } from "./codex-tmux.ts";
-import { setSubagentEmitter } from "./claude-subagents.ts";
+import {
+  setSubagentEmitter,
+  setSubagentSettleHook,
+  orphanRunningSubagents,
+  attachSubagentWatcher,
+} from "./claude-subagents.ts";
 import { prepareWorkdir, removeWorktree, repoRoot, resolveRef, branchName } from "./worktree.ts";
 import { killTerminalsForTask } from "./terminals.ts";
 import { ensureInstalledForCwd } from "./hook-installer.ts";
@@ -114,6 +120,12 @@ function emit(e: RunEvent) {
 // channel the UI already subscribes to.
 setSubagentEmitter(emit);
 
+// A held task's terminal run is already `succeeded`, so nothing in the run
+// lifecycle will ever move it out of `running` — the release has to be driven
+// by the background agents themselves. Register the release as the subagent
+// settle hook so the last-agent-finishing edge lands the card in `review`.
+setSubagentSettleHook(maybeReleaseHeldTask);
+
 /**
  * Subscribe to the app-wide lifecycle stream — terminal run-status
  * transitions and column changes. Live-only: subscribers see events from the
@@ -167,6 +179,36 @@ function updateColumn(
   if (prev !== next) {
     emitGlobal({ kind: "column", taskId, runId, column: next, prev, ts: Date.now(), reason });
   }
+}
+
+/**
+ * A task is "held" when its terminal run already succeeded but background
+ * agents are still running. Derived purely from the DB (not the in-memory
+ * `active` map) so the answer survives a restart and doesn't depend on
+ * whether the subagent's settle fired before or after the run's completion
+ * landed — either interleaving reads the same committed rows.
+ */
+function isHeldByBackgroundAgents(taskId: string): boolean {
+  const task = tasks.get(taskId);
+  if (!task || task.column !== "running" || task.runId == null) return false;
+  if (runs.get(task.runId)?.status !== "succeeded") return false;
+  return subagents.hasRunning(taskId);
+}
+
+/**
+ * Flip a held task to `review` once its last subagent finishes. Called on
+ * every subagent completion (via the settle hook), so it must be cheap and
+ * safe to call repeatedly — it no-ops unless the task is still held-and-clear:
+ * the user hasn't moved the card, the terminal run still succeeded, and no
+ * subagent is left running. A newer in-flight run (status !== succeeded) also
+ * bails, so a held release can't stomp a follow-up turn's `running` state.
+ */
+function maybeReleaseHeldTask(taskId: string): void {
+  const task = tasks.get(taskId);
+  if (!task || task.column !== "running" || task.runId == null) return;
+  if (runs.get(task.runId)?.status !== "succeeded") return;
+  if (subagents.hasRunning(taskId)) return;
+  updateColumn(taskId, task.runId, "review");
 }
 
 /** Test hook: drive the event bus directly to verify SSE routing without
@@ -421,6 +463,52 @@ export function reconcileOrphans(): number {
   if (orphaned.length > 0) {
     console.log(`[agetor] orphaned ${orphaned.length} run(s) with no recoverable session`);
   }
+
+  // Held tasks are invisible to the pass above: their terminal run is already
+  // `succeeded`, so it never appears in the `status='running'` scan and nothing
+  // re-arms the subagent watcher that would eventually release the card. Left
+  // alone, a restart strands a held task in `running` forever. Walk the
+  // `column='running'` tasks whose terminal run isn't running but that still
+  // have live subagent rows, and either re-arm the watcher (session still up,
+  // the background agent can finish and settle) or orphan the rows (session
+  // gone → settle hook lands the card in `review`).
+  let reArmed = 0;
+  let released = 0;
+  const heldTaskIds = db.query<{ id: string }, []>(
+    `SELECT id FROM tasks WHERE "column" = 'running'`,
+  ).all();
+  for (const { id: heldId } of heldTaskIds) {
+    if (!isHeldByBackgroundAgents(heldId)) continue;
+    const task = tasks.get(heldId);
+    if (!task) continue;
+    // Only claude-code writes subagent rows; a codex task can never be held, so
+    // it never reaches here. Guard the session probe on kind for clarity.
+    if (resolveHarness(task.agent)?.kind !== "claude-code") continue;
+    if (sessionExistsByName(sessionNameFor(heldId))) {
+      const run = task.runId ? runs.get(task.runId) : null;
+      // No JSONL session id means no watch directory to derive — the background
+      // agents can't be re-tailed, so leave the rows for a later settle rather
+      // than fabricating a path.
+      if (!run?.claudeSessionId) continue;
+      const cwd = task.worktreePath ?? task.workdir;
+      const harness = resolveHarness(task.agent);
+      attachSubagentWatcher({
+        taskId: heldId,
+        jsonlPath: jsonlPathFor(cwd, run.claudeSessionId, harness?.home ?? null),
+      });
+      reArmed++;
+    } else {
+      // Session gone: no watcher could ever observe these agents finishing, so
+      // flip the rows now. `orphanRunningSubagents` fires the settle hook →
+      // `maybeReleaseHeldTask` → the card advances to `review`.
+      orphanRunningSubagents(heldId);
+      released++;
+    }
+  }
+  if (reArmed > 0 || released > 0) {
+    console.log(`[agetor] held tasks: re-armed ${reArmed} watcher(s), released ${released} to review`);
+  }
+
   return orphaned.length;
 }
 
@@ -641,14 +729,37 @@ function attachDoneHandler(
       const task = tasks.get(taskId);
       const isTerminalRun = !!task && task.runId === runId;
       if (isTerminalRun) {
-        // Cancellation wins over api-error here, matching the newStatus
-        // resolution above — a user-cancelled run shouldn't land in
-        // `blocked` just because it had previously hit an API error.
-        const nextColumn: ColumnId = wasCancelled
-          ? "ready"
-          : (wasApiError || wasSessionDied) ? "blocked"
-          : newStatus === "succeeded" ? "review" : "ready";
-        updateColumn(taskId, runId, nextColumn);
+        // A clean success with background agents still in flight is HELD in
+        // `running` rather than advanced to `review` — the run finished but the
+        // task's work hasn't. `runs.update(..., "succeeded")` already landed
+        // above, so the concurrent-settle path (`maybeReleaseHeldTask`) reads
+        // the correct terminal status; whichever of the two fires last wins and
+        // both interleavings converge on the right column, so no lock is needed.
+        const holdForSubagents =
+          newStatus === "succeeded"
+          && !wasCancelled
+          && !wasApiError
+          && !wasSessionDied
+          && subagents.hasRunning(taskId);
+        if (holdForSubagents) {
+          const runningCount = subagents.runningCountsByTask().get(taskId) ?? 0;
+          emit({
+            runId,
+            taskId,
+            stream: "status",
+            data: `background agents still running (${runningCount}) — holding in running`,
+            ts: Date.now(),
+          });
+        } else {
+          // Cancellation wins over api-error here, matching the newStatus
+          // resolution above — a user-cancelled run shouldn't land in
+          // `blocked` just because it had previously hit an API error.
+          const nextColumn: ColumnId = wasCancelled
+            ? "ready"
+            : (wasApiError || wasSessionDied) ? "blocked"
+            : newStatus === "succeeded" ? "review" : "ready";
+          updateColumn(taskId, runId, nextColumn);
+        }
       }
       emit({
         runId,

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -48,6 +48,7 @@ import {
   sessionLiveness,
   sessionNameFor,
   jsonlPathFor,
+  interruptTaskSession,
 } from "./claude-tmux.ts";
 import {
   dropCodexSession,
@@ -486,10 +487,14 @@ export function reconcileOrphans(): number {
     if (resolveHarness(task.agent)?.kind !== "claude-code") continue;
     if (sessionExistsByName(sessionNameFor(heldId))) {
       const run = task.runId ? runs.get(task.runId) : null;
-      // No JSONL session id means no watch directory to derive — the background
-      // agents can't be re-tailed, so leave the rows for a later settle rather
-      // than fabricating a path.
-      if (!run?.claudeSessionId) continue;
+      // No JSONL session id means no watch directory to derive, so nothing will
+      // ever observe these agents finishing. Treat it exactly like a dead
+      // session and release, rather than leaving the card held forever.
+      if (!run?.claudeSessionId) {
+        orphanRunningSubagents(heldId);
+        released++;
+        continue;
+      }
       const cwd = task.worktreePath ?? task.workdir;
       const harness = resolveHarness(task.agent);
       attachSubagentWatcher({
@@ -742,7 +747,7 @@ function attachDoneHandler(
           && !wasSessionDied
           && subagents.hasRunning(taskId);
         if (holdForSubagents) {
-          const runningCount = subagents.runningCountsByTask().get(taskId) ?? 0;
+          const runningCount = subagents.runningCountForTask(taskId);
           emit({
             runId,
             taskId,
@@ -956,7 +961,20 @@ function formatModeChangeFailure(agetorMode: string, result: Extract<CycleResult
 
 export function cancelRun(runId: string): boolean {
   const h = active.get(runId);
-  if (!h) return false;
+  if (!h) {
+    // A held task (turn succeeded, background agents still running) has no
+    // `active` handle — `attachDoneHandler` dropped it before parking the card
+    // in `running`. Its Stop button must still do something, or a background
+    // agent that wedges without dying leaves the user no way out short of a
+    // restart. Interrupt the live session and release the hold; the run itself
+    // already succeeded, so the card advances to `review`.
+    const taskId = runs.get(runId)?.taskId;
+    if (!taskId || !isHeldByBackgroundAgents(taskId)) return false;
+    cancelPendingForTask(taskId, "cancelled by user");
+    interruptTaskSession(taskId);
+    orphanRunningSubagents(taskId);
+    return true;
+  }
   // Stop targets the whole task, not just one run. `kill()` sends Ctrl+C
   // to the tmux session, which also clears claude's queued-input buffer,
   // so every queued run in this task is going down too. Mark each

--- a/src/bun/reconcile.test.ts
+++ b/src/bun/reconcile.test.ts
@@ -1,14 +1,128 @@
-import { test, expect, beforeAll, afterAll } from "bun:test";
+import { test, expect, beforeAll, afterAll, afterEach } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import type { Task, Run, Subagent } from "../shared/types.ts";
 
 const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-reconcile-"));
 process.env.AGETOR_DATA_DIR = DATA_DIR;
 
+/** Tracks task ids created by the boot-reconciliation-of-held-tasks tests
+ *  below so `afterEach` can drop them (cascade-deletes their runs +
+ *  subagents rows via the FK). Pre-existing tests above/below don't push
+ *  here, so this is a silent no-op for them. Cleanup matters here more than
+ *  in most files: `reconcileOrphans` now scans `tasks WHERE "column" =
+ *  'running'` globally, so a leftover held-shaped row would keep getting
+ *  re-visited (harmlessly, but wastefully) by every later call in this
+ *  process, including from sibling test files in the combined `bun test`. */
+let cleanupTaskIds: string[] = [];
+afterEach(async () => {
+  if (cleanupTaskIds.length === 0) return;
+  const { db } = await import("./db.ts");
+  for (const id of cleanupTaskIds) {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [id]);
+  }
+  cleanupTaskIds = [];
+});
+
+/** Write an executable fake `tmux` that always exits `code` regardless of
+ *  args, then point AGETOR_TMUX_BIN at it — makes `sessionExistsByName`
+ *  deterministic without depending on a real tmux server or on whatever
+ *  ambient AGETOR_TMUX_BIN a sibling test file left behind in this shared
+ *  process. Mirrors the `fakeTmux` helper in claude-tmux-death.test.ts.
+ *  Returns a restore fn; callers must call it (use try/finally). */
+function fakeTmux(code: number, stderr = "") {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-reconcile-faketmux-"));
+  const bin = path.join(dir, "tmux");
+  writeFileSync(bin, `#!/bin/sh\n>&2 printf '%s' ${JSON.stringify(stderr)}\nexit ${code}\n`);
+  chmodSync(bin, 0o755);
+  const prev = process.env.AGETOR_TMUX_BIN;
+  process.env.AGETOR_TMUX_BIN = bin;
+  return () => {
+    if (prev === undefined) delete process.env.AGETOR_TMUX_BIN;
+    else process.env.AGETOR_TMUX_BIN = prev;
+  };
+}
+
+/** A task row shaped like the "held by background agents" state: parked in
+ *  `running` with a run id already set. Callers override `column`/`agent`/etc.
+ *  as needed per case. */
+function heldTaskRow(overrides: Partial<Task> & { id: string; runId: string | null }): Task {
+  const now = Date.now();
+  return {
+    title: "held",
+    prompt: "p",
+    column: "running",
+    agent: "claude-code",
+    workdir: "/tmp",
+    isolation: "none",
+    taskType: "task",
+    branch: null,
+    worktreePath: null,
+    baseRef: null,
+    mode: null,
+    model: null,
+    effort: null,
+    references: [],
+    hasOpenableRun: false,
+    pendingInteractionCount: 0,
+    openTerminalCount: 0,
+    archivedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+/** A terminal ("succeeded") run row — the shape a held task's run must have
+ *  per `isHeldByBackgroundAgents`. Per the plan's documented test gotcha,
+ *  tests must never leave a `status:'running'` run row lying around: the
+ *  FIRST reconcile pass scans `runs WHERE status='running'` globally, so a
+ *  stray one breaks sibling assertions in the combined `bun test`. */
+function succeededRun(id: string, taskId: string, overrides: Partial<Run> = {}): Run {
+  const now = Date.now();
+  return {
+    id,
+    taskId,
+    agent: "claude-code",
+    status: "succeeded",
+    startedAt: now,
+    endedAt: now,
+    exitCode: 0,
+    tmuxSession: null,
+    claudeSessionId: `sess-${randomUUID()}`,
+    codexSessionId: null,
+    ...overrides,
+  };
+}
+
+function subagentRow(id: string, taskId: string, runId: string | null, overrides: Partial<Subagent> = {}): Subagent {
+  const now = Date.now();
+  return {
+    id,
+    taskId,
+    runId,
+    parentKind: "subagent",
+    agentType: "Explore",
+    description: "test subagent",
+    spawnDepth: 1,
+    sourcePath: "/tmp/agent.jsonl",
+    status: "running",
+    startedAt: now,
+    endedAt: null,
+    ...overrides,
+  };
+}
+
 beforeAll(async () => {
   await import("./db.ts");
+  // Importing orchestrator.ts runs its module top level, which registers the
+  // real `maybeReleaseHeldTask` as the subagent settle hook. The held-task
+  // tests below rely on that hook firing when `orphanRunningSubagents` clears
+  // the last `running` row. (Sibling test files save/restore the hook rather
+  // than nulling it, so it survives whatever order `bun test` picks.)
+  await import("./orchestrator.ts");
 });
 
 afterAll(async () => {
@@ -211,4 +325,179 @@ test("startTask honors cancel — exit handler records status 'cancelled'", asyn
 
   const list = runs.listForTask(created.task.id);
   expect(list[0]?.status).toBe("cancelled");
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Boot reconciliation of tasks held `running` by background agents
+ * (orchestrator.ts's second `reconcileOrphans` pass, appended after the
+ * runs-scan pass above). A held task's terminal run is already `succeeded`,
+ * so the runs-scan pass never sees it — nothing would re-arm its subagent
+ * watcher after a restart without this second pass. See
+ * docs/plans/hold-task-running-while-background-agents-run.md §4/T4.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("held-task boot pass: dead tmux session → subagent orphaned, task released to review", async () => {
+  const { tasks, runs, subagents } = await import("./db.ts");
+  const { reconcileOrphans } = await import("./orchestrator.ts");
+
+  const restoreTmux = fakeTmux(1, "can't find session"); // has-session always fails → "gone"
+  try {
+    const taskId = `task-held-dead-${randomUUID()}`;
+    const runId = `run-held-dead-${randomUUID()}`;
+    const subId = `sub-held-dead-${randomUUID()}`;
+    cleanupTaskIds.push(taskId);
+
+    tasks.insert(heldTaskRow({ id: taskId, runId }));
+    runs.insert(succeededRun(runId, taskId));
+    subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
+
+    reconcileOrphans();
+
+    const sub = subagents.get(subId);
+    expect(sub?.status).toBe("orphaned");
+    expect(sub?.endedAt).not.toBeNull();
+
+    const task = tasks.get(taskId);
+    expect(task?.column).toBe("review");
+  } finally {
+    restoreTmux();
+  }
+});
+
+test("held-task boot pass: a task whose terminal run is still 'running' is left to the existing orphan pass, not double-handled", async () => {
+  // Guards against the two reconcile passes fighting: this task LOOKS
+  // held-shaped (column='running', a `running` subagent row) but its run
+  // hasn't actually finished, so `isHeldByBackgroundAgents` must be false
+  // and the FIRST pass (runs WHERE status='running') must own it instead —
+  // orphaning the run and dropping the column to `ready`, not `review`.
+  const { tasks, runs, subagents } = await import("./db.ts");
+  const { reconcileOrphans } = await import("./orchestrator.ts");
+
+  const taskId = `task-notheld-running-${randomUUID()}`;
+  const runId = `run-notheld-running-${randomUUID()}`;
+  const subId = `sub-notheld-running-${randomUUID()}`;
+  cleanupTaskIds.push(taskId);
+
+  tasks.insert(heldTaskRow({ id: taskId, runId }));
+  // status:'running', no tmux_session/claude_session_id → the first pass's
+  // `canTryReattach` is false, so it falls straight to orphaning — no tmux
+  // dependency needed here, keeping this test fully deterministic.
+  runs.insert(succeededRun(runId, taskId, {
+    status: "running", endedAt: null, exitCode: null,
+    tmuxSession: null, claudeSessionId: null,
+  }));
+  subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
+
+  reconcileOrphans();
+
+  const run = runs.get(runId);
+  expect(run?.status).toBe("orphaned");
+
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("ready");
+
+  // The new pass never gets a chance to touch this subagent row: the first
+  // pass's transaction already flipped the task out of `running` before the
+  // second pass's `tasks WHERE "column" = 'running'` scan runs (both passes
+  // execute inside the same `reconcileOrphans()` call), so the task is
+  // invisible to it. The row is left exactly as seeded.
+  const sub = subagents.get(subId);
+  expect(sub?.status).toBe("running");
+});
+
+test("held-task boot pass: succeeded run with no running subagents is left untouched in running", async () => {
+  // Not held (no `running` subagent row) → `isHeldByBackgroundAgents` is
+  // false → the pass's `if (!isHeldByBackgroundAgents(heldId)) continue;`
+  // skips this task outright. Verified by reading orchestrator.ts, not
+  // assumed: this leaves the card resting in `running` with nothing armed to
+  // move it (no live SessionState from this boot, no subagent watcher) until
+  // some other action touches it — a slightly odd resting state, but it is
+  // what the code does, and matches the plan's success criterion #3 ("no
+  // running subagents → unchanged behavior") applied at boot time rather
+  // than at settle time.
+  const { tasks, runs, subagents } = await import("./db.ts");
+  const { reconcileOrphans } = await import("./orchestrator.ts");
+
+  const taskId = `task-notheld-clean-${randomUUID()}`;
+  const runId = `run-notheld-clean-${randomUUID()}`;
+  const subId = `sub-notheld-clean-${randomUUID()}`;
+  cleanupTaskIds.push(taskId);
+
+  tasks.insert(heldTaskRow({ id: taskId, runId }));
+  runs.insert(succeededRun(runId, taskId));
+  subagents.insertIfAbsent(subagentRow(subId, taskId, runId, { status: "completed", endedAt: Date.now() }));
+
+  reconcileOrphans();
+
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("running");
+
+  const sub = subagents.get(subId);
+  expect(sub?.status).toBe("completed");
+});
+
+test("held-task boot pass: a codex task can never be held — the kind !== 'claude-code' guard skips it untouched", async () => {
+  // Codex never actually writes `subagents` rows (the table is claude-only —
+  // grep confirms zero call sites in codex-tmux.ts). This constructs the
+  // closest synthetic analogue (a codex task with a `running` subagent row
+  // it would never really have) purely to exercise the
+  // `resolveHarness(task.agent)?.kind !== "claude-code"` guard in the new
+  // pass. `isHeldByBackgroundAgents` itself doesn't check kind — it would
+  // report this task as held — so this test pins the guard as the thing
+  // actually protecting codex, not an accident of the predicate.
+  const { tasks, runs, subagents } = await import("./db.ts");
+  const { reconcileOrphans } = await import("./orchestrator.ts");
+
+  const taskId = `task-codex-held-shaped-${randomUUID()}`;
+  const runId = `run-codex-held-shaped-${randomUUID()}`;
+  const subId = `sub-codex-held-shaped-${randomUUID()}`;
+  cleanupTaskIds.push(taskId);
+
+  tasks.insert(heldTaskRow({ id: taskId, runId, agent: "codex" }));
+  runs.insert(succeededRun(runId, taskId, {
+    agent: "codex", claudeSessionId: null, codexSessionId: `thread-${randomUUID()}`,
+  }));
+  subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
+
+  reconcileOrphans();
+
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("running");
+
+  const sub = subagents.get(subId);
+  expect(sub?.status).toBe("running");
+});
+
+test("held-task boot pass: null claudeSessionId with a live tmux session is released, not stranded", async () => {
+  // No JSONL session id means there's no watch directory to derive, so a
+  // live tmux session can't help re-arm a watcher — orchestrator.ts's
+  // `if (!run?.claudeSessionId)` branch treats this exactly like a dead
+  // session and releases immediately rather than leaving the card held
+  // forever. `fakeTmux(0, ...)` makes "session alive" deterministic for
+  // every has-session probe regardless of the actual session name, so this
+  // doesn't depend on a real tmux server or session.
+  const { tasks, runs, subagents } = await import("./db.ts");
+  const { reconcileOrphans } = await import("./orchestrator.ts");
+
+  const restoreTmux = fakeTmux(0, "");
+  try {
+    const taskId = `task-held-nosession-${randomUUID()}`;
+    const runId = `run-held-nosession-${randomUUID()}`;
+    const subId = `sub-held-nosession-${randomUUID()}`;
+    cleanupTaskIds.push(taskId);
+
+    tasks.insert(heldTaskRow({ id: taskId, runId }));
+    runs.insert(succeededRun(runId, taskId, { claudeSessionId: null }));
+    subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
+
+    reconcileOrphans();
+
+    const task = tasks.get(taskId);
+    expect(task?.column).toBe("review");
+
+    const sub = subagents.get(subId);
+    expect(sub?.status).toBe("orphaned");
+  } finally {
+    restoreTmux();
+  }
 });

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -103,6 +103,17 @@ const json = (data: unknown, init?: ResponseInit) =>
     status: init?.status,
   });
 
+// Derived, never-persisted count of this task's still-`running` subagent
+// rows — drives the kanban card's "N background agents" badge. Single-task
+// routes are called far less often than the 2s `/tasks` poll, so a one-off
+// filter over `listForTask` (already exported, already indexed by task_id)
+// is fine here; `/tasks` itself uses the grouped `runningCountsByTask()`
+// query instead of calling this per row.
+function withRunningSubagents(t: Task): Task & { runningSubagents: number } {
+  const runningSubagents = subagents.listForTask(t.id).filter((s) => s.status === "running").length;
+  return { ...t, runningSubagents };
+}
+
 // Turn raw path strings into references: keep only existing absolute paths,
 // dedupe, and read directory-ness from the filesystem (authoritative — more
 // reliable than the webview's view). The stat filter also discards the bogus
@@ -862,7 +873,13 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       },
 
       "/tasks": {
-        GET: authed((req) => json(tasks.list(), { headers: corsHeaders(req) })),
+        GET: authed((req) => {
+          const counts = subagents.runningCountsByTask();
+          return json(
+            tasks.list().map((t) => ({ ...t, runningSubagents: counts.get(t.id) ?? 0 })),
+            { headers: corsHeaders(req) },
+          );
+        }),
         POST: authed(async (req) => {
           const body = (await req.json()) as Partial<Task> & {
             baseRef?: string;
@@ -901,7 +918,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if ("error" in result) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }
-          return json(result.task, { headers: corsHeaders(req) });
+          return json(withRunningSubagents(result.task), { headers: corsHeaders(req) });
         }),
       },
 
@@ -909,7 +926,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
         GET: authed((req) => {
           const t = tasks.get(req.params.id);
           return t
-            ? json(t, { headers: corsHeaders(req) })
+            ? json(withRunningSubagents(t), { headers: corsHeaders(req) })
             : json({ error: "not found" }, { status: 404, headers: corsHeaders(req) });
         }),
         PATCH: authed(async (req) => {
@@ -1006,7 +1023,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           reconcileTaskSession(req.params.id, before, updated).catch((err: unknown) => {
             console.error("reconcileTaskSession failed:", err);
           });
-          return json(updated, { headers: corsHeaders(req) });
+          return json(withRunningSubagents(updated), { headers: corsHeaders(req) });
         }),
         DELETE: authed(async (req) => {
           await deleteTask(req.params.id);
@@ -1028,7 +1045,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           const result = archiveTask(req.params.id);
           return "error" in result
             ? json(result, { status: 400, headers: corsHeaders(req) })
-            : json(result.task, { headers: corsHeaders(req) });
+            : json(withRunningSubagents(result.task), { headers: corsHeaders(req) });
         }),
       },
 
@@ -1037,7 +1054,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           const result = unarchiveTask(req.params.id);
           return "error" in result
             ? json(result, { status: 400, headers: corsHeaders(req) })
-            : json(result.task, { headers: corsHeaders(req) });
+            : json(withRunningSubagents(result.task), { headers: corsHeaders(req) });
         }),
       },
 

--- a/src/bun/subagent-hold.test.ts
+++ b/src/bun/subagent-hold.test.ts
@@ -1,0 +1,368 @@
+import { test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+// Only AGETOR_DATA_DIR belongs at module top level: db.ts captures it at first
+// import, `beforeAll` would race a sibling that already imported db.ts, and the
+// value is unique per file so nobody inherits it harmfully.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-test-"));
+
+// Every OTHER override is scoped to this file and restored afterwards. `bun
+// test` shares one process, so a top-level `process.env.X = …` leaks into every
+// file that runs later. Concretely: AGETOR_CODEX_DRIVER=fake and
+// AGETOR_TMUX_BIN=/bin/echo would break reconcile.test.ts's "startTask honors
+// cancel" test, which deliberately uses the REAL codex driver in a REAL tmux
+// session so there is something alive to cancel. spawnAgent and the
+// agent-status preflight both read these at CALL time, so beforeAll is early
+// enough.
+const ENV_OVERRIDES: Record<string, string> = {
+  AGETOR_CLAUDE_DRIVER: "fake", // in-process fake instead of tmux + the real CLI
+  AGETOR_CLAUDE_BIN: "/bin/echo", // agent-status preflight passes without claude
+  AGETOR_TMUX_BIN: "/bin/echo", // tmux probe in agent-status passes
+  AGETOR_CLAUDE_ARGS: "",
+  AGETOR_CODEX_DRIVER: "fake", // only the "codex is inert" test needs this
+  AGETOR_CODEX_BIN: "/bin/echo",
+};
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeAll(() => {
+  for (const [k, v] of Object.entries(ENV_OVERRIDES)) {
+    savedEnv[k] = process.env[k];
+    process.env[k] = v;
+  }
+});
+
+afterAll(() => {
+  for (const k of Object.keys(ENV_OVERRIDES)) {
+    const prev = savedEnv[k];
+    if (prev === undefined) delete process.env[k];
+    else process.env[k] = prev;
+  }
+});
+
+/*
+ * Covers the "hold a task in `running` while its background agents are still
+ * running" behavior added to `attachDoneHandler` / `maybeReleaseHeldTask` /
+ * `isHeldByBackgroundAgents` in src/bun/orchestrator.ts.
+ *
+ * IMPORTANT — shared-DB hygiene (see docs/plans/hold-task-running-while-
+ * background-agents-run.md and the module CLAUDE.md): `bun test` runs every
+ * *.test.ts in one process against one SQLite DB. `reconcileOrphans`' boot
+ * pass scans BOTH `runs WHERE status='running'` and `tasks WHERE column=
+ * 'running'` globally, and will mutate (orphan subagents / release to
+ * review) any held task it finds left over from this file. Every task
+ * created here is tracked and hard-deleted (cascades to runs/subagents/
+ * run_events via FK) in `afterEach` so no test in this file can ever leak a
+ * `running` row into `reconcile.test.ts` or any other sibling.
+ */
+
+const createdTaskIds: string[] = [];
+
+afterEach(async () => {
+  const { db } = await import("./db.ts");
+  for (const id of createdTaskIds.splice(0)) {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [id]);
+  }
+});
+
+function wait(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function createClaudeTask(title: string): Promise<string> {
+  const { createTask } = await import("./orchestrator.ts");
+  const created = await createTask({
+    title,
+    prompt: "hello",
+    agent: "claude-code",
+    workdir: process.cwd(),
+    isolation: "none", // don't materialize a worktree off the live repo during tests
+  });
+  if ("error" in created) throw new Error(created.error);
+  createdTaskIds.push(created.task.id);
+  return created.task.id;
+}
+
+async function insertRunningSubagent(taskId: string): Promise<string> {
+  const { subagents } = await import("./db.ts");
+  const id = `agent-${randomUUID()}`;
+  subagents.insertIfAbsent({
+    id,
+    taskId,
+    runId: null, // the gate only keys off task_id — see subagents.hasRunning
+    parentKind: "subagent",
+    agentType: "Explore",
+    description: "test subagent",
+    spawnDepth: 1,
+    sourcePath: `/tmp/${id}.jsonl`,
+    status: "running",
+    startedAt: Date.now(),
+    endedAt: null,
+  });
+  return id;
+}
+
+test("hold: a succeeded run with a running subagent keeps the task in running", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks, runs } = await import("./db.ts");
+
+  const taskId = await createClaudeTask("hold-basic");
+  // Insert the running subagent row BEFORE startTask so the gate is
+  // deterministic against the fake driver's ~20ms resolve — no race.
+  await insertRunningSubagent(taskId);
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  const runId = res.runId;
+
+  await wait(250);
+
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("running");
+  const run = runs.get(runId);
+  expect(run?.status).toBe("succeeded");
+});
+
+test("release: the last subagent leaving running fires the settle hook and moves the task to review", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks, subagents } = await import("./db.ts");
+  const { orphanRunningSubagents } = await import("./claude-subagents.ts");
+
+  const taskId = await createClaudeTask("hold-release");
+  await insertRunningSubagent(taskId);
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  await wait(250);
+
+  // Sanity: confirm the task is actually held before driving the release.
+  expect(tasks.get(taskId)?.column).toBe("running");
+  expect(subagents.hasRunning(taskId)).toBe(true);
+
+  // Drive maybeReleaseHeldTask the same way the real watcher does: the last
+  // running subagent leaving `running` state fires the settle hook. There's
+  // no exported "mark completed and settle" helper, so `orphanRunningSubagents`
+  // (which flips every running row and THEN calls the settle hook) is the
+  // documented, supported way to trigger this from a test.
+  orphanRunningSubagents(taskId);
+
+  expect(subagents.hasRunning(taskId)).toBe(false);
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("review");
+});
+
+test("no hold (regression guard): a succeeded run with no subagent rows goes straight to review", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks } = await import("./db.ts");
+
+  const taskId = await createClaudeTask("hold-none");
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  await wait(250);
+
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("review");
+});
+
+test("cancelled wins over a hold: task goes to ready, not running", async () => {
+  const { startTask, cancelRun } = await import("./orchestrator.ts");
+  const { tasks } = await import("./db.ts");
+
+  const taskId = await createClaudeTask("hold-cancel");
+  await insertRunningSubagent(taskId);
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  const runId = res.runId;
+
+  // Cancel immediately — the fake driver's success path doesn't resolve
+  // `done()` until ~20ms, so this races ahead of it deterministically.
+  const cancelled = cancelRun(runId);
+  expect(cancelled).toBe(true);
+
+  await wait(250);
+
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("ready");
+});
+
+test("api-error wins over a hold: task goes to blocked, not running", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks } = await import("./db.ts");
+
+  const taskId = await createClaudeTask("hold-api-error");
+  await insertRunningSubagent(taskId);
+
+  // AGETOR_FAKE_CLAUDE_API_ERROR is read inside makeFakeAgent at spawn time —
+  // set it right before starting the run and restore it immediately after so
+  // it can't leak into sibling tests in this file or elsewhere.
+  const prev = process.env.AGETOR_FAKE_CLAUDE_API_ERROR;
+  process.env.AGETOR_FAKE_CLAUDE_API_ERROR = "1";
+  try {
+    const res = await startTask(taskId);
+    if (!("runId" in res)) throw new Error("expected the run to start");
+    await wait(250);
+  } finally {
+    if (prev === undefined) delete process.env.AGETOR_FAKE_CLAUDE_API_ERROR;
+    else process.env.AGETOR_FAKE_CLAUDE_API_ERROR = prev;
+  }
+
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("blocked");
+});
+
+test("session-died wins over a hold: task goes to blocked, not running", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks } = await import("./db.ts");
+
+  const taskId = await createClaudeTask("hold-session-died");
+  await insertRunningSubagent(taskId);
+
+  const prev = process.env.AGETOR_FAKE_CLAUDE_SESSION_DIED;
+  process.env.AGETOR_FAKE_CLAUDE_SESSION_DIED = "1";
+  try {
+    const res = await startTask(taskId);
+    if (!("runId" in res)) throw new Error("expected the run to start");
+    await wait(250);
+  } finally {
+    if (prev === undefined) delete process.env.AGETOR_FAKE_CLAUDE_SESSION_DIED;
+    else process.env.AGETOR_FAKE_CLAUDE_SESSION_DIED = prev;
+  }
+
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("blocked");
+});
+
+test("codex is inert to the hold gate: no subagent rows means straight to review", async () => {
+  const { createTask, startTask } = await import("./orchestrator.ts");
+  const { tasks, harnesses } = await import("./db.ts");
+
+  // Fresh test DBs ship codex disabled by default (migration
+  // 016_disable_codex.sql) — enable it for this test only and restore.
+  const prevEnabled = harnesses.get("codex")?.enabled ?? false;
+  harnesses.setEnabled("codex", true);
+  try {
+    const created = await createTask({
+      title: "hold-codex",
+      prompt: "hello",
+      agent: "codex",
+      workdir: process.cwd(),
+      isolation: "none",
+    });
+    if ("error" in created) throw new Error(created.error);
+    createdTaskIds.push(created.task.id);
+    const taskId = created.task.id;
+
+    // Codex never writes subagent rows, so the gate is inert by
+    // construction — no need to assert `subagents.hasRunning` here.
+    const res = await startTask(taskId);
+    if (!("runId" in res)) throw new Error("expected the run to start");
+    await wait(250);
+
+    const task = tasks.get(taskId);
+    expect(task?.column).toBe("review");
+  } finally {
+    harnesses.setEnabled("codex", prevEnabled);
+  }
+});
+
+test("maybeReleaseHeldTask does not misfire when the user dragged the card out of running", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks } = await import("./db.ts");
+  const { orphanRunningSubagents } = await import("./claude-subagents.ts");
+
+  const taskId = await createClaudeTask("hold-dragged-away");
+  await insertRunningSubagent(taskId);
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  await wait(250);
+  expect(tasks.get(taskId)?.column).toBe("running"); // sanity: held
+
+  // The user moves the card out of `running` while it's held.
+  tasks.update(taskId, { column: "done" });
+
+  // Fires the settle hook (there's still a running subagent row) — the
+  // release predicate must see column !== 'running' and bail.
+  orphanRunningSubagents(taskId);
+
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("done");
+});
+
+test("maybeReleaseHeldTask does not misfire when a newer run is already in flight", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks, runs } = await import("./db.ts");
+  const { orphanRunningSubagents } = await import("./claude-subagents.ts");
+
+  const taskId = await createClaudeTask("hold-newer-run");
+  await insertRunningSubagent(taskId);
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  await wait(250);
+  expect(tasks.get(taskId)?.column).toBe("running"); // sanity: held
+
+  // Simulate a follow-up turn already in flight: a second run row that
+  // hasn't resolved yet, with the task pointed at it (mirrors what
+  // sendTurnInExistingSession does for a real follow-up).
+  const runId2 = randomUUID();
+  const now = Date.now();
+  runs.insert({
+    id: runId2,
+    taskId,
+    agent: "claude-code",
+    status: "running",
+    startedAt: now,
+    endedAt: null,
+    exitCode: null,
+    tmuxSession: null,
+    claudeSessionId: null,
+    codexSessionId: null,
+  });
+  tasks.update(taskId, { runId: runId2 });
+
+  // Fires the settle hook — the release predicate must see the pointed-at
+  // run isn't `succeeded` yet and bail, leaving the card in `running`.
+  orphanRunningSubagents(taskId);
+
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("running");
+
+  // Terminal-ize the hand-inserted run immediately so no `status='running'`
+  // row survives this test — reconcileOrphans scans that globally.
+  runs.update(runId2, { status: "succeeded", endedAt: Date.now(), exitCode: 0 });
+});
+
+test("Stop on a held task releases it: cancelRun orphans subagents and moves the card to review", async () => {
+  const { startTask, cancelRun } = await import("./orchestrator.ts");
+  const { tasks, subagents } = await import("./db.ts");
+
+  const taskId = await createClaudeTask("hold-stop");
+  await insertRunningSubagent(taskId);
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  const runId = res.runId;
+  await wait(250);
+
+  // Sanity: the run has already settled and the task is held — the run id
+  // is no longer in the orchestrator's `active` map, so cancelRun must take
+  // the held-task branch (not the normal in-flight-handle branch).
+  expect(tasks.get(taskId)?.column).toBe("running");
+  expect(subagents.hasRunning(taskId)).toBe(true);
+
+  // `cancelRun`'s held-task branch calls `interruptTaskSession` only for its
+  // side effect (best-effort Ctrl+C) — it never reads the return value, so
+  // whatever `/bin/echo` makes the underlying tmux probe report doesn't
+  // change the outcome here; the assertion is on cancelRun's own return.
+  const cancelled = cancelRun(runId);
+  expect(cancelled).toBe(true);
+
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("review");
+  expect(subagents.hasRunning(taskId)).toBe(false);
+});

--- a/src/mainview/components/kanban/TaskCard.tsx
+++ b/src/mainview/components/kanban/TaskCard.tsx
@@ -1,6 +1,6 @@
 import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
-import { Archive, ArchiveRestore, ArrowRight, CheckCircle2, FolderOpen, GitBranch, GitCompare, MessageCircleQuestion, Play, Square, Terminal, Trash2 } from "lucide-react";
+import { Archive, ArchiveRestore, ArrowRight, Bot, CheckCircle2, FolderOpen, GitBranch, GitCompare, MessageCircleQuestion, Play, Square, Terminal, Trash2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -62,6 +62,7 @@ export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen, o
 
   const type = taskTypeMeta(task.taskType);
   const TypeIcon = taskTypeIcon(type.icon);
+  const runningSubagents = task.runningSubagents ?? 0;
 
   return (
     <Card
@@ -105,6 +106,16 @@ export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen, o
               >
                 <Terminal className="size-3" />
                 {task.openTerminalCount}
+              </Badge>
+            )}
+            {runningSubagents > 0 && (
+              <Badge
+                variant="outline"
+                className="gap-1 text-[10px]"
+                title={`${runningSubagents} background agent${runningSubagents > 1 ? "s" : ""} running`}
+              >
+                <Bot className="size-3" />
+                {runningSubagents}
               </Badge>
             )}
           </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -329,6 +329,10 @@ export interface Task {
    * default kanban filter and rendered read-only in the run panel.
    */
   archivedAt: number | null;
+  /** Count of this task's subagents currently `status:"running"`. Derived per
+   *  request by the server (never persisted, never patchable). Absent on payloads
+   *  that don't join the subagents table. */
+  runningSubagents?: number;
 }
 
 /** A live terminal tab for a task. Returned by the terminal REST endpoints;


### PR DESCRIPTION
A claude task whose main turn ends with `end_turn` currently jumps straight to `review`, even when the agent has spawned background/sub agents that are still working. The card reads "done" while work is visibly ongoing in the run panel's subagent tabs.

This holds the card in `running` until the last background agent finishes, then moves it to `review` automatically.

## How it works

The hold is **derived from the database on every read**, never tracked in an in-memory map:

```ts
task.column === "running"
  && task.runId != null
  && runs.get(task.runId).status === "succeeded"
  && subagents.hasRunning(taskId)
```

`attachDoneHandler` skips the column update when that predicate holds. `claude-subagents.ts` fires an injected settle hook — mirroring the existing `setSubagentEmitter` cycle-avoidance — and the orchestrator releases the card when the last subagent goes terminal.

Two properties fall out of deriving it rather than storing it: it survives a restart, and it's immune to the settle-vs-completion ordering (the run row is written `succeeded` *before* the gate reads `hasRunning`, so whichever of the gate and the hook runs second sees consistent state). No lock.

**Codex is inert by construction** — it never writes `subagents` rows, so `hasRunning` is always false. There is no `kind` branching anywhere in the gate.

**Only `succeeded → review` is gated.** `cancelled → ready` and `apiError` / `sessionDied → blocked` still win outright — those need attention now and must not hide behind a churning background agent.

## What to review closely

**`cancelRun`'s held-task branch (`orchestrator.ts`).** `attachDoneHandler` runs `active.delete(runId)` before parking the card, so a held run has no `active` handle and `cancelRun`'s `if (!h) return false` made Stop a silent no-op — on exactly the task it was meant to rescue. Since we deliberately ship no watchdog timeout, that button *is* the escape hatch for a background agent that wedges but stays alive. It now interrupts the session and releases the hold. Supporting this is a new `interruptTaskSession`, which addresses tmux by its deterministic session name so it works with no `SessionState` (the state after a boot re-arm).

**The boot pass appended to `reconcileOrphans`.** A held task's run row is `succeeded`, so the existing pass — which scans `runs WHERE status='running'` — never sees it and nothing re-arms its subagent watcher. Without a second pass over `tasks WHERE "column"='running'`, a restart strands the card in `running` forever. It re-arms the watcher when the tmux session is still alive (the background agent may genuinely still be working, which is the whole point of agetor's detached-tmux design) and releases to `review` when it's gone. It issues **no kills** — only `sessionExistsByName` reads and watcher attaches.

**`disposeSessionState` is parameterized, not unconditional.** Of its three call sites, `reattachSession`'s defensive pre-dispose may refer to a *live* session that will keep writing subagent transcripts. Only `spawnClaudeViaTmux` and `dropSession` — both provably preceded by a `killTaskSession` — pass `orphanSubagents: true`.

## Accepted trade-off

A background agent that **hangs but stays alive** holds the card indefinitely. This is the direct consequence of choosing "release on session death / detach" over a watchdog timeout. Session death, session disposal, restart, and Stop all release it.

## Test-infrastructure fixes included

Both surfaced while writing the tests, and both are fixed at the source rather than worked around, because `bun test` shares one process and one SQLite DB across every file:

1. `setSubagentEmitter` / `setSubagentSettleHook` now return the previous value. A test that installed a spy and reset to `null` in `afterEach` was silently un-wiring the orchestrator for every file that ran afterwards, so a held task could never reach `review`. Tests save and restore. Production ignores the return value.
2. `subagent-hold.test.ts` scopes its env overrides to `beforeAll`/`afterAll`. `AGETOR_CODEX_DRIVER=fake` and `AGETOR_TMUX_BIN=/bin/echo` at module top level leaked into `reconcile.test.ts`'s cancel test, which needs the real codex driver in a real tmux session.

## UI

`GET /tasks` now derives a `runningSubagents` count (never persisted, not in the `PATCH` allow-list), and `TaskCard` renders a background-agent count badge next to the existing open-terminal badge. It reuses that badge's exact idiom — no new tokens, no new dependency.

## Testing

`bun run typecheck` clean. `bun test` → **789 pass, 0 fail**, stable across three consecutive full runs and with each new file run in isolation. 29 new tests covering the hold, the release, the no-hold regression, `cancelled`/`apiError`/`sessionDied` precedence, codex inertness, no-misfire (dragged card, newer run in flight), Stop on a held task, the settle-hook ordering guarantee, `orphanRunningSubagents`, the watcher registry, and every branch of the boot pass.

**Not verified in the real app.** No `bun run dev` pass yet. This changes when kanban cards move columns, so a manual smoke test with a task that spawns a background agent is worth doing before merge.

Plan and the full list of deviations from it: `docs/plans/hold-task-running-while-background-agents-run.md`.