### PR TITLE
Keep the task-details stream live and truthful across background-agent continuations

### DIFF
--- a/docs/plans/fix-stream-list-stalls-with-bg-agents.md
+++ b/docs/plans/fix-stream-list-stalls-with-bg-agents.md
@@ -1,0 +1,101 @@
+# Plan — Keep the task-details stream live & truthful across background-agent turns
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-09 |
+| Source | /implement — "stream messages list in task details stops updating by itself, or wrongly streams / wrongly gets updates; perhaps due to having agents running" + screenshot forensics on task `cb537f02` |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | agetor/a12b321d0e5f-after-many-bg-tasks-stream-messages-list |
+| Base SHA | 3d9811b6f87e00121ee100119fa82c3ec3b86332 (clean tree at Phase 4 start) |
+
+## 1. Objective & success criteria
+
+When a claude-code main agent hands work to background agents and later auto-resumes (task-notification continuation), the task-details panel must keep rendering the main stream live, run status must reflect reality, and the kanban card must not get stuck (neither frozen in `review` while work continues, nor pinned in `running` forever by stale subagent rows).
+
+Success =
+1. Main tab keeps updating live after a run resolves while the same session keeps emitting (no `rebuilt`-mask freeze).
+2. A post-`end_turn` auto-continuation opens a **new run row** (`origin: "continuation"`): heartbeat on, events attributed to it, resolves on its own end_turn.
+3. A continuation (or a newly-discovered running subagent) pulls a `review` card back to `running`.
+4. A tmux session dying **during a #92 hold** is detected (death-watch armed while held) → subagents orphaned, hold released.
+5. Subagent completion detection hardened: parent's task-notification marks the named subagent settled; boot reconciliation orphans running subagent rows whose session is gone.
+6. `bun run typecheck` green; `bun test` green.
+
+## 2. Context & constraints (Phase 1 findings, verified)
+
+- **Freeze mechanism (frontend, primary symptom).** `RunPanel.tsx:487-503` — when `latestRun.status !== "running"`, a one-time JSONL rebuild snapshot is stored in `rebuilt`; `displayedEvents` (`RunPanel.tsx:539-544`) filters out ALL live main events whose `runId` is in `rebuiltRunIds` (`RunPanel.tsx:505-516`, matched by `claudeSessionId` — so it also masks future runs of the same session). Nothing clears `rebuilt` except the local composer's `send()`/`sendCommitPush()`. DB forensics: 502/570 events of the screenshot's run were persisted after `ended_at` — data flows, UI hides it. The rebuild exists because *older* agetor mappers truncated tool inputs at 500 chars; the current mapper does not truncate.
+- **Premature resolution (backend trigger).** Claude legitimately emits `end_turn` when delegating to background tasks and auto-resumes later via a synthetic `user` line with `origin.kind: "task-notification"` (`claude-tmux.ts:479-494`) or `queue-operation` (`claude-tmux.ts:669-694`). `isEndTurnContinuation` (`claude-tmux.ts:383-395`) doesn't treat these as continuations, and the 800ms idle-fire (`claude-tmux.ts:1389`, `2049-2057`) confirms the staged end_turn. This resolution is *by design* per the #92 decision ("the turn genuinely resolved; only the column should wait") — we keep it.
+- **Orphaned continuation events.** After `popEndOfTurn` (`claude-tmux.ts:1395-1416`) drains the queue, later lines dispatch through the stale `state.lastChunk` (`claude-tmux.ts:1904-1908`) → persisted+broadcast under the already-`succeeded` runId. No heartbeat, no Stop handle, "TURN COMPLETE" renders mid-work.
+- **#92 hold gaps.** Hold predicate is DB-derived (`orchestrator.ts:743-748` + `isHeldByBackgroundAgents`); engage races subagent discovery (fast-poll 600ms / slow-poll 4s / best-effort fs.watch, `claude-subagents.ts:53-59, 348-382, 446-481`) — end_turn at ~800ms can beat discovery → no hold. The #88 death-watch is gated on `turnInFlight` (`claude-tmux.ts:~2718-2742`) and goes idle exactly when a hold starts → a session dying during a hold is never detected. Headless idle-shutdown (`headless.ts:36-48`) is also blind to holds (noted; low priority here).
+- **Stale subagent rows (prod evidence).** 2 of 8 subagent rows for task `cb537f02` stuck `running` (last events 8–14 min old). Under #92's no-watchdog rule that pins the card in `running` until Stop/restart.
+- **Follow-up-run template.** `sendTurnInExistingSession`'s idle branch (`orchestrator.ts:1242-1277`) is the pattern for continuation runs: `runs.insert` (inherited `claudeSessionId`), `tasks.update({column:"running", runId})`, `emitGlobal(column)`, `makeChunkHandler`, `registerActiveRun`, `attachDoneHandler`. Continuation differs only in *not* pasting keystrokes and in the run's `origin`.
+- **Conventions.** Injected-setter seams already exist between orchestrator ↔ claude-subagents (#92); tests must save/restore injected setters (peer entry `b7ff666a`). Migrations: numbered SQL + `migrations/index.ts` text-import append-only. Frontend has NO DOM test harness — only pure-helper unit tests; UI behavior verified via `bun run dev:hmr`. Tests importing db/orchestrator must set `AGETOR_DATA_DIR` to a mkdtemp in `beforeAll`.
+
+## 3. Approach & key decisions (owner-confirmed in Phase 2)
+
+1. **Full package** (frontend un-freeze + continuation runs + hold robustness) — owner picked.
+2. **Continuation = new auto run row** (owner picked). Respects #92's "the run genuinely succeeded" decision; mirrors the existing one-row-per-turn invariant. Rejected: suppressing end_turn (contradicts #92 decision), reopening the succeeded run (falsifies history).
+3. **Harden detection, no wall-clock watchdog** (owner picked, consistent with prior owner decision): settle signals = parent task-notification naming the agent, session death (now detectable during holds), boot reconciliation.
+4. **Pull-back to `running`** (owner picked): continuation runs always set column `running`; a newly-running subagent row pulls the card back **only from `review`** (never from `done`/`blocked`/`ready` — those states encode user intent or errors).
+5. Frontend fix = **clear `rebuilt` when a newer live main event arrives for a masked run** (fall back to live events; re-rebuild happens naturally when the newest run next resolves). Rejected: re-running the JSONL rebuild per live batch (expensive, racy); splicing live tail onto the snapshot (two representations, fragile dedup).
+
+## 4. Work breakdown — implementation tasks
+
+### Wave 1 (parallel, file-disjoint)
+
+**T1 — Frontend un-freeze** — owns `src/mainview/components/kanban/RunPanel.tsx`, `src/mainview/lib/rebuilt-mask.ts` (new).
+Extract a pure helper (new file) deciding "does this incoming event invalidate the rebuilt snapshot?": given the snapshot metadata `{ sessionId, maxLiveEventIdAtSnapshot }` and an incoming event `{ id, runId, subagentId }` plus the current `rebuiltRunIds` set → boolean. In RunPanel: when storing `rebuilt`, also store the max id across current `mainEvents`; in the SSE delivery path (the batched flush that appends to `events`), if any appended main-stream event has `id > maxLiveEventIdAtSnapshot` and `runId ∈ rebuiltRunIds` → `setRebuilt(null)` (and clear `rebuildNote`). The rebuild effect must NOT immediately re-fire and re-mask: it currently only depends on `latestRun` fields, and after clearing, `latestRun` is unchanged — verify this holds and leave a comment. Acceptance: with a finished run whose session keeps emitting, live events render; when the newest run later resolves, the rebuild snapshot returns.
+
+**T2 — Driver seams (claude-tmux)** — owns `src/bun/claude-tmux.ts` only.
+(a) **Continuation adoption**: module-level injected factory `setContinuationRunFactory(fn: (taskId: string) => ContinuationHooks | null)` with `ContinuationHooks = { onChunk: ChunkSink; onAdopted: (handle: { done: Promise<number>; kill: () => void; writeInput: (line: string) => boolean }) => void }`. In `dispatchLine`, when a **new** (non-replayed — must pass the `seenLineUuids` dedup) content line (`user`/`assistant`/`thinking`/`tool_use`/`tool_result` mapped kinds) arrives while `!turnInFlight(state)` and the queue is empty: call the factory; on non-null, push a fresh turn slot wired to `hooks.onChunk`, resolve its `done` on that continuation's own end_turn (normal staging/idle-fire semantics apply), call `hooks.onAdopted(handle)` **before** dispatching the triggering line so registration precedes the first chunk; the triggering line then routes to the new slot. On null factory result, keep today's `lastChunk` fallback. Map the task-notification line itself to a `status` chunk (e.g. `background task finished — continuing`) rather than a fake user bubble.
+(b) **Death-watch during hold**: injected `setHeldSessionProbe(fn: (taskId: string) => boolean)`; arm/keep the death-watch loop when `turnInFlight(state) || heldProbe(taskId)`. Existing two-miss threshold and death handling unchanged — on death the existing `signalSessionDeath` path already orphans subagents (#92).
+(c) **Background-task settle signal**: injected `setBackgroundTaskSettledHandler(fn: (taskId: string, agentId: string) => void)`; when parsing a task-notification line, extract the finishing background agent/task id (inspect real transcripts under `~/.claude/projects/` for the exact shape — e.g. the screenshot task's session; be tolerant of absent ids) and invoke the handler. Follow the file's existing injected-setter idiom.
+
+**T3 — DB layer + subagent watcher** — owns `src/bun/db.ts`, `src/bun/claude-subagents.ts`, `src/bun/migrations/0NN_run_origin.sql` (new; next free number), `src/bun/migrations/index.ts`, `src/shared/types.ts`.
+(a) Migration: `ALTER TABLE runs ADD COLUMN origin TEXT` (`NULL` = user-initiated, `'continuation'` = auto). Thread through `runs.insert`/row mapping/`Run` type in shared types (optional field).
+(b) `subagents` helpers: `markSettledById(agentId, status)` (idempotent: only flips rows still `running`; sets `ended_at`), plus whatever `orphanRunning*` variants the boot pass extension needs (check what #92 already added and extend, don't duplicate).
+(c) Watcher: injected `setParkedDiscoveryHandler(fn: (taskId: string) => void)` — invoked when `discover()` inserts a running row (or flips one back to running) — orchestrator decides pull-back. Ensure the watcher keeps tailing while ANY running subagent row exists for the task (verify #92's module-level registry already guarantees this; fix if the watcher is torn down on parent-run resolution when the hold never engaged).
+(d) `fireSettle` path: expose a settle entry point that `markSettledById` triggers so `maybeReleaseHeldTask` runs (wired by T4).
+
+### Wave 2 (after wave 1 lands)
+
+**T4 — Orchestrator + server wiring** — owns `src/bun/orchestrator.ts`, `src/bun/server.ts`.
+(a) `startContinuationRun(taskId)`: mirror the idle branch (`orchestrator.ts:1242-1277`) minus `sendTurn`/user-line: insert run row with `origin:"continuation"` + inherited `claudeSessionId`, `tasks.update({column:"running", runId})` + `emitGlobal(column)` (pull-back from any prior column — continuations always run), emit a `status` chunk `auto-continued after background task`, return `ContinuationHooks` whose `onAdopted` does `registerActiveRun` + `attachDoneHandler`. Wire via `setContinuationRunFactory` at module init; return null for unknown/archived tasks.
+(b) Wire `setHeldSessionProbe(taskId => isHeldByBackgroundAgents(taskId))` (already exists from #92 — reuse, don't re-derive).
+(c) Wire `setBackgroundTaskSettledHandler` → `subagents.markSettledById(agentId, "completed")` → settle/`maybeReleaseHeldTask`.
+(d) Wire `setParkedDiscoveryHandler` → pull card back to `running` **iff** `task.column === "review"` and its latest run `succeeded`; emit column GlobalEvent + a status event on the run.
+(e) Boot reconciliation: extend the #92 boot pass — orphan `running` subagent rows whose task has no live tmux session; release/settle held tasks accordingly.
+(f) `server.ts`: include `origin` in run serialization (and anything `/tasks/:id/subagents` needs for the settled statuses).
+
+**T5 — Frontend polish** — owns `src/mainview/components/kanban/RunPanel.tsx` (wave 2 so it can't collide with T1).
+Label continuation runs in the runs list (small "auto" chip off `run.origin === "continuation"`); sanity-check the heartbeat and Stop gating work with continuation runs (they should fall out of `status === "running"` + `active` registration untouched).
+
+## 5. Work breakdown — test tasks (Phase 6, file-disjoint)
+
+- **TT1** `src/mainview/lib/rebuilt-mask.test.ts` — pure-helper coverage: newer masked-run event invalidates; subagent events never invalidate; older/other-run events don't. (Covers T1.)
+- **TT2** `src/bun/claude-continuation.test.ts` (new) — fake-driver/JSONL-fixture test: turn resolves → new content lines → factory called once, slot adopted, chunks route to new sink, continuation resolves on its own end_turn; replayed (deduped) lines do NOT trigger; null factory falls back to lastChunk. (Covers T2a.)
+- **TT3** `src/bun/claude-tmux-death.test.ts` (extend existing) — death-watch stays armed while heldProbe true; session death during hold → sentinel + orphan path. Save/restore injected setters (peer gotcha `b7ff666a`). (Covers T2b.)
+- **TT4** `src/bun/subagent-settle.test.ts` (new) — markSettledById idempotency; task-notification handler settles row + releases hold; parked-discovery pull-back only from `review`; boot pass orphans dead-session rows. (Covers T3/T4 c-e.)
+- **TT5** `src/bun/orchestrator-continuation.test.ts` (new) — startContinuationRun end-to-end with fake driver: run row origin, column pull-back, active registration, done handling, follow-up fold into continuation run. (Covers T4a.)
+- Migration smoke: covered by existing `migrate.test.ts` conventions — TT4 or TT5 asserts `origin` round-trips; don't edit applied migrations.
+
+## 6. Execution waves
+
+- Wave 1: T1 ∥ T2 ∥ T3 (disjoint: mainview files / claude-tmux.ts / db+subagents+migrations+shared-types) → typecheck checkpoint + commit.
+- Wave 2: T4 ∥ T5 (orchestrator+server / RunPanel) → typecheck checkpoint + commit.
+- Phase 5 review → Phase 6 tests TT1–TT5 (parallel, disjoint new/extended files) → Phase 7 run `bun test` + `bun run typecheck` → Phase 8 fixes.
+
+## 7. Blast radius & risks
+
+- `claude-tmux.ts` is the subtlest surface (staging/idle-fire/dedup/reattach). Continuation detection MUST ignore replayed lines (reattach re-tails from offset 0) or reattach would spawn phantom continuation runs — the `seenLineUuids` gate is the guard.
+- Continuation-run creation changes `task.runId` → interacts with fold-vs-idle branch in `sendTurnInExistingSession` (desirable: follow-ups during a continuation fold into it) and with `/tasks/:id/runs` polling UI.
+- Pull-back must not fight the user: only `review → running`, and only when triggered by genuinely-new activity.
+- rebuilt-mask clear removes the truncation-repair view while a session is live; acceptable since current mapper doesn't truncate — the repair snapshot returns when the newest run resolves.
+- Codex is inert by construction everywhere here (no subagents rows, no JSONL continuation lines) — assert nothing regresses via existing codex tests.
+- Death-watch now probes `tmux has-session` during holds — slightly more tmux traffic; two-miss threshold already tolerates transients (#88).
+
+## 8. Open questions / assumptions
+
+- Task-notification JSONL shape: assumed to carry the finishing agent/background-task id; T2c must verify against real transcripts (claude 2.1.x) and degrade gracefully (no id → no settle signal, other signals still work).
+- Assumed continuation turns should always pull the card to `running` regardless of prior column except archived (owner approved pull-back for `review`; continuation-run creation itself mirrors follow-up-turn behavior which already moves any column to `running`).
+- Headless idle-shutdown hold-blindness (`headless.ts`) noted but OUT of scope this branch (surface in final report).
+- Event-dedup key-collision under same-millisecond fan-out (webview finding 5) judged secondary; not addressed here.

--- a/src/bun/claude-continuation.test.ts
+++ b/src/bun/claude-continuation.test.ts
@@ -8,7 +8,7 @@ import { randomUUID } from "node:crypto";
 // same convention as claude-tmux-queue.test.ts / claude-tmux-death.test.ts.
 process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-continuation-"));
 
-const { __forTest, setContinuationRunFactory } = await import("./claude-tmux.ts");
+const { __forTest, setContinuationRunFactory, setBackgroundTaskSettledHandler } = await import("./claude-tmux.ts");
 import type { ContinuationHooks, SpawnedAgent, ChunkHandler } from "./claude-tmux.ts";
 
 // ─── fixtures ───────────────────────────────────────────────────────────
@@ -324,6 +324,48 @@ test("factory returning null falls back to legacy lastChunk routing — no throw
       setContinuationRunFactory(prev);
     }
   } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+// ─── F1: __rebuild__ settle-block guard ────────────────────────────────
+//
+// `rebuildEventsFromJsonl` drives `dispatchLine` against a synthetic
+// SessionState keyed `taskId: "__rebuild__"` to re-emit a finished session's
+// JSONL for a UI replay — a read-only operation. The background-task/agent
+// settle block in `dispatchLine` (which calls
+// `setBackgroundTaskSettledHandler`'s installed hook) must not run for that
+// synthetic state: `markSettledById` keys on agentId alone with no taskId
+// scoping, so firing it from a rebuild would settle a REAL subagent row.
+
+test("dispatchLine's background-task settle block is skipped for the synthetic __rebuild__ state", () => {
+  const { jsonlPath } = freshSession();
+  const rebuildState = __forTest.installSession("__rebuild__", jsonlPath);
+  const calls: Array<{ taskId: string; agentId: string }> = [];
+  const prev = setBackgroundTaskSettledHandler((tid, agentId) => {
+    calls.push({ taskId: tid, agentId });
+  });
+  try {
+    __forTest.dispatchLine(rebuildState, taskNotificationLine("agent-rebuild"));
+    expect(calls).toEqual([]);
+  } finally {
+    setBackgroundTaskSettledHandler(prev);
+    __forTest.uninstallSession("__rebuild__");
+  }
+});
+
+test("dispatchLine's background-task settle block still fires for a normal (non-rebuild) session state", () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  const calls: Array<{ taskId: string; agentId: string }> = [];
+  const prev = setBackgroundTaskSettledHandler((tid, agentId) => {
+    calls.push({ taskId: tid, agentId });
+  });
+  try {
+    __forTest.dispatchLine(state, taskNotificationLine("agent-normal"));
+    expect(calls).toEqual([{ taskId, agentId: "agent-normal" }]);
+  } finally {
+    setBackgroundTaskSettledHandler(prev);
     __forTest.uninstallSession(taskId);
   }
 });

--- a/src/bun/claude-continuation.test.ts
+++ b/src/bun/claude-continuation.test.ts
@@ -1,0 +1,347 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+// Pre-set AGETOR_DATA_DIR before claude-tmux.ts's transitive db.ts import —
+// same convention as claude-tmux-queue.test.ts / claude-tmux-death.test.ts.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-continuation-"));
+
+const { __forTest, setContinuationRunFactory } = await import("./claude-tmux.ts");
+import type { ContinuationHooks, SpawnedAgent, ChunkHandler } from "./claude-tmux.ts";
+
+// ─── fixtures ───────────────────────────────────────────────────────────
+
+interface Recorded { stream: string; data: string; uuid?: string }
+function recorder() {
+  const out: Recorded[] = [];
+  return {
+    out,
+    onChunk: ((stream, data, uuid) => out.push({ stream, data, uuid })) as ChunkHandler,
+  };
+}
+
+function freshSession(): { taskId: string; jsonlPath: string } {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-continuation-sess-"));
+  const jsonlPath = path.join(dir, `${randomUUID()}.jsonl`);
+  writeFileSync(jsonlPath, "");
+  return { taskId: randomUUID(), jsonlPath };
+}
+
+/** An assistant line that claims to end the turn (`stop_reason: "end_turn"`). */
+function endTurnLineId(text: string, id: string, uuid?: string): string {
+  return JSON.stringify({
+    type: "assistant",
+    uuid,
+    message: { id, content: [{ type: "text", text }], stop_reason: "end_turn" },
+  }) + "\n";
+}
+
+/** An assistant line still mid-turn (`stop_reason: "tool_use"`) — this is the
+ *  shape `isContinuationContentEvent` treats as genuine new content regardless
+ *  of stop_reason (it checks `evt.type === "assistant"` unconditionally), so
+ *  it can't itself be mistaken for a turn resolution in the same dispatch. */
+function assistantLineId(text: string, id: string, uuid?: string): string {
+  return JSON.stringify({
+    type: "assistant",
+    uuid,
+    message: { id, content: [{ type: "text", text }], stop_reason: "tool_use" },
+  }) + "\n";
+}
+
+/** Synthetic `<task-notification>` breadcrumb claude injects as a `user` line
+ *  after a background agent/command finishes. `isContinuationContentEvent`
+ *  filters this out (`origin.kind === "task-notification"`) so it must never
+ *  itself trigger continuation adoption — only the real content line that
+ *  follows should. */
+function taskNotificationLine(taskTag: string, uuid?: string): string {
+  return JSON.stringify({
+    type: "user",
+    uuid,
+    origin: { kind: "task-notification" },
+    message: { content: `<task-notification><task-id>${taskTag}</task-id></task-notification>` },
+  }) + "\n";
+}
+
+/** The `queue-operation` shape claude also uses to report a background
+ *  command/agent's completion. `isContinuationContentEvent` returns false for
+ *  any non-assistant/non-user event type, so this must not trigger adoption
+ *  either. */
+function queueOperationLine(content: string, uuid?: string): string {
+  return JSON.stringify({ type: "queue-operation", operation: "enqueue", uuid, content }) + "\n";
+}
+
+/** Resolve a fresh session's first turn via a normal end_turn, leaving the
+ *  session idle (empty turnQueue, no pending) — the state a post-end_turn
+ *  background-task auto-resume finds the session in. */
+async function resolveFirstTurn(
+  state: ReturnType<typeof __forTest.installSession>,
+  jsonlPath: string,
+): Promise<Recorded[]> {
+  const first = recorder();
+  const done = __forTest.pushTurnSlot(state, first.onChunk);
+  appendFileSync(jsonlPath, endTurnLineId("first turn done", "msg-1", "uuid-1"));
+  __forTest.flushSync(state);
+  await expect(done).resolves.toBe(0);
+  expect(state.turnQueue.length).toBe(0);
+  return first.out;
+}
+
+/** Install a factory for the duration of `body`, always restoring whatever
+ *  was previously installed — required so a leaked factory can't strand
+ *  every later test file in the shared bun test process (the file's own doc
+ *  comment on `setContinuationRunFactory` calls this out explicitly). */
+async function withContinuationFactory<T>(
+  factory: (taskId: string) => ContinuationHooks | null,
+  body: () => Promise<T> | T,
+): Promise<T> {
+  const prev = setContinuationRunFactory(factory);
+  try {
+    return await body();
+  } finally {
+    setContinuationRunFactory(prev);
+  }
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────
+
+test("a genuinely-new assistant content line after a resolved turn adopts a continuation exactly once, onAdopted before the first chunk", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    const order: string[] = [];
+    const calls: string[] = [];
+    const cont = recorder();
+    let adoptedHandle: SpawnedAgent | null = null;
+
+    await withContinuationFactory(
+      (tid) => {
+        calls.push(tid);
+        return {
+          onChunk: (stream, data, uuid) => {
+            order.push("chunk");
+            cont.onChunk(stream, data, uuid);
+          },
+          onAdopted: (handle) => {
+            order.push("adopted");
+            adoptedHandle = handle;
+          },
+        };
+      },
+      () => {
+        // The auto-resume: no turn in flight, queue empty, genuinely new content.
+        appendFileSync(jsonlPath, assistantLineId("continuing after background task", "msg-2", "uuid-2"));
+        __forTest.flushSync(state);
+      },
+    );
+
+    expect(calls).toEqual([taskId]); // factory called exactly once for this taskId
+    expect(order[0]).toBe("adopted"); // onAdopted fires before the first chunk
+    expect(order).toContain("chunk");
+    expect(cont.out.some((r) => r.data === "continuing after background task")).toBe(true);
+    expect(adoptedHandle).not.toBeNull();
+    // The adopted slot is now the live turn.
+    expect(state.turnQueue.length).toBe(1);
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("the adopted continuation resolves via the normal end_turn path", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    const cont = recorder();
+    let handle: SpawnedAgent | null = null;
+
+    const prev = setContinuationRunFactory(() => ({
+      onChunk: cont.onChunk,
+      onAdopted: (h) => { handle = h; },
+    }));
+    try {
+      appendFileSync(jsonlPath, assistantLineId("continuing after background task", "msg-2", "uuid-2"));
+      __forTest.flushSync(state);
+      expect(handle).not.toBeNull();
+      expect(state.turnQueue.length).toBe(1);
+
+      // The continuation's own end_turn resolves it — same staging/idle-fire
+      // semantics as any other turn (flushSync force-resolves the staged
+      // end_turn immediately, as in the existing queue-test conventions).
+      appendFileSync(jsonlPath, endTurnLineId("continuation done", "msg-2", "uuid-3"));
+      __forTest.flushSync(state);
+
+      await expect(handle!.done).resolves.toBe(0);
+      expect(state.turnQueue.length).toBe(0);
+      expect(cont.out.some((r) => r.data === "continuation done")).toBe(true);
+    } finally {
+      setContinuationRunFactory(prev);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("replayed (deduped) lines do not trigger the factory even when they'd otherwise qualify as new content", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    // Simulate this line having already been dispatched in a prior process —
+    // pre-seed the dedup set the way reattach does.
+    state.seenLineUuids.add("uuid-2");
+
+    let calls = 0;
+    const prev = setContinuationRunFactory(() => {
+      calls++;
+      return { onChunk: () => {}, onAdopted: () => {} };
+    });
+    try {
+      appendFileSync(jsonlPath, assistantLineId("this looks new but isn't", "msg-2", "uuid-2"));
+      __forTest.flushSync(state);
+
+      expect(calls).toBe(0);
+      // No slot was pushed — the dedup path returns before continuation
+      // adoption is even considered.
+      expect(state.turnQueue.length).toBe(0);
+    } finally {
+      setContinuationRunFactory(prev);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("a task-notification breadcrumb (user, origin.kind=task-notification) does not trigger the factory", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    let calls = 0;
+    const prev = setContinuationRunFactory(() => {
+      calls++;
+      return { onChunk: () => {}, onAdopted: () => {} };
+    });
+    try {
+      appendFileSync(jsonlPath, taskNotificationLine("agent-123", "uuid-notif"));
+      __forTest.flushSync(state);
+
+      expect(calls).toBe(0);
+      expect(state.turnQueue.length).toBe(0);
+    } finally {
+      setContinuationRunFactory(prev);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("a queue-operation breadcrumb does not trigger the factory", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    let calls = 0;
+    const prev = setContinuationRunFactory(() => {
+      calls++;
+      return { onChunk: () => {}, onAdopted: () => {} };
+    });
+    try {
+      appendFileSync(
+        jsonlPath,
+        queueOperationLine("<task-notification><task-id>agent-456</task-id></task-notification>", "uuid-qop"),
+      );
+      __forTest.flushSync(state);
+
+      expect(calls).toBe(0);
+      expect(state.turnQueue.length).toBe(0);
+    } finally {
+      setContinuationRunFactory(prev);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("a status-only breadcrumb followed by genuine content still adopts on the content line, not the breadcrumb", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    const calls: string[] = [];
+    const cont = recorder();
+    const prev = setContinuationRunFactory((tid) => {
+      calls.push(tid);
+      return { onChunk: cont.onChunk, onAdopted: () => {} };
+    });
+    try {
+      // Notification breadcrumb, then the real auto-resumed content, in one batch.
+      appendFileSync(jsonlPath, taskNotificationLine("agent-789", "uuid-notif-2"));
+      appendFileSync(jsonlPath, assistantLineId("resuming after the background task", "msg-3", "uuid-4"));
+      __forTest.flushSync(state);
+
+      expect(calls).toEqual([taskId]); // adopted exactly once, on the content line
+      expect(cont.out.some((r) => r.data === "resuming after the background task")).toBe(true);
+    } finally {
+      setContinuationRunFactory(prev);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("factory returning null falls back to legacy lastChunk routing — no throw, chunks still delivered", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    const firstOut = await resolveFirstTurn(state, jsonlPath);
+
+    let calls = 0;
+    const prev = setContinuationRunFactory((_tid) => {
+      calls++;
+      return null;
+    });
+    try {
+      expect(() => {
+        appendFileSync(jsonlPath, assistantLineId("no factory adoption here", "msg-2", "uuid-2"));
+        __forTest.flushSync(state);
+      }).not.toThrow();
+
+      expect(calls).toBe(1); // factory WAS consulted...
+      expect(state.turnQueue.length).toBe(0); // ...but declined, so no slot was pushed
+      // ...and the line still routed through the pre-existing lastChunk
+      // hangover (the first turn's own recorder, per popEndOfTurn).
+      expect(firstOut.some((r) => r.data === "no factory adoption here")).toBe(true);
+    } finally {
+      setContinuationRunFactory(prev);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("with no factory installed at all, behavior is identical to pre-change: no calls, routes via lastChunk", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    const firstOut = await resolveFirstTurn(state, jsonlPath);
+
+    // Deliberately do NOT install a factory — confirms the module-level
+    // default (null, unset by any earlier test) leaves dispatch unchanged.
+    appendFileSync(jsonlPath, assistantLineId("plain trailing content, no adoption seam active", "msg-2", "uuid-2"));
+    __forTest.flushSync(state);
+
+    expect(state.turnQueue.length).toBe(0);
+    expect(firstOut.some((r) => r.data === "plain trailing content, no adoption seam active")).toBe(true);
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -112,6 +112,41 @@ function fireSettle(taskId: string): void {
   }
 }
 
+/**
+ * Parked-discovery hook, injected once by the orchestrator at startup. Fired
+ * whenever this module notices a subagent that is (newly, or once again)
+ * `running` — a fresh `discover()` insert, or an existing row flipping back
+ * to running after a resumed background agent starts writing again. This is
+ * the *opposite* direction from `settleFn`: that one says "something finished,
+ * maybe release the hold"; this one says "something just started/resumed,
+ * maybe pull the card back". Same cycle-avoidance rationale as `emitFn` /
+ * `settleFn` — the pull-back policy (only from `review`, never from
+ * `done`/`blocked`/`ready`) lives on the orchestrator side. This module only
+ * signals "a subagent is running for taskId," never decides what to do.
+ */
+let parkedDiscoveryFn: ((taskId: string) => void) | null = null;
+/** Returns the previously-registered hook, for the same save/restore reason as
+ *  `setSubagentEmitter`/`setSubagentSettleHook`: a test that installs a spy
+ *  here must put the real one back in `afterEach`, or every later test file
+ *  loses the pull-back wiring. */
+export function setParkedDiscoveryHandler(
+  fn: ((taskId: string) => void) | null,
+): ((taskId: string) => void) | null {
+  const prev = parkedDiscoveryFn;
+  parkedDiscoveryFn = fn;
+  return prev;
+}
+
+/** Call the parked-discovery hook, never letting a throwing hook reach the
+ *  poll timer / dir watcher callback — mirrors `fireSettle`'s posture. */
+function fireParkedDiscovery(taskId: string): void {
+  try {
+    parkedDiscoveryFn?.(taskId);
+  } catch (e) {
+    console.error(`[claude-subagents] parked-discovery hook threw for task ${taskId}:`, e);
+  }
+}
+
 interface SubagentMeta {
   agentType: string | null;
   description: string | null;
@@ -180,6 +215,14 @@ export interface SubagentWatcherHandle {
    *  it); tests use it with an injected `now` to exercise the watcher
    *  deterministically instead of waiting on real timers. */
   pump(now?: number): void;
+  /** Reflect an externally-driven settle (see `settleSubagentById`) into this
+   *  watcher's in-memory `FileState`, if it's tracking `id` — a no-op
+   *  otherwise. The DB write already happened before this is called; this
+   *  just keeps the tailer's resume-detection (`tailFile`'s
+   *  `fs.status !== "running"` check) and `checkDone`'s idle-detection from
+   *  re-deriving a status the external settle already decided, which would
+   *  otherwise re-fire a duplicate lifecycle/settle signal on the next tick. */
+  syncSettled(id: string, status: SubagentStatus, endedAt: number): void;
 }
 
 /** One live watcher per task, tops — a second `attachSubagentWatcher` for the
@@ -285,7 +328,7 @@ export function attachSubagentWatcher(opts: {
   // spawn) gets torn down before we build the new one.
   detachWatcherFor(taskId);
 
-  if (!ENABLED) return { detach() { /* disabled */ }, pump() { /* disabled */ } };
+  if (!ENABLED) return { detach() { /* disabled */ }, pump() { /* disabled */ }, syncSettled() { /* disabled */ } };
 
   const sessionId = path.basename(opts.jsonlPath, ".jsonl");
   const subagentsDir = path.join(path.dirname(opts.jsonlPath), sessionId, "subagents");
@@ -378,6 +421,7 @@ export function attachSubagentWatcher(opts: {
       files.set(id, fs);
       subagentsDb.insertIfAbsent(toSubagentShape(fs, taskId));
       emitLifecycle(fs, "started");
+      fireParkedDiscovery(taskId);
     }
   }
 
@@ -417,6 +461,7 @@ export function attachSubagentWatcher(opts: {
         fs.sawEndOfTurn = false;
         subagentsDb.setStatus(fs.subagentId, "running", null);
         emitLifecycle(fs, "started");
+        fireParkedDiscovery(taskId);
       }
       const { endOfTurn } = mapJsonlEventToChunks(line, (stream, data, lineUuid) => {
         runs.appendEvent(fs.runId, stream, data, lineUuid ?? null, fs.subagentId);
@@ -502,7 +547,50 @@ export function attachSubagentWatcher(opts: {
     pump(now?: number): void {
       cycle(now ?? Date.now());
     },
+    syncSettled(id: string, status: SubagentStatus, endedAt: number): void {
+      const fs = files.get(id);
+      if (!fs) return;
+      fs.status = status;
+      fs.endedAt = endedAt;
+    },
   };
   watchers.set(taskId, handle);
   return handle;
+}
+
+/**
+ * Settle a single subagent from OUTSIDE the watcher's own idle-detection —
+ * the entry point for an externally-detected completion: a parent
+ * task-notification naming the finishing agent (`setBackgroundTaskSettledHandler`
+ * on the claude-tmux side), or boot reconciliation finding its session gone.
+ * Runs the exact same bookkeeping a naturally-detected completion runs in
+ * `checkDone` (DB write → lifecycle emit → in-memory sync → settle hook), so a
+ * held task releases identically regardless of which path noticed the
+ * completion first. Idempotent via `subagentsDb.markSettledById` — a
+ * duplicate/late signal (e.g. this races the watcher's own `checkDone`) is a
+ * harmless no-op that returns `false` without emitting a second lifecycle
+ * event or firing the settle hook again.
+ */
+export function settleSubagentById(id: string, status: "completed" | "orphaned"): boolean {
+  let result: { changed: boolean; taskId: string | null };
+  try {
+    result = subagentsDb.markSettledById(id, status);
+  } catch (e) {
+    console.error(`[claude-subagents] markSettledById failed for subagent ${id}:`, e);
+    return false;
+  }
+  if (!result.changed || !result.taskId) return false;
+  const taskId = result.taskId;
+  const now = Date.now();
+  const row = subagentsDb.get(id);
+  if (row) {
+    try {
+      emitLifecycleForRow(row);
+    } catch (e) {
+      console.error(`[claude-subagents] settle lifecycle emit failed for subagent ${id}:`, e);
+    }
+  }
+  watchers.get(taskId)?.syncSettled(id, status, row?.endedAt ?? now);
+  fireSettle(taskId);
+  return true;
 }

--- a/src/bun/claude-tmux-death.test.ts
+++ b/src/bun/claude-tmux-death.test.ts
@@ -104,6 +104,27 @@ test("signalSessionDeath is a no-op when no turn is in flight (idle session deat
   }
 });
 
+test("F5: a throwing heldSessionProbe is treated as not-held (no crash, no emission)", async () => {
+  const { taskId, state } = freshSession();
+  const rec = recorder();
+  const prevProbe = setHeldSessionProbe(() => { throw new Error("boom: SQLite busy"); });
+  try {
+    // No slot pushed and no reattach onEndOfTurn → not in flight — the only
+    // way this call reaches the probe at all is the `!turnInFlight` guard.
+    expect(__forTest.turnInFlight(state)).toBe(false);
+
+    // Must not throw out of signalSessionDeath even though the probe does.
+    expect(() => __forTest.signalSessionDeath(state)).not.toThrow();
+
+    // Treated as "not held" (same as the probe returning false / being unset)
+    // → the no-op idle-death path, nothing emitted.
+    expect(rec.out.length).toBe(0);
+  } finally {
+    setHeldSessionProbe(prevProbe);
+    __forTest.uninstallSession(taskId);
+  }
+});
+
 test("sessionLiveness: exit 0 is alive", () => {
   const restore = fakeTmux(0, "");
   try { expect(sessionLiveness("agetor-x")).toBe("alive"); } finally { restore(); }
@@ -384,10 +405,20 @@ test(
 
       await wait(DEATH_WINDOW_MS);
 
+      // Held-death case (no turn in flight, task held for background agents):
+      // the sentinel prefix would falsely imply the orchestrator flips the
+      // card to `blocked`, but a held task actually releases to `review` —
+      // so this path emits the honest, prefix-free held-death wording instead
+      // (see F3: `signalSessionDeath`'s `inFlight` branch).
       const sentinel = rec.out.find(
         (c) => c.stream === "status" && c.data.startsWith(SESSION_DIED_STATUS_PREFIX),
       );
-      expect(sentinel).toBeDefined();
+      expect(sentinel).toBeUndefined();
+      const heldDeath = rec.out.find(
+        (c) => c.stream === "status"
+          && c.data.includes("ended while background agents were running — releasing task"),
+      );
+      expect(heldDeath).toBeDefined();
 
       expect(subagents.get("agent-1")?.status).toBe("orphaned");
     } finally {
@@ -456,10 +487,16 @@ test(
       held = true;
       await wait(DEATH_WINDOW_MS);
 
+      // Held-death case — see the wording note in the "stays armed" test above.
       const sentinel = rec.out.find(
         (c) => c.stream === "status" && c.data.startsWith(SESSION_DIED_STATUS_PREFIX),
       );
-      expect(sentinel).toBeDefined();
+      expect(sentinel).toBeUndefined();
+      const heldDeath = rec.out.find(
+        (c) => c.stream === "status"
+          && c.data.includes("ended while background agents were running — releasing task"),
+      );
+      expect(heldDeath).toBeDefined();
     } finally {
       setHeldSessionProbe(prevProbe);
       ctrlTmux.restore();
@@ -496,6 +533,46 @@ test(
         (c) => c.stream === "status" && c.data.startsWith(SESSION_DIED_STATUS_PREFIX),
       );
       expect(sentinel).toBeUndefined();
+    } finally {
+      setHeldSessionProbe(prevProbe);
+      ctrlTmux.restore();
+      if (taskId) cleanupHeldReattach(taskId);
+    }
+  },
+);
+
+test(
+  "F5: a throwing heldSessionProbe on the real poll interval never crashes the tick and behaves as not-held",
+  async () => {
+    const ctrlTmux = controllableTmux();
+    let taskId = "";
+    const prevProbe = setHeldSessionProbe(() => { throw new Error("boom: SQLite busy"); });
+    try {
+      const setup = await setupHeldReattach();
+      taskId = setup.taskId;
+      const { rec } = setup;
+
+      // Session reports `gone` the whole window — with a healthy probe
+      // returning true this would fire (per the "stays armed" test above).
+      // With a throwing probe, `heldProbeSafe` swallows the throw and
+      // returns false, so the poll behaves exactly like the "probe returns
+      // false" case: `misses` resets every tick and nothing ever fires. The
+      // real assertion here is that the process is still alive to check —
+      // an unguarded probe would have thrown inside the `setInterval`
+      // callback and (depending on the runtime) could abort the tick chain
+      // or surface as an unhandled error.
+      ctrlTmux.setGone(true);
+      await wait(DEATH_WINDOW_MS);
+
+      const sentinel = rec.out.find(
+        (c) => c.stream === "status" && c.data.startsWith(SESSION_DIED_STATUS_PREFIX),
+      );
+      expect(sentinel).toBeUndefined();
+      const heldDeath = rec.out.find(
+        (c) => c.stream === "status"
+          && c.data.includes("ended while background agents were running — releasing task"),
+      );
+      expect(heldDeath).toBeUndefined();
     } finally {
       setHeldSessionProbe(prevProbe);
       ctrlTmux.restore();

--- a/src/bun/claude-tmux-death.test.ts
+++ b/src/bun/claude-tmux-death.test.ts
@@ -1,14 +1,29 @@
 import { test, expect } from "bun:test";
-import { chmodSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { SESSION_DIED_STATUS_PREFIX } from "../shared/types.ts";
+import type { Task } from "../shared/types.ts";
 
 // Pre-set AGETOR_DATA_DIR before claude-tmux.ts's transitive db.ts import.
 process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-tmux-death-"));
 
-const { __forTest, sessionLiveness, fileWrittenWithin, deathTickOutcome } = await import("./claude-tmux.ts");
+const {
+  __forTest,
+  sessionLiveness,
+  fileWrittenWithin,
+  deathTickOutcome,
+  reattachSession,
+  jsonlPathFor,
+  dropSession,
+  setHeldSessionProbe,
+} = await import("./claude-tmux.ts");
+// Dynamic import (not a static top-level one) so it resolves AFTER the
+// AGETOR_DATA_DIR assignment above — a static import would be hoisted and
+// run before that assignment, capturing the wrong data dir (db.ts reads the
+// env var at module load).
+const { db, tasks, subagents } = await import("./db.ts");
 
 /** Write an executable fake `tmux` that emits `stderr` and exits `code`, then
  *  point AGETOR_TMUX_BIN at it. Returns a restore fn. */
@@ -177,3 +192,314 @@ test("signalSessionDeath fires the reattach onEndOfTurn hook when there's no slo
     __forTest.uninstallSession(taskId);
   }
 });
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * #93/wave-1 — `setHeldSessionProbe` widened BOTH `startDeathWatch`'s
+ * poll-reset guard and `signalSessionDeath`'s early-return guard from
+ * `!turnInFlight(state)` to `!turnInFlight(state) && !heldSessionProbe?.(taskId)`
+ * (see docs/plans/fix-stream-list-stalls-with-bg-agents.md §4/T2b). The tests
+ * above exercise `signalSessionDeath` directly against a synthetic
+ * `installSession` state (no live timers) — that's the right tool for the
+ * early-return guard alone, but proving the *poll loop* actually stays armed
+ * (misses accumulating tick over tick) requires a REAL `setInterval`, which
+ * only `attachTailer` (private, armed via the public `reattachSession`/
+ * `spawnClaudeViaTmux` entry points) creates. The cases below drive that real
+ * timer end-to-end through `reattachSession` + a scripted, stateful fake tmux
+ * binary, rather than reimplementing the guard's boolean logic in the test.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function wait(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Write an executable fake `tmux` whose `has-session` answer is controlled at
+ * runtime via a flag file re-read on every invocation, so a test can flip a
+ * "live" session to "gone" (or back) mid-poll without restarting the real
+ * `setInterval` the death watch runs on. Every other subcommand
+ * (capture-pane from the pane-scraper backstop, kill-session from
+ * `dropSession`, send-keys, …) succeeds silently — none of those side
+ * channels matter for what this suite asserts.
+ */
+function controllableTmux() {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-ctrltmux-"));
+  const bin = path.join(dir, "tmux");
+  const stateFile = path.join(dir, "state");
+  writeFileSync(stateFile, "alive");
+  writeFileSync(
+    bin,
+    "#!/bin/sh\n"
+    + "for a in \"$@\"; do\n"
+    + "  if [ \"$a\" = \"has-session\" ]; then\n"
+    + `    v=$(cat ${JSON.stringify(stateFile)} 2>/dev/null)\n`
+    + "    if [ \"$v\" = \"gone\" ]; then\n"
+    + "      printf \"can't find session: fake\" 1>&2\n"
+    + "      exit 1\n"
+    + "    fi\n"
+    + "    exit 0\n"
+    + "  fi\n"
+    + "done\n"
+    + "exit 0\n",
+  );
+  chmodSync(bin, 0o755);
+  const prev = process.env.AGETOR_TMUX_BIN;
+  process.env.AGETOR_TMUX_BIN = bin;
+  return {
+    setGone(gone: boolean) { writeFileSync(stateFile, gone ? "gone" : "alive"); },
+    restore() {
+      if (prev === undefined) delete process.env.AGETOR_TMUX_BIN;
+      else process.env.AGETOR_TMUX_BIN = prev;
+    },
+  };
+}
+
+/** Minimal `tasks` row so `subagents.insertIfAbsent`'s `task_id` FK (and
+ *  `reattachSession`'s bookkeeping) has something real to point at. Field
+ *  values mostly don't matter for this suite — only `id`/`agent` do. */
+function baseTask(id: string): Task {
+  return {
+    id,
+    title: "death-watch held test",
+    prompt: "p",
+    column: "running",
+    agent: "claude-code",
+    workdir: "/tmp",
+    isolation: "none",
+    taskType: "task",
+    branch: null,
+    worktreePath: null,
+    baseRef: null,
+    mode: "auto",
+    model: null,
+    effort: null,
+    references: [],
+    runId: null,
+    hasOpenableRun: false,
+    pendingInteractionCount: 0,
+    openTerminalCount: 0,
+    archivedAt: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+/**
+ * Pre-seed a reattach-able JSONL with one `end_turn` line followed by a
+ * benign, unrelated line, so the tailer's initial replay-from-offset-0
+ * stages then immediately fires the end_turn (no need to wait on the 800ms
+ * idle-fire) — `turnInFlight(state)` goes false as soon as the returned
+ * agent's `done` promise resolves, deterministically (no sleep needed to
+ * reach the "no turn in flight" state these cases are about).
+ *
+ * The file's mtime is backdated well past `DEATH_JSONL_QUIET_MS` (3s) so the
+ * death-watch's "was the log just written?" veto can never mask the `gone`
+ * probes the test drives afterward — without this, every `gone` tick within
+ * the first 3s after the file's real creation time would be vetoed back to
+ * "reset" and misses would never accumulate.
+ */
+function seedReattachableJsonl(jsonlPath: string) {
+  mkdirSync(path.dirname(jsonlPath), { recursive: true });
+  const lines = [
+    JSON.stringify({
+      type: "assistant",
+      uuid: "et-1",
+      message: { id: "msg-1", role: "assistant", content: [{ type: "text", text: "done" }], stop_reason: "end_turn" },
+    }),
+    JSON.stringify({ type: "system", uuid: "et-2", permissionMode: "default" }),
+  ];
+  writeFileSync(jsonlPath, lines.join("\n") + "\n");
+  const old = Date.now() / 1000 - 60;
+  utimesSync(jsonlPath, old, old);
+}
+
+/** Real end-to-end wait past the death watch's threshold: DEATH_POLL_MS(400)
+ *  * DEATH_MISS_THRESHOLD(4) consecutive `gone` ticks + DEATH_GRACE_MS(250),
+ *  plus generous scheduling slack. */
+const DEATH_WINDOW_MS = 2_500;
+
+async function setupHeldReattach() {
+  const taskId = randomUUID();
+  const sessionId = randomUUID();
+  const cwd = mkdtempSync(path.join(tmpdir(), "agetor-death-cwd-"));
+  const configDir = mkdtempSync(path.join(tmpdir(), "agetor-death-config-"));
+  const jsonlPath = jsonlPathFor(cwd, sessionId, configDir);
+  seedReattachableJsonl(jsonlPath);
+  tasks.insert(baseTask(taskId));
+
+  const rec = recorder();
+  const agent = reattachSession({
+    taskId,
+    cwd,
+    sessionId,
+    configDir,
+    onChunk: rec.onChunk,
+    seenLineUuids: new Set(),
+  });
+  expect(agent).not.toBeNull();
+  await agent!.done; // the pre-seeded end_turn fired — turnInFlight(state) is now false
+
+  return { taskId, rec };
+}
+
+function cleanupHeldReattach(taskId: string) {
+  dropSession(taskId); // clears any still-armed timers, kills the (fake) tmux session
+  db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]); // cascades subagents/runs/run_events
+}
+
+test(
+  "startDeathWatch stays armed (misses accumulate) when idle but heldSessionProbe is true, "
+  + "and fires the sentinel + orphans subagents after the threshold",
+  async () => {
+    const ctrlTmux = controllableTmux();
+    let taskId = "";
+    const prevProbe = setHeldSessionProbe((id) => id === taskId);
+    try {
+      const setup = await setupHeldReattach();
+      taskId = setup.taskId;
+      const { rec } = setup;
+
+      // A running subagent row for this task — the death path's unconditional
+      // `orphanRunningSubagents` call at the bottom of `signalSessionDeath`
+      // should flip this to `orphaned` when death fires.
+      subagents.insertIfAbsent({
+        id: "agent-1",
+        taskId,
+        runId: null,
+        parentKind: "subagent",
+        agentType: "Explore",
+        description: "held probe test",
+        spawnDepth: 1,
+        sourcePath: "/tmp/fake-agent-1.jsonl",
+        status: "running",
+        startedAt: Date.now(),
+        endedAt: null,
+      });
+
+      // No turn in flight (asserted implicitly by `setupHeldReattach` having
+      // awaited `agent.done`) and the session is `gone` from tick one — before
+      // #93/wave-1 this would reset `misses` to 0 forever (`!turnInFlight` was
+      // the whole gate). With `heldSessionProbe` wired to return true for this
+      // task, the poll stays armed and should accumulate to the fire threshold.
+      ctrlTmux.setGone(true);
+
+      await wait(DEATH_WINDOW_MS);
+
+      const sentinel = rec.out.find(
+        (c) => c.stream === "status" && c.data.startsWith(SESSION_DIED_STATUS_PREFIX),
+      );
+      expect(sentinel).toBeDefined();
+
+      expect(subagents.get("agent-1")?.status).toBe("orphaned");
+    } finally {
+      setHeldSessionProbe(prevProbe);
+      ctrlTmux.restore();
+      if (taskId) cleanupHeldReattach(taskId);
+    }
+  },
+);
+
+test(
+  "startDeathWatch resets misses (never fires) when idle and heldSessionProbe returns false "
+  + "— pre-#93 behavior preserved",
+  async () => {
+    const ctrlTmux = controllableTmux();
+    const prevProbe = setHeldSessionProbe(() => false);
+    let taskId = "";
+    try {
+      const setup = await setupHeldReattach();
+      taskId = setup.taskId;
+      const { rec } = setup;
+
+      // Session reports `gone` the whole time too — the ONLY thing keeping
+      // this idle task from being polled to death should be the probe
+      // returning false (mirroring the original `!turnInFlight` gate with no
+      // held-task carve-out at all).
+      ctrlTmux.setGone(true);
+
+      await wait(DEATH_WINDOW_MS);
+
+      const sentinel = rec.out.find(
+        (c) => c.stream === "status" && c.data.startsWith(SESSION_DIED_STATUS_PREFIX),
+      );
+      expect(sentinel).toBeUndefined();
+    } finally {
+      setHeldSessionProbe(prevProbe);
+      ctrlTmux.restore();
+      if (taskId) cleanupHeldReattach(taskId);
+    }
+  },
+);
+
+test(
+  "startDeathWatch resumes probing once heldSessionProbe flips false→true mid-watch",
+  async () => {
+    const ctrlTmux = controllableTmux();
+    let held = false;
+    let taskId = "";
+    const prevProbe = setHeldSessionProbe((id) => held && id === taskId);
+    try {
+      const setup = await setupHeldReattach();
+      taskId = setup.taskId;
+      const { rec } = setup;
+
+      // Session already reports `gone`, but the probe is false — the poll
+      // should keep resetting `misses` to 0 every tick, so waiting almost the
+      // full fire window must NOT produce a sentinel yet.
+      ctrlTmux.setGone(true);
+      await wait(1_000);
+      expect(
+        rec.out.some((c) => c.stream === "status" && c.data.startsWith(SESSION_DIED_STATUS_PREFIX)),
+      ).toBe(false);
+
+      // Engage the hold — probing should resume/arm from a clean slate and
+      // fire again within one full threshold window from THIS point.
+      held = true;
+      await wait(DEATH_WINDOW_MS);
+
+      const sentinel = rec.out.find(
+        (c) => c.stream === "status" && c.data.startsWith(SESSION_DIED_STATUS_PREFIX),
+      );
+      expect(sentinel).toBeDefined();
+    } finally {
+      setHeldSessionProbe(prevProbe);
+      ctrlTmux.restore();
+      if (taskId) cleanupHeldReattach(taskId);
+    }
+  },
+);
+
+test(
+  "intentional teardown (dropSession) clears the death timer even while heldSessionProbe is true "
+  + "— no zombie timer, no false death after a legit kill",
+  async () => {
+    const ctrlTmux = controllableTmux();
+    let taskId = "";
+    const prevProbe = setHeldSessionProbe((id) => id === taskId);
+    try {
+      const setup = await setupHeldReattach();
+      taskId = setup.taskId;
+      const { rec } = setup;
+
+      // Session is already `gone` and the task is held — left alone, this is
+      // EXACTLY the setup that fires death in the first test above. Instead,
+      // tear the session down intentionally right away (mirrors delete/
+      // archive/agent-switch calling `dropSession` on a held task).
+      ctrlTmux.setGone(true);
+      dropSession(taskId);
+
+      // Wait a full fire window past the teardown. If `dropSession` failed to
+      // clear the real `deathTimer` (a "zombie" interval left running against
+      // a disposed/half-torn-down state), this would still emit the sentinel.
+      await wait(DEATH_WINDOW_MS);
+
+      const sentinel = rec.out.find(
+        (c) => c.stream === "status" && c.data.startsWith(SESSION_DIED_STATUS_PREFIX),
+      );
+      expect(sentinel).toBeUndefined();
+    } finally {
+      setHeldSessionProbe(prevProbe);
+      ctrlTmux.restore();
+      if (taskId) cleanupHeldReattach(taskId);
+    }
+  },
+);

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -144,6 +144,20 @@ export function setHeldSessionProbe(
   return prev;
 }
 
+/** Call `heldSessionProbe`, never letting a throwing probe reach the death
+ *  watch — mirrors `fireBackgroundTaskSettled` just below: the probe runs
+ *  orchestrator DB reads we don't control (SQLite can transiently throw,
+ *  e.g. "database is busy"), and a bad read must not crash the poll tick.
+ *  Treats a throw as "not held", the same as the unset (`null`) case. */
+function heldProbeSafe(taskId: string): boolean {
+  try {
+    return heldSessionProbe?.(taskId) ?? false;
+  } catch (e) {
+    console.error(`[claude-tmux] heldSessionProbe threw for task ${taskId}:`, e);
+    return false;
+  }
+}
+
 /**
  * Handler the orchestrator installs to learn that a background task/agent
  * named in a task-notification JSONL line has settled, so it can flip the
@@ -2058,10 +2072,23 @@ function dispatchLine(state: SessionState, line: string): void {
   // background agent settled while the process was down, and the consumer
   // (`subagents.markSettledById`) is idempotent, so re-firing for an
   // already-seen line is harmless.
-  const notifContent = taskNotificationContent(evt);
-  if (notifContent) {
-    const agentId = extractTaskNotificationAgentId(notifContent);
-    if (agentId) fireBackgroundTaskSettled(state.taskId, agentId);
+  //
+  // Skipped for the synthetic `__rebuild__` state (see `rebuildEventsFromJsonl`):
+  // that helper's contract is a read-only re-emission of a finished session's
+  // JSONL for a UI replay, not a second live tailer. `markSettledById` keys
+  // on agentId alone with no taskId scoping, so firing here would settle a
+  // REAL subagent/background-task row from a request that never touched a
+  // live session — e.g. a rebuild racing a genuine resume could release a
+  // hold the live tailer still needs. Mirrors how the continuation-adoption
+  // check further down is naturally inert for `__rebuild__` (its factory
+  // looks the taskId up and finds no such task), just made explicit here
+  // since this block runs unconditionally rather than through a factory.
+  if (state.taskId !== "__rebuild__") {
+    const notifContent = taskNotificationContent(evt);
+    if (notifContent) {
+      const agentId = extractTaskNotificationAgentId(notifContent);
+      if (agentId) fireBackgroundTaskSettled(state.taskId, agentId);
+    }
   }
 
   // Already-seen lines (reattach replay-from-offset-0) skip chunk emission
@@ -2875,31 +2902,47 @@ export const DEATH_JSONL_QUIET_MS = 3_000;
  * Settle an in-flight turn (or a held task — see below) because its tmux
  * session died unexpectedly.
  *
- * Emits the shared `SESSION_DIED_STATUS_PREFIX` sentinel (which the
- * orchestrator's chunk handler pattern-matches to flip the card to `blocked`
- * and mark the run's handle), then resolves the active turn so the done
- * handler runs — exactly mirroring the claude API-error path, where the
- * outcome is driven by the handle flag, not the exit code.
+ * While a turn is genuinely in flight, emits the shared
+ * `SESSION_DIED_STATUS_PREFIX` sentinel (which the orchestrator's chunk
+ * handler pattern-matches to flip the card to `blocked` and mark the run's
+ * handle), then resolves the active turn so the done handler runs — exactly
+ * mirroring the claude API-error path, where the outcome is driven by the
+ * handle flag, not the exit code.
+ *
+ * When there's no turn in flight and death fired only because the task is
+ * held open for background agents, the sentinel would lie: there's no
+ * active handle for the orchestrator to flip to `blocked`, so a held task
+ * actually releases to `review` instead. That case emits a plain status
+ * chunk WITHOUT the sentinel prefix — see the held branch below.
  *
  * No-ops when no turn is in flight AND the task isn't held for background
- * agents (`heldSessionProbe`): if the final flush already popped the slot
+ * agents (`heldProbeSafe`): if the final flush already popped the slot
  * (the turn genuinely completed a beat before the session vanished) and
  * nothing is holding the card open, there's nothing to settle — an idle
  * session dying between turns is out of scope (the card isn't "running"; a
  * re-run self-heals via spawn's pre-kill). When the task IS held, the main
  * run already resolved so there's no slot/onEndOfTurn to settle below (both
- * branches are skipped harmlessly) — this call still emits the sentinel
- * (via `state.lastChunk`, the succeeded run's handler) and, unconditionally
- * at the bottom, orphans any still-`running` subagent rows, which is what
- * lets the orchestrator's settle hook release the hold.
+ * branches are skipped harmlessly) — this call still emits the held-death
+ * status (via `state.lastChunk`, the succeeded run's handler) and,
+ * unconditionally at the bottom, orphans any still-`running` subagent rows,
+ * which is what lets the orchestrator's settle hook release the hold.
  */
 function signalSessionDeath(state: SessionState): void {
-  if (!turnInFlight(state) && !heldSessionProbe?.(state.taskId)) return;
+  const inFlight = turnInFlight(state);
+  if (!inFlight && !heldProbeSafe(state.taskId)) return;
   const slot = state.turnQueue[0];
   const onChunk = slot?.onChunk ?? state.lastChunk ?? (() => {});
   onChunk(
     "status",
-    `${SESSION_DIED_STATUS_PREFIX}tmux session ${state.sessionName} ended unexpectedly — task blocked`,
+    inFlight
+      ? `${SESSION_DIED_STATUS_PREFIX}tmux session ${state.sessionName} ended unexpectedly — task blocked`
+      // Held-probe-driven death, no active turn: the main run already
+      // resolved, so there's no handle for the orchestrator to flip to
+      // `blocked` — the task actually releases to `review`. Say so honestly
+      // instead of reusing the sentinel, which the orchestrator would
+      // otherwise pattern-match into a "blocked" breadcrumb that never
+      // happens for this path.
+      : `tmux session ${state.sessionName} ended while background agents were running — releasing task`,
   );
   if (slot && slot.resolve) {
     state.turnQueue.shift();
@@ -2966,7 +3009,7 @@ function startDeathWatch(state: SessionState): void {
   // task isn't held open for background agents).
   let misses = 0;
   state.deathTimer = setInterval(() => {
-    if (!turnInFlight(state) && !heldSessionProbe?.(state.taskId)) { misses = 0; return; } // idle & not held — skip the tmux poll
+    if (!turnInFlight(state) && !heldProbeSafe(state.taskId)) { misses = 0; return; } // idle & not held — skip the tmux poll
     // Compute the log-recency veto lazily — it only matters for a `gone` probe,
     // and `gone` is the rare tick, so we skip a statSync on every `alive` poll.
     const liveness = sessionLiveness(state.sessionName);

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -71,6 +71,109 @@ export interface SpawnedAgent {
   done: Promise<number>;
 }
 
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Orchestrator injection seams.
+ *
+ * The orchestrator (server-side, imports this module) needs to reach INTO a
+ * live tmux-driven session at a few points this module can't decide on its
+ * own: which task a stray content line belongs to, whether a task is being
+ * held open for background agents, and when a background task/agent settles.
+ * Rather than import orchestrator.ts here (a cycle — orchestrator already
+ * imports claude-tmux for spawn/sendTurn/etc.), each seam is a module-level
+ * setter the orchestrator calls once at startup, mirroring the `emitFn` /
+ * `settleFn` pattern in claude-subagents.ts. All three default to null
+ * (no-op), so this file's behavior is byte-for-byte unchanged until
+ * something wires them up.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Everything `dispatchLine` needs to adopt a stray content line into a fresh
+ * run — see `setContinuationRunFactory` below. `onChunk` matches
+ * `ChunkHandler` exactly (the same sink shape every turn slot already uses);
+ * `onAdopted` hands back a live control handle shaped exactly like
+ * `SpawnedAgent` (kill / writeInput / done) so the caller can Stop or fold a
+ * follow-up into the continuation run the same way it already does for a
+ * normal turn.
+ */
+export type ContinuationHooks = {
+  onChunk: ChunkHandler;
+  onAdopted: (handle: SpawnedAgent) => void;
+};
+
+/**
+ * Factory the orchestrator installs to adopt a "stray" content line — one
+ * that arrives on a session with no turn in flight and nothing queued to
+ * receive it. This is exactly what happens after claude auto-resumes
+ * following a background-task notification (see the call site in
+ * `dispatchLine`): the prior run already resolved on its own `end_turn`, so
+ * without this seam the resumed conversation would silently dispatch
+ * through the stale `state.lastChunk` under the already-succeeded run.
+ * Returns `null` for a task the orchestrator doesn't want to (or can't)
+ * open a new run for — e.g. the task row is gone or archived — in which
+ * case `dispatchLine` falls back to today's `lastChunk` routing.
+ *
+ * Save/restore this like `claude-subagents.ts`'s `setSubagentEmitter`: a
+ * test that installs a fake here and doesn't put the real one back strands
+ * every later test file that dispatches a JSONL line while idle.
+ */
+let continuationRunFactory: ((taskId: string) => ContinuationHooks | null) | null = null;
+export function setContinuationRunFactory(
+  fn: ((taskId: string) => ContinuationHooks | null) | null,
+): ((taskId: string) => ContinuationHooks | null) | null {
+  const prev = continuationRunFactory;
+  continuationRunFactory = fn;
+  return prev;
+}
+
+/**
+ * Predicate the orchestrator installs to answer "is this task being held
+ * open for background agents right now?" (the #92 hold: the main run
+ * already resolved but the kanban card stays in `running` while subagents
+ * finish). `startDeathWatch` keeps polling `tmux has-session` while this is
+ * true even though `turnInFlight` is false — otherwise a session dying
+ * mid-hold would never be detected until the next boot's reconciliation.
+ * Returns `false` (via the `?.` at call sites) when unset, so death-watch
+ * gating is byte-for-byte unchanged until this is wired.
+ */
+let heldSessionProbe: ((taskId: string) => boolean) | null = null;
+export function setHeldSessionProbe(
+  fn: ((taskId: string) => boolean) | null,
+): ((taskId: string) => boolean) | null {
+  const prev = heldSessionProbe;
+  heldSessionProbe = fn;
+  return prev;
+}
+
+/**
+ * Handler the orchestrator installs to learn that a background task/agent
+ * named in a task-notification JSONL line has settled, so it can flip the
+ * matching `subagents` row and re-check the hold predicate above. Fired
+ * from `dispatchLine` whenever a task-notification's `<task-id>` can be
+ * parsed out of the line — tolerant by design: when no id is found the call
+ * is simply skipped, since session death and boot reconciliation are
+ * independent settle signals that don't depend on this one firing.
+ */
+let backgroundTaskSettledFn: ((taskId: string, agentId: string) => void) | null = null;
+export function setBackgroundTaskSettledHandler(
+  fn: ((taskId: string, agentId: string) => void) | null,
+): ((taskId: string, agentId: string) => void) | null {
+  const prev = backgroundTaskSettledFn;
+  backgroundTaskSettledFn = fn;
+  return prev;
+}
+
+/** Call the background-task-settled hook, never letting a throwing hook
+ *  reach the tailer — mirrors `fireSettle` in claude-subagents.ts; the hook
+ *  runs orchestrator logic we don't control, and a bad handler must not
+ *  take the JSONL tail down. */
+function fireBackgroundTaskSettled(taskId: string, agentId: string): void {
+  try {
+    backgroundTaskSettledFn?.(taskId, agentId);
+  } catch (e) {
+    console.error(`[claude-tmux] background-task-settled hook threw for task ${taskId}:`, e);
+  }
+}
+
 export interface ClaudeLaunchOptions {
   taskId: string;
   /**
@@ -390,6 +493,69 @@ function isEndTurnContinuation(
   if (next.type === "user") {
     const content = next.message?.content;
     if (Array.isArray(content) && content.some((b) => b?.type === "tool_result")) return true;
+  }
+  return false;
+}
+
+/**
+ * Extract the raw `<task-notification>…</task-notification>` XML payload from
+ * `evt`, or `null` when `evt` isn't one of the two shapes claude uses to
+ * report a background command/agent's completion. Mirrors the detection in
+ * `mapParsedEventToChunks`'s `user` and `queue-operation` cases exactly, so
+ * the settle signal (`fireBackgroundTaskSettled`) and the status breadcrumb
+ * the user sees always agree on what counts as a notification. A third shape
+ * (`type: "attachment"`, `attachment.commandMode: "task-notification"`) has
+ * been observed carrying the same payload as a `queue-operation`/`user`
+ * companion line for the same event — deliberately not handled here since
+ * the other two already fire the settle signal for it and a duplicate would
+ * just be a harmless extra (idempotent) call.
+ */
+function taskNotificationContent(evt: ParsedJsonlEvent): string | null {
+  if (evt.type === "user" && evt.origin?.kind === "task-notification") {
+    const content = evt.message?.content;
+    return typeof content === "string" ? content : null;
+  }
+  if (evt.type === "queue-operation" && evt.operation === "enqueue" && typeof evt.content === "string") {
+    return evt.content;
+  }
+  return null;
+}
+
+/**
+ * Pull the `<task-id>` out of a task-notification payload. This id is
+ * identical to the finishing subagent's on-disk id — claude-subagents.ts
+ * tails `<sessionId>/subagents/agent-<agentId>.jsonl`, and empirically (see
+ * real transcripts under `~/.claude/projects/`) `<task-id>` in the
+ * notification and `<agentId>` in that filename are the same token for a
+ * background AGENT (Task-tool) completion. For a background *shell command*
+ * notification there's no matching subagent row; `setBackgroundTaskSettledHandler`'s
+ * callee is expected to no-op on an id it doesn't recognise. Returns `null`
+ * when no `<task-id>` tag is present so callers degrade gracefully.
+ */
+function extractTaskNotificationAgentId(content: string): string | null {
+  const m = /<task-id>([^<]+)<\/task-id>/.exec(content);
+  return m ? m[1]!.trim() : null;
+}
+
+/**
+ * True when `evt`, once mapped, would emit genuine conversational content —
+ * a `user` / `assistant` / `thinking` / `tool_use` / `tool_result` chunk —
+ * rather than a bare status/heartbeat breadcrumb. Used by `dispatchLine` to
+ * decide whether an unattributed line (no turn in flight, nothing queued) is
+ * significant enough to adopt via `continuationRunFactory`: a status-only
+ * line (a mode banner, a turn-duration footer, a task-notification
+ * breadcrumb) must NOT open a new run on its own — only the human/agent
+ * content that follows should.
+ */
+function isContinuationContentEvent(evt: ParsedJsonlEvent): boolean {
+  if (evt.type === "assistant") return true;
+  if (evt.type === "user") {
+    // Same filter mapParsedEventToChunks applies before emitting a `user`
+    // chunk — synthetic entries claude injects itself never count as new
+    // content on their own.
+    if (evt.origin?.kind === "task-notification") return false;
+    if (evt.isMeta === true) return false;
+    return true;
   }
   return false;
 }
@@ -1885,6 +2051,19 @@ function dispatchLine(state: SessionState, line: string): void {
     }
   }
 
+  // Background-task/agent settle signal. Deliberately runs BEFORE the dedup
+  // early-return below (unlike the continuation-adoption check further down,
+  // which must NOT fire on replayed lines): a reattach replay (offset-0
+  // re-read after an agetor restart) may be the only chance to learn that a
+  // background agent settled while the process was down, and the consumer
+  // (`subagents.markSettledById`) is idempotent, so re-firing for an
+  // already-seen line is harmless.
+  const notifContent = taskNotificationContent(evt);
+  if (notifContent) {
+    const agentId = extractTaskNotificationAgentId(notifContent);
+    if (agentId) fireBackgroundTaskSettled(state.taskId, agentId);
+  }
+
   // Already-seen lines (reattach replay-from-offset-0) skip chunk emission
   // but still stage an end_turn so the run-row status transition can fire
   // when the next line confirms it. The banner is suppressed (emitBanner:
@@ -1899,6 +2078,39 @@ function dispatchLine(state: SessionState, line: string): void {
       };
     }
     return;
+  }
+
+  // Continuation adoption: this line is provably NEW (it passed the dedup
+  // return above). If no turn is in flight and nothing is queued to receive
+  // it, yet it carries genuine content, claude has resumed talking with no
+  // run listening — the case a post-end_turn background-task auto-resume
+  // produces (the notification breadcrumb itself never reaches here; it's a
+  // status-only line filtered out by `isContinuationContentEvent`, and it
+  // already returned above via the dedup path on any replay). Ask the
+  // orchestrator to adopt a fresh run before this line is dispatched, so the
+  // run exists before its first chunk lands.
+  if (
+    continuationRunFactory
+    && !turnInFlight(state)
+    && state.turnQueue.length === 0
+    && !state.onEndOfTurn
+    && isContinuationContentEvent(evt)
+  ) {
+    const hooks = continuationRunFactory(state.taskId);
+    if (hooks) {
+      const adopted: TurnSlot = { onChunk: hooks.onChunk, resolve: null, reject: null };
+      const done = new Promise<number>((resolve, reject) => {
+        adopted.resolve = resolve;
+        adopted.reject = reject;
+      });
+      state.turnQueue.push(adopted);
+      // Register the run with the orchestrator BEFORE the triggering line
+      // dispatches below — the caller must be able to observe "running"
+      // before the first chunk arrives, not after.
+      hooks.onAdopted(makeAgent(state.taskId, done));
+    }
+    // A null factory result (unknown/archived task) intentionally falls
+    // through to the pre-existing `lastChunk` routing below — unchanged.
   }
 
   const slot = state.turnQueue[0];
@@ -2660,7 +2872,8 @@ export const DEATH_MISS_THRESHOLD = 4;
 export const DEATH_JSONL_QUIET_MS = 3_000;
 
 /**
- * Settle an in-flight turn because its tmux session died unexpectedly.
+ * Settle an in-flight turn (or a held task — see below) because its tmux
+ * session died unexpectedly.
  *
  * Emits the shared `SESSION_DIED_STATUS_PREFIX` sentinel (which the
  * orchestrator's chunk handler pattern-matches to flip the card to `blocked`
@@ -2668,13 +2881,20 @@ export const DEATH_JSONL_QUIET_MS = 3_000;
  * handler runs — exactly mirroring the claude API-error path, where the
  * outcome is driven by the handle flag, not the exit code.
  *
- * No-ops when no turn is in flight: if the final flush already popped the slot
- * (the turn genuinely completed a beat before the session vanished) there's
- * nothing to settle, and an idle session dying between turns is out of scope
- * (the card isn't "running"; a re-run self-heals via spawn's pre-kill).
+ * No-ops when no turn is in flight AND the task isn't held for background
+ * agents (`heldSessionProbe`): if the final flush already popped the slot
+ * (the turn genuinely completed a beat before the session vanished) and
+ * nothing is holding the card open, there's nothing to settle — an idle
+ * session dying between turns is out of scope (the card isn't "running"; a
+ * re-run self-heals via spawn's pre-kill). When the task IS held, the main
+ * run already resolved so there's no slot/onEndOfTurn to settle below (both
+ * branches are skipped harmlessly) — this call still emits the sentinel
+ * (via `state.lastChunk`, the succeeded run's handler) and, unconditionally
+ * at the bottom, orphans any still-`running` subagent rows, which is what
+ * lets the orchestrator's settle hook release the hold.
  */
 function signalSessionDeath(state: SessionState): void {
-  if (!turnInFlight(state)) return;
+  if (!turnInFlight(state) && !heldSessionProbe?.(state.taskId)) return;
   const slot = state.turnQueue[0];
   const onChunk = slot?.onChunk ?? state.lastChunk ?? (() => {});
   onChunk(
@@ -2724,11 +2944,17 @@ function turnInFlight(state: SessionState): boolean {
  *  session is long-lived and idle between turns, so we gate the actual
  *  `tmux has-session` subprocess on a turn being in flight — an idle session
  *  dying isn't a "running task" problem (and `signalSessionDeath` would no-op
- *  anyway). While a turn IS in flight, when the session vanishes we one-shot
- *  stop the poll, give the FS a grace beat to surface any final bytes, flush,
- *  then settle the run via `signalSessionDeath`. Torn down by
- *  `disposeSessionState` (intentional teardown clears it before the kill, so a
- *  Stop/delete can't be mistaken for an unexpected death). */
+ *  anyway) UNLESS the task is being held open for background agents
+ *  (`heldSessionProbe`, the #92 hold: the main run already resolved but the
+ *  kanban card stays `running` while subagents finish). Without probing
+ *  during a hold, a session dying mid-hold would go undetected until the
+ *  next boot's reconciliation — the poll would hit `!turnInFlight` on every
+ *  tick and reset `misses` to 0 forever. While a turn IS in flight (or the
+ *  task is held), when the session vanishes we one-shot stop the poll, give
+ *  the FS a grace beat to surface any final bytes, flush, then settle via
+ *  `signalSessionDeath`. Torn down by `disposeSessionState` (intentional
+ *  teardown clears it before the kill, so a Stop/delete can't be mistaken
+ *  for an unexpected death). */
 function startDeathWatch(state: SessionState): void {
   if (state.deathTimer) return;
   // Only a definitive `gone` probe (tmux server answered, this session absent)
@@ -2736,10 +2962,11 @@ function startDeathWatch(state: SessionState): void {
   // resets the counter (see `sessionLiveness`). Require DEATH_MISS_THRESHOLD
   // consecutive `gone` probes, and veto on recent JSONL writes, so a live task
   // is never wrongly blocked. Reset on any tick where the session is alive/
-  // unreachable, the JSONL was just written, or no turn is running.
+  // unreachable, the JSONL was just written, or no turn is running (and the
+  // task isn't held open for background agents).
   let misses = 0;
   state.deathTimer = setInterval(() => {
-    if (!turnInFlight(state)) { misses = 0; return; } // idle — no running turn; skip the tmux poll
+    if (!turnInFlight(state) && !heldSessionProbe?.(state.taskId)) { misses = 0; return; } // idle & not held — skip the tmux poll
     // Compute the log-recency veto lazily — it only matters for a `gone` probe,
     // and `gone` is the rare tick, so we skip a statSync on every `alive` poll.
     const liveness = sessionLiveness(state.sessionName);

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -482,6 +482,7 @@ type RunRow = {
   tmux_session: string | null;
   claude_session_id: string | null;
   codex_session_id: string | null;
+  origin: string | null;
 };
 
 const toRun = (r: RunRow): Run => ({
@@ -495,6 +496,7 @@ const toRun = (r: RunRow): Run => ({
   tmuxSession: r.tmux_session,
   claudeSessionId: r.claude_session_id,
   codexSessionId: r.codex_session_id,
+  origin: (r.origin as Run["origin"]) ?? null,
 });
 
 export const runs = {
@@ -507,13 +509,17 @@ export const runs = {
     const row = db.query<RunRow, [string]>(`SELECT * FROM runs WHERE id = ?`).get(id);
     return row ? toRun(row) : null;
   },
+  /** `r.origin` is optional on the `Run` type (most callers don't set it —
+   *  only the continuation-run factory does) so `?? null` keeps a
+   *  user-initiated run's row explicitly NULL rather than the JS `undefined`
+   *  bun:sqlite would otherwise bind. */
   insert(r: Run): Run {
     db.run(
-      `INSERT INTO runs (id, task_id, agent, status, started_at, ended_at, exit_code, tmux_session, claude_session_id, codex_session_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [r.id, r.taskId, r.agent, r.status, r.startedAt, r.endedAt, r.exitCode, r.tmuxSession, r.claudeSessionId, r.codexSessionId],
+      `INSERT INTO runs (id, task_id, agent, status, started_at, ended_at, exit_code, tmux_session, claude_session_id, codex_session_id, origin)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [r.id, r.taskId, r.agent, r.status, r.startedAt, r.endedAt, r.exitCode, r.tmuxSession, r.claudeSessionId, r.codexSessionId, r.origin ?? null],
     );
-    return r;
+    return { ...r, origin: r.origin ?? null };
   },
   update(id: string, patch: Partial<Run>): Run | null {
     const row = db.query<RunRow, [string]>(`SELECT * FROM runs WHERE id = ?`).get(id);
@@ -681,6 +687,25 @@ export const subagents = {
   },
   setStatus(id: string, status: SubagentStatus, endedAt: number | null): void {
     db.run(`UPDATE subagents SET status = ?, ended_at = ? WHERE id = ?`, [status, endedAt, id]);
+  },
+  /** Settle a single subagent by id — the DB half of an *externally*-detected
+   *  completion (a parent task-notification naming the finishing agent, or
+   *  boot reconciliation finding its session gone), as opposed to the
+   *  watcher's own `checkDone` idle-detection. Idempotent: only flips a row
+   *  whose status is currently `running`, so a duplicate/late signal (e.g.
+   *  the watcher's own idle-detection racing the same completion) is a
+   *  harmless no-op rather than double-firing `ended_at`. Returns whether a
+   *  row actually changed, plus its `taskId` (cheap — same SELECT) so the
+   *  caller can trigger the settle/release-hold bookkeeping without a second
+   *  query. */
+  markSettledById(id: string, status: "completed" | "orphaned"): { changed: boolean; taskId: string | null } {
+    const row = db.query<SubagentRow, [string]>(
+      `SELECT * FROM subagents WHERE id = ? AND status = 'running'`,
+    ).get(id);
+    if (!row) return { changed: false, taskId: null };
+    const now = Date.now();
+    db.run(`UPDATE subagents SET status = ?, ended_at = ? WHERE id = ?`, [status, now, id]);
+    return { changed: true, taskId: row.task_id };
   },
   /** True when at least one subagent row for this task is still `running`. */
   hasRunning(taskId: string): boolean {

--- a/src/bun/migrations/023_run_origin.sql
+++ b/src/bun/migrations/023_run_origin.sql
@@ -1,0 +1,8 @@
+-- Distinguish a user-initiated run from one the orchestrator opened on the
+-- user's behalf after a claude session auto-resumed post `end_turn` (e.g. the
+-- main agent delegated to a background task and later continued talking once
+-- it finished). NULL = user-initiated (the existing behavior for every prior
+-- row); 'continuation' = opened by the orchestrator's continuation-run
+-- factory. Nullable, no default needed — SQLite backfills existing rows with
+-- NULL, which is exactly the "user-initiated" reading.
+ALTER TABLE runs ADD COLUMN origin TEXT;

--- a/src/bun/migrations/index.ts
+++ b/src/bun/migrations/index.ts
@@ -22,6 +22,7 @@ import m019 from "./019_archived_at.sql" with { type: "text" };
 import m020 from "./020_task_type.sql" with { type: "text" };
 import m021 from "./021_codex_session_id.sql" with { type: "text" };
 import m022 from "./022_subagents.sql" with { type: "text" };
+import m023 from "./023_run_origin.sql" with { type: "text" };
 
 import type { Migration } from "../migrate.ts";
 
@@ -48,4 +49,5 @@ export const migrations: Migration[] = [
   { id: "020_task_type", sql: m020 },
   { id: "021_codex_session_id", sql: m021 },
   { id: "022_subagents", sql: m022 },
+  { id: "023_run_origin", sql: m023 },
 ];

--- a/src/bun/orchestrator-continuation.test.ts
+++ b/src/bun/orchestrator-continuation.test.ts
@@ -349,37 +349,38 @@ test("a follow-up sent while the continuation run is in flight folds into it (bu
 
 // ── 5. Codex — is the factory actually agent-kind-guarded? ─────────────────
 
-test("codex task: startContinuationRun has NO explicit agent-kind guard (documents a real gap, not a fix)", async () => {
+test("codex task → factory returns null (agent-kind guard)", async () => {
   // In production this factory is only ever invoked from claude-tmux.ts's
   // `dispatchLine` — codex-tmux.ts never references
   // `continuationRunFactory`/`setContinuationRunFactory` at all (grepped;
   // zero hits), so a codex task's session never reaches this path today.
-  // But `startContinuationRun`'s own body (orchestrator.ts ~1365) only
-  // checks `taskId === "__rebuild__"` and `!task || task.archivedAt != null`
-  // — there is no `resolveHarness(task.agent)?.kind === "claude-code"` guard.
-  // Calling it directly (as this test does, standing in for a hypothetical
-  // future caller or refactor that wires it up for codex too) produces a
-  // real `origin: "continuation"` run row stamped with the codex task's own
-  // agent id. This test asserts the ACTUAL behavior, not the wished-for
-  // guard — see this file's final report for the flag.
+  // `startContinuationRun`'s own body (orchestrator.ts ~1365) now guards on
+  // `resolveHarness(task.agent)?.kind !== "claude-code"` in addition to the
+  // `"__rebuild__"` and unknown/archived-task checks — continuations are a
+  // claude-JSONL concept (a background-task auto-continuation observed via
+  // `dispatchLine`'s tail of the session's own JSONL); codex is one-shot per
+  // turn and has no equivalent notion of "kept talking after end_turn". This
+  // test asserts the factory declines a codex task outright — defense in
+  // depth for a path that's inert today but would otherwise mint a real
+  // `origin: "continuation"` run row stamped with codex's agent id if a
+  // future caller or refactor ever wired codex into this factory.
   const taskId = await createTaskWithAgent("continuation-codex-gap", "codex");
-  await seedPriorRun(taskId, {
+  const priorRunId = await seedPriorRun(taskId, {
     agent: "codex",
     codexSessionId: `codex-sess-${randomUUID()}`,
     column: "review",
   });
 
   const hooks = realFactory!(taskId);
-  expect(hooks).not.toBeNull();
+  expect(hooks).toBeNull();
 
   const { tasks, runs } = await import("./db.ts");
   const task = tasks.get(taskId);
-  expect(task?.column).toBe("running");
-  const newRun = runs.get(task!.runId!);
-  expect(newRun?.agent).toBe("codex");
-  expect(newRun?.origin).toBe("continuation");
-  // claudeSessionId inheritance is claude-specific (`findLastClaudeSessionId`
-  // filters on `claude_session_id IS NOT NULL`) — a codex-only run history
-  // has none, so it comes back null. Documented, not asserted as "correct".
-  expect(newRun?.claudeSessionId).toBeNull();
+  // No adoption happened: column and runId stay exactly as seeded.
+  expect(task?.column).toBe("review");
+  expect(task?.runId).toBe(priorRunId);
+  // No new run row was created — only the seeded prior run exists.
+  const rows = runs.listForTask(taskId);
+  expect(rows.length).toBe(1);
+  expect(rows[0]?.id).toBe(priorRunId);
 });

--- a/src/bun/orchestrator-continuation.test.ts
+++ b/src/bun/orchestrator-continuation.test.ts
@@ -1,0 +1,385 @@
+import { test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import type { ColumnId } from "../shared/types.ts";
+import type { ContinuationHooks, SpawnedAgent } from "./claude-tmux.ts";
+
+/*
+ * Covers `startContinuationRun` (src/bun/orchestrator.ts, ~line 1365) — the
+ * factory the orchestrator installs via `setContinuationRunFactory` at
+ * module init (claude-tmux.ts wiring, see docs/plans/
+ * fix-stream-list-stalls-with-bg-agents.md sections 4/T4a and 5/TT5).
+ *
+ * `startContinuationRun` is NOT exported. The only way to reach it from a
+ * test is through the injected-setter seam itself: `setContinuationRunFactory`
+ * returns the PREVIOUS value when called, so calling it with `null` captures
+ * whatever orchestrator.ts registered at module load, and we immediately pass
+ * that same value back in to restore it (a true no-op from the module's
+ * point of view — we never leave the factory unset for any other test file
+ * or later test in this file). This mirrors the save/restore discipline
+ * `subagent-hold.test.ts` uses for its own env-var seam.
+ */
+
+// Only AGETOR_DATA_DIR belongs at module top level: db.ts captures it at first
+// import, and a `beforeAll` would race a sibling file that already imported
+// db.ts. The value is unique per file so nobody inherits it harmfully.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-test-"));
+
+// Every OTHER override is scoped to this file and restored afterwards — see
+// subagent-hold.test.ts's comment on why AGETOR_CLAUDE_DRIVER=fake /
+// AGETOR_TMUX_BIN=/bin/echo must not leak into files (like reconcile.test.ts)
+// that deliberately exercise the real driver.
+const ENV_OVERRIDES: Record<string, string> = {
+  AGETOR_CLAUDE_DRIVER: "fake", // not actually used to spawn here (we call the
+  // factory directly), but harmless and keeps this file consistent with its
+  // siblings in case a future test in here calls startTask/sendInput's spawn
+  // path.
+  AGETOR_CLAUDE_BIN: "/bin/echo",
+  AGETOR_TMUX_BIN: "/bin/echo", // tmux probe + every `tmux(...)` call (pasteFollowUp,
+  // sessionLiveness, etc.) becomes a no-op success — required for the
+  // fold-while-busy test (#4), which drives real claude-tmux code paths.
+  AGETOR_CLAUDE_ARGS: "",
+  AGETOR_CODEX_DRIVER: "fake",
+  AGETOR_CODEX_BIN: "/bin/echo",
+};
+const savedEnv: Record<string, string | undefined> = {};
+
+let realFactory: ((taskId: string) => ContinuationHooks | null) | null = null;
+
+beforeAll(async () => {
+  for (const [k, v] of Object.entries(ENV_OVERRIDES)) {
+    savedEnv[k] = process.env[k];
+    process.env[k] = v;
+  }
+  // Force orchestrator.ts's module-init side effects (including
+  // `setContinuationRunFactory(startContinuationRun)`) to have run before we
+  // try to capture the factory.
+  await import("./orchestrator.ts");
+  const { setContinuationRunFactory } = await import("./claude-tmux.ts");
+  realFactory = setContinuationRunFactory(null);
+  setContinuationRunFactory(realFactory); // restore immediately — see file header.
+  if (!realFactory) {
+    throw new Error(
+      "expected orchestrator.ts to have registered a continuation-run factory via setContinuationRunFactory",
+    );
+  }
+});
+
+afterAll(() => {
+  for (const k of Object.keys(ENV_OVERRIDES)) {
+    const prev = savedEnv[k];
+    if (prev === undefined) delete process.env[k];
+    else process.env[k] = prev;
+  }
+});
+
+// Same shared-DB hygiene as subagent-hold.test.ts: `bun test` runs every
+// *.test.ts in one process against one SQLite DB, and boot-reconciliation-style
+// global scans in other files could pick up a leftover `running` row. Every
+// task created here is tracked and hard-deleted in `afterEach` (cascades to
+// runs/subagents/run_events via FK).
+const createdTaskIds: string[] = [];
+afterEach(async () => {
+  const { db } = await import("./db.ts");
+  for (const id of createdTaskIds.splice(0)) {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [id]);
+  }
+});
+
+async function createTaskWithAgent(title: string, agent: "claude-code" | "codex"): Promise<string> {
+  const { createTask } = await import("./orchestrator.ts");
+  const created = await createTask({
+    title,
+    prompt: "hello",
+    agent,
+    workdir: process.cwd(),
+    isolation: "none", // don't materialize a worktree off the live repo during tests
+  });
+  if ("error" in created) throw new Error(created.error);
+  createdTaskIds.push(created.task.id);
+  return created.task.id;
+}
+
+/**
+ * Seed a "prior run" row directly (bypassing startTask/spawnAgent entirely)
+ * so the factory has something to inherit `claudeSessionId` from and a
+ * column to pull the card back from. Defaults model the common #92-hold
+ * shape: a succeeded claude run sitting in `review`.
+ */
+async function seedPriorRun(
+  taskId: string,
+  opts: {
+    agent?: string;
+    claudeSessionId?: string | null;
+    codexSessionId?: string | null;
+    column?: ColumnId;
+  } = {},
+): Promise<string> {
+  const { runs, tasks } = await import("./db.ts");
+  const runId = randomUUID();
+  const now = Date.now();
+  runs.insert({
+    id: runId,
+    taskId,
+    agent: opts.agent ?? "claude-code",
+    status: "succeeded",
+    startedAt: now - 5000,
+    endedAt: now,
+    exitCode: 0,
+    tmuxSession: `agetor-test-${taskId}`,
+    claudeSessionId: opts.claudeSessionId ?? null,
+    codexSessionId: opts.codexSessionId ?? null,
+  });
+  tasks.update(taskId, { column: opts.column ?? "review", runId });
+  return runId;
+}
+
+async function insertRunningSubagent(taskId: string): Promise<string> {
+  const { subagents } = await import("./db.ts");
+  const id = `agent-${randomUUID()}`;
+  subagents.insertIfAbsent({
+    id,
+    taskId,
+    runId: null, // the hold gate only keys off task_id — see subagents.hasRunning
+    parentKind: "subagent",
+    agentType: "Explore",
+    description: "test subagent",
+    spawnDepth: 1,
+    sourcePath: `/tmp/${id}.jsonl`,
+    status: "running",
+    startedAt: Date.now(),
+    endedAt: null,
+  });
+  return id;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** A never-resolving `done` — used when a test only cares about adoption/
+ *  registration, not the resolve path, and doesn't want a dangling `.then`
+ *  to fire mid-test. */
+function neverDone(): Promise<number> {
+  return new Promise<number>(() => {});
+}
+
+// ── 1. Guard rails ──────────────────────────────────────────────────────────
+
+test("factory returns null for an unknown taskId", () => {
+  expect(realFactory!(randomUUID())).toBeNull();
+});
+
+test("factory returns null for the synthetic __rebuild__ taskId", () => {
+  expect(realFactory!("__rebuild__")).toBeNull();
+});
+
+test("factory returns null for an archived task", async () => {
+  const taskId = await createTaskWithAgent("continuation-archived", "claude-code");
+  await seedPriorRun(taskId, { claudeSessionId: `sess-${randomUUID()}` });
+  const { tasks } = await import("./db.ts");
+  tasks.update(taskId, { archivedAt: Date.now() });
+
+  expect(realFactory!(taskId)).toBeNull();
+});
+
+// ── 2. Happy path ────────────────────────────────────────────────────────────
+
+test("happy path: new run row (origin continuation, inherited session, running) + column pulled back from review", async () => {
+  const taskId = await createTaskWithAgent("continuation-happy", "claude-code");
+  const priorSessionId = `sess-${randomUUID()}`;
+  const priorRunId = await seedPriorRun(taskId, { claudeSessionId: priorSessionId, column: "review" });
+
+  const hooks = realFactory!(taskId);
+  expect(hooks).not.toBeNull();
+
+  const { tasks, runs } = await import("./db.ts");
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("running");
+  expect(task?.runId).not.toBeNull();
+  expect(task?.runId).not.toBe(priorRunId);
+
+  const newRunId = task!.runId!;
+  const newRun = runs.get(newRunId);
+  expect(newRun?.status).toBe("running");
+  expect(newRun?.origin).toBe("continuation");
+  expect(newRun?.claudeSessionId).toBe(priorSessionId);
+  expect(newRun?.tmuxSession).not.toBeNull();
+
+  const events = runs.events(newRunId);
+  expect(
+    events.some((e) => e.stream === "status" && e.data === "auto-continued after background task"),
+  ).toBe(true);
+});
+
+test("happy path: pulls back from an arbitrary non-running column too (continuations always land in running)", async () => {
+  // The plan (section 4/T4a, section 3 decision 4) says continuation runs
+  // always pull the card to `running` regardless of prior column — unlike
+  // the parked-discovery pull-back, which is narrowly `review`-only. Exercise
+  // a non-review starting column to pin that distinction down.
+  const taskId = await createTaskWithAgent("continuation-happy-blocked", "claude-code");
+  await seedPriorRun(taskId, { claudeSessionId: `sess-${randomUUID()}`, column: "blocked" });
+
+  const hooks = realFactory!(taskId);
+  expect(hooks).not.toBeNull();
+
+  const { tasks } = await import("./db.ts");
+  expect(tasks.get(taskId)?.column).toBe("running");
+});
+
+// ── 3. onAdopted: active-map registration + done resolution ────────────────
+
+test("onAdopted registers the continuation run as active (cancelRun succeeds against it)", async () => {
+  const taskId = await createTaskWithAgent("continuation-adopt-active", "claude-code");
+  await seedPriorRun(taskId, { claudeSessionId: `sess-${randomUUID()}` });
+
+  const hooks = realFactory!(taskId)!;
+  const { tasks } = await import("./db.ts");
+  const newRunId = tasks.get(taskId)!.runId!;
+
+  let killed = false;
+  const handle: SpawnedAgent = {
+    kill: () => { killed = true; },
+    writeInput: () => true,
+    done: neverDone(),
+  };
+  hooks.onAdopted(handle);
+
+  // There's no exported accessor for the orchestrator's in-memory `active`
+  // map, so `cancelRun` — the public API that consults it — is the
+  // documented way to observe registration (same technique
+  // subagent-hold.test.ts uses for the settle-hook side of #92).
+  const { cancelRun } = await import("./orchestrator.ts");
+  const result = cancelRun(newRunId);
+  expect(result).toBe(true);
+  expect(killed).toBe(true);
+});
+
+test("attachDoneHandler resolves the run: exit 0 -> succeeded, column -> review (no running subagents)", async () => {
+  const taskId = await createTaskWithAgent("continuation-done-review", "claude-code");
+  await seedPriorRun(taskId, { claudeSessionId: `sess-${randomUUID()}` });
+
+  const hooks = realFactory!(taskId)!;
+  const { tasks, runs } = await import("./db.ts");
+  const newRunId = tasks.get(taskId)!.runId!;
+
+  let resolveDone!: (code: number) => void;
+  const donePromise = new Promise<number>((r) => { resolveDone = r; });
+  hooks.onAdopted({ kill: () => {}, writeInput: () => true, done: donePromise });
+
+  resolveDone(0);
+  await wait(75);
+
+  expect(runs.get(newRunId)?.status).toBe("succeeded");
+  expect(tasks.get(taskId)?.column).toBe("review");
+});
+
+test("attachDoneHandler + a running subagent: the #92 hold applies to continuation runs too — task stays HELD in running", async () => {
+  const taskId = await createTaskWithAgent("continuation-done-held", "claude-code");
+  await seedPriorRun(taskId, { claudeSessionId: `sess-${randomUUID()}` });
+  await insertRunningSubagent(taskId);
+
+  const hooks = realFactory!(taskId)!;
+  const { tasks, runs, subagents } = await import("./db.ts");
+  const newRunId = tasks.get(taskId)!.runId!;
+
+  let resolveDone!: (code: number) => void;
+  const donePromise = new Promise<number>((r) => { resolveDone = r; });
+  hooks.onAdopted({ kill: () => {}, writeInput: () => true, done: donePromise });
+
+  resolveDone(0);
+  await wait(75);
+
+  expect(runs.get(newRunId)?.status).toBe("succeeded");
+  expect(subagents.hasRunning(taskId)).toBe(true);
+  // Held, not advanced — matches isHeldByBackgroundAgents/attachDoneHandler's
+  // holdForSubagents branch.
+  expect(tasks.get(taskId)?.column).toBe("running");
+});
+
+// ── 4. Fold-while-busy for a continuation run ───────────────────────────────
+
+test("a follow-up sent while the continuation run is in flight folds into it (busy branch), not a new row", async () => {
+  // sendClaudeTurn's fold path requires BOTH `hasSessionState(taskId)` (a
+  // real, in-memory claude-tmux SessionState — NOT something
+  // startContinuationRun touches) AND `active.has(task.runId)` (populated by
+  // onAdopted above). claude-tmux.ts exposes `__forTest.installSession` for
+  // exactly this — the same seam orchestrator.test.ts's own
+  // "sendInput folds a follow-up into the in-flight run" test uses — so this
+  // IS cheap to drive with the fake driver + /bin/echo tmux stub; no skip
+  // needed.
+  const taskId = await createTaskWithAgent("continuation-fold", "claude-code");
+  await seedPriorRun(taskId, { claudeSessionId: `sess-${randomUUID()}` });
+
+  const hooks = realFactory!(taskId)!;
+  const { tasks, runs } = await import("./db.ts");
+  const newRunId = tasks.get(taskId)!.runId!;
+
+  const donePromise = neverDone(); // stays "in flight" for the whole test
+  hooks.onAdopted({ kill: () => {}, writeInput: () => true, done: donePromise });
+
+  const claudeTmux = await import("./claude-tmux.ts");
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-cont-fold-"));
+  const jsonlPath = path.join(dir, `${randomUUID()}.jsonl`);
+  writeFileSync(jsonlPath, "");
+  claudeTmux.__forTest.installSession(taskId, jsonlPath);
+  try {
+    const { sendInput } = await import("./orchestrator.ts");
+    const sent = sendInput(newRunId, "follow-up while continuation is in flight");
+    expect(sent.delivered).toBe(true);
+    if (sent.delivered) expect(sent.runId).toBe(newRunId);
+
+    // No third run row: exactly the seeded prior run + the continuation run.
+    const rows = runs.listForTask(taskId);
+    expect(rows.length).toBe(2);
+    expect(rows.some((r) => r.id === newRunId)).toBe(true);
+
+    const events = runs.eventsForTask(taskId);
+    expect(
+      events.some(
+        (e) => e.stream === "user" && e.data.includes("follow-up while continuation is in flight"),
+      ),
+    ).toBe(true);
+  } finally {
+    claudeTmux.__forTest.uninstallSession(taskId);
+  }
+});
+
+// ── 5. Codex — is the factory actually agent-kind-guarded? ─────────────────
+
+test("codex task: startContinuationRun has NO explicit agent-kind guard (documents a real gap, not a fix)", async () => {
+  // In production this factory is only ever invoked from claude-tmux.ts's
+  // `dispatchLine` — codex-tmux.ts never references
+  // `continuationRunFactory`/`setContinuationRunFactory` at all (grepped;
+  // zero hits), so a codex task's session never reaches this path today.
+  // But `startContinuationRun`'s own body (orchestrator.ts ~1365) only
+  // checks `taskId === "__rebuild__"` and `!task || task.archivedAt != null`
+  // — there is no `resolveHarness(task.agent)?.kind === "claude-code"` guard.
+  // Calling it directly (as this test does, standing in for a hypothetical
+  // future caller or refactor that wires it up for codex too) produces a
+  // real `origin: "continuation"` run row stamped with the codex task's own
+  // agent id. This test asserts the ACTUAL behavior, not the wished-for
+  // guard — see this file's final report for the flag.
+  const taskId = await createTaskWithAgent("continuation-codex-gap", "codex");
+  await seedPriorRun(taskId, {
+    agent: "codex",
+    codexSessionId: `codex-sess-${randomUUID()}`,
+    column: "review",
+  });
+
+  const hooks = realFactory!(taskId);
+  expect(hooks).not.toBeNull();
+
+  const { tasks, runs } = await import("./db.ts");
+  const task = tasks.get(taskId);
+  expect(task?.column).toBe("running");
+  const newRun = runs.get(task!.runId!);
+  expect(newRun?.agent).toBe("codex");
+  expect(newRun?.origin).toBe("continuation");
+  // claudeSessionId inheritance is claude-specific (`findLastClaudeSessionId`
+  // filters on `claude_session_id IS NOT NULL`) — a codex-only run history
+  // has none, so it comes back null. Documented, not asserted as "correct".
+  expect(newRun?.claudeSessionId).toBeNull();
+});

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -36,6 +36,7 @@ import {
   CLAUDE_API_ERROR_STATUS_PREFIX,
   cycleToMode,
   type CycleResult,
+  type ContinuationHooks,
   dropSession,
   killSessionByName,
   reattachSession,
@@ -49,6 +50,9 @@ import {
   sessionNameFor,
   jsonlPathFor,
   interruptTaskSession,
+  setContinuationRunFactory,
+  setHeldSessionProbe,
+  setBackgroundTaskSettledHandler,
 } from "./claude-tmux.ts";
 import {
   dropCodexSession,
@@ -57,6 +61,8 @@ import {
 import {
   setSubagentEmitter,
   setSubagentSettleHook,
+  setParkedDiscoveryHandler,
+  settleSubagentById,
   orphanRunningSubagents,
   attachSubagentWatcher,
 } from "./claude-subagents.ts";
@@ -126,6 +132,35 @@ setSubagentEmitter(emit);
 // by the background agents themselves. Register the release as the subagent
 // settle hook so the last-agent-finishing edge lands the card in `review`.
 setSubagentSettleHook(maybeReleaseHeldTask);
+
+// Parked-discovery: a subagent newly (or once again) `running` should pull a
+// `review` card back to `running` — the mirror-image of the settle hook
+// above. Registered here (not inline) so it's visible alongside the other
+// claude-subagents.ts seams; see `pullBackParkedTask` below for the policy
+// (only from `review`, only when the terminal run actually succeeded).
+setParkedDiscoveryHandler(pullBackParkedTask);
+
+// Continuation-run adoption: claude-tmux calls this when a genuinely-new
+// content line arrives on a task's session with no turn in flight — the case
+// a post-`end_turn` background-task auto-continuation produces. See
+// `startContinuationRun` below.
+setContinuationRunFactory(startContinuationRun);
+
+// Death-watch during a #92 hold: keep polling `tmux has-session` even though
+// no turn is in flight, so a session dying mid-hold is caught instead of
+// silently stranding the card in `running` until the next boot. Reuses the
+// existing DB-derived hold predicate — no new state to track.
+setHeldSessionProbe(isHeldByBackgroundAgents);
+
+// Background-task settle signal: a parent task-notification JSONL line named
+// the finishing agent/background-task id — settle that subagent row the same
+// way a naturally-detected completion would (DB flip → lifecycle emit →
+// settle hook → `maybeReleaseHeldTask`). Tolerant by design: a line whose id
+// matches no row, or a duplicate fired again on reattach replay, is a no-op
+// inside `settleSubagentById`.
+setBackgroundTaskSettledHandler((_taskId, agentId) => {
+  settleSubagentById(agentId, "completed");
+});
 
 /**
  * Subscribe to the app-wide lifecycle stream — terminal run-status
@@ -210,6 +245,33 @@ function maybeReleaseHeldTask(taskId: string): void {
   if (runs.get(task.runId)?.status !== "succeeded") return;
   if (subagents.hasRunning(taskId)) return;
   updateColumn(taskId, task.runId, "review");
+}
+
+/**
+ * Pull a `review` card back to `running` when a background agent is
+ * discovered (newly, or once again) `running` for its task — the mirror
+ * image of `maybeReleaseHeldTask` above. Fired from claude-subagents.ts'
+ * `setParkedDiscoveryHandler` on every fresh-insert or resumed-running edge,
+ * so it must be cheap and idempotent (a no-op call is the common case: most
+ * discoveries happen while the card is already `running`, not `review`).
+ *
+ * Deliberately narrow — only `review → running`, and only when the card's
+ * own terminal run actually `succeeded` (i.e. this looks like the #92 hold
+ * shape: the visible turn finished, background work continued after it).
+ * Never pulls from `done`/`blocked`/`ready`/`backlog` — those encode user
+ * intent or an error state the discovery of a background agent must not
+ * override.
+ */
+function pullBackParkedTask(taskId: string): void {
+  const task = tasks.get(taskId);
+  if (!task || task.column !== "review" || task.runId == null) return;
+  if (runs.get(task.runId)?.status !== "succeeded") return;
+  const runId = task.runId;
+  updateColumn(taskId, runId, "running");
+  const data = "background agent active — task pulled back to running";
+  const ts = Date.now();
+  runs.appendEvent(runId, "status", data);
+  emit({ runId, taskId, stream: "status", data, ts });
 }
 
 /** Test hook: drive the event bus directly to verify SSE routing without
@@ -1275,6 +1337,74 @@ function sendTurnInExistingSession(task: Task, taskId: string, line: string): st
   registerActiveRun(newRunId, taskId, task, agent);
   attachDoneHandler(newRunId, taskId, agent);
   return newRunId;
+}
+
+/**
+ * Factory installed via `setContinuationRunFactory` (module init, above).
+ * claude-tmux's `dispatchLine` calls this when a genuinely-new content line
+ * arrives on a task's session with no turn in flight and nothing queued to
+ * receive it — the case a post-`end_turn` background-task auto-continuation
+ * produces (claude legitimately resolved the visible turn, then kept talking
+ * once the delegated work finished). Mirrors the idle branch of
+ * `sendTurnInExistingSession` above (run-row insert with an inherited
+ * `claudeSessionId`, column pull-back to `running`, chunk handler, active-run
+ * registration) minus the `sendTurn`/keystroke-paste step — claude is already
+ * mid-response, so there's no prompt to send, only a new run row to listen
+ * with.
+ *
+ * Returns `null` for a task the caller can't safely adopt a run for, which
+ * falls back to claude-tmux's pre-existing `lastChunk` routing:
+ *   - the synthetic `"__rebuild__"` taskId `rebuildEventsFromJsonl` uses for
+ *     its local, DB-detached synthetic SessionState — that id can never
+ *     resolve to a real task row via `tasks.get` either, but the check is
+ *     spelled out explicitly so it's visible here (and testable) rather than
+ *     relying on that incidental fact alone;
+ *   - an unknown task (deleted out from under a live session); or
+ *   - an archived task (no new run should reopen the card).
+ */
+function startContinuationRun(taskId: string): ContinuationHooks | null {
+  if (taskId === "__rebuild__") return null;
+  const task = tasks.get(taskId);
+  if (!task || task.archivedAt != null) return null;
+
+  const newRunId = randomUUID();
+  const now = Date.now();
+  const inheritedSessionId = findLastClaudeSessionId(taskId);
+  runs.insert({
+    id: newRunId,
+    taskId,
+    agent: task.agent,
+    status: "running",
+    startedAt: now,
+    endedAt: null,
+    exitCode: null,
+    tmuxSession: sessionNameFor(taskId),
+    claudeSessionId: inheritedSessionId,
+    codexSessionId: null,
+    origin: "continuation",
+  });
+  const prevColumn: ColumnId = task.column;
+  // Continuation turns always pull the card to `running`, regardless of
+  // prior column (mirrors the idle branch above, and matches the owner
+  // decision in the plan: the session genuinely resumed talking, so the
+  // card must reflect that live activity).
+  tasks.update(taskId, { column: "running", runId: newRunId });
+  if (prevColumn !== "running") {
+    emitGlobal({ kind: "column", taskId, runId: newRunId, column: "running", prev: prevColumn, ts: now });
+  }
+
+  const harness = resolveHarness(task.agent);
+  const kind: AgentKind = harness?.kind ?? "claude-code";
+  const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
+  onChunk("status", "auto-continued after background task");
+
+  return {
+    onChunk,
+    onAdopted: (handle) => {
+      registerActiveRun(newRunId, taskId, task, handle);
+      attachDoneHandler(newRunId, taskId, handle);
+    },
+  };
 }
 
 /**

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -1361,11 +1361,18 @@ function sendTurnInExistingSession(task: Task, taskId: string, line: string): st
  *     relying on that incidental fact alone;
  *   - an unknown task (deleted out from under a live session); or
  *   - an archived task (no new run should reopen the card).
+ *   - a non-claude-code task: continuations are a claude-JSONL concept (a
+ *     background-task auto-continuation observed via `dispatchLine`'s tail of
+ *     the session's own JSONL); codex is one-shot per turn and has no
+ *     equivalent notion of "kept talking after end_turn", so there's nothing
+ *     to adopt a run for. Only claude-tmux's `dispatchLine` calls this
+ *     factory today, so this is defense in depth rather than a live path.
  */
 function startContinuationRun(taskId: string): ContinuationHooks | null {
   if (taskId === "__rebuild__") return null;
   const task = tasks.get(taskId);
   if (!task || task.archivedAt != null) return null;
+  if (resolveHarness(task.agent)?.kind !== "claude-code") return null;
 
   const newRunId = randomUUID();
   const now = Date.now();

--- a/src/bun/subagent-settle.test.ts
+++ b/src/bun/subagent-settle.test.ts
@@ -1,0 +1,355 @@
+import { test, expect, beforeAll, afterEach } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { RunEvent } from "../shared/types.ts";
+
+// Only AGETOR_DATA_DIR belongs at module top level — db.ts captures it at
+// first import, and the value is unique per file (see the module CLAUDE.md /
+// claude-subagents.test.ts / subagent-hold.test.ts for the same convention).
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-subagent-settle-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+
+/*
+ * Covers TT4 (docs/plans/fix-stream-list-stalls-with-bg-agents.md, section 4
+ * T3/T4, section 5 TT4):
+ *   1. db.ts `subagents.markSettledById` idempotency/edge cases.
+ *   2. claude-subagents.ts `settleSubagentById` settling a row AND driving the
+ *      real orchestrator release path (`maybeReleaseHeldTask`), observed via
+ *      the subagent-emitter seam.
+ *   3. `settleSubagentById` on an agentId with no matching row: clean no-op.
+ *   4. orchestrator.ts `pullBackParkedTask`, reached through the
+ *      `setParkedDiscoveryHandler` seam (not exported directly).
+ *   5. `runs.origin` round-trip through `insert`/`get`/`listForTask`
+ *      (migration 023 compat: an old row with no `origin` reads back null).
+ *
+ * Importing orchestrator.ts (below) is what installs the REAL
+ * `setSubagentSettleHook(maybeReleaseHeldTask)` and
+ * `setParkedDiscoveryHandler(pullBackParkedTask)` wiring at module load —
+ * exactly like subagent-hold.test.ts relies on for `maybeReleaseHeldTask`.
+ * This file never overrides either hook; it only swaps the subagent EMITTER
+ * (to observe lifecycle events) and restores it every time, following the
+ * read-modify-restore idiom from claude-subagents.test.ts's beforeAll — a
+ * test that forgot to restore it would silently un-wire the orchestrator's
+ * SSE fan-out for every test file that runs after this one in the same `bun
+ * test` process.
+ */
+
+let originalEmitter: ((e: RunEvent) => void) | null = null;
+
+beforeAll(async () => {
+  await import("./orchestrator.ts"); // installs the real settle / parked-discovery hooks
+  const { setSubagentEmitter } = await import("./claude-subagents.ts");
+  originalEmitter = setSubagentEmitter(null);
+  setSubagentEmitter(originalEmitter);
+});
+
+// Every task this file creates is tracked and hard-deleted in `afterEach`
+// (FK ON DELETE CASCADE covers runs/subagents/run_events) so no `running`
+// row leaks into a sibling file's `reconcileOrphans()` sweep — same hygiene
+// as subagent-hold.test.ts / claude-subagents.test.ts.
+const createdTaskIds: string[] = [];
+
+afterEach(async () => {
+  const { setSubagentEmitter } = await import("./claude-subagents.ts");
+  setSubagentEmitter(originalEmitter);
+  if (createdTaskIds.length === 0) return;
+  const { tasks } = await import("./db.ts");
+  for (const id of createdTaskIds.splice(0)) {
+    try {
+      tasks.delete(id);
+    } catch {
+      /* best-effort */
+    }
+  }
+});
+
+/** Seed a task + a terminal run, mirroring claude-subagents.test.ts's
+ *  `seed()` helper. `column`/`runStatus` are parameterized so callers can
+ *  build the exact held/parked/error shapes each test needs. */
+async function seedTask(opts: {
+  column: "running" | "review" | "done" | "blocked" | "ready" | "backlog";
+  runStatus: "succeeded" | "failed" | "running";
+}): Promise<{ taskId: string; runId: string }> {
+  const { tasks, runs } = await import("./db.ts");
+  const taskId = `task-settle-${randomUUID()}`;
+  const runId = `run-settle-${randomUUID()}`;
+  createdTaskIds.push(taskId);
+  const now = Date.now();
+  tasks.insert({
+    id: taskId, title: "t", prompt: "p", column: opts.column, agent: "claude-code",
+    workdir: "/tmp", isolation: "none", taskType: "task", branch: null, worktreePath: null,
+    baseRef: null, mode: null, model: null, effort: null, references: [], runId,
+    hasOpenableRun: false, pendingInteractionCount: 0, openTerminalCount: 0,
+    archivedAt: null, createdAt: now, updatedAt: now,
+  });
+  runs.insert({
+    id: runId, taskId, agent: "claude-code", status: opts.runStatus, startedAt: now,
+    endedAt: opts.runStatus === "running" ? null : now,
+    exitCode: opts.runStatus === "succeeded" ? 0 : opts.runStatus === "failed" ? 1 : null,
+    tmuxSession: null, claudeSessionId: null, codexSessionId: null,
+  });
+  return { taskId, runId };
+}
+
+async function insertRunningSubagent(taskId: string, runId: string): Promise<string> {
+  const { subagents } = await import("./db.ts");
+  const id = `agent-${randomUUID()}`;
+  subagents.insertIfAbsent({
+    id, taskId, runId, parentKind: "subagent", agentType: "Explore",
+    description: "test subagent", spawnDepth: 1, sourcePath: `/tmp/${id}.jsonl`,
+    status: "running", startedAt: Date.now(), endedAt: null,
+  });
+  return id;
+}
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 1. subagents.markSettledById
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("markSettledById flips a running row to completed, sets ended_at, returns {changed:true, taskId}", async () => {
+  const { subagents } = await import("./db.ts");
+  const { taskId, runId } = await seedTask({ column: "running", runStatus: "succeeded" });
+  const agentId = await insertRunningSubagent(taskId, runId);
+
+  const result = subagents.markSettledById(agentId, "completed");
+  expect(result).toEqual({ changed: true, taskId });
+
+  const row = subagents.get(agentId)!;
+  expect(row.status).toBe("completed");
+  expect(row.endedAt).not.toBeNull();
+});
+
+test("markSettledById is a no-op on a second call for the same (now-settled) row", async () => {
+  const { subagents } = await import("./db.ts");
+  const { taskId, runId } = await seedTask({ column: "running", runStatus: "succeeded" });
+  const agentId = await insertRunningSubagent(taskId, runId);
+
+  const first = subagents.markSettledById(agentId, "completed");
+  expect(first.changed).toBe(true);
+  const endedAtAfterFirst = subagents.get(agentId)!.endedAt;
+
+  const second = subagents.markSettledById(agentId, "completed");
+  expect(second).toEqual({ changed: false, taskId: null });
+  // Untouched by the no-op call.
+  expect(subagents.get(agentId)!.endedAt).toBe(endedAtAfterFirst);
+});
+
+test("markSettledById on an unknown id returns {changed:false, taskId:null}", async () => {
+  const { subagents } = await import("./db.ts");
+  const result = subagents.markSettledById(`no-such-agent-${randomUUID()}`, "completed");
+  expect(result).toEqual({ changed: false, taskId: null });
+});
+
+test("markSettledById leaves an already-completed row untouched", async () => {
+  const { subagents } = await import("./db.ts");
+  const { taskId, runId } = await seedTask({ column: "review", runStatus: "succeeded" });
+  const id = `agent-${randomUUID()}`;
+  const endedAt = Date.now() - 5_000;
+  subagents.insertIfAbsent({
+    id, taskId, runId, parentKind: "subagent", agentType: "Explore",
+    description: "already done", spawnDepth: 1, sourcePath: `/tmp/${id}.jsonl`,
+    status: "completed", startedAt: Date.now() - 10_000, endedAt,
+  });
+
+  const result = subagents.markSettledById(id, "completed");
+  expect(result).toEqual({ changed: false, taskId: null });
+  const row = subagents.get(id)!;
+  expect(row.status).toBe("completed");
+  expect(row.endedAt).toBe(endedAt); // untouched, not bumped to "now"
+});
+
+test("markSettledById leaves an already-orphaned row untouched", async () => {
+  const { subagents } = await import("./db.ts");
+  const { taskId, runId } = await seedTask({ column: "review", runStatus: "succeeded" });
+  const id = `agent-${randomUUID()}`;
+  const endedAt = Date.now() - 5_000;
+  subagents.insertIfAbsent({
+    id, taskId, runId, parentKind: "subagent", agentType: "Explore",
+    description: "already orphaned", spawnDepth: 1, sourcePath: `/tmp/${id}.jsonl`,
+    status: "orphaned", startedAt: Date.now() - 10_000, endedAt,
+  });
+
+  const result = subagents.markSettledById(id, "orphaned");
+  expect(result).toEqual({ changed: false, taskId: null });
+  const row = subagents.get(id)!;
+  expect(row.status).toBe("orphaned");
+  expect(row.endedAt).toBe(endedAt);
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 2 & 3. claude-subagents.ts settleSubagentById
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("settleSubagentById settles the row, emits the lifecycle event, and releases a held task to review", async () => {
+  const { subagents, tasks } = await import("./db.ts");
+  const { setSubagentEmitter, settleSubagentById } = await import("./claude-subagents.ts");
+  const { taskId, runId } = await seedTask({ column: "running", runStatus: "succeeded" });
+  const agentId = await insertRunningSubagent(taskId, runId);
+
+  // Sanity: this is the held shape (column running, terminal run succeeded,
+  // one running subagent) that maybeReleaseHeldTask requires.
+  expect(subagents.hasRunning(taskId)).toBe(true);
+
+  const captured: RunEvent[] = [];
+  setSubagentEmitter((e) => captured.push(e));
+
+  const changed = settleSubagentById(agentId, "completed");
+  expect(changed).toBe(true);
+
+  // DB half: row settled.
+  const row = subagents.get(agentId)!;
+  expect(row.status).toBe("completed");
+  expect(row.endedAt).not.toBeNull();
+
+  // Lifecycle event emitted via the real subagent-emitter seam.
+  const lifecycle = captured.filter((e) => e.stream === "subagent");
+  expect(lifecycle.length).toBe(1);
+  const payload = JSON.parse(lifecycle[0]!.data);
+  expect(payload.phase).toBe("finished");
+  expect(payload.subagent.id).toBe(agentId);
+  expect(lifecycle[0]!.taskId).toBe(taskId);
+
+  // Settle path: the last running subagent leaving running fires the real
+  // maybeReleaseHeldTask hook (wired by orchestrator.ts at module load),
+  // which releases the held task to review.
+  expect(subagents.hasRunning(taskId)).toBe(false);
+  expect(tasks.get(taskId)!.column).toBe("review");
+});
+
+test("settleSubagentById is idempotent on repeat: second call is a no-op, task stays released", async () => {
+  const { subagents, tasks } = await import("./db.ts");
+  const { setSubagentEmitter, settleSubagentById } = await import("./claude-subagents.ts");
+  const { taskId, runId } = await seedTask({ column: "running", runStatus: "succeeded" });
+  const agentId = await insertRunningSubagent(taskId, runId);
+
+  const captured: RunEvent[] = [];
+  setSubagentEmitter((e) => captured.push(e));
+
+  expect(settleSubagentById(agentId, "completed")).toBe(true);
+  expect(tasks.get(taskId)!.column).toBe("review");
+  const eventCountAfterFirst = captured.length;
+
+  // Manually move the card back to running to prove the repeat call truly
+  // doesn't re-drive the settle/release path (if it did, this would flip
+  // straight back to review).
+  tasks.update(taskId, { column: "running" });
+
+  expect(settleSubagentById(agentId, "completed")).toBe(false);
+  expect(captured.length).toBe(eventCountAfterFirst); // no new lifecycle event
+  expect(tasks.get(taskId)!.column).toBe("running"); // untouched by the no-op
+});
+
+test("settleSubagentById on an agentId matching no subagent row is a clean no-op", async () => {
+  const { setSubagentEmitter, settleSubagentById } = await import("./claude-subagents.ts");
+  const { tasks } = await import("./db.ts");
+  const { taskId } = await seedTask({ column: "running", runStatus: "succeeded" });
+
+  const captured: RunEvent[] = [];
+  setSubagentEmitter((e) => captured.push(e));
+
+  let changed: boolean | undefined;
+  expect(() => {
+    changed = settleSubagentById(`no-such-background-agent-${randomUUID()}`, "completed");
+  }).not.toThrow();
+  expect(changed).toBe(false);
+  expect(captured.length).toBe(0); // no lifecycle event
+  expect(tasks.get(taskId)!.column).toBe("running"); // no release fired
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 4. orchestrator.ts pullBackParkedTask (via setParkedDiscoveryHandler)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** `pullBackParkedTask` isn't exported directly — it's installed once, at
+ *  orchestrator.ts module load, via `setParkedDiscoveryHandler`. Capture the
+ *  currently-registered (real) handler with the same read-modify-restore
+ *  dance the module itself documents for tests (`setSubagentEmitter` /
+ *  `setSubagentSettleHook`): swap in a throwaway, read back the previous
+ *  value (the real handler), then immediately put it back so no other test
+ *  file in this shared process ever observes the wiring changed. */
+async function getRealParkedDiscoveryHandler(): Promise<(taskId: string) => void> {
+  const { setParkedDiscoveryHandler } = await import("./claude-subagents.ts");
+  const real = setParkedDiscoveryHandler(() => {});
+  setParkedDiscoveryHandler(real);
+  if (!real) throw new Error("expected orchestrator.ts to have installed a real parked-discovery handler");
+  return real;
+}
+
+test("pullBackParkedTask: a review card whose latest run succeeded is pulled back to running with a status event", async () => {
+  const { tasks, runs } = await import("./db.ts");
+  const { taskId, runId } = await seedTask({ column: "review", runStatus: "succeeded" });
+  const pullBackParkedTask = await getRealParkedDiscoveryHandler();
+
+  pullBackParkedTask(taskId);
+
+  expect(tasks.get(taskId)!.column).toBe("running");
+  const events = runs.events(runId);
+  const statusEvents = events.filter((e) => e.stream === "status");
+  expect(statusEvents.length).toBe(1);
+  expect(statusEvents[0]!.data).toContain("running");
+});
+
+for (const column of ["done", "blocked", "ready", "backlog"] as const) {
+  test(`pullBackParkedTask: a ${column} card is left untouched (only review is pulled back)`, async () => {
+    const { tasks } = await import("./db.ts");
+    const { taskId } = await seedTask({ column, runStatus: "succeeded" });
+    const pullBackParkedTask = await getRealParkedDiscoveryHandler();
+
+    pullBackParkedTask(taskId);
+
+    expect(tasks.get(taskId)!.column).toBe(column);
+  });
+}
+
+test("pullBackParkedTask: a review card whose latest run FAILED is left untouched", async () => {
+  const { tasks } = await import("./db.ts");
+  const { taskId } = await seedTask({ column: "review", runStatus: "failed" });
+  const pullBackParkedTask = await getRealParkedDiscoveryHandler();
+
+  pullBackParkedTask(taskId);
+
+  expect(tasks.get(taskId)!.column).toBe("review");
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 5. runs.origin round-trip (migration 023 compat)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("runs.origin round-trips through insert/get/listForTask", async () => {
+  const { tasks, runs } = await import("./db.ts");
+  const taskId = `task-origin-${randomUUID()}`;
+  createdTaskIds.push(taskId);
+  const now = Date.now();
+  tasks.insert({
+    id: taskId, title: "t", prompt: "p", column: "running", agent: "claude-code",
+    workdir: "/tmp", isolation: "none", taskType: "task", branch: null, worktreePath: null,
+    baseRef: null, mode: null, model: null, effort: null, references: [], runId: null,
+    hasOpenableRun: false, pendingInteractionCount: 0, openTerminalCount: 0,
+    archivedAt: null, createdAt: now, updatedAt: now,
+  });
+
+  const contRunId = `run-origin-cont-${randomUUID()}`;
+  runs.insert({
+    id: contRunId, taskId, agent: "claude-code", status: "running", startedAt: now,
+    endedAt: null, exitCode: null, tmuxSession: null, claudeSessionId: "sess-1",
+    codexSessionId: null, origin: "continuation",
+  });
+
+  const plainRunId = `run-origin-plain-${randomUUID()}`;
+  runs.insert({
+    id: plainRunId, taskId, agent: "claude-code", status: "succeeded", startedAt: now,
+    endedAt: now, exitCode: 0, tmuxSession: null, claudeSessionId: null, codexSessionId: null,
+    // origin intentionally omitted — the pre-migration-023 shape.
+  });
+
+  expect(runs.get(contRunId)!.origin).toBe("continuation");
+  expect(runs.get(plainRunId)!.origin ?? null).toBeNull();
+
+  const list = runs.listForTask(taskId);
+  const contFromList = list.find((r) => r.id === contRunId)!;
+  const plainFromList = list.find((r) => r.id === plainRunId)!;
+  expect(contFromList.origin).toBe("continuation");
+  expect(plainFromList.origin ?? null).toBeNull();
+});

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -567,7 +567,26 @@ function RunPanelBody({
   // instead of flapping.
   useEffect(() => {
     if (!latestRun) return;
-    if (latestRun.status === "running") return;
+    if (latestRun.status === "running") {
+      // The newest run just became "running" again — e.g. a background-agent
+      // continuation turn that shares `claudeSessionId` with the run the
+      // current `rebuilt` snapshot was captured from, whose first live events
+      // can land before the 2s runs-poll updates `runs`/`latestRun` (see
+      // `rebuiltRunIds` and the SSE batch-flush invalidation above). If a
+      // snapshot is still set at that point, `displayedEvents` will mask the
+      // new run's live events behind it — and because this effect only
+      // re-fires on `latestRun` id/status/claudeSessionId changes, the
+      // freeze would persist until the run resolves. Clear eagerly instead:
+      // "the newest run is live again ⇒ no snapshot should mask the stream."
+      // Functional updaters read the current value without adding
+      // `rebuilt`/`rebuildNote` to this effect's deps, so this can't loop —
+      // clearing them doesn't change `latestRun`, the only thing gating
+      // re-runs, and is a no-op (bails to the same reference) once already
+      // clear.
+      setRebuilt((prev) => (prev ? null : prev));
+      setRebuildNote((prev) => (prev ? null : prev));
+      return;
+    }
     if (!latestRun.claudeSessionId) return;
     const sessionId = latestRun.claudeSessionId;
     let cancelled = false;

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -1452,6 +1452,15 @@ function RunsList({ runs }: { runs: Run[] }) {
           <Badge variant={STATUS_VARIANT[latest.status]} className="shrink-0">
             {latest.status}
           </Badge>
+          {latest.origin === "continuation" && (
+            <Badge
+              variant="secondary"
+              className="shrink-0 px-1.5 py-0 text-[9px] uppercase text-muted-foreground"
+              title="auto-continued after a background task"
+            >
+              auto
+            </Badge>
+          )}
           <span className="truncate">
             Run #{ordinalFor(latest.id)} · {formatTime(latest.startedAt)}
           </span>
@@ -1482,6 +1491,15 @@ function RunsList({ runs }: { runs: Run[] }) {
                 <Badge variant={STATUS_VARIANT[r.status]} className="shrink-0">
                   {r.status}
                 </Badge>
+                {r.origin === "continuation" && (
+                  <Badge
+                    variant="secondary"
+                    className="shrink-0 px-1.5 py-0 text-[9px] uppercase text-muted-foreground"
+                    title="auto-continued after a background task"
+                  >
+                    auto
+                  </Badge>
+                )}
                 <span className="truncate text-muted-foreground">
                   #{ordinalFor(r.id)} · {formatTime(r.startedAt)}
                 </span>

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -34,6 +34,7 @@ import {
 import { appendReferences } from "../../../shared/refs.ts";
 import { createEventDeduper } from "@/lib/event-dedup";
 import { createEventBuffer } from "@/lib/event-buffer";
+import { invalidatesRebuiltSnapshot } from "@/lib/rebuilt-mask";
 import { AgentIcon } from "./AgentIcon";
 import {
   ReferencesPicker,
@@ -55,6 +56,17 @@ import { TerminalView } from "./TerminalView";
 function harnessKindOf(harnessId: string, harnesses: Harness[]): AgentKind {
   return harnesses.find((h) => h.id === harnessId)?.kind ?? "claude-code";
 }
+
+/**
+ * `RunEvent` as held in the panel's local `events` state, tagged with a
+ * client-assigned monotonic id. The server doesn't expose a stable event id
+ * over SSE (`run_events.id` never leaves the DB layer) — `id` here is
+ * assigned by `nextEventIdRef` the moment an event is accepted into the
+ * unified stream, purely so `rebuilt-mask.ts` can tell a genuinely NEW live
+ * event apart from one the server re-delivers on SSE reconnect (full-history
+ * replay) when deciding whether the JSONL rebuild snapshot has gone stale.
+ */
+type StreamEvent = RunEvent & { id: number };
 
 interface Props {
   /** When null, the panel slides off-screen and unmounts after the exit animation. */
@@ -232,16 +244,25 @@ function RunPanelBody({
    *  codex stdout/stderr chunk. The renderer dispatches on `stream` to
    *  pick a component (assistant text, thinking, tool call, tool result,
    *  status divider, error). Events from EVERY run of the task are
-   *  merged here so the user sees one unified scrollback. */
-  const [events, setEvents] = useState<RunEvent[]>([]);
+   *  merged here so the user sees one unified scrollback. Each event is
+   *  tagged with a client-assigned `id` (see `StreamEvent`) as it's
+   *  accepted, in arrival order. */
+  const [events, setEvents] = useState<StreamEvent[]>([]);
   /** When the user clicks "Rebuild from session JSONL" (or the auto-
    *  rebuild fires after a run finishes), we patch the latest claude
    *  session's events with the freshly-parsed on-disk version.
    *  `sessionId` is the `claudeSessionId` the rebuild covers — used at
    *  render time to splice the rebuilt events into the unified stream
    *  in place of the live ones for runs that share that session id.
-   *  Null means "use the live streamed events as normal". */
-  const [rebuilt, setRebuilt] = useState<{ sessionId: string; events: RunEvent[] } | null>(null);
+   *  `maxLiveEventIdAtSnapshot` is the highest `StreamEvent.id` observed
+   *  at capture time — the SSE delivery path (below) uses it, together
+   *  with `rebuiltRunIds`, to detect a genuinely NEW live event landing
+   *  for a masked run and clear the snapshot so live events render again
+   *  (see `rebuilt-mask.ts`). Null means "use the live streamed events
+   *  as normal". */
+  const [rebuilt, setRebuilt] = useState<
+    { sessionId: string; events: RunEvent[]; maxLiveEventIdAtSnapshot: number } | null
+  >(null);
   const [rebuildBusy, setRebuildBusy] = useState(false);
   const [rebuildNote, setRebuildNote] = useState<string | null>(null);
   const [interactions, setInteractions] = useState<PendingInteraction[]>([]);
@@ -259,6 +280,14 @@ function RunPanelBody({
   // true, so a user who scrolls up to read history isn't yanked back down on
   // every streamed chunk.
   const nearBottomRef = useRef(true);
+  // Monotonic id source for `StreamEvent.id`, incremented once per event as
+  // it's accepted into the unified stream (see the SSE subscription effect
+  // below). Assigning synchronously at push time — rather than deriving from
+  // `events.length` inside a render — means it's always current even while a
+  // batch is buffered and hasn't flushed into React state yet, which is what
+  // the rebuild-snapshot-invalidation check needs to be race-free. Reset to
+  // 0 on task switch alongside the rest of the stream state.
+  const nextEventIdRef = useRef(0);
 
   // Reset on task switch (no remount because we no longer key on task.id).
   // Re-arm the auto-scroll heuristic so opening a different task pins the
@@ -288,7 +317,12 @@ function RunPanelBody({
         setRebuildNote(res.reason ?? "no events found in JSONL");
         return;
       }
-      setRebuilt({ sessionId: latestRun.claudeSessionId, events: res.events });
+      setRebuilt({
+        sessionId: latestRun.claudeSessionId,
+        events: res.events,
+        // "Everything observed so far" — see `nextEventIdRef`.
+        maxLiveEventIdAtSnapshot: nextEventIdRef.current - 1,
+      });
       setRebuildNote(`Loaded ${res.events.length} events from session JSONL.`);
     } catch (e) {
       setRebuildNote(`rebuild failed: ${(e as Error).message}`);
@@ -362,6 +396,7 @@ function RunPanelBody({
   // panel shows the whole conversation as a single scrollback.
   useEffect(() => {
     setEvents([]);
+    nextEventIdRef.current = 0;
     // Collapse the dual-emit + replay duplicates the server stream carries
     // (live echo + JSONL twin per user message; full-history replay on every
     // reconnect). The deduper keeps `user` keys in a never-trimmed set so a
@@ -388,8 +423,38 @@ function RunPanelBody({
     // arm/flush bookkeeping (and the re-arm-after-flush invariant that fixes
     // the freeze) lives in `createEventBuffer` so it can be unit-tested.
     const FLUSH_FALLBACK_MS = 250;
-    const buffer = createEventBuffer<RunEvent>(
-      (batch) => setEvents((cur) => [...cur, ...batch]),
+    const buffer = createEventBuffer<StreamEvent>(
+      (batch) => {
+        setEvents((cur) => [...cur, ...batch]);
+        // A newer live MAIN-stream event landing for a run the rebuilt-from-
+        // JSONL snapshot is currently masking means the snapshot is stale —
+        // clear it so `displayedEvents` falls back to the live stream. This
+        // is what un-freezes the panel when a post-`end_turn` background-
+        // agent continuation keeps emitting into a run the panel already
+        // considers finished (the snapshot only ever covers events observed
+        // up to the moment it was captured). `rebuiltMaskRef` (defined below,
+        // synced from `rebuilt`/`rebuiltRunIds`) is read fresh on every batch
+        // rather than closed over at effect-setup time, since this callback
+        // is created once per SSE subscription and would otherwise see a
+        // stale snapshot. Clearing here does NOT touch `latestRun`, so the
+        // auto-rebuild effect (deps: latestRun id/status/claudeSessionId)
+        // does not immediately re-fire and re-mask — it only fires again
+        // when the newest run itself next resolves.
+        const mask = rebuiltMaskRef.current;
+        if (mask) {
+          const invalidated = batch.some((e) =>
+            invalidatesRebuiltSnapshot(
+              { maxLiveEventIdAtSnapshot: mask.maxLiveEventIdAtSnapshot },
+              e,
+              mask.runIds,
+            ),
+          );
+          if (invalidated) {
+            setRebuilt(null);
+            setRebuildNote(null);
+          }
+        }
+      },
       (flush) => {
         const raf = requestAnimationFrame(flush);
         const timer = setTimeout(flush, FLUSH_FALLBACK_MS);
@@ -440,7 +505,11 @@ function RunPanelBody({
         } catch { /* ignore malformed */ }
         return;
       }
-      buffer.push(e);
+      // Tag with the next client-assigned id (see `StreamEvent`) — the
+      // server doesn't send one over SSE, and the invalidation check above
+      // needs a monotonic ordering to distinguish a genuinely new event from
+      // one the replay burst re-delivers on reconnect.
+      buffer.push({ ...e, id: nextEventIdRef.current++ });
     });
     return () => {
       buffer.dispose();
@@ -484,6 +553,18 @@ function RunPanelBody({
   // at 500 chars), so the JSONL is the canonical source. Skips while
   // a run is in flight (live tailing is still appending) and codex
   // (no JSONL transcript).
+  //
+  // This effect's deps are ONLY `latestRun` id/status/claudeSessionId, which
+  // is deliberate and load-bearing: when the SSE batch-flush callback above
+  // detects a newer live event for a masked run and calls
+  // `setRebuilt(null)`/`setRebuildNote(null)`, none of those three fields
+  // change (the run itself hasn't — its status is still whatever it was),
+  // so this effect does NOT re-run and immediately re-mask the stream it
+  // was just un-frozen from. It only fires again — legitimately re-snapshot-
+  // ting — when the newest run's own id/status/sessionId next changes, i.e.
+  // when a later run resolves. This is what makes clearing the snapshot on a
+  // background-agent continuation's post-`end_turn` activity actually stick
+  // instead of flapping.
   useEffect(() => {
     if (!latestRun) return;
     if (latestRun.status === "running") return;
@@ -493,7 +574,12 @@ function RunPanelBody({
     void api.rebuildRunEvents(latestRun.id).then((res) => {
       if (cancelled) return;
       if (res.events.length > 0) {
-        setRebuilt({ sessionId, events: res.events });
+        setRebuilt({
+          sessionId,
+          events: res.events,
+          // "Everything observed so far" — see `nextEventIdRef`.
+          maxLiveEventIdAtSnapshot: nextEventIdRef.current - 1,
+        });
         setRebuildNote(`Loaded ${res.events.length} events from session JSONL.`);
       } else if (res.reason) {
         setRebuildNote(res.reason);
@@ -514,6 +600,20 @@ function RunPanelBody({
     }
     return ids;
   }, [rebuilt, runs]);
+
+  /** Live mirror of `{ maxLiveEventIdAtSnapshot, runIds }` derived from
+   *  `rebuilt`/`rebuiltRunIds`, read by the SSE batch-flush callback in the
+   *  subscription effect above. That callback is created once per task
+   *  subscription and closes over whatever `rebuilt`/`rebuiltRunIds` were at
+   *  effect-setup time — without this ref it would keep checking against a
+   *  stale (or even already-cleared) snapshot instead of the current one.
+   *  `null` (no active snapshot) short-circuits the check entirely. */
+  const rebuiltMaskRef = useRef<{ maxLiveEventIdAtSnapshot: number; runIds: Set<string> } | null>(null);
+  useEffect(() => {
+    rebuiltMaskRef.current = rebuilt && rebuiltRunIds
+      ? { maxLiveEventIdAtSnapshot: rebuilt.maxLiveEventIdAtSnapshot, runIds: rebuiltRunIds }
+      : null;
+  }, [rebuilt, rebuiltRunIds]);
 
   /** The task's own (main) agent events — everything not tagged to a subagent.
    *  The rebuild-from-JSONL path only ever covers the main session transcript,

--- a/src/mainview/lib/rebuilt-mask.test.ts
+++ b/src/mainview/lib/rebuilt-mask.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { invalidatesRebuiltSnapshot, type RebuiltSnapshotMeta } from "./rebuilt-mask.ts";
+
+const snapshot = (maxLiveEventIdAtSnapshot: number): RebuiltSnapshotMeta => ({
+  maxLiveEventIdAtSnapshot,
+});
+
+describe("invalidatesRebuiltSnapshot", () => {
+  test("a newer main-stream event for a masked run invalidates the snapshot", () => {
+    const masked = new Set(["run-1"]);
+    expect(
+      invalidatesRebuiltSnapshot(snapshot(10), { id: 11, runId: "run-1" }, masked),
+    ).toBe(true);
+  });
+
+  test("subagent events never invalidate, regardless of id or run", () => {
+    const masked = new Set(["run-1"]);
+    // Newer id, masked run, but tagged as a subagent event.
+    expect(
+      invalidatesRebuiltSnapshot(
+        snapshot(10),
+        { id: 999, runId: "run-1", subagentId: "sub-1" },
+        masked,
+      ),
+    ).toBe(false);
+  });
+
+  test("subagent events don't invalidate even for an unmasked run at a huge id", () => {
+    const masked = new Set(["run-1"]);
+    expect(
+      invalidatesRebuiltSnapshot(
+        snapshot(0),
+        { id: 100000, runId: "run-unrelated", subagentId: "sub-2" },
+        masked,
+      ),
+    ).toBe(false);
+  });
+
+  test("events at or below the snapshot's max id never invalidate (SSE replay safety)", () => {
+    const masked = new Set(["run-1"]);
+    expect(
+      invalidatesRebuiltSnapshot(snapshot(10), { id: 10, runId: "run-1" }, masked),
+    ).toBe(false);
+    expect(
+      invalidatesRebuiltSnapshot(snapshot(10), { id: 1, runId: "run-1" }, masked),
+    ).toBe(false);
+  });
+
+  test("a replay burst of old ids for the masked run does not re-trip the clear", () => {
+    const masked = new Set(["run-1", "run-2"]);
+    // Simulates SSE reconnect replaying the full history, including ids well
+    // below the snapshot's watermark, for every run sharing the session.
+    for (let id = 0; id <= 10; id++) {
+      expect(
+        invalidatesRebuiltSnapshot(snapshot(10), { id, runId: "run-1" }, masked),
+      ).toBe(false);
+    }
+  });
+
+  test("events for non-masked runs never invalidate, even when strictly newer", () => {
+    const masked = new Set(["run-1"]);
+    expect(
+      invalidatesRebuiltSnapshot(snapshot(10), { id: 11, runId: "run-2" }, masked),
+    ).toBe(false);
+  });
+
+  test("empty maskedRunIds set never invalidates", () => {
+    const masked = new Set<string>();
+    expect(
+      invalidatesRebuiltSnapshot(snapshot(0), { id: 1, runId: "run-1" }, masked),
+    ).toBe(false);
+  });
+
+  test("a main-stream event newer than the snapshot but for a different masked run in a multi-run snapshot is ignored", () => {
+    const masked = new Set(["run-1", "run-2"]);
+    expect(
+      invalidatesRebuiltSnapshot(snapshot(5), { id: 6, runId: "run-3" }, masked),
+    ).toBe(false);
+    expect(
+      invalidatesRebuiltSnapshot(snapshot(5), { id: 6, runId: "run-2" }, masked),
+    ).toBe(true);
+  });
+});

--- a/src/mainview/lib/rebuilt-mask.ts
+++ b/src/mainview/lib/rebuilt-mask.ts
@@ -1,0 +1,66 @@
+// Pure decision helper for RunPanel's "rebuild from session JSONL" snapshot.
+//
+// Background: once a run leaves `status: "running"`, RunPanel re-parses the
+// claude session JSONL and stores it as `rebuilt` — `displayedEvents` then
+// splices those events in place of the live ones for every run sharing the
+// snapshot's `claudeSessionId` (see `rebuiltRunIds` in RunPanel.tsx). That
+// splice is a point-in-time snapshot: claude legitimately keeps emitting into
+// the SAME session after a run resolves (a post-`end_turn` background-agent
+// continuation is the main case), and without this check those later events
+// are silently swallowed — the log looks frozen even though data is still
+// flowing server-side. This module answers "does this incoming live event
+// mean the snapshot is now stale and should be dropped?" so RunPanel can fall
+// back to the live stream the moment that happens. It has no React/DOM
+// dependency so it's unit-testable on its own (see the paired test task).
+
+/** The subset of `rebuilt` state this check needs. */
+export interface RebuiltSnapshotMeta {
+  /**
+   * The highest client-assigned event id RunPanel had observed at the moment
+   * the snapshot was captured. Events at or below this id were already
+   * accounted for (either folded into the snapshot or superseded by it), so
+   * they must never re-trigger invalidation — this is what makes the check
+   * safe against the server's SSE replay-on-(re)connect burst, which
+   * re-delivers the full history (including old ids) on every subscribe.
+   */
+  maxLiveEventIdAtSnapshot: number;
+}
+
+/** The subset of a streamed event this check needs. RunPanel doesn't get a
+ *  stable event id from the wire (the server doesn't expose `run_events.id`
+ *  over SSE), so it assigns one client-side as events arrive — see
+ *  `nextEventIdRef` in RunPanel.tsx. */
+export interface RebuiltMaskEvent {
+  id: number;
+  runId: string;
+  /** Set when this event belongs to a background/sub agent's stream rather
+   *  than the task's main agent stream. Mirrors `RunEvent.subagentId`. */
+  subagentId?: string | null;
+}
+
+/**
+ * Does `event` invalidate the current rebuilt-from-JSONL snapshot?
+ *
+ * True only when ALL of:
+ *  - the event is on the MAIN stream (no `subagentId`) — the rebuild splice
+ *    only ever covers the main session transcript, and a subagent tab renders
+ *    its own events directly (no rebuilt path applies there), so a subagent
+ *    event can never make the main snapshot stale;
+ *  - the event's `runId` is one the snapshot is currently standing in for
+ *    (`maskedRunIds` — RunPanel's `rebuiltRunIds`, every run sharing the
+ *    snapshot's `claudeSessionId`); an event for an unrelated run/session
+ *    doesn't affect what the snapshot is displaying;
+ *  - the event is strictly newer than everything the snapshot already
+ *    accounts for (`id > maxLiveEventIdAtSnapshot`) — guards against the SSE
+ *    replay burst (full history re-delivered on every reconnect) re-tripping
+ *    the clear on events that predate the snapshot.
+ */
+export function invalidatesRebuiltSnapshot(
+  snapshot: RebuiltSnapshotMeta,
+  event: RebuiltMaskEvent,
+  maskedRunIds: ReadonlySet<string>,
+): boolean {
+  if (event.subagentId) return false;
+  if (event.id <= snapshot.maxLiveEventIdAtSnapshot) return false;
+  return maskedRunIds.has(event.runId);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -620,6 +620,17 @@ export interface Run {
    * for claude-code and legacy rows.
    */
   codexSessionId: string | null;
+  /**
+   * How this run came to exist. `null`/undefined = user-initiated (Run
+   * button, a follow-up message typed into the panel — every run before
+   * this field existed). `"continuation"` = opened automatically by the
+   * orchestrator after the same claude session auto-resumed post `end_turn`
+   * (e.g. it delegated to a background task and later kept talking once
+   * that task finished). Optional so callers that don't pass it (most of
+   * them — only the continuation-run factory sets it) keep compiling
+   * unchanged; DB rows predating migration 023 read back as null.
+   */
+  origin?: "continuation" | null;
 }
 
 /** One changed file in a task's git diff (worktree vs its pinned base). */


### PR DESCRIPTION
## Problem

When a claude-code task spawns background agents, the task-details message stream freezes and the run state lies:

- The main agent legitimately ends its turn when delegating to background agents, so the run resolves `succeeded` — then claude auto-resumes via task-notifications and keeps working for minutes with **no run row**: no heartbeat, Stop unavailable, "TURN COMPLETE" rendered mid-work.
- The panel hides all of it: the moment a run's status leaves `running`, RunPanel swaps to a one-time rebuilt-from-JSONL snapshot that permanently masks every live main-stream event for that claude session (subagent tabs bypass the mask, which is why they kept moving while Main froze). Forensics on a real task: **502 of 570 events were persisted after the run "succeeded"** — the backend was fine; the UI hid them.
- #92's hold had two holes: it can fail to engage (end_turn idle-fire races subagent discovery) and can fail to release forever (the #88 death-watch is disarmed exactly while a hold is active; prod DB had subagent rows stuck `running` indefinitely) — the "after many bg tasks" degradation.

## Changes

**Frontend (RunPanel)**
- Clear the rebuilt snapshot when a genuinely-new live main event arrives for a masked run (pure helper `src/mainview/lib/rebuilt-mask.ts`), and whenever the latest run is `running` again — live events always win over a stale snapshot.
- Small "auto" chip on continuation runs in the runs list.

**Backend (continuation runs)**
- Auto-resumes after a background task now open a real run row (`runs.origin = 'continuation'`, migration 023), adopted via a new `setContinuationRunFactory` seam in claude-tmux: truthful heartbeat/status/attribution, Stop works, follow-ups fold in, card pulls back to `running`. Triggers only on post-dedup content lines, so reattach replay can't spawn phantom runs; guarded for `__rebuild__`, archived tasks, and non-claude agents.

**Hold robustness (#92 follow-ups)**
- Death-watch stays armed while a task is held (`setHeldSessionProbe`, throw-guarded); a session dying mid-hold now orphans subagents and releases the card, with honest status wording (held death releases to `review` — it no longer claims "blocked").
- Parent task-notifications settle the named subagent row (`settleSubagentById`, idempotent, verified against real claude 2.1.x transcripts — three JSONL shapes).
- A late-discovered running subagent pulls a `review` card back to `running` (self-heals the hold-engage race).

## Review & tests

- Reviewed with opus (code-review skill): 1 must-fix (read-only JSONL rebuild fired live settle side effects) + 1 should-fix (stale snapshot transiently hiding continuation events) + 2 smaller items — all fixed in `9434afc`.
- 5 new test files, ~50 tests: rebuilt-mask invalidation, continuation adoption (incl. reattach-replay and rebuild guards), death-watch-during-hold against the real interval, settle/pull-back/origin round-trip, continuation e2e (incl. #92 hold applying to continuation runs).
- Full suite: **886 pass / 0 fail** across 84 files; `bun run typecheck` clean.

## Out of scope (known follow-ups)

- `headless.ts` idle-shutdown can't see held tasks (a held task's run is `succeeded`, so the daemon may shut down mid-hold when no client is attached).
- Theoretical event-dedup key collision under same-millisecond subagent bursts.
- Not yet smoke-tested in the running app — recommend one manual pass with a bg-agent-heavy task before release.

Plan doc: `docs/plans/fix-stream-list-stalls-with-bg-agents.md`