### PR TITLE
feat(run-panel): sort running background-agent tabs first, right after Main

### DIFF
--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -8,7 +8,7 @@ import {
   Sparkles, Square, Terminal, Wrench, X,
 } from "lucide-react";
 import { api, COMMIT_PUSH_PROMPT, type AgentModelMap, type AvailableCommand, type AvailableExtension, type PendingInteraction } from "@/lib/api";
-import { shouldShowSubagentTabs, resolveActiveStream, splitTabsForOverflow } from "@/lib/subagent-tabs";
+import { shouldShowSubagentTabs, resolveActiveStream, splitTabsForOverflow, sortSubagentTabs } from "@/lib/subagent-tabs";
 import { shouldOfferCommitPush, type TaskGitStatus } from "@/lib/commit-push";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -1329,7 +1329,8 @@ function basename(p: string): string {
  * agent stream and each background/sub agent it has spawned. Shown only while
  * background agents are active (see `showSubagentTabs`). The Main tab is always
  * first and visually emphasised — it's the one stream you can actually talk to;
- * the background tabs are watch-only. A running agent shows a pulsing green dot,
+ * the background tabs are watch-only, and the running ones sort directly after
+ * Main (see `sortSubagentTabs`). A running agent shows a pulsing green dot,
  * a finished one a check.
  */
 function SubagentTab({ s, selected, onSelect }: { s: Subagent; selected: boolean; onSelect: (id: string) => void }) {
@@ -1376,12 +1377,17 @@ function SubagentTabs({
   active: string;
   onSelect: (id: string) => void;
 }) {
-  // Collapse a large fan-out behind a "+N" pill; expanding wraps the strip onto
-  // multiple rows rather than forcing a long horizontal scroll. A running or
-  // currently-active tab is never hidden (see `splitTabsForOverflow`).
+  // Running agents sort first, right after Main, so what's live is always the
+  // closest thing to hand (see `sortSubagentTabs`). Then collapse a large
+  // fan-out behind a "+N" pill; expanding wraps the strip onto multiple rows
+  // rather than forcing a long horizontal scroll. A running or currently-active
+  // tab is never hidden (see `splitTabsForOverflow`).
   const [expanded, setExpanded] = useState(false);
-  const { visible, overflow } = splitTabsForOverflow(subagents, active);
-  const shown = expanded ? subagents : visible;
+  // No useMemo: the 2s poll rebuilds `subagents` into a fresh array every tick,
+  // so memoising on it would never hit. The partition is O(n) on a handful.
+  const sorted = sortSubagentTabs(subagents);
+  const { visible, overflow } = splitTabsForOverflow(sorted, active);
+  const shown = expanded ? sorted : visible;
 
   return (
     <div

--- a/src/mainview/lib/subagent-tabs.test.ts
+++ b/src/mainview/lib/subagent-tabs.test.ts
@@ -4,6 +4,7 @@ import {
   shouldShowSubagentTabs,
   resolveActiveStream,
   splitTabsForOverflow,
+  sortSubagentTabs,
   anySubagentRunning,
   MAX_VISIBLE_TABS,
 } from "./subagent-tabs.ts";
@@ -65,6 +66,42 @@ test("splitTabsForOverflow: never hides a running or the active tab", () => {
   expect(visible.map((s) => s.id)).toContain("s7");
   expect(overflow.map((s) => s.id)).not.toContain("s8");
   expect(overflow.map((s) => s.id)).not.toContain("s7");
+});
+
+test("sortSubagentTabs: running agents sort ahead of finished ones", () => {
+  const subs = [sub("a", "completed", 0), sub("b", "running", 1), sub("c", "failed", 2), sub("d", "running", 3)];
+  expect(sortSubagentTabs(subs).map((s) => s.id)).toEqual(["b", "d", "a", "c"]);
+});
+
+test("sortSubagentTabs: stable — spawn order kept within each group", () => {
+  // Every non-"running" status trails, in spawn order; no shuffling among peers.
+  const subs = [
+    sub("a", "cancelled", 0), sub("b", "running", 1), sub("c", "orphaned", 2),
+    sub("d", "running", 3), sub("e", "completed", 4),
+  ];
+  expect(sortSubagentTabs(subs).map((s) => s.id)).toEqual(["b", "d", "a", "c", "e"]);
+});
+
+test("sortSubagentTabs: does not mutate its input (it's React state)", () => {
+  const subs = [sub("a", "completed", 0), sub("b", "running", 1)];
+  const sorted = sortSubagentTabs(subs);
+  expect(subs.map((s) => s.id)).toEqual(["a", "b"]); // original untouched
+  expect(sorted).not.toBe(subs);
+});
+
+test("sortSubagentTabs: no-ops on empty and all-same-status lists", () => {
+  expect(sortSubagentTabs([])).toEqual([]);
+  const running = [sub("a", "running", 0), sub("b", "running", 1)];
+  expect(sortSubagentTabs(running).map((s) => s.id)).toEqual(["a", "b"]);
+});
+
+test("sortSubagentTabs + splitTabsForOverflow: running fill the head, finished overflow", () => {
+  // 9 agents, the last 3 running → sorted head is the running ones, and the
+  // oldest finished tabs are what fall behind the "+N" pill.
+  const subs = Array.from({ length: 9 }, (_, i) => sub(`s${i}`, i >= 6 ? "running" : "completed", i));
+  const { visible, overflow } = splitTabsForOverflow(sortSubagentTabs(subs), "main", 6);
+  expect(visible.map((s) => s.id)).toEqual(["s6", "s7", "s8", "s0", "s1", "s2"]);
+  expect(overflow.map((s) => s.id)).toEqual(["s3", "s4", "s5"]);
 });
 
 test("MAX_VISIBLE_TABS default applies", () => {

--- a/src/mainview/lib/subagent-tabs.ts
+++ b/src/mainview/lib/subagent-tabs.ts
@@ -35,10 +35,27 @@ export function resolveActiveStream(active: string, show: boolean, subs: Subagen
 }
 
 /**
+ * Order tabs so the *active* (running) agents sit first, immediately after the
+ * pinned "Main" tab, with finished ones trailing behind. Within each group the
+ * incoming spawn order is preserved, so a tab only ever moves across the
+ * running→finished boundary — never shuffles among its peers.
+ *
+ * Returns a NEW array: the caller passes React state (`subagentList`) straight
+ * in, and an in-place `.sort()` would mutate it.
+ */
+export function sortSubagentTabs(subs: Subagent[]): Subagent[] {
+  const running: Subagent[] = [];
+  const finished: Subagent[] = [];
+  for (const s of subs) (s.status === "running" ? running : finished).push(s);
+  return [...running, ...finished];
+}
+
+/**
  * Split tabs into an always-visible head + an overflow tail for the "+N" pill.
- * Spawn order is preserved, and a running agent or the currently-active tab is
- * never pushed into overflow (you should always see what's live and what you're
- * looking at) — so `visible` can exceed `limit` when many agents run at once.
+ * The incoming order is preserved (callers pass a `sortSubagentTabs`-ordered
+ * list), and a running agent or the currently-active tab is never pushed into
+ * overflow (you should always see what's live and what you're looking at) — so
+ * `visible` can exceed `limit` when many agents run at once.
  */
 export function splitTabsForOverflow(
   subs: Subagent[],


### PR DESCRIPTION
In the task-details modal's background-agent tab strip, running agents now sort ahead of finished ones, immediately after the pinned Main tab, so what is live is always the closest thing to hand.

- Add `sortSubagentTabs` to lib/subagent-tabs.ts: a stable partition into running[] + finished[] that returns a new array. It must not sort in place — callers pass React state (`subagentList`). Stability plus the poll's existing `startedAt` ordering means a tab only ever moves across the running -> finished boundary, never shuffles among its peers.
- Feed the sorted list into both the overflow split and the `expanded` branch of `SubagentTabs`, so the collapsed and expanded strips agree on order. Ordering stays at the call site rather than inside `splitTabsForOverflow`, keeping ordering and overflow independently testable.
- Cover the new helper with unit tests (running-first, stability within groups, non-mutation of input, empty/all-same no-op, and composition with `splitTabsForOverflow`).

Deliberately no useMemo on the derivation: the 2s subagent poll rebuilds `subagentList` into a fresh array every tick, so the dep never stabilises and the memo could never hit.

Verified: `bun run typecheck` clean; `bun test src/mainview/lib/` 73 pass.