### PR TITLE
fix(notifications): raise and focus the window on notification click

### DIFF
--- a/docs/plans/notification-click-focus.md
+++ b/docs/plans/notification-click-focus.md
@@ -1,0 +1,141 @@
+# Plan — Notification click should focus/raise the Agetor window
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-09 |
+| Source | User report: "Clicking on the native macOS notification is not opening/focusing Agetor window. It's indeed opening the correct task, but is not opening/focusing the software. Consider support to multiple screens and desktops/docks as well" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | `agetor/dd57e65731fb-clicking-on-native-notifcation-doesnt-op` |
+| Base SHA | `5df9a2ee26a150ee9ac398d3ac3d7be16b97b742` |
+
+## 1. Objective & success criteria
+
+Clicking a native macOS notification posted by `AgetorNotifier.app` must **raise, focus and (if needed) un-minimize** the Agetor window, in addition to selecting the right task — which already works.
+
+Success criteria:
+
+1. Window buried behind other apps → comes to the front, becomes key.
+2. Window minimized to the Dock → is restored, then focused.
+3. Window on a **secondary display** → is raised on that display, not teleported.
+4. Window on **another Space** → macOS switches to it (owner's explicit choice; see §3).
+5. Window fully closed (`exitOnLastWindowClosed:false`) → recreated and focused. *(Already works — `new BrowserWindow()` calls `showWindow(ptr, activate=true)`.)*
+6. Remembered frame that no longer intersects any live display (monitor unplugged) → re-centered on the primary rather than opened off-screen.
+7. Dock-icon click on a buried/minimized window → focuses it.
+8. In-app toast "Open" button → actually raises the window.
+9. `bun test` and `bun run typecheck` green. No regression in `window-lifecycle.test.ts`.
+
+Non-goals: overlaying another app's **fullscreen** Space (Electrobun exposes no `.fullScreenAuxiliary`); persisting the window frame across process restarts; any change to how notifications are *posted*.
+
+## 2. Context & constraints (grounded)
+
+**Root cause.** `Electrobun.events.on("open-url")` (`src/bun/index.ts:471-486`) parses the deep link, calls `setPendingOpenTask` (`:475`), and then — when a window already exists — only `broadcastAppEvent({type:"open_task"})` (`:477`). It never asks macOS to activate anything. The `else` branch calls `windowLifecycle.createMainWindow()` (`:479`), which **returns early when a window is already registered** (`src/bun/window-lifecycle.ts:59`), so it is not a focus path either.
+
+The only "focus" in the codebase is renderer-side `window.focus()` (`src/mainview/App.tsx:224,234,299`), whose own comment concedes it is "a no-op in many browsers". A WKWebView cannot activate its host NSApplication.
+
+**Electrobun 1.18.1 surface** (verified against `node_modules/electrobun/dist/api/bun/`):
+
+| Available | Anchor |
+| --- | --- |
+| `BrowserWindow.activate()` | `core/BrowserWindow.ts:279` → ffi `activateWindow` |
+| `BrowserWindow.unminimize()` / `isMinimized()` | `:306` / `:310` → ffi `restoreWindow` |
+| `BrowserWindow.setFrame()` / `getFrame()` | `:366` / `:371` |
+| `BrowserWindow.setVisibleOnAllWorkspaces()` | `:342` (not used — see §3) |
+| `Screen.getAllDisplays()` | `proc/native.ts:2208`, exported `index.ts:229` |
+
+`BrowserWindow.focus()` (`:283`) is **deprecated** — it logs a warning and delegates to `activate()`. Use `activate()`.
+
+**Absent, and unaddable:** standalone `NSApp.activate`, `moveToActiveSpace`, general `setCollectionBehavior`. The FFI table is one `dlopen` of a **prebuilt** `libNativeWrapper.dylib` (`proc/native.ts:82-723`); the npm package ships no native source, and `dlopen` throws on a missing symbol. Adding one means forking Electrobun.
+
+A symbol dump of that dylib shows `activateWindow`, `restoreWindow`, `setWindowVisibleOnAllWorkspaces`, `getAllDisplays` all exported, and the binary references the ObjC selectors `activateIgnoringOtherApps:`, `makeKeyAndOrderFront:`, `deminiaturize:`, `setCollectionBehavior:`. So `activate()` *does* attempt an app-level activation.
+
+**Cooperative activation (macOS 14+).** `activateIgnoringOtherApps:` is deprecated and its argument ignored; activation is now a *request* that the system denies for a background app with no user action behind it (denial ⇒ Dock bounce). A notification click makes the posting helper the active app, giving it an activation right it can yield onward. `NSWorkspace.open(_:configuration:)` with `activates = true` performs that yield implicitly; `NSApp.yieldActivation(to:)` (macOS 14+) does it explicitly. Our helper currently calls bare `NSWorkspace.shared.open(url)` (`native/notifier/notifier.swift:118`).
+
+**Coordinate system — verified, not assumed.** Ran `getAllDisplays` against the prebuilt dylib on this machine:
+
+```json
+[{"id":1,"bounds":{"x":0,"y":0,"width":1728,"height":1117},"workArea":{"x":0,"y":33,...},"isPrimary":true},
+ {"id":3,"bounds":{"x":-449,"y":-1080,"width":2560,"height":1080},"isPrimary":false},
+ {"id":5,"bounds":{"x":-1366,"y":0,"width":1366,"height":1024},"isPrimary":false}]
+```
+
+Top-left origin, y grows downward, secondary displays carry **negative** origins — consistent with `DEFAULT_FRAME = {x:120,y:120,...}` (`window-lifecycle.ts:14`) landing below the menu bar. `workArea` excludes the menu bar. No coordinate flip is needed between `getFrame()` and display bounds.
+
+`Screen.getAllDisplays()` returns `[]` when the native lib is absent (`proc/native.ts:2210-2213`) — i.e. under `bun test`. Frame repair must treat an empty list as "do nothing".
+
+**Frame memory is in-memory only** (`window-lifecycle.ts:54`), reset to `DEFAULT_FRAME` per process, and is **never validated against connected displays** (`index.ts:386-393`).
+
+**Testing reality.** `bun run dev` does not build the notifier (`package.json:8-9`), and `agetor://` only routes once the built `.app` is LaunchServices-registered. Per `docs/qa/native-notifier-qa.md:57-61`, the click loop is a **packaged-build manual test**. `bun run build` does run `vendor:notifier` (`package.json:13-14`). There is no CI (`.github/` holds only `FUNDING.yml`).
+
+Test conventions: `bun:test`; `window-lifecycle.test.ts` uses pure dependency injection with a `{id} as any` fake window and no Electrobun runtime; `notifications.test.ts:20-31` uses `mock.module("electrobun/bun", …)` for server-level tests. Pure modules (`deep-link.test.ts`, `notifier.test.ts`, `pending-open.test.ts`) import no Electrobun at all.
+
+## 3. Approach & key decisions
+
+**Decision 1 — Spaces: let macOS switch (owner's call).** We call `unminimize()` + `activate()` and let macOS decide. The alternative — `setVisibleOnAllWorkspaces(true)` → `activate()` → `false` on a later tick — would pull the window to the user's current Space, but it is timing-sensitive, cannot enter another app's fullscreen Space, and is a behavior the owner explicitly did not want. **Rejected by the owner.** Consequence to accept: if the user's *Desktop & Dock → "switch to a Space with open windows"* setting is **off**, activating leaves the window invisible on its own Space. That is standard macOS app behavior and is the documented trade-off.
+
+**Decision 2 — one shared focus routine, three call sites.** A single `focusWindow()` in a new `src/bun/window-focus.ts`, invoked from the `open-url` handler, the `reopen` handler, and a new `POST /window/focus` route.
+
+**Decision 3 — `POST /window/focus` is a mechanism, not a feature.** The owner asked for the in-app toast "Open" button to raise the window. The toast lives in the webview, which reaches the Bun process only over HTTP. The route is the enabling transport, modeled on the existing `POST /window/toggle-zoom` (`server.ts:430-449`) — same `authed()` wrapper, same `503 {error:"no main window"}` shape. It also gives us the *only* way to exercise the focus sequence from `bun run dev`.
+
+**Decision 4 — harden the helper, don't rewrite it.** Keep `NSWorkspace` as the delivery mechanism, but (a) yield activation explicitly to `sh.alamops.agetor` when running on macOS 14+, (b) open with `OpenConfiguration.activates = true`, (c) fall back to `NSRunningApplication.activate(options:)` if the open reports an error, (d) exit from the completion handler rather than a fixed 0.2 s timer, with a safety-net timeout. Guard the 14+ APIs with `if #available` — the helper targets `arm64-apple-macos13` (`scripts/build-notifier.ts:90-96`).
+
+**Decision 5 — conservative frame repair.** Re-center **only** when the frame has no meaningful intersection with *any* live display. "Meaningful" = at least a 120×40 pt region, so the title bar stays grabbable. Empty display list ⇒ no-op. This keeps a legitimately-placed window on a negative-origin secondary display untouched.
+
+## 4. Work breakdown — implementation tasks
+
+| ID | Goal | Owns (exactly) | Depends on |
+| --- | --- | --- | --- |
+| **T1** | Pure display/frame geometry: `Rect`, `rectsIntersect`, `frameIsVisible`, `repairFrame`. Empty-display no-op; centers on primary `workArea`, clamping size. No Electrobun import (types only). | `src/bun/screen-frame.ts` *(new)* | — |
+| **T2** | `focusWindow(win, deps)`: repair frame → `unminimize()` if `isMinimized()` → `activate()`. Each step individually try/caught so one failure can't skip `activate()`. `FocusableWindow` structural interface + injectable `getAllDisplays` so tests never load the native lib. Returns `false` when `win` is null. | `src/bun/window-focus.ts` *(new)* | T1 |
+| **T3** | Helper activation hardening per Decision 4. Preserve the existing `url.scheme == "agetor"` defense-in-depth check and the exit-code contract (0 = posted, 2 = denied). | `native/notifier/notifier.swift` | — |
+| **T4** | Wire `focusWindow` into `open-url` (warm path, `:476-477`) and `reopen` (`:442-446`). Repair the frame in `buildWindow` before `new BrowserWindow({frame})` so the cold path can't open off-screen. Pass the real `Screen.getAllDisplays`. | `src/bun/index.ts` | T1, T2 |
+| **T5** | `POST /window/focus` route mirroring `/window/toggle-zoom`; `api.focusWindow()` client; toast `onOpen` + the two `open_task` handlers call it instead of `window.focus()`. | `src/bun/server.ts`, `src/mainview/lib/api.ts`, `src/mainview/App.tsx` | T2 |
+
+File ownership is disjoint within each wave (see §6).
+
+## 5. Work breakdown — test tasks
+
+| ID | Covers | Owns (exactly) |
+| --- | --- | --- |
+| **TT1** | T1. Table-driven: window wholly inside primary; straddling two displays; on the negative-origin display above (`y:-1080`) and left (`x:-1366`); 1-px sliver ⇒ repaired; zero overlap ⇒ centered on primary `workArea`; oversized frame clamped; `displays: []` ⇒ identity; no-primary-flag ⇒ falls back to `displays[0]`. | `src/bun/screen-frame.test.ts` *(new)* |
+| **TT2** | T2. Fake `FocusableWindow` recording calls: minimized ⇒ `unminimize` before `activate`; not minimized ⇒ no `unminimize`; off-screen frame ⇒ `setFrame` before `activate`; on-screen ⇒ no `setFrame`; `getFrame`/`isMinimized` throwing ⇒ `activate` still called; `null` window ⇒ `false`, no throw. | `src/bun/window-focus.test.ts` *(new)* |
+| **TT3** | T5's route. Follows `notifications.test.ts:20-31` `mock.module("electrobun/bun", …)`. Asserts: 401 unauthed; 503 `{error:"no main window"}`; 200 + `activate()` called on the registered fake window. | `src/bun/window-focus-route.test.ts` *(new)* |
+
+T3 (Swift) gets **no** automated test — there is no Swift test harness or CI in this repo. It is covered by an added section in `docs/qa/native-notifier-qa.md` (owned by T3).
+
+## 6. Execution waves
+
+- **Wave 1** — T1. *(Foundation; everything else imports it.)*
+- **Wave 2** — T2 ‖ T3. *(Disjoint files, no interdependency.)*
+- **Wave 3** — T4 ‖ T5. *(Disjoint files; both consume T2 but neither edits it.)*
+- **Wave 4** *(Phase 6)* — TT1 ‖ TT2 ‖ TT3.
+
+Barrier between waves. Checkpoint commit + `bun run typecheck` after each.
+
+Note: `bun` is not on `PATH` in this environment — every command needs `export PATH="$HOME/.bun/bin:$PATH"` first. `node_modules/` was absent in this worktree and has been installed.
+
+## 7. Blast radius & risks
+
+| Risk | Mitigation |
+| --- | --- |
+| `getFrame()` returns a **bottom-left** y while display bounds are top-left, causing a valid window to be judged off-screen and yanked to the primary. | Repair only on **zero** meaningful intersection (Decision 5) — the failure mode requires the frame to miss *every* display. Verified that display bounds and `DEFAULT_FRAME` share a top-left origin; `setFrame`/`getFrame` are symmetric by construction. Flagged for manual QA on the three-display setup. |
+| `activate()` denied by cooperative activation ⇒ Dock bounce instead of focus. | T3 yields activation from the helper, which holds the right by virtue of the click. Confirmed the dylib's `activateWindow` references `activateIgnoringOtherApps:`/`makeKeyAndOrderFront:`. |
+| Swift helper regression breaks **all** notifications, not just focus. | Preserve the exit-code contract; keep bare `open(url)` reachable as a fallback path; the `showTaskNotification` fallback (`index.ts:148-205`) already degrades to `Utils.showNotification` on non-zero exit — but note **exit 2 deliberately does not fall back** (`:185-190`). Don't touch the exit-2 branch. |
+| Helper exits before `NSWorkspace.open` completes. | Exit from the completion handler; retain a `scheduleExit(after: 5)` safety net. |
+| `mock.module` in TT3 is process-wide (`notifications.test.ts:16-18`) and can leak into sibling tests. | Mirror the existing file's isolation exactly; run the full `bun test` suite, not just the new file. |
+| Notifier change is unverifiable headlessly. | Owner runs `bun run build` + manual QA (their explicit choice). QA doc extended by T3. |
+
+Rollback: the change is additive — three call sites and two new modules. Reverting T4/T5 restores today's behavior exactly.
+
+## 8. Open questions / assumptions
+
+Resolved with the owner before planning:
+
+1. **Spaces** → let macOS switch to the window's Space; do *not* use the `visibleOnAllWorkspaces` trick.
+2. **Triggers** → notification click, Dock-icon click, and the in-app toast "Open" button. (`POST /window/focus` follows necessarily from the third; the owner did not select it as a standalone item.)
+3. **Multi-display** → yes, repair off-screen remembered frames.
+4. **Verification** → unit tests + typecheck here; owner performs the packaged-build manual QA.
+
+Remaining assumptions:
+
+- `BrowserWindow.getFrame()` reports the same top-left coordinate space as `Screen.getAllDisplays()`. Verified for display bounds and for `setFrame` input; **not** directly verified for `getFrame` output (needs a live window). Mitigated by Decision 5.
+- The main app's bundle id is `sh.alamops.agetor` (`electrobun.config.ts:6`); the helper's is `sh.alamops.agetor.notifier` and must stay stable (TCC keys the notification grant on it).

--- a/docs/qa/native-notifier-qa.md
+++ b/docs/qa/native-notifier-qa.md
@@ -59,3 +59,39 @@ bun run build     # runs vendor:notifier (builds+signs AgetorNotifier.app), then
   `bun run vendor:notifier`; the `agetor://` scheme only routes once the built
   `.app` is registered with LaunchServices, so the full click loop is a
   built-app test, not a dev-server test.
+
+## Focus behavior on click (macOS 14+ cooperative activation)
+
+macOS 14 made `activate` a *request* the currently-active app can deny —
+`NSApplication.activate` / `NSRunningApplication.activate(options:
+.activateIgnoringOtherApps)` are deprecated no-ops. Clicking a notification
+briefly makes the helper the active app with a real, yieldable activation
+right, which it now explicitly yields to Agetor (`sh.alamops.agetor`) before
+opening the deep link, so the request is honored instead of just bouncing the
+Dock icon. Verify each scenario below on a real, signed, packaged build (per
+the steps above) — this cannot be verified from `bun run dev`.
+
+- [ ] **Buried behind other apps.** With several other apps' windows layered
+      on top of Agetor's, click the notification → Agetor's window is raised
+      above them and gets keyboard focus (not just a Dock bounce).
+- [ ] **Minimized to the Dock.** Minimize the Agetor window, then click the
+      notification → the window un-minimizes and comes to the front.
+- [ ] **On a secondary display.** With Agetor's window on a second monitor and
+      focus on the primary, click the notification → the secondary display's
+      window is raised and focused; the OS switches your active display/cursor
+      context to it as normal for cross-display activation.
+- [ ] **On another Space.** With Agetor's window on a different Space than the
+      one you're on, click the notification:
+      - If **Desktop & Dock → Mission Control → "When switching to an
+        application, switch to a Space with open windows for the
+        application"** is **on** (the default): macOS switches you to
+        Agetor's Space and focuses its window.
+      - If that setting is **off**: the Space does *not* switch — only the
+        menu bar changes to Agetor's and the window stays on its own Space.
+        This is expected OS behavior, not a bug in the helper; don't file it
+        as a regression.
+- [ ] **Window fully closed** (not just minimized — actually closed, process
+      still running). Click the notification → Agetor recreates/opens a
+      window and it comes to the foreground with the right task open (same as
+      the "window closed" case in the core loop above, verified here
+      specifically for focus/activation rather than task routing).

--- a/native/notifier/notifier.swift
+++ b/native/notifier/notifier.swift
@@ -18,6 +18,7 @@
 // AppKit + UserNotifications (see scripts/build-notifier.ts).
 
 import AppKit
+import Foundation
 import UserNotifications
 
 struct Options {
@@ -109,17 +110,78 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     didReceive response: UNNotificationResponse,
-    withCompletionHandler completionHandler: @escaping () -> Void
+    withCompletionHandler unCompletionHandler: @escaping () -> Void
   ) {
-    if response.actionIdentifier == UNNotificationDefaultActionIdentifier,
+    guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
       let urlString = response.notification.request.content.userInfo["url"] as? String,
       let url = URL(string: urlString),
       url.scheme == "agetor"  // defense in depth: only ever open our own deep links
-    {
-      NSWorkspace.shared.open(url)
+    else {
+      unCompletionHandler()
+      exit(0)
     }
-    completionHandler()
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { exit(0) }
+
+    // Ack UN only *after* the open has been handed to LaunchServices, never
+    // before. Acking declares we're done handling the response, at which
+    // point nothing obliges the system to keep this relaunched agent alive —
+    // and a deep link that never left the process is exactly the silent
+    // "click does nothing" failure this helper exists to prevent. A late ack
+    // costs at most a UN warning; an early one can cost the click.
+    activateMainAppAndOpen(url, ack: unCompletionHandler)
+  }
+
+  // Opens the agetor:// deep link and brings the main app forward. Split out
+  // of didReceive because there are two distinct completion callbacks in play
+  // here — UN's (`ack`) and NSWorkspace's (below) — and keeping them in one
+  // function invites confusing them.
+  private func activateMainAppAndOpen(_ url: URL, ack: @escaping () -> Void) {
+    let target = NSRunningApplication.runningApplications(
+      withBundleIdentifier: "sh.alamops.agetor"
+    ).first
+
+    // macOS 14 (Sonoma) made activation cooperative: NSApplication.activate
+    // and NSRunningApplication.activate(options: .activateIgnoringOtherApps)
+    // are deprecated no-ops now — a denied activation request just bounces
+    // the Dock icon instead of raising the window. A request is honored only
+    // once the currently-active app YIELDS its activation right to the
+    // target (or NSWorkspace performs that yield on our behalf below).
+    // Clicking a notification makes this helper — even though it's
+    // .accessory — the active app, holding a real, yieldable activation
+    // right. Explicitly yielding it to the main app before opening is what
+    // makes the subsequent activation request actually get honored instead
+    // of just bouncing. yieldActivation(to:) itself only exists on macOS
+    // 14.0+, and the helper is built targeting macOS 13, so it must stay
+    // guarded.
+    if let target, #available(macOS 14.0, *) {
+      NSApp.yieldActivation(to: target)
+    }
+
+    // Safety net: if NSWorkspace's completion handler below never fires (the
+    // open hangs, LaunchServices is slow, whatever), don't leave the
+    // relaunched helper running forever.
+    scheduleExit(after: 5)
+
+    let cfg = NSWorkspace.OpenConfiguration()
+    cfg.activates = true
+    NSWorkspace.shared.open(url, configuration: cfg) { openedApp, openError in
+      // NSWorkspace's own completion, on a background queue — not UN's `ack`.
+      if openedApp == nil || openError != nil {
+        // The cooperative yield only helps if NSWorkspace's own activation
+        // follow-through succeeds; if the open itself failed, fall back to a
+        // direct activate request. No .activateIgnoringOtherApps — that flag
+        // is ignored on 14+ and the selector is deprecated.
+        target?.activate(options: [.activateAllWindows])
+        if let openError {
+          let msg = "AgetorNotifier: open agetor:// failed: \(openError)\n"
+          FileHandle.standardError.write(Data(msg.utf8))
+        }
+      }
+      exit(0)
+    }
+
+    // `open` returns once the request is queued with LaunchServices, so by
+    // here the deep link survives this process dying. Safe to ack UN.
+    ack()
   }
 
   // If agetor is frontmost when the notification arrives, still show the banner

--- a/src/bun/headless-routes.test.ts
+++ b/src/bun/headless-routes.test.ts
@@ -44,6 +44,7 @@ test("every native-host route returns 501 when running headless", async () => {
     ["/updates/status", { method: "GET", headers: auth() }],
     ["/updates/check", { method: "POST", headers: auth() }],
     ["/updates/apply", { method: "POST", headers: auth() }],
+    ["/window/focus", { method: "POST", headers: auth() }],
   ];
   for (const [p, init] of cases) {
     const res = await fetch(u(p), init);

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -238,6 +238,7 @@ const native: ApiNative = {
   openPath: (p) => Utils.openPath(p),
   openExternal: (url) => Utils.openExternal(url),
   showNotification: (n) => showTaskNotification(n),
+  focusWindow: () => focusMainWindow(),
   quit: () => Utils.quit(),
   updates: {
     snapshot: () => getUpdateSnapshot(),

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -1,5 +1,5 @@
 import { writeFileSync, existsSync } from "node:fs";
-import Electrobun, { ApplicationMenu, BrowserWindow, Updater, Utils } from "electrobun/bun";
+import Electrobun, { ApplicationMenu, BrowserWindow, Screen, Updater, Utils } from "electrobun/bun";
 import { rehydratePath } from "./login-path.ts";
 import { startApiServer, API_PORT, API_TOKEN, type ApiNative } from "./server.ts";
 import { db, harnesses, pidFilePath, tasks, dataDir } from "./db.ts";
@@ -9,6 +9,8 @@ import { refreshDiscoveredModels } from "./agent-discovery.ts";
 import { startUpdaterLoop, applyUpdate, checkForUpdate, getUpdateSnapshot } from "./updater.ts";
 import { getMainWindow, setMainWindow } from "./window.ts";
 import { makeWindowLifecycle, type Frame } from "./window-lifecycle.ts";
+import { focusWindow } from "./window-focus.ts";
+import { repairFrame } from "./screen-frame.ts";
 import { writeCoreCreds, removeCoreCreds, readCoreCreds, probeLiveCore, waitForPortFree } from "./core-creds.ts";
 import { resolveNotifier, resolveNotifierApp, buildNotifierArgs } from "./notifier.ts";
 import { buildTaskDeepLink, parseTaskDeepLink } from "./deep-link.ts";
@@ -377,6 +379,18 @@ const windowLifecycle = makeWindowLifecycle({
       token: API_TOKEN,
     })};`;
     const isHttpUrl = url.startsWith("http://") || url.startsWith("https://");
+    // `remembered` (window-lifecycle.ts) is in-memory only, updated live from
+    // "move"/"resize" events — it's never validated against the display
+    // layout at the time it was captured. If the user unplugs the display the
+    // window was last on and then closes + reopens the window within the
+    // same process (no restart, so this isn't the boot-reconciliation path),
+    // `frame` here can describe a rect no longer on any screen. Neither
+    // `BrowserWindow`'s construction nor a later `setFrame` auto-constrains
+    // an out-of-bounds frame onto a live display — AppKit's
+    // `constrainFrameRect` only clamps within the window's *current* screen,
+    // which doesn't help a window that hasn't been placed yet — so repair
+    // has to happen here, before construction, not after.
+    const safeFrame = repairFrame(frame, Screen.getAllDisplays());
     // macOS-only chrome: `hiddenInset` removes the native title bar background
     // + text but keeps inset traffic lights, letting the React header at the
     // top of App.tsx render full-bleed on the same row. `trafficLightOffset`
@@ -389,12 +403,21 @@ const windowLifecycle = makeWindowLifecycle({
       trafficLightOffset: { x: 8, y: 8 },
       url: isHttpUrl ? `${url}#api=${API_PORT}&token=${API_TOKEN}` : url,
       preload: bootGlobals,
-      frame,
+      frame: safeFrame,
     });
     setMainWindow(mainWindow);
     console.log("[agetor] main window ready");
   },
 });
+
+/** Shared "bring the app to front" call for every raise trigger (notification
+ *  click, Dock reopen) — wraps focusWindow() with this process's concrete
+ *  getMainWindow()/Screen.getAllDisplays() so the three call sites below
+ *  don't each re-spell the deps. Returns false when there's no window to
+ *  focus (caller's cue to create one instead). */
+function focusMainWindow(): boolean {
+  return focusWindow(getMainWindow(), { getAllDisplays: () => Screen.getAllDisplays() });
+}
 
 // Shadow the window's frame as the user moves / resizes it, so the next
 // reopen restores their last placement. Both events carry `id`; we filter
@@ -431,15 +454,23 @@ Electrobun.events.on("close", (e: { data: { id: number } }) => {
 // `applicationShouldHandleReopen:hasVisibleWindows:`, which Electrobun
 // surfaces as the "reopen" event (see node_modules/electrobun/dist/api/
 // bun/proc/native.ts setAppReopenHandler). Re-create the window if the
-// user dismissed it earlier — this is the modern replacement for the
-// old HTTP /focus endpoint, and it's what makes agetor feel like a real
-// macOS app rather than a webapp that happens to live in a window.
+// user dismissed it earlier, or raise+focus it if it's merely buried or
+// minimized — createMainWindow() no-ops when a window is already
+// registered, so without the focus branch a Dock click on a minimized or
+// background window did nothing from our side. This is the modern
+// replacement for the old HTTP /focus endpoint, and it's what makes agetor
+// feel like a real macOS app rather than a webapp that happens to live in
+// a window.
 //
 // We catch errors here because a silent fail-to-recreate would look
 // like "Dock click does nothing" to the user, with no diagnostic. The
 // boot-time await further below surfaces first-launch failures via the
 // top-level await; this catch covers every subsequent reopen.
 Electrobun.events.on("reopen", () => {
+  if (getMainWindow()) {
+    focusMainWindow();
+    return;
+  }
   windowLifecycle.createMainWindow().catch((err) => {
     console.error("[agetor] failed to recreate window on reopen:", err);
   });
@@ -453,16 +484,26 @@ Electrobun.events.on("reopen", () => {
 // the app — see the design note at src/mainview/lib/api.ts:424.
 //
 // We ALWAYS stash the taskId in pending-open.ts (short-TTL) and, if a window
-// already exists, ALSO broadcast immediately:
+// already exists, ALSO broadcast immediately and raise the window:
 //   - Window exists: the webview is connected to /app/events, so the direct
 //     broadcast arrives instantly. The pending stash is belt-and-suspenders —
 //     if the broadcast happens to land while the webview is mid-reload or
 //     between EventSource reconnects, the next subscriber flushes the pending
-//     entry (within its TTL) so the click isn't silently lost.
+//     entry (within its TTL) so the click isn't silently lost. We broadcast
+//     BEFORE focusing: the SSE message is a fire-and-forget dispatch (no
+//     round-trip to wait on), so issuing it first lets the webview start
+//     selecting the task while the native activate/un-minimize calls are
+//     still in flight, instead of the reverse order where the window
+//     visibly raises a beat before the UI catches up to it.
 //   - No window (app was fully dismissed / cold start): there's no SSE
 //     subscriber yet, so we rely entirely on the pending flush — create the
 //     window and the freshly-booted webview picks it up when it subscribes
 //     (see the consumePendingOpenTask() flush in server.ts's SSE route).
+//     No focusMainWindow() call here: constructing a BrowserWindow already
+//     calls showWindow(ptr, activate=true) natively, so a freshly built
+//     window is activated on creation — calling focusMainWindow() too would
+//     be redundant, not incorrect, but it'd suggest the two paths need
+//     separate raise logic when they don't.
 // The pending entry's TTL (pending-open.ts) prevents a much-later, unrelated
 // reconnect from resurrecting a stale click. Re-opening the same task is
 // idempotent (webview just re-selects it), so a rare double-delivery is
@@ -475,6 +516,7 @@ Electrobun.events.on("open-url", (e: { data: { url: string } }) => {
     setPendingOpenTask(taskId);
     if (getMainWindow()) {
       broadcastAppEvent({ type: "open_task", taskId, ts: Date.now() });
+      focusMainWindow();
     } else {
       windowLifecycle.createMainWindow().catch((err) => {
         console.error("[agetor] failed to create window for open-url:", err);

--- a/src/bun/screen-frame.test.ts
+++ b/src/bun/screen-frame.test.ts
@@ -119,6 +119,24 @@ describe("frameIsVisible", () => {
   test("window entirely off every display is not visible", () => {
     expect(frameIsVisible({ x: 5000, y: 5000, width: 800, height: 600 }, DISPLAYS)).toBe(false);
   });
+
+  test("narrow window straddling the LEFT/PRIMARY seam is reported not visible (deliberate false negative)", () => {
+    // LEFT spans x:-1366..0 and PRIMARY spans x:0..1728, so this 120pt-wide
+    // frame is fully on-screen to the user: 60pt either side of the seam. The
+    // threshold is checked per display, so neither reaches MIN_VISIBLE_WIDTH
+    // and repair re-centres it. Pinned because the obvious "fix" — summing
+    // coverage across displays — would start accepting ungrabbable slivers.
+    const straddling: Rect = { x: -60, y: 100, width: 120, height: 600 };
+    expect(intersection(straddling, LEFT.bounds)).toEqual({ x: -60, y: 100, width: 60, height: 600 });
+    expect(intersection(straddling, PRIMARY.bounds)).toEqual({ x: 0, y: 100, width: 60, height: 600 });
+    expect(frameIsVisible(straddling, DISPLAYS)).toBe(false);
+  });
+
+  test("a wide window straddling the same seam is visible (one side clears the threshold)", () => {
+    // The false negative above is confined to windows narrower than
+    // 2 x MIN_VISIBLE_WIDTH. A normal-sized window on the seam is fine.
+    expect(frameIsVisible({ x: -200, y: 100, width: 800, height: 600 }, DISPLAYS)).toBe(true);
+  });
 });
 
 describe("repairFrame", () => {

--- a/src/bun/screen-frame.test.ts
+++ b/src/bun/screen-frame.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MIN_VISIBLE_WIDTH,
+  MIN_VISIBLE_HEIGHT,
+  frameIsVisible,
+  intersection,
+  repairFrame,
+  type DisplayInfo,
+  type Rect,
+} from "./screen-frame.ts";
+
+// Real three-display layout captured from the dev machine. Negative origins
+// on ABOVE/LEFT are the whole point — they sit above/left of PRIMARY's
+// (0,0) origin, matching how Electrobun reports secondary displays.
+const PRIMARY: DisplayInfo = {
+  bounds: { x: 0, y: 0, width: 1728, height: 1117 },
+  workArea: { x: 0, y: 33, width: 1728, height: 1084 },
+  isPrimary: true,
+};
+const ABOVE: DisplayInfo = {
+  bounds: { x: -449, y: -1080, width: 2560, height: 1080 },
+  workArea: { x: -449, y: -1080, width: 2560, height: 1080 },
+  isPrimary: false,
+};
+const LEFT: DisplayInfo = {
+  bounds: { x: -1366, y: 0, width: 1366, height: 1024 },
+  workArea: { x: -1366, y: 0, width: 1366, height: 1024 },
+  isPrimary: false,
+};
+const DISPLAYS: DisplayInfo[] = [PRIMARY, ABOVE, LEFT];
+
+describe("intersection", () => {
+  test("disjoint rects have no intersection", () => {
+    const a: Rect = { x: 0, y: 0, width: 100, height: 100 };
+    const b: Rect = { x: 500, y: 500, width: 100, height: 100 };
+    expect(intersection(a, b)).toBeNull();
+  });
+
+  test("partial overlap returns the exact overlap rect", () => {
+    const a: Rect = { x: 0, y: 0, width: 100, height: 100 };
+    const b: Rect = { x: 50, y: 50, width: 100, height: 100 };
+    expect(intersection(a, b)).toEqual({ x: 50, y: 50, width: 50, height: 50 });
+  });
+
+  test("identical rects intersect to the same rect", () => {
+    const a: Rect = { x: 10, y: 20, width: 300, height: 400 };
+    expect(intersection(a, { ...a })).toEqual(a);
+  });
+
+  test("one rect fully containing the other returns the inner rect", () => {
+    const outer: Rect = { x: 0, y: 0, width: 1000, height: 1000 };
+    const inner: Rect = { x: 100, y: 200, width: 50, height: 60 };
+    expect(intersection(outer, inner)).toEqual(inner);
+    expect(intersection(inner, outer)).toEqual(inner);
+  });
+
+  test("edge-touching only (zero-area overlap) is not an intersection", () => {
+    // a's right edge lands exactly on b's left edge: a.x + a.width === b.x.
+    // Zero-area contact doesn't count — x2 <= x1 must reject it, not just x2 < x1.
+    const a: Rect = { x: 0, y: 0, width: 100, height: 100 };
+    const b: Rect = { x: 100, y: 0, width: 100, height: 100 };
+    expect(intersection(a, b)).toBeNull();
+  });
+
+  test("correct with negative coordinates on both rects", () => {
+    const a: Rect = { x: -1366, y: 0, width: 1366, height: 1024 };
+    const b: Rect = { x: -800, y: -200, width: 1000, height: 500 };
+    expect(intersection(a, b)).toEqual({ x: -800, y: 0, width: 800, height: 300 });
+  });
+});
+
+describe("frameIsVisible", () => {
+  test("empty displays list means 'unknown', not 'invisible' — returns true", () => {
+    // Screen.getAllDisplays() returns [] under bun test (no native enumeration
+    // library loaded). An empty list carries no information about the real
+    // layout, so it must not be treated as "nothing is visible" — that would
+    // make every repair path fire in tests and mask the bug it exists to catch.
+    const frame: Rect = { x: 5000, y: 5000, width: 800, height: 600 };
+    expect(frameIsVisible(frame, [])).toBe(true);
+  });
+
+  test("window wholly inside PRIMARY is visible", () => {
+    expect(frameIsVisible({ x: 100, y: 100, width: 400, height: 300 }, DISPLAYS)).toBe(true);
+  });
+
+  test("window wholly inside ABOVE is visible", () => {
+    expect(frameIsVisible({ x: -400, y: -1000, width: 800, height: 600 }, DISPLAYS)).toBe(true);
+  });
+
+  test("window wholly inside LEFT is visible", () => {
+    expect(frameIsVisible({ x: -1200, y: 100, width: 800, height: 600 }, DISPLAYS)).toBe(true);
+  });
+
+  test("window straddling PRIMARY and LEFT is visible", () => {
+    expect(frameIsVisible({ x: -200, y: 0, width: 400, height: 200 }, DISPLAYS)).toBe(true);
+  });
+
+  // Boundary triple around MIN_VISIBLE_WIDTH x MIN_VISIBLE_HEIGHT (120x40).
+  // Each frame sits flush against PRIMARY's right edge (x + width === 1728)
+  // and is fully within bounds vertically, so the frame *is* the overlap
+  // rect exactly — no extra arithmetic to get wrong.
+  test("overlap of 119x40 (width one short) is not visible", () => {
+    expect(MIN_VISIBLE_WIDTH).toBe(120);
+    const frame: Rect = { x: 1728 - 119, y: 0, width: 119, height: 40 };
+    expect(frameIsVisible(frame, DISPLAYS)).toBe(false);
+  });
+
+  test("overlap of 120x39 (height one short) is not visible", () => {
+    expect(MIN_VISIBLE_HEIGHT).toBe(40);
+    const frame: Rect = { x: 1728 - 120, y: 0, width: 120, height: 39 };
+    expect(frameIsVisible(frame, DISPLAYS)).toBe(false);
+  });
+
+  test("overlap of exactly 120x40 meets the threshold and is visible", () => {
+    const frame: Rect = { x: 1728 - 120, y: 0, width: 120, height: 40 };
+    expect(frameIsVisible(frame, DISPLAYS)).toBe(true);
+  });
+
+  test("window entirely off every display is not visible", () => {
+    expect(frameIsVisible({ x: 5000, y: 5000, width: 800, height: 600 }, DISPLAYS)).toBe(false);
+  });
+});
+
+describe("repairFrame", () => {
+  test("visible frame is returned unchanged, same object identity", () => {
+    const frame: Rect = { x: 100, y: 100, width: 400, height: 300 };
+    const result = repairFrame(frame, DISPLAYS);
+    expect(result).toBe(frame);
+    expect(result).toEqual({ x: 100, y: 100, width: 400, height: 300 });
+  });
+
+  test("empty displays list leaves the frame unchanged", () => {
+    const frame: Rect = { x: 5000, y: 5000, width: 800, height: 600 };
+    const result = repairFrame(frame, []);
+    expect(result).toBe(frame);
+  });
+
+  test("degenerate zero-size frame is left unchanged (dead window pointer regression guard)", () => {
+    // getWindowFrame reports {0,0,0,0} for a window whose native handle is
+    // already gone. Centering that would produce a live, zero-sized window.
+    const frame: Rect = { x: 0, y: 0, width: 0, height: 0 };
+    const result = repairFrame(frame, DISPLAYS);
+    expect(result).toBe(frame);
+  });
+
+  test("degenerate frame with zero height is left unchanged", () => {
+    const frame: Rect = { x: 200, y: 200, width: 800, height: 0 };
+    const result = repairFrame(frame, DISPLAYS);
+    expect(result).toBe(frame);
+  });
+
+  test("degenerate frame with negative width is left unchanged", () => {
+    const frame: Rect = { x: 200, y: 200, width: -100, height: 600 };
+    const result = repairFrame(frame, DISPLAYS);
+    expect(result).toBe(frame);
+  });
+
+  test("off-screen frame is centered on the primary display's workArea, not bounds", () => {
+    const frame: Rect = { x: 9000, y: 9000, width: 1200, height: 800 };
+    const result = repairFrame(frame, DISPLAYS);
+    // PRIMARY.workArea = {x:0, y:33, width:1728, height:1084}
+    // x = round(0 + (1728-1200)/2) = round(264) = 264
+    // y = round(33 + (1084-800)/2) = round(175) = 175
+    expect(result).toEqual({ x: 264, y: 175, width: 1200, height: 800 });
+  });
+
+  test("off-screen frame larger than the primary workArea is clamped to it", () => {
+    const frame: Rect = { x: 9000, y: 9000, width: 2000, height: 1200 };
+    const result = repairFrame(frame, DISPLAYS);
+    // Both dimensions exceed PRIMARY.workArea (1728x1084), so both clamp to
+    // the full workArea and the origin collapses to the workArea's own origin.
+    expect(result).toEqual({ x: 0, y: 33, width: 1728, height: 1084 });
+    expect(Number.isInteger(result.x)).toBe(true);
+    expect(Number.isInteger(result.y)).toBe(true);
+  });
+
+  test("no display flagged primary falls back to the first usable display in list order", () => {
+    const noPrimary: DisplayInfo[] = [
+      { ...LEFT, isPrimary: false },
+      { ...ABOVE, isPrimary: false },
+      { ...PRIMARY, isPrimary: false },
+    ];
+    const frame: Rect = { x: 9000, y: 9000, width: 800, height: 600 };
+    const result = repairFrame(frame, noPrimary);
+    // Falls back to LEFT (first in the array), workArea {x:-1366,y:0,width:1366,height:1024}
+    // x = round(-1366 + (1366-800)/2) = round(-1083) = -1083
+    // y = round(0 + (1024-600)/2) = round(212) = 212
+    expect(result).toEqual({ x: -1083, y: 212, width: 800, height: 600 });
+  });
+
+  test("primary flagged but degenerate (0x0 workArea) is skipped for the first usable non-primary", () => {
+    const degeneratePrimary: DisplayInfo = { ...PRIMARY, workArea: { x: 0, y: 0, width: 0, height: 0 } };
+    const displays: DisplayInfo[] = [degeneratePrimary, ABOVE, LEFT];
+    const frame: Rect = { x: 9000, y: 9000, width: 800, height: 600 };
+    const result = repairFrame(frame, displays);
+    // degeneratePrimary is filtered out of `usable` entirely, so the primary
+    // flag never matches anything usable — falls to first usable, ABOVE.
+    // ABOVE.workArea = {x:-449,y:-1080,width:2560,height:1080}
+    // x = round(-449 + (2560-800)/2) = round(431) = 431
+    // y = round(-1080 + (1080-600)/2) = round(-840) = -840
+    expect(result).toEqual({ x: 431, y: -840, width: 800, height: 600 });
+  });
+
+  test("every display degenerate leaves the frame unchanged", () => {
+    const allDegenerate: DisplayInfo[] = [
+      { ...PRIMARY, workArea: { x: 0, y: 0, width: 0, height: 0 } },
+      { ...ABOVE, workArea: { x: 0, y: 0, width: -10, height: 0 } },
+    ];
+    const frame: Rect = { x: 9000, y: 9000, width: 800, height: 600 };
+    const result = repairFrame(frame, allDegenerate);
+    expect(result).toBe(frame);
+  });
+
+  test("result is never NaN, negative-size, or fractional-origin for an odd-sized frame", () => {
+    const frame: Rect = { x: 9001, y: 9001, width: 401, height: 301 };
+    const result = repairFrame(frame, DISPLAYS);
+    expect(Number.isNaN(result.x)).toBe(false);
+    expect(Number.isNaN(result.y)).toBe(false);
+    expect(result.width).toBeGreaterThanOrEqual(0);
+    expect(result.height).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(result.x)).toBe(true);
+    expect(Number.isInteger(result.y)).toBe(true);
+  });
+});

--- a/src/bun/screen-frame.ts
+++ b/src/bun/screen-frame.ts
@@ -112,8 +112,18 @@ export function frameIsVisible(frame: Rect, displays: DisplayInfo[]): boolean {
  * unchanged — there's no usable target to repair onto, and returning
  * something is worse than returning the (already known to be off-screen,
  * but at least not garbage) original.
+ *
+ * A degenerate *input* frame is likewise returned untouched. Electrobun's
+ * `getWindowFrame` reports `{0,0,0,0}` rather than throwing when the native
+ * window pointer is already gone, and a zero-area rect overlaps nothing, so
+ * it would otherwise be diagnosed as "off-screen" and re-centered — turning
+ * a dead handle into a live, zero-sized window. There is no width or height
+ * here to preserve, so there is nothing to repair: a caller that hands us a
+ * degenerate frame has a problem this function cannot fix, and inventing an
+ * origin for it only hides that.
  */
 export function repairFrame(frame: Rect, displays: DisplayInfo[]): Rect {
+  if (frame.width <= 0 || frame.height <= 0) return frame;
   if (frameIsVisible(frame, displays)) return frame;
 
   const usable = displays.filter((d) => d.workArea.width > 0 && d.workArea.height > 0);

--- a/src/bun/screen-frame.ts
+++ b/src/bun/screen-frame.ts
@@ -61,12 +61,23 @@ export function intersection(a: Rect, b: Rect): Rect | null {
 }
 
 /**
- * True iff `frame` overlaps some display's `bounds` (not `workArea`) by at
- * least `MIN_VISIBLE_WIDTH` x `MIN_VISIBLE_HEIGHT`. `bounds` is used here
+ * True iff `frame` overlaps a *single* display's `bounds` (not `workArea`) by
+ * at least `MIN_VISIBLE_WIDTH` x `MIN_VISIBLE_HEIGHT`. `bounds` is used here
  * rather than `workArea` because a frame that pokes up under the menu bar
  * or down over the Dock is still visible and draggable — visibility only
  * cares about the physical screen, not the region an app window is polite
  * enough to avoid.
+ *
+ * The threshold is evaluated **per display, not against the union of them**.
+ * Adjacent displays form one contiguous desktop, so a window straddling the
+ * seam can present a usable strip to the user while clearing the threshold on
+ * neither screen alone — e.g. a 120pt-wide window centred on the boundary
+ * shows 60pt on each side and is reported here as not visible. That is a
+ * deliberate false negative. The alternative, summing coverage across
+ * displays, would accept a 10x600 sliver (6000px² > the 4800px² threshold
+ * area) as "visible" even though there's no grabbable title bar anywhere —
+ * trading a rare, harmless re-centering for a window the user genuinely
+ * cannot reach. Erring toward repair is the safer failure.
  *
  * Returns `true` when `displays` is empty. `Screen.getAllDisplays()`
  * returns `[]` when the native display-enumeration library isn't loaded
@@ -95,9 +106,11 @@ export function frameIsVisible(frame: Rect, displays: DisplayInfo[]): boolean {
  * purpose. Visibility checks (above) and repair placement (here) are
  * deliberately asymmetric for this reason.
  *
- * Repair only fires on *total* loss of visibility (delegated to
- * `frameIsVisible`), never on a partial mismatch or an unfamiliar-looking
- * position. A frame legitimately placed on a secondary display can have
+ * Repair fires only when `frameIsVisible` reports no display showing a usable
+ * part of the frame — never on a partial mismatch or an unfamiliar-looking
+ * position. (See `frameIsVisible` for the one deliberate false negative: a
+ * window straddling the seam between two adjacent displays.) A frame
+ * legitimately placed on a secondary display can have
  * wildly different-looking coordinates from the primary display (e.g. a
  * large negative x) without being wrong — display layouts are stored in
  * whatever coordinate space macOS handed back at placement time, and a

--- a/src/bun/screen-frame.ts
+++ b/src/bun/screen-frame.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure geometry for validating and repairing a window frame against the set
+ * of connected displays. Used at window-restore time to catch the case
+ * where the remembered frame was computed on a monitor arrangement that no
+ * longer exists (a laptop undocked, an external display unplugged, a
+ * different display layout on next launch) and would otherwise place the
+ * window fully off-screen and unreachable.
+ *
+ * `DisplayInfo` is a structural subset of Electrobun's `Display` — only
+ * `bounds`, `workArea`, and `isPrimary` are read — so this module never
+ * imports from `electrobun/bun`. That keeps it free of native bindings and
+ * side effects at import time, which is what makes it trivially unit
+ * testable without a real windowing system underneath.
+ *
+ * Coordinates throughout are top-left origin, y grows downward, matching
+ * both Electrobun's `Display.bounds` and the existing `Frame` type in
+ * `window-lifecycle.ts`. Secondary displays legitimately report negative
+ * `x`/`y` (anything above or left of the primary display's origin), so no
+ * function here may assume non-negative coordinates.
+ */
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Structural subset of Electrobun's `Display` — extra fields on the real
+ *  object (id, scaleFactor, ...) are fine, TypeScript structural typing
+ *  accepts them without this module needing to know about them. */
+export interface DisplayInfo {
+  bounds: Rect;
+  workArea: Rect;
+  isPrimary: boolean;
+}
+
+/**
+ * Smallest on-screen region a frame must occupy to count as "visible".
+ * A single pixel of overlap technically satisfies "the window is on
+ * screen" but leaves nothing a user can grab to drag it back into view —
+ * so the threshold is sized to guarantee at least a sliver of title bar
+ * stays reachable, not just technically non-zero overlap.
+ */
+export const MIN_VISIBLE_WIDTH = 120;
+export const MIN_VISIBLE_HEIGHT = 40;
+
+/**
+ * Returns the overlapping rectangle of `a` and `b`, or `null` if they don't
+ * overlap at all. Works for negative origins (secondary displays sit at
+ * negative x/y relative to the primary) since it only ever compares
+ * coordinates, never assumes a sign.
+ */
+export function intersection(a: Rect, b: Rect): Rect | null {
+  const x1 = Math.max(a.x, b.x);
+  const y1 = Math.max(a.y, b.y);
+  const x2 = Math.min(a.x + a.width, b.x + b.width);
+  const y2 = Math.min(a.y + a.height, b.y + b.height);
+  if (x2 <= x1 || y2 <= y1) return null;
+  return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
+}
+
+/**
+ * True iff `frame` overlaps some display's `bounds` (not `workArea`) by at
+ * least `MIN_VISIBLE_WIDTH` x `MIN_VISIBLE_HEIGHT`. `bounds` is used here
+ * rather than `workArea` because a frame that pokes up under the menu bar
+ * or down over the Dock is still visible and draggable — visibility only
+ * cares about the physical screen, not the region an app window is polite
+ * enough to avoid.
+ *
+ * Returns `true` when `displays` is empty. `Screen.getAllDisplays()`
+ * returns `[]` when the native display-enumeration library isn't loaded
+ * (notably under `bun test`), and an empty list carries no information
+ * about the real screen layout — treating "unknown" as "invisible" would
+ * make every repair path fire in that environment and mask the very bug
+ * it exists to catch. Unknown must mean "don't touch it".
+ */
+export function frameIsVisible(frame: Rect, displays: DisplayInfo[]): boolean {
+  if (displays.length === 0) return true;
+  return displays.some((display) => {
+    const overlap = intersection(frame, display.bounds);
+    return overlap !== null && overlap.width >= MIN_VISIBLE_WIDTH && overlap.height >= MIN_VISIBLE_HEIGHT;
+  });
+}
+
+/**
+ * Returns `frame` unchanged if it's already visible on some display,
+ * otherwise a new frame centered on the primary display's `workArea`
+ * (falling back to the first display if none is flagged primary), with
+ * width/height clamped to fit.
+ *
+ * Repair targets `workArea` rather than `bounds`: a frame *placed* there
+ * should end up somewhere the menu bar and Dock don't immediately cover it
+ * again, and workArea is exactly the region macOS itself reserves for that
+ * purpose. Visibility checks (above) and repair placement (here) are
+ * deliberately asymmetric for this reason.
+ *
+ * Repair only fires on *total* loss of visibility (delegated to
+ * `frameIsVisible`), never on a partial mismatch or an unfamiliar-looking
+ * position. A frame legitimately placed on a secondary display can have
+ * wildly different-looking coordinates from the primary display (e.g. a
+ * large negative x) without being wrong — display layouts are stored in
+ * whatever coordinate space macOS handed back at placement time, and a
+ * naive "does this look sane" heuristic would misidentify that as damage
+ * and yank the window off a monitor it's correctly sitting on. Only "no
+ * display can show any usable part of this frame" is treated as broken.
+ *
+ * A display whose `workArea` has zero width or height is degenerate (can't
+ * meaningfully host a centered window) and is skipped when picking the
+ * repair target, including when it's the one flagged primary. If every
+ * display is degenerate, or `displays` is empty, `frame` is returned
+ * unchanged — there's no usable target to repair onto, and returning
+ * something is worse than returning the (already known to be off-screen,
+ * but at least not garbage) original.
+ */
+export function repairFrame(frame: Rect, displays: DisplayInfo[]): Rect {
+  if (frameIsVisible(frame, displays)) return frame;
+
+  const usable = displays.filter((d) => d.workArea.width > 0 && d.workArea.height > 0);
+  const first = usable[0];
+  if (!first) return frame;
+
+  const target = usable.find((d) => d.isPrimary) ?? first;
+  const workArea = target.workArea;
+
+  const width = Math.max(0, Math.min(frame.width, workArea.width));
+  const height = Math.max(0, Math.min(frame.height, workArea.height));
+  const x = Math.round(workArea.x + (workArea.width - width) / 2);
+  const y = Math.round(workArea.y + (workArea.height - height) / 2);
+
+  return { x, y, width, height };
+}

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -2,6 +2,14 @@ import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import type { WebSocketHandler } from "bun";
+// Namespace import, not `import { Screen } from "electrobun/bun"`: tests
+// mock.module("electrobun/bun", ...) with a stub that doesn't export
+// `Screen` (see notifications.test.ts), and Bun's ESM linker rejects a
+// named import of a binding the mock doesn't provide at *import* time,
+// before any test even runs. A namespace import always resolves; the
+// `/window/focus` handler below reads `.Screen` off it lazily, so a mocked
+// module missing that key only matters if the route is actually hit.
+import * as ElectrobunBun from "electrobun/bun";
 import pkg from "../../package.json" with { type: "json" };
 import { API_TOKEN, getApiPort } from "./api-config.ts";
 import { removeCoreCreds } from "./core-creds.ts";
@@ -61,6 +69,7 @@ import {
 import { listAgentCapabilities } from "./commands.ts";
 import { getDiscoveredModels, refreshDiscoveredModels } from "./agent-discovery.ts";
 import { getMainWindow } from "./window.ts";
+import { focusWindow } from "./window-focus.ts";
 import {
   answerTmuxPrompt,
   findTmuxPromptById,
@@ -444,6 +453,25 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           }
           if (win.isMaximized()) win.unmaximize();
           else win.maximize();
+          return json({ ok: true }, { headers: corsHeaders(req) });
+        }),
+      },
+
+      // Bring the main window to the front from the webview side — the
+      // counterpart to `focusMainWindow()` in index.ts (notification click,
+      // Dock reopen). The webview needs this too: a clicked toast's `onOpen`
+      // runs entirely in the renderer, and a WKWebView's own `window.focus()`
+      // can't activate the host NSApplication, so it has to round-trip
+      // through here to reach the same `focusWindow` routine.
+      "/window/focus": {
+        POST: authed((req) => {
+          const focused = focusWindow(getMainWindow(), { getAllDisplays: () => ElectrobunBun.Screen.getAllDisplays() });
+          if (!focused) {
+            return json(
+              { error: "no main window" },
+              { status: 503, headers: corsHeaders(req) },
+            );
+          }
           return json({ ok: true }, { headers: corsHeaders(req) });
         }),
       },

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -2,14 +2,6 @@ import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import type { WebSocketHandler } from "bun";
-// Namespace import, not `import { Screen } from "electrobun/bun"`: tests
-// mock.module("electrobun/bun", ...) with a stub that doesn't export
-// `Screen` (see notifications.test.ts), and Bun's ESM linker rejects a
-// named import of a binding the mock doesn't provide at *import* time,
-// before any test even runs. A namespace import always resolves; the
-// `/window/focus` handler below reads `.Screen` off it lazily, so a mocked
-// module missing that key only matters if the route is actually hit.
-import * as ElectrobunBun from "electrobun/bun";
 import pkg from "../../package.json" with { type: "json" };
 import { API_TOKEN, getApiPort } from "./api-config.ts";
 import { removeCoreCreds } from "./core-creds.ts";
@@ -69,7 +61,6 @@ import {
 import { listAgentCapabilities } from "./commands.ts";
 import { getDiscoveredModels, refreshDiscoveredModels } from "./agent-discovery.ts";
 import { getMainWindow } from "./window.ts";
-import { focusWindow } from "./window-focus.ts";
 import {
   answerTmuxPrompt,
   findTmuxPromptById,
@@ -220,6 +211,14 @@ export interface ApiNative {
     /** Task to deep-link to on click, e.g. via terminal-notifier's -open. */
     taskId?: string;
   }): void;
+  /** Raise + focus the app window. Returns `false` when there is no window to
+   *  act on — never to report a failed native call, so callers can map `false`
+   *  to "no window" without conflating it with a platform hiccup. Lives behind
+   *  this interface (rather than calling `focusWindow` here) because resolving
+   *  the display layout needs `Screen` from `electrobun/bun`, and importing
+   *  that at module scope would drag Electrobun — and its transitive `three`
+   *  dependency — into the headless CLI daemon, which imports this file. */
+  focusWindow(): boolean;
   quit(): void;
   updates: {
     snapshot(): UpdaterSnapshot;
@@ -462,11 +461,18 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       // Dock reopen). The webview needs this too: a clicked toast's `onOpen`
       // runs entirely in the renderer, and a WKWebView's own `window.focus()`
       // can't activate the host NSApplication, so it has to round-trip
-      // through here to reach the same `focusWindow` routine.
+      // through here.
+      //
+      // Native-gated rather than calling `focusWindow()` inline (the way
+      // `/window/toggle-zoom` above pokes `getMainWindow()` directly): raising
+      // a window means first checking the frame against the live display
+      // layout, which needs `Screen` from `electrobun/bun`. Importing that
+      // here would pull Electrobun into the headless CLI daemon, which imports
+      // this module — see the note on ApiNative.
       "/window/focus": {
         POST: authed((req) => {
-          const focused = focusWindow(getMainWindow(), { getAllDisplays: () => ElectrobunBun.Screen.getAllDisplays() });
-          if (!focused) {
+          if (!native) return notAvailableHeadless(req);
+          if (!native.focusWindow()) {
             return json(
               { error: "no main window" },
               { status: 503, headers: corsHeaders(req) },

--- a/src/bun/test-native.ts
+++ b/src/bun/test-native.ts
@@ -14,6 +14,9 @@ export function makeTestNative(over: Partial<ApiNative> = {}): ApiNative {
     openPath: () => true,
     openExternal: () => true,
     showNotification: () => {},
+    // Matches the headless/no-window reality: `false` means "no window to
+    // focus", which the /window/focus route maps to 503.
+    focusWindow: () => false,
     quit: () => {},
     updates: {
       snapshot: () => ({

--- a/src/bun/window-focus-route.test.ts
+++ b/src/bun/window-focus-route.test.ts
@@ -1,53 +1,48 @@
-import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { makeTestNative } from "./test-native.ts";
+import { focusWindow } from "./window-focus.ts";
 
 const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-window-focus-route-"));
 process.env.AGETOR_DATA_DIR = DATA_DIR;
 // Distinct from other server-test ports so parallel test runs don't fight.
 process.env.AGETOR_API_PORT = "4402";
 
-// Stub electrobun's native bridge before server.ts imports it — same reason
-// as notifications.test.ts. Critically, this stub MUST export `Screen`:
-// server.ts's `/window/focus` handler reads `ElectrobunBun.Screen.getAllDisplays()`
-// lazily inside the handler and passes it straight through to `focusWindow`,
-// which calls it inside a guarded try/catch as part of frame repair. Without
-// a `Screen` export here, `getAllDisplays()` would throw, the guard would
-// swallow it, and `activate()` would still run — the test would pass for the
-// wrong reason (proving nothing about the frame-repair path actually running).
-mock.module("electrobun/bun", () => ({
-  Utils: {
-    showNotification: () => {},
-    openPath: () => true,
-    openFileDialog: async () => [],
-  },
-  BrowserWindow: class { /* unused in this test */ },
-  ApplicationMenu: { setApplicationMenu: () => { /* noop */ } },
-  Updater: { /* noop */ },
-  Screen: { getAllDisplays: () => [] },
-}));
-
-let server: { stop: () => void; port: number };
-let token: string;
+// No mock.module("electrobun/bun") here, deliberately: server.ts must never
+// import Electrobun (that would drag it, and `three`, into the headless CLI
+// daemon — see the ApiNative doc-comment). /window/focus reaches the native
+// host through the same injected `ApiNative` seam every other native route
+// uses, so this test injects one instead of stubbing a module.
+let server: { stop: () => void };
 let setMainWindow: (win: unknown) => void;
+let token: string;
 
 beforeAll(async () => {
   await import("./db.ts");
   const { startApiServer, API_TOKEN } = await import("./server.ts");
   const windowModule = await import("./window.ts");
   setMainWindow = windowModule.setMainWindow as unknown as (win: unknown) => void;
-  server = startApiServer() as unknown as { stop: () => void; port: number };
+  const { getMainWindow } = windowModule;
+
+  // Mirror index.ts's real wiring: the injected focusWindow() resolves the
+  // window through the same registry the app uses and delegates to the same
+  // routine. `getAllDisplays: () => []` is what Electrobun itself returns when
+  // the native display library isn't loaded, which is exactly this process.
+  const native = makeTestNative({
+    focusWindow: () => focusWindow(getMainWindow(), { getAllDisplays: () => [] }),
+  });
+
+  server = startApiServer({ native }) as unknown as { stop: () => void };
   token = API_TOKEN;
 });
 
-afterAll(() => {
-  server?.stop?.();
-});
+afterAll(() => server?.stop?.());
 
 afterEach(() => {
-  // A registered fake window must never leak into another test in this file
-  // (or a sibling test file, given mock.module's process-wide reach).
+  // A registered fake window must never leak into another test in this file,
+  // or into a sibling file sharing the module registry.
   setMainWindow(null);
 });
 

--- a/src/bun/window-focus-route.test.ts
+++ b/src/bun/window-focus-route.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-window-focus-route-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+// Distinct from other server-test ports so parallel test runs don't fight.
+process.env.AGETOR_API_PORT = "4402";
+
+// Stub electrobun's native bridge before server.ts imports it — same reason
+// as notifications.test.ts. Critically, this stub MUST export `Screen`:
+// server.ts's `/window/focus` handler reads `ElectrobunBun.Screen.getAllDisplays()`
+// lazily inside the handler and passes it straight through to `focusWindow`,
+// which calls it inside a guarded try/catch as part of frame repair. Without
+// a `Screen` export here, `getAllDisplays()` would throw, the guard would
+// swallow it, and `activate()` would still run — the test would pass for the
+// wrong reason (proving nothing about the frame-repair path actually running).
+mock.module("electrobun/bun", () => ({
+  Utils: {
+    showNotification: () => {},
+    openPath: () => true,
+    openFileDialog: async () => [],
+  },
+  BrowserWindow: class { /* unused in this test */ },
+  ApplicationMenu: { setApplicationMenu: () => { /* noop */ } },
+  Updater: { /* noop */ },
+  Screen: { getAllDisplays: () => [] },
+}));
+
+let server: { stop: () => void; port: number };
+let token: string;
+let setMainWindow: (win: unknown) => void;
+
+beforeAll(async () => {
+  await import("./db.ts");
+  const { startApiServer, API_TOKEN } = await import("./server.ts");
+  const windowModule = await import("./window.ts");
+  setMainWindow = windowModule.setMainWindow as unknown as (win: unknown) => void;
+  server = startApiServer() as unknown as { stop: () => void; port: number };
+  token = API_TOKEN;
+});
+
+afterAll(() => {
+  server?.stop?.();
+});
+
+afterEach(() => {
+  // A registered fake window must never leak into another test in this file
+  // (or a sibling test file, given mock.module's process-wide reach).
+  setMainWindow(null);
+});
+
+const url = (p: string) => `http://127.0.0.1:4402${p}`;
+const auth = () => ({ authorization: `Bearer ${token}`, "content-type": "application/json" });
+
+function makeFakeWindow(over: Partial<{
+  isMinimized: () => boolean;
+  unminimize: () => void;
+  activate: () => void;
+  getFrame: () => { x: number; y: number; width: number; height: number };
+  setFrame: (x: number, y: number, width: number, height: number) => void;
+}> = {}) {
+  return {
+    isMinimized: () => false,
+    unminimize: () => {},
+    activate: () => {},
+    getFrame: () => ({ x: 0, y: 0, width: 800, height: 600 }),
+    setFrame: () => {},
+    ...over,
+  };
+}
+
+describe("POST /window/focus", () => {
+  test("without a token returns 401", async () => {
+    const res = await fetch(url("/window/focus"), { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 503 with no main window registered", async () => {
+    setMainWindow(null);
+    const res = await fetch(url("/window/focus"), { method: "POST", headers: auth() });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "no main window" });
+  });
+
+  test("returns 200 and calls activate() exactly once on a normal window", async () => {
+    let activateCalls = 0;
+    const fake = makeFakeWindow({ activate: () => { activateCalls++; } });
+    setMainWindow(fake as any);
+
+    const res = await fetch(url("/window/focus"), { method: "POST", headers: auth() });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(activateCalls).toBe(1);
+  });
+
+  test("restores a minimized window (unminimize before activate)", async () => {
+    const calls: string[] = [];
+    const fake = makeFakeWindow({
+      isMinimized: () => true,
+      unminimize: () => { calls.push("unminimize"); },
+      activate: () => { calls.push("activate"); },
+    });
+    setMainWindow(fake as any);
+
+    const res = await fetch(url("/window/focus"), { method: "POST", headers: auth() });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(calls).toEqual(["unminimize", "activate"]);
+  });
+
+  test("a native activate() throw is still a 200, never a 503 — 503 means 'no window', not 'a native call failed'", async () => {
+    const origError = console.error;
+    console.error = () => {}; // focusWindow logs this guarded failure; keep suite output clean
+    try {
+      const fake = makeFakeWindow({
+        activate: () => { throw new Error("native activate boom"); },
+      });
+      setMainWindow(fake as any);
+
+      const res = await fetch(url("/window/focus"), { method: "POST", headers: auth() });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  test("GET is not a valid focus trigger (route only registers POST)", async () => {
+    const fake = makeFakeWindow();
+    setMainWindow(fake as any);
+
+    const res = await fetch(url("/window/focus"), { method: "GET", headers: auth() });
+    // The route only registers a POST handler; Bun's router falls through to
+    // the server's catch-all fetch handler for an unmatched method, which
+    // responds 404 (matches the "not found" shape used elsewhere in server.ts).
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/bun/window-focus.test.ts
+++ b/src/bun/window-focus.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, test } from "bun:test";
+import { focusWindow, type FocusableWindow, type FocusDeps } from "./window-focus.ts";
+import { repairFrame, type DisplayInfo, type Rect } from "./screen-frame.ts";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+// Real display layout pulled from the dev machine. Negative-origin secondary
+// displays aren't exercised here (only one display), but the shape matches
+// what `screen-frame.ts` expects to read.
+const PRIMARY: DisplayInfo = {
+  bounds: { x: 0, y: 0, width: 1728, height: 1117 },
+  workArea: { x: 0, y: 33, width: 1728, height: 1084 },
+  isPrimary: true,
+};
+const DISPLAYS: DisplayInfo[] = [PRIMARY];
+
+const ONSCREEN_FRAME: Rect = { x: 100, y: 100, width: 800, height: 600 };
+const OFFSCREEN_FRAME: Rect = { x: 5000, y: 5000, width: 1200, height: 800 };
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Recording fake for `FocusableWindow`. Every method call is appended to
+ *  `calls` (setFrame includes its args) so tests can assert both presence
+ *  and ORDER. Any method named in `throws` throws after recording the call —
+ *  matching real native bindings, which fail loudly rather than silently. */
+function makeWindow(
+  opts: {
+    frame?: Rect;
+    minimized?: boolean;
+    throws?: Partial<Record<"getFrame" | "setFrame" | "isMinimized" | "unminimize" | "activate", boolean>>;
+  } = {},
+): { win: FocusableWindow; calls: string[] } {
+  const frame = opts.frame ?? ONSCREEN_FRAME;
+  const minimized = opts.minimized ?? false;
+  const throwsCfg = opts.throws ?? {};
+  const calls: string[] = [];
+
+  const win: FocusableWindow = {
+    isMinimized: () => {
+      calls.push("isMinimized");
+      if (throwsCfg.isMinimized) throw new Error("isMinimized failed (test)");
+      return minimized;
+    },
+    unminimize: () => {
+      calls.push("unminimize");
+      if (throwsCfg.unminimize) throw new Error("unminimize failed (test)");
+    },
+    activate: () => {
+      calls.push("activate");
+      if (throwsCfg.activate) throw new Error("activate failed (test)");
+    },
+    getFrame: () => {
+      calls.push("getFrame");
+      if (throwsCfg.getFrame) throw new Error("getFrame failed (test)");
+      return frame;
+    },
+    setFrame: (x: number, y: number, width: number, height: number) => {
+      calls.push(`setFrame:${x},${y},${width},${height}`);
+      if (throwsCfg.setFrame) throw new Error("setFrame failed (test)");
+    },
+  };
+
+  return { win, calls };
+}
+
+/** Recording fake for `FocusDeps`. */
+function makeDeps(
+  displays: DisplayInfo[] = DISPLAYS,
+  opts: { throws?: boolean } = {},
+): { deps: FocusDeps; calls: string[] } {
+  const calls: string[] = [];
+  const deps: FocusDeps = {
+    getAllDisplays: () => {
+      calls.push("getAllDisplays");
+      if (opts.throws) throw new Error("getAllDisplays failed (test)");
+      return displays;
+    },
+  };
+  return { deps, calls };
+}
+
+/** Runs `fn` with `console.error` swapped for a recorder, then restores it —
+ *  so tests that deliberately trigger the module's error-logging paths don't
+ *  spew into the suite's output, while still letting a test assert the log
+ *  actually happened. */
+function withSilencedConsoleError<T>(fn: () => T): { result: T; errorCalls: unknown[][] } {
+  const original = console.error;
+  const errorCalls: unknown[][] = [];
+  console.error = (...args: unknown[]) => {
+    errorCalls.push(args);
+  };
+  try {
+    return { result: fn(), errorCalls };
+  } finally {
+    console.error = original;
+  }
+}
+
+// ─── No window ──────────────────────────────────────────────────────────────
+
+describe("no window to focus", () => {
+  test("returns false for null and never touches deps", () => {
+    const { deps, calls } = makeDeps();
+    expect(focusWindow(null, deps)).toBe(false);
+    expect(calls).toEqual([]);
+  });
+
+  test("returns false for undefined and never touches deps", () => {
+    const { deps, calls } = makeDeps();
+    expect(focusWindow(undefined, deps)).toBe(false);
+    expect(calls).toEqual([]);
+  });
+});
+
+// ─── Happy paths ────────────────────────────────────────────────────────────
+
+describe("happy path ordering", () => {
+  test("not minimized, on-screen frame: activate() runs once, unminimize and setFrame are skipped", () => {
+    const { win, calls } = makeWindow({ frame: ONSCREEN_FRAME, minimized: false });
+    const { deps } = makeDeps();
+
+    expect(focusWindow(win, deps)).toBe(true);
+
+    expect(calls).toEqual(["getFrame", "isMinimized", "activate"]);
+  });
+
+  test("minimized window: unminimize() runs before activate()", () => {
+    const { win, calls } = makeWindow({ frame: ONSCREEN_FRAME, minimized: true });
+    const { deps } = makeDeps();
+
+    expect(focusWindow(win, deps)).toBe(true);
+
+    expect(calls).toEqual(["getFrame", "isMinimized", "unminimize", "activate"]);
+    expect(calls.indexOf("unminimize")).toBeLessThan(calls.indexOf("activate"));
+  });
+
+  test("off-screen frame: setFrame() repairs it before activate(), using repairFrame's own output", () => {
+    const repaired = repairFrame(OFFSCREEN_FRAME, DISPLAYS);
+    expect(repaired).not.toEqual(OFFSCREEN_FRAME); // sanity: fixture really is off-screen
+    // Pin the concrete numbers too, so a change to repairFrame's centering
+    // math is visible here rather than only silently shifting the fixture.
+    expect(repaired).toEqual({ x: 264, y: 175, width: 1200, height: 800 });
+
+    const { win, calls } = makeWindow({ frame: OFFSCREEN_FRAME });
+    const { deps } = makeDeps();
+
+    expect(focusWindow(win, deps)).toBe(true);
+
+    expect(calls).toEqual([
+      "getFrame",
+      `setFrame:${repaired.x},${repaired.y},${repaired.width},${repaired.height}`,
+      "isMinimized",
+      "activate",
+    ]);
+    expect(calls.indexOf("setFrame:264,175,1200,800")).toBeLessThan(calls.indexOf("activate"));
+  });
+
+  test("on-screen frame: setFrame() is never called (repair is a no-op when the rect is unchanged)", () => {
+    const { win, calls } = makeWindow({ frame: ONSCREEN_FRAME });
+    const { deps } = makeDeps();
+
+    focusWindow(win, deps);
+
+    expect(calls.some((c) => c.startsWith("setFrame"))).toBe(false);
+  });
+});
+
+// ─── Resilience: every best-effort step is independently fault-tolerant ────
+
+const RESILIENCE_CASES: Array<{
+  name: string;
+  build: () => { win: FocusableWindow; deps: FocusDeps; calls: string[] };
+}> = [
+  {
+    name: "getAllDisplays throws",
+    build: () => {
+      const { win, calls } = makeWindow({ frame: ONSCREEN_FRAME });
+      const { deps } = makeDeps(DISPLAYS, { throws: true });
+      return { win, deps, calls };
+    },
+  },
+  {
+    name: "getFrame throws",
+    build: () => {
+      const { win, calls } = makeWindow({ frame: ONSCREEN_FRAME, throws: { getFrame: true } });
+      const { deps } = makeDeps();
+      return { win, deps, calls };
+    },
+  },
+  {
+    name: "setFrame throws",
+    build: () => {
+      // Off-screen frame so the repair path actually reaches setFrame().
+      const { win, calls } = makeWindow({ frame: OFFSCREEN_FRAME, throws: { setFrame: true } });
+      const { deps } = makeDeps();
+      return { win, deps, calls };
+    },
+  },
+  {
+    name: "isMinimized throws",
+    build: () => {
+      const { win, calls } = makeWindow({ frame: ONSCREEN_FRAME, throws: { isMinimized: true } });
+      const { deps } = makeDeps();
+      return { win, deps, calls };
+    },
+  },
+  {
+    name: "unminimize throws",
+    build: () => {
+      const { win, calls } = makeWindow({
+        frame: ONSCREEN_FRAME,
+        minimized: true,
+        throws: { unminimize: true },
+      });
+      const { deps } = makeDeps();
+      return { win, deps, calls };
+    },
+  },
+];
+
+describe("resilience matrix: a best-effort step failing never costs activate()", () => {
+  for (const { name, build } of RESILIENCE_CASES) {
+    test(`${name} → activate() still runs exactly once and focusWindow still returns true`, () => {
+      const { win, deps, calls } = build();
+
+      const { result } = withSilencedConsoleError(() => focusWindow(win, deps));
+
+      expect(result).toBe(true);
+      expect(calls.filter((c) => c === "activate").length).toBe(1);
+    });
+  }
+});
+
+test("activate() itself throwing still returns true, not false — false means 'no window', never a native error", () => {
+  // server.ts's POST /window/focus turns `false` into a 503 "no main window".
+  // A window that exists but whose activate() call failed natively is a
+  // completely different situation and must not be reported the same way.
+  const { win, calls } = makeWindow({ frame: ONSCREEN_FRAME, throws: { activate: true } });
+  const { deps } = makeDeps();
+
+  const { result } = withSilencedConsoleError(() => focusWindow(win, deps));
+
+  expect(result).toBe(true);
+  expect(calls).toEqual(["getFrame", "isMinimized", "activate"]);
+});
+
+test("empty display list (native display library absent, e.g. under bun test) skips repair but still activates", () => {
+  // getAllDisplays() legitimately returns [] when the native lib isn't
+  // loaded. screen-frame.ts treats that as "unknown, don't touch it" —
+  // frameIsVisible short-circuits to true — so setFrame must not fire even
+  // though the frame is nowhere near real screen bounds.
+  const { win, calls } = makeWindow({ frame: OFFSCREEN_FRAME });
+  const { deps } = makeDeps([]);
+
+  expect(focusWindow(win, deps)).toBe(true);
+
+  expect(calls.some((c) => c.startsWith("setFrame"))).toBe(false);
+  expect(calls).toContain("activate");
+});
+
+// ─── Error logging ──────────────────────────────────────────────────────────
+
+test("a failed step is logged via console.error rather than surfaced as an unhandled throw", () => {
+  const { win } = makeWindow({ frame: ONSCREEN_FRAME, throws: { getFrame: true } });
+  const { deps } = makeDeps();
+
+  const { errorCalls } = withSilencedConsoleError(() => focusWindow(win, deps));
+
+  expect(errorCalls.length).toBeGreaterThan(0);
+});

--- a/src/bun/window-focus.ts
+++ b/src/bun/window-focus.ts
@@ -1,4 +1,4 @@
-import { repairFrame, type DisplayInfo, type Rect } from "./screen-frame";
+import { repairFrame, type DisplayInfo, type Rect } from "./screen-frame.ts";
 
 /**
  * Structural subset of Electrobun's `BrowserWindow` — only the members this

--- a/src/bun/window-focus.ts
+++ b/src/bun/window-focus.ts
@@ -80,13 +80,20 @@ export function focusWindow(win: FocusableWindow | null | undefined, deps: Focus
   // `activateIgnoringOtherApps:` + `makeKeyAndOrderFront:` under the hood.
   //
   // Deliberately not doing the `setVisibleOnAllWorkspaces(true) → activate()
-  // → false` trick some Electron apps use to force a Space switch:
-  // Electrobun exposes no such API (no `NSApp.activate`, no
-  // `moveToActiveSpace`), and even if it did, forcing a Space switch is the
-  // app overriding a user-level macOS setting ("switch to a Space with open
-  // windows"). If the window lives on another Space, macOS decides whether
-  // to switch to it. This is a deliberate product choice, not a gap — don't
-  // "fix" it by reaching for cross-Space tricks later.
+  // → false` trick that would pull the window onto whichever Space the user
+  // is currently looking at. Electrobun *does* expose
+  // `setVisibleOnAllWorkspaces` (BrowserWindow.ts:342 — it's the one
+  // `collectionBehavior` bit the FFI surfaces), so this is buildable: leaving
+  // it out is a product decision, not a missing API. Forcing the window
+  // across Spaces overrides a user-level macOS setting ("switch to a Space
+  // with open windows"), the toggle-off half of the trick is timing-sensitive,
+  // and `canJoinAllSpaces` alone still can't enter another app's fullscreen
+  // Space. So if the window lives on another Space, macOS decides. Don't
+  // "fix" this later without re-litigating the product call.
+  //
+  // (`NSApp.activate` and `moveToActiveSpace` genuinely don't exist in the
+  // FFI table, and can't be added: the native wrapper ships as a prebuilt
+  // dylib with no source, and dlopen throws on an undeclared symbol.)
   try {
     win.activate();
   } catch (err) {

--- a/src/bun/window-focus.ts
+++ b/src/bun/window-focus.ts
@@ -1,0 +1,97 @@
+import { repairFrame, type DisplayInfo, type Rect } from "./screen-frame";
+
+/**
+ * Structural subset of Electrobun's `BrowserWindow` — only the members this
+ * module needs to raise, un-minimize and focus a window. Kept structural
+ * (not `import type { BrowserWindow } from "electrobun/bun"`) so this module
+ * has zero runtime or type dependency on the native library: a real
+ * `BrowserWindow` satisfies it for free, and `bun test` can pass a plain
+ * object fake without ever loading Electrobun's native bindings.
+ */
+export interface FocusableWindow {
+  isMinimized(): boolean;
+  unminimize(): void;
+  activate(): void;
+  getFrame(): Rect;
+  setFrame(x: number, y: number, width: number, height: number): void;
+}
+
+export interface FocusDeps {
+  getAllDisplays: () => DisplayInfo[];
+}
+
+/**
+ * Raises, un-minimizes and focuses the app's main window. This is the single
+ * shared routine behind every "bring the app to the front" trigger — a
+ * clicked native notification, a deep link, a Dock reopen — so those callers
+ * don't each reinvent the ordering below.
+ *
+ * Returns `false` only when there was no window to act on at all (`win` is
+ * `null`/`undefined`) — that's the signal callers use to decide whether to
+ * fall back to a 503 or to create a fresh window. Once a window exists, this
+ * function always returns `true`, even if the native `activate()` call below
+ * throws: a throw there is a platform hiccup on a window that legitimately
+ * exists, not the "nothing to focus" case, and conflating the two would send
+ * "no window" callers down the wrong recovery path.
+ */
+export function focusWindow(win: FocusableWindow | null | undefined, deps: FocusDeps): boolean {
+  if (!win) return false;
+
+  // Repair the frame *before* un-minimizing/activating so a window whose
+  // remembered position has gone off-screen (monitor unplugged, display
+  // arrangement changed since last launch) doesn't visibly animate in at an
+  // unreachable location before snapping back — the fix has to land before
+  // the window is shown, not after.
+  try {
+    const displays = deps.getAllDisplays();
+    const current = win.getFrame();
+    const repaired = repairFrame(current, displays);
+    if (
+      repaired.x !== current.x ||
+      repaired.y !== current.y ||
+      repaired.width !== current.width ||
+      repaired.height !== current.height
+    ) {
+      win.setFrame(repaired.x, repaired.y, repaired.width, repaired.height);
+    }
+  } catch (err) {
+    console.error("[agetor] window-focus: frame repair failed", err);
+  }
+
+  // Un-minimize next, still before activating, so the window is in a normal
+  // (restorable) state by the time activation asks macOS to bring it
+  // forward.
+  try {
+    if (win.isMinimized()) win.unminimize();
+  } catch (err) {
+    console.error("[agetor] window-focus: unminimize failed", err);
+  }
+
+  // Each step above is independently guarded so that a native failure in a
+  // best-effort enhancement (frame repair, un-minimize) can never cost the
+  // user the one thing that actually matters: getting the window in front
+  // of them. Activation is guarded the same way for symmetry and so a throw
+  // here can't escape to the caller, but unlike the steps above it is not
+  // optional — this function's whole purpose is to attempt it.
+  //
+  // `activate()`, not the deprecated `focus()`: Electrobun's `focus()` just
+  // logs a warning and delegates to `activate()`, so calling it directly
+  // only adds noise. `activate()` is what actually drives macOS's
+  // `activateIgnoringOtherApps:` + `makeKeyAndOrderFront:` under the hood.
+  //
+  // Deliberately not doing the `setVisibleOnAllWorkspaces(true) → activate()
+  // → false` trick some Electron apps use to force a Space switch:
+  // Electrobun exposes no such API (no `NSApp.activate`, no
+  // `moveToActiveSpace`), and even if it did, forcing a Space switch is the
+  // app overriding a user-level macOS setting ("switch to a Space with open
+  // windows"). If the window lives on another Space, macOS decides whether
+  // to switch to it. This is a deliberate product choice, not a gap — don't
+  // "fix" it by reaching for cross-Space tricks later.
+  try {
+    win.activate();
+  } catch (err) {
+    console.error("[agetor] window-focus: activate failed", err);
+  }
+
+  return true;
+}

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -217,11 +217,12 @@ export default function App() {
         // in the GlobalEvent handler below, but this handler closes over
         // its own scope, so the fresh list has to be fetched directly
         // rather than relying on `tasksRef` updating synchronously after
-        // `setTasks`.
+        // `setTasks`. No focusWindow() call here: this handler only fires
+        // after the main process has already handled `open-url` and focused
+        // the window itself, so a second call would be redundant.
         const fresh = findTaskById(tasksRef.current, ev.taskId);
         if (fresh) {
           setSelected(fresh);
-          window.focus();
           return;
         }
         void (async () => {
@@ -231,7 +232,6 @@ export default function App() {
             const found = findTaskById(list, ev.taskId);
             if (found) {
               setSelected(found);
-              window.focus();
             }
             // else: silently no-op — the task doesn't exist (deleted?).
           } catch {
@@ -294,9 +294,11 @@ export default function App() {
         const fresh = tasksRef.current.find((t) => t.id === ev.taskId);
         if (fresh) setSelected(fresh);
         // Best-effort: bring the agetor window forward when the user clicks
-        // through from a native notification. window.focus() is a no-op in
-        // many browsers but works inside WKWebView.
-        window.focus();
+        // through from a toast. Unlike the open_task handler above, nothing
+        // else focuses the window on this path — a WKWebView's own
+        // `window.focus()` can't activate the host NSApplication, so it has
+        // to round-trip through the main process.
+        void api.focusWindow();
       };
       if (ev.kind === "interaction") {
         // A question / permission prompt opened or closed. The tracker raises

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -185,6 +185,15 @@ export const api = {
    *  implement the native title-bar double-click gesture. */
   toggleWindowZoom: () =>
     j<{ ok: boolean; skipped?: string }>("/window/toggle-zoom", { method: "POST" }),
+  /** Ask the main process to raise + focus the app window. A WKWebView's own
+   *  `window.focus()` can't activate the host NSApplication, so every "bring
+   *  agetor to front" affordance (toast clicks, etc.) has to round-trip
+   *  through here instead. Best-effort UI polish: swallows failures behind a
+   *  console.warn rather than throwing into a React event handler. */
+  focusWindow: (): Promise<void> =>
+    j<{ ok: true }>("/window/focus", { method: "POST" })
+      .then(() => undefined)
+      .catch((e) => { console.warn("[agetor] focusWindow failed", e); }),
   getUpdateStatus: () => j<UpdateSnapshot>("/updates/status"),
   checkForUpdate: () => j<UpdateSnapshot>("/updates/check", { method: "POST" }),
   applyUpdate: () => j<{ ok: true }>("/updates/apply", { method: "POST" }),


### PR DESCRIPTION
Clicking a native macOS notification now raises and focuses the window.
The open-url handler broadcast open_task over SSE and stopped — it never asked macOS to activate anything, so the right task opened behind whatever you were looking at. The only "focus" in the tree was App.tsx's renderer-side window.focus(), which cannot activate a WKWebView's host NSApplication.
The other half is macOS-side: Sonoma made activation cooperative, so activate() can be denied and merely bounce the Dock icon. The notifier helper is the one process holding an activation right at click time (clicking a notification makes the posting app active), so it now yields that right to sh.alamops.agetor before opening the deep link.
Also: Dock-icon clicks and the in-app toast now focus the window, and a remembered frame that no longer intersects any live display is re-centred before the window is shown.
815 tests pass. notifier.swift changes need manual QA from a packaged build — see the new focus section in docs/qa/native-notifier-qa.md.