### PR TITLE
fix(orchestrator): adopt continuations on the task-notification line so a task isn't parked in Review while claude is still working

### DIFF
--- a/docs/plans/adopt-continuation-on-task-notification.md
+++ b/docs/plans/adopt-continuation-on-task-notification.md
@@ -1,0 +1,76 @@
+# Plan — Adopt continuations on the task-notification line (fix "card in Review while claude still works")
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-10 |
+| Source | /implement: "tasks are being moved to Review after bg agents complete but still has loading indicator" + owner screenshot (claude TUI footer still spinning) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | agetor/f00ff7864feb-task-is-being-moving-to-review-even-with |
+| Base SHA | 1e28eb6140f2f066fd2b6a258b1a28972c6d571b |
+
+## 1. Objective & success criteria
+
+When a claude-code task's background agents finish and claude auto-continues, the kanban card must reflect the live session for the *entire* continuation — including the (potentially minutes-long) extended-thinking window before the first assistant content line hits the JSONL. Success:
+
+1. On the `<task-notification>` JSONL line, a continuation run is adopted immediately (card in `running`, Stop works, heartbeat on) instead of waiting for the first assistant content line.
+2. If claude never actually continues after a notification, a watchdog settles the adopted run after 10 minutes of no content, releasing the card to `review` (owner-chosen guard).
+3. After an agetor restart, a `review`/`done`-column task with a stuck `running` subagent row is reconciled (watcher re-armed if the session is alive, rows orphaned if not) — today it is invisible to boot reconciliation and stuck forever.
+4. Claude's TUI spinner footer (`✱ Scurrying… (1m 13s · ↓ 3.7k tokens · esc to interrupt)`) never renders inside a TmuxPromptCard's pane excerpt.
+5. `bun run typecheck` green; `bun test` green.
+
+## 2. Context & constraints (grounded findings)
+
+- **Root cause (primary symptom):** the last subagent settles via its own ~1.5s JSONL-idle heuristic (`claude-subagents.ts` `checkDone`, DONE_IDLE_MS) or via the notification's agent-id extraction → `maybeReleaseHeldTask` (`orchestrator.ts:242-248`) flips the card to `review`. Continuation adoption (`claude-tmux.ts:2119-2141`) requires `isContinuationContentEvent(evt)` (`claude-tmux.ts:564-575`), which is explicitly false for `origin.kind === "task-notification"` / `isMeta` lines — so during extended thinking there is **no** `runs`/`subagents` row tracking the genuinely-live session, for an unbounded window.
+- The `<task-notification>` line is a reliable, early, latency-free signal that claude noticed the background work finished; today it only drives the (pre-dedup, idempotent) settle block at `claude-tmux.ts:2086-2092` (`taskNotificationContent` / `extractTaskNotificationAgentId` / `fireBackgroundTaskSettled`).
+- **dispatchLine ordering (`claude-tmux.ts:2024-2148`):** (1) pendingEndTurn staging/confirm `:2045-2066` → (2) bg settle block (pre-dedup) `:2086-2092` → (3) dedup early-return `:2098-2108` → (4) continuation adoption (post-dedup) `:2119-2141`. Adoption registers the run with the orchestrator **before** the triggering line dispatches.
+- **Owner-approved prior decisions honored:** continuations are NEW run rows (`runs.origin='continuation'`) adopted via `setContinuationRunFactory` — never reopen the resolved run (decision 2026-07-09). The hold predicate is DB-derived, no in-memory map (decision 2026-07-09). Boot reconciliation must never enumerate-and-kill `agetor-*` sessions — only reattach or orphan DB rows (shared tmux socket).
+- **Boot blind spot (confirmed bug #2):** `reconcileOrphans`' held-task pass scans only `SELECT id FROM tasks WHERE "column"='running'` (`orchestrator.ts:540-542`). A `review`-column task with a `running` subagents row after a restart never gets a watcher re-armed nor its rows orphaned → permanently stuck badge/tab dot (`Task.runningSubagents` is a live DB derivation, `server.ts:918-921`, honestly reporting a dead row).
+- **Cosmetic bug #3:** the runtime pane scraper captures the last 12 pane lines verbatim into `tmux_prompt` interactions; `PROMPT_NOISE_RE` (`RunPanel.tsx:~3157-3165`) strips hint lines but not the spinner footer, so literal "✱ Scurrying…" text can render inside prompt cards.
+- **Known-good machinery not to disturb:** end-turn fingerprint staging is per-message-id and cannot coalesce a continuation's own end_turn (verified); `fireParkedDiscovery` → `pullBackParkedTask` already handles a subagent resuming after `review` (#95); `holdUntilIdle` is exclusively for folded follow-ups.
+
+## 3. Approach & key decisions
+
+- **Adopt on notification (owner decision):** extend adoption eligibility to a provably-NEW task-notification line, keeping every existing guard (`continuationRunFactory` set, `!turnInFlight`, empty `turnQueue`, `!state.onEndOfTurn`). Reuse `startContinuationRun` unchanged — the trigger moves earlier; the modeling (new run row, `origin='continuation'`) stays per the standing decision.
+- **Kill the review→running flicker:** today, the notification line's settle block runs before adoption would, so `maybeReleaseHeldTask` can flip to `review` microseconds before adoption pulls back to `running`. Restructure `dispatchLine` so adoption-on-notification is evaluated **before** the settle block for new (non-replayed) lines: extract the adoption block into a helper and call it between the staging block and the settle block, gated on an explicit `uuid && !seenLineUuids.has(uuid)` check (it now sits above the dedup return; replayed lines must still never adopt). Content-line adoption keeps working through the same helper at the same effective position.
+- **Watchdog (owner decision):** `CONTINUATION_WATCHDOG_MS = 10 * 60_000` (module const, test-injectable like the other timing knobs). Armed on SessionState only when adoption was triggered by a notification (content-triggered adoption needs none — content already arrived). Reset on a subsequent notification (another wake signal). Cleared when the first content line reaches the adopted turn, when the turn resolves normally, and in `disposeSessionState`. On fire — if the adopted slot is still the active turn with no content observed — emit a `status` chunk ("no continuation followed the background task; settling") and resolve the slot as success through the same path the end-turn idle-fire uses, so `attachDoneHandler` → hold gate → `review` runs normally.
+- **Old-run-done vs adoption interleaving (must verify, not assume):** the notification line both confirms `pendingEndTurn` (main run resolves in a `.then()` **microtask**) and now synchronously adopts. The old run's done-handler must not flip the column to `review` when `task.runId` already points at the newer running continuation. Verify the existing gate in `attachDoneHandler` covers this (task.runId/staleness or `maybeReleaseHeldTask`-style DB re-derivation); if not, add the guard. A regression test for exactly this interleaving is mandatory (task T-A below).
+- **Boot pass (owner scope):** widen the held-task pass source set from `tasks WHERE column='running'` to "tasks having any `running` subagents row" (new db helper, e.g. `subagents.taskIdsWithRunning()`). For `column='running'` tasks, behavior is unchanged (still gated on `isHeldByBackgroundAgents`). For any other column: same branch structure as `orchestrator.ts:550-573` — session alive **and** a `claudeSessionId` available → `attachSubagentWatcher`; otherwise `orphanRunningSubagents` (its settle hook fires `maybeReleaseHeldTask`, which safely bails for non-running columns). No kills, ever. Skip non-claude-code agents as today.
+- **Noise filter:** extract the prompt-noise pattern list from `RunPanel.tsx` into `src/mainview/lib/prompt-noise.ts` (repo convention: testable logic lives in `lib/` because there is no DOM harness), add a spinner-footer pattern (spinner glyph optional + `\w+…` verb + parenthesized elapsed/tokens/esc-to-interrupt tail), keep all existing patterns byte-identical, and unit-test positives + negatives.
+
+**Alternatives rejected:** grace-delay before release (any fixed delay loses to extended thinking); "continuation pending" flag holding the release with no run row (no Stop affordance, no heartbeat, invents a second hold mechanism alongside the DB-derived one); reopening the succeeded run (contradicts standing decision).
+
+## 4. Work breakdown — implementation (Wave 1, all file-disjoint)
+
+- **T1 — notification adoption + watchdog.** Owns `src/bun/claude-tmux.ts` ONLY. Extract/reorder the adoption helper per §3; extend eligibility to new task-notification lines; add `continuationWatchdog` state + arm/reset/clear/fire per §3; clear in `disposeSessionState`. Acceptance: notification line with no turn in flight → run adopted before the line dispatches, no `review` GlobalEvent emitted in between; watchdog wiring exported/injectable enough to unit-test.
+- **T2 — boot pass widening.** Owns `src/bun/orchestrator.ts` + `src/bun/db.ts`. New db helper for task-ids-with-running-subagents; widen the pass per §3 preserving the `column='running'` behavior byte-for-byte; update the summary log line. Acceptance: a `review` task with a running subagent row and a dead session gets its rows orphaned at boot; with a live session + claudeSessionId it gets a watcher re-armed; `column='running'` behavior unchanged.
+- **T3 — spinner noise filter.** Owns `src/mainview/components/kanban/RunPanel.tsx` + new `src/mainview/lib/prompt-noise.ts`. Extract patterns, add spinner-footer pattern, re-import from RunPanel. Acceptance: `"✱ Scurrying… (1m 13s · ↓ 3.7k tokens)"`, `"* Reticulating… (3s · esc to interrupt)"` filtered; modal body/choice lines (e.g. `"1. Yes, run it"`, `"Do you want to proceed?"`) not filtered.
+
+No two tasks touch the same file → one wave, fully parallel.
+
+## 5. Work breakdown — test tasks (Phase 6)
+
+- **T-A** (covers T1) — extend `src/bun/claude-continuation.test.ts`: adoption fires on a new notification line (card `running`, run `origin='continuation'`); no adoption on replayed notification lines (seeded `seenLineUuids`); no `review` column event between settle and adoption for the same line; watchdog fires after fake-timer 10min with no content → run `succeeded`, card `review`; watchdog cancelled by a content line; watchdog reset by a second notification; the old-run-microtask interleaving regression from §3. Owns that test file only.
+- **T-B** (covers T2) — extend the reconcile/boot test file (`src/bun/reconcile.test.ts` or wherever `reconcileOrphans`' held-task pass is tested — discover, then own that file): review-column stuck row orphaned on boot (dead session); watcher re-armed (live session, real-tmux test pattern already exists there); running-column behavior unchanged.
+- **T-C** (covers T3) — new `src/mainview/lib/prompt-noise.test.ts`. Owns that file only.
+
+Test tasks are file-disjoint from each other and from Wave 1 (which is already committed by then).
+
+## 6. Execution waves
+
+1. Wave 1: T1 ∥ T2 ∥ T3 → typecheck + commit.
+2. Phase 5: code review of the full diff vs base SHA.
+3. Wave 2 (Phase 6): T-A ∥ T-B ∥ T-C → commit.
+4. Phase 7: `bun test` + `bun run typecheck` (background agent). Phase 8 fix loop if needed (≤3 rounds).
+
+## 7. Blast radius & risks
+
+- `dispatchLine` is the hottest path in claude-tmux; the reorder moves adoption above the settle block — replay safety now rests on the explicit seen-uuid guard instead of block position. Mitigate with the replay test in T-A.
+- Watchdog false-fire during >10min silent thinking: accepted by owner (explicit choice of "adopt + watchdog" over "no watchdog"). The consequence is the pre-fix behavior (card in `review` while claude works), not a broken session — the eventual content line re-adopts a fresh continuation run and pulls the card back.
+- Boot-pass widening touches restart reconciliation — the no-kill invariant must hold (only `attachSubagentWatcher` / `orphanRunningSubagents`, both DB/watcher-level).
+- `bun test` currently at 789+ passing; shared-process test leaks have bitten before (injected setters, module-level env) — test tasks must save/restore any injected factories/timers.
+
+## 8. Open questions / assumptions
+
+- Assumption: a `<task-notification>` line reliably precedes any auto-continuation (it is the wake signal itself). If claude versions change the JSONL shape, `taskNotificationContent` already centralizes detection.
+- Assumption: 10min watchdog constant needs no env override for now (module const, test-injectable).
+- Codex remains inert by construction throughout (writes no subagents rows; factory rejects non-claude-code).

--- a/src/bun/claude-continuation.test.ts
+++ b/src/bun/claude-continuation.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { test, expect, afterAll } from "bun:test";
 import { mkdtempSync, writeFileSync, appendFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -8,8 +8,22 @@ import { randomUUID } from "node:crypto";
 // same convention as claude-tmux-queue.test.ts / claude-tmux-death.test.ts.
 process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-continuation-"));
 
-const { __forTest, setContinuationRunFactory, setBackgroundTaskSettledHandler } = await import("./claude-tmux.ts");
+const { __forTest, setContinuationRunFactory, setBackgroundTaskSettledHandler, setContinuationWatchdogMs } =
+  await import("./claude-tmux.ts");
 import type { ContinuationHooks, SpawnedAgent, ChunkHandler } from "./claude-tmux.ts";
+
+// Safety net for the whole file: several tests below arm a REAL
+// notification-triggered watchdog (a real `setTimeout`, per
+// `armContinuationWatchdog` — see claude-tmux.ts). Every such test cancels
+// its own timer explicitly (see `clearArmedWatchdog` below), but shrinking
+// the default window here too means a test that forgets can't leave a real
+// ~10-minute timer pending past this file's run — which would otherwise
+// block `bun test`'s process exit rather than just failing an assertion.
+// Restored in `afterAll` so it can't leak into a sibling test file.
+const prevWatchdogMs = setContinuationWatchdogMs(50);
+afterAll(() => {
+  setContinuationWatchdogMs(prevWatchdogMs);
+});
 
 // ─── fixtures ───────────────────────────────────────────────────────────
 
@@ -104,6 +118,18 @@ async function withContinuationFactory<T>(
   }
 }
 
+/** Cancel any real (armed) watchdog timer on `state` directly, bypassing the
+ *  normal SUT clear path. A per-test cleanup companion to the module-level
+ *  `setContinuationWatchdogMs` shrink above — call this in a `finally` for
+ *  any test that arms a notification-triggered watchdog and doesn't already
+ *  let it resolve/clear itself (via content arriving, a real end_turn, or an
+ *  explicit `__forTest.fireContinuationWatchdog` call), so no real timer
+ *  outlives the test. */
+function clearArmedWatchdog(state: ReturnType<typeof __forTest.installSession>): void {
+  const wd = __forTest.getContinuationWatchdog(state);
+  if (wd) clearTimeout(wd.timer);
+}
+
 // ─── tests ──────────────────────────────────────────────────────────────
 
 test("a genuinely-new assistant content line after a resolved turn adopts a continuation exactly once, onAdopted before the first chunk", async () => {
@@ -145,6 +171,10 @@ test("a genuinely-new assistant content line after a resolved turn adopts a cont
     expect(adoptedHandle).not.toBeNull();
     // The adopted slot is now the live turn.
     expect(state.turnQueue.length).toBe(1);
+    // Content-triggered adoption needs no watchdog — real content already
+    // arrived, so there's nothing to wait for (contrast with the
+    // notification-triggered adoption tests below, which DO arm one).
+    expect(__forTest.getContinuationWatchdog(state)).toBeNull();
   } finally {
     __forTest.uninstallSession(taskId);
   }
@@ -217,41 +247,91 @@ test("replayed (deduped) lines do not trigger the factory even when they'd other
   }
 });
 
-test("a task-notification breadcrumb (user, origin.kind=task-notification) does not trigger the factory", async () => {
+// ─── notification-triggered adoption (docs/plans/adopt-continuation-on-task-notification.md §3) ──
+//
+// `maybeAdoptContinuation`'s eligibility is now `isContinuationContentEvent(evt)
+// || taskNotificationContent(evt) !== null` — a task-notification line is
+// itself an adoption trigger (not just a precursor the model must "confirm"
+// with real content), specifically so the card snaps to `running` for the
+// whole extended-thinking window that can precede the first content line.
+// Adoption on a notification also arms `CONTINUATION_WATCHDOG_MS` — see the
+// watchdog section further below.
+
+test("a provably-new task-notification line with no turn in flight adopts a continuation, arms the watchdog, and routes both the breadcrumb and subsequent content through the adopted slot", async () => {
   const { taskId, jsonlPath } = freshSession();
   const state = __forTest.installSession(taskId, jsonlPath);
   try {
     await resolveFirstTurn(state, jsonlPath);
 
     let calls = 0;
-    const prev = setContinuationRunFactory(() => {
+    const cont = recorder();
+    let adoptedHandle: SpawnedAgent | null = null;
+    const prev = setContinuationRunFactory((tid) => {
       calls++;
-      return { onChunk: () => {}, onAdopted: () => {} };
+      expect(tid).toBe(taskId);
+      return { onChunk: cont.onChunk, onAdopted: (h) => { adoptedHandle = h; } };
     });
     try {
       appendFileSync(jsonlPath, taskNotificationLine("agent-123", "uuid-notif"));
       __forTest.flushSync(state);
 
-      expect(calls).toBe(0);
-      expect(state.turnQueue.length).toBe(0);
+      expect(calls).toBe(1);
+      expect(adoptedHandle).not.toBeNull();
+      expect(state.turnQueue.length).toBe(1); // adopted slot pushed, no turn resolved yet
+
+      // The notification line itself is not silent — it routes through the
+      // now-adopted slot as a status breadcrumb (mapParsedEventToChunks'
+      // `user`/`origin.kind=task-notification` case: no `<summary>` tag in
+      // this fixture, so it falls back to the generic message).
+      expect(cont.out.some((r) => r.stream === "status" && r.data === "background task completed")).toBe(true);
+
+      // Notification-triggered adoption is a bet that claude will keep
+      // talking — unlike content-triggered adoption, it arms a watchdog.
+      const armed = __forTest.getContinuationWatchdog(state);
+      expect(armed).not.toBeNull();
+      expect(armed!.slot).toBe(state.turnQueue[0]!);
+
+      // Genuine content then arrives on the adopted slot...
+      appendFileSync(jsonlPath, assistantLineId("continuing after background task", "msg-2", "uuid-2"));
+      __forTest.flushSync(state);
+
+      expect(calls).toBe(1); // still exactly one adoption — no re-adopt on content
+      expect(cont.out.some((r) => r.data === "continuing after background task")).toBe(true);
+      // ...which proves the continuation is real and clears the watchdog.
+      expect(__forTest.getContinuationWatchdog(state)).toBeNull();
     } finally {
       setContinuationRunFactory(prev);
+      clearArmedWatchdog(state);
     }
   } finally {
     __forTest.uninstallSession(taskId);
   }
 });
 
-test("a queue-operation breadcrumb does not trigger the factory", async () => {
+test("a queue-operation breadcrumb — the other task-notification shape — also adopts a continuation with a watchdog armed, exactly like the user/origin shape", async () => {
+  // `taskNotificationContent` treats `queue-operation`/`enqueue` and
+  // `user`/`origin.kind=task-notification` as the SAME signal (see its
+  // doc comment: "one of the two shapes claude uses to report a background
+  // command/agent's completion") — both are meant to arm the watchdog and
+  // pull the card to `running` for the extended-thinking window. This
+  // supersedes an earlier assumption (encoded in this file's previous
+  // version) that queue-operation breadcrumbs never adopt; empirically,
+  // `maybeAdoptContinuation`'s eligibility check
+  // (`isContinuationContentEvent(evt) || taskNotificationContent(evt) !== null`)
+  // is satisfied by a queue-operation/enqueue line with string `content`,
+  // and this test pins that down against the real implementation rather
+  // than the earlier assumption.
   const { taskId, jsonlPath } = freshSession();
   const state = __forTest.installSession(taskId, jsonlPath);
   try {
     await resolveFirstTurn(state, jsonlPath);
 
     let calls = 0;
-    const prev = setContinuationRunFactory(() => {
+    let adoptedHandle: SpawnedAgent | null = null;
+    const prev = setContinuationRunFactory((tid) => {
       calls++;
-      return { onChunk: () => {}, onAdopted: () => {} };
+      expect(tid).toBe(taskId);
+      return { onChunk: () => {}, onAdopted: (h) => { adoptedHandle = h; } };
     });
     try {
       appendFileSync(
@@ -260,8 +340,42 @@ test("a queue-operation breadcrumb does not trigger the factory", async () => {
       );
       __forTest.flushSync(state);
 
+      expect(calls).toBe(1);
+      expect(adoptedHandle).not.toBeNull();
+      expect(state.turnQueue.length).toBe(1);
+      expect(__forTest.getContinuationWatchdog(state)).not.toBeNull();
+    } finally {
+      setContinuationRunFactory(prev);
+      clearArmedWatchdog(state);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("a task-notification line whose uuid was already seen (reattach replay) does not trigger the factory", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    // Simulate this notification line having already been dispatched in a
+    // prior process — pre-seed the dedup set the way reattach does (same
+    // technique the existing content-line replay test above uses).
+    state.seenLineUuids.add("uuid-replayed-notif");
+
+    let calls = 0;
+    const prev = setContinuationRunFactory(() => {
+      calls++;
+      return { onChunk: () => {}, onAdopted: () => {} };
+    });
+    try {
+      appendFileSync(jsonlPath, taskNotificationLine("agent-replayed", "uuid-replayed-notif"));
+      __forTest.flushSync(state);
+
       expect(calls).toBe(0);
       expect(state.turnQueue.length).toBe(0);
+      expect(__forTest.getContinuationWatchdog(state)).toBeNull();
     } finally {
       setContinuationRunFactory(prev);
     }
@@ -270,7 +384,259 @@ test("a queue-operation breadcrumb does not trigger the factory", async () => {
   }
 });
 
-test("a status-only breadcrumb followed by genuine content still adopts on the content line, not the breadcrumb", async () => {
+test("a second task-notification line while the watchdog is already armed resets it (same slot, fresh timer) instead of re-adopting", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    let calls = 0;
+    const prev = setContinuationRunFactory(() => {
+      calls++;
+      return { onChunk: () => {}, onAdopted: () => {} };
+    });
+    try {
+      appendFileSync(jsonlPath, taskNotificationLine("agent-first", "uuid-notif-a"));
+      __forTest.flushSync(state);
+      expect(calls).toBe(1);
+      const wd1 = __forTest.getContinuationWatchdog(state);
+      expect(wd1).not.toBeNull();
+
+      appendFileSync(jsonlPath, taskNotificationLine("agent-second", "uuid-notif-b"));
+      __forTest.flushSync(state);
+
+      expect(calls).toBe(1); // no re-adoption — the eligibility guard rejects
+      // it anyway (turnQueue is non-empty), so maybeAdoptContinuation's
+      // early "reset, don't re-adopt" branch is what actually runs.
+      const wd2 = __forTest.getContinuationWatchdog(state);
+      expect(wd2).not.toBeNull();
+      expect(wd2!.slot).toBe(wd1!.slot); // still guarding the SAME continuation
+      expect(wd2!.timer).not.toBe(wd1!.timer); // but a fresh timer — the window restarted
+      expect(state.turnQueue.length).toBe(1);
+    } finally {
+      setContinuationRunFactory(prev);
+      clearArmedWatchdog(state);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+// ─── continuation watchdog: fire + stale-fire guards ───────────────────────
+
+test("the continuation watchdog firing settles the adopted turn as succeeded, emitting the settle-status chunk through the normal end-turn path", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    const cont = recorder();
+    let handle: SpawnedAgent | null = null;
+    const prev = setContinuationRunFactory(() => ({
+      onChunk: cont.onChunk,
+      onAdopted: (h) => { handle = h; },
+    }));
+    try {
+      appendFileSync(jsonlPath, taskNotificationLine("agent-watchdog", "uuid-notif-wd"));
+      __forTest.flushSync(state);
+      expect(handle).not.toBeNull();
+      expect(__forTest.getContinuationWatchdog(state)).not.toBeNull();
+
+      // Drive the destructive branch directly instead of waiting out
+      // CONTINUATION_WATCHDOG_MS (real minutes, even at this file's shrunk
+      // override) — __forTest exposes fireContinuationWatchdog exactly for
+      // deterministic tests like this one.
+      __forTest.fireContinuationWatchdog(state);
+
+      expect(cont.out.some((r) =>
+        r.stream === "status" && r.data === "no continuation followed the background task; settling",
+      )).toBe(true);
+      // Resolves through the normal end-turn path (firePendingEndTurn ->
+      // popEndOfTurn), same as any other turn completion.
+      await expect(handle!.done).resolves.toBe(0);
+      expect(state.turnQueue.length).toBe(0);
+      expect(__forTest.getContinuationWatchdog(state)).toBeNull();
+    } finally {
+      setContinuationRunFactory(prev);
+      clearArmedWatchdog(state);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("firing the watchdog again after it already settled the turn is a clean no-op (no double resolution)", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    let handle: SpawnedAgent | null = null;
+    const prev = setContinuationRunFactory(() => ({
+      onChunk: () => {},
+      onAdopted: (h) => { handle = h; },
+    }));
+    try {
+      appendFileSync(jsonlPath, taskNotificationLine("agent-refire", "uuid-notif-refire"));
+      __forTest.flushSync(state);
+      expect(handle).not.toBeNull();
+
+      __forTest.fireContinuationWatchdog(state);
+      await expect(handle!.done).resolves.toBe(0);
+      expect(state.turnQueue.length).toBe(0);
+      expect(__forTest.getContinuationWatchdog(state)).toBeNull();
+
+      // Re-fire: `state.continuationWatchdog` is already null (one-shot),
+      // so this must be inert — no throw, no further queue mutation.
+      expect(() => __forTest.fireContinuationWatchdog(state)).not.toThrow();
+      expect(state.turnQueue.length).toBe(0);
+    } finally {
+      setContinuationRunFactory(prev);
+      clearArmedWatchdog(state);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("firing a watchdog whose armed slot is no longer the active turn is a no-op that leaves the new turn untouched", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    const prev = setContinuationRunFactory(() => ({ onChunk: () => {}, onAdopted: () => {} }));
+    try {
+      appendFileSync(jsonlPath, taskNotificationLine("agent-stale-slot", "uuid-notif-stale"));
+      __forTest.flushSync(state);
+      const armed = __forTest.getContinuationWatchdog(state);
+      expect(armed).not.toBeNull();
+      expect(state.turnQueue[0]).toBe(armed!.slot);
+
+      // Reproduce the race `fireContinuationWatchdog`'s own doc comment
+      // calls out: a timer callback already queued on the event loop when
+      // something else advanced the turn queue past the guarded slot, a
+      // beat before the timer's own clear could run. Displace the adopted
+      // slot and put a DIFFERENT slot at the head WITHOUT going through the
+      // normal clear path (which would have nulled `continuationWatchdog`),
+      // so the stale reference survives to be fired against a slot that's
+      // no longer current.
+      const displaced = state.turnQueue.shift();
+      expect(displaced).toBe(armed!.slot);
+      let bResolved = false;
+      const bSlot = { onChunk: () => {}, resolve: () => { bResolved = true; }, reject: () => {} };
+      state.turnQueue.push(bSlot as unknown as (typeof state.turnQueue)[number]);
+
+      __forTest.fireContinuationWatchdog(state);
+
+      // Guard tripped on slot identity (`state.turnQueue[0] !== armed.slot`):
+      // bSlot is untouched, no double resolution of anything.
+      expect(bResolved).toBe(false);
+      expect(state.turnQueue.length).toBe(1);
+      expect(state.turnQueue[0]).toBe(bSlot);
+      // One-shot regardless of outcome: the stale reference is gone either way.
+      expect(__forTest.getContinuationWatchdog(state)).toBeNull();
+    } finally {
+      setContinuationRunFactory(prev);
+      clearArmedWatchdog(state);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+// ─── old-run vs adoption interleaving (docs/plans §3 "must verify, not assume") ──
+//
+// A task-notification line can, in the same dispatch, both (a) confirm a
+// staged `pendingEndTurn` from the turn that just ended — the OLD run's
+// slot.resolve() runs synchronously, but anything chained on that `done`
+// promise via `.then()` only runs as a queued MICROTASK — and (b) itself be
+// the adoption trigger for the continuation, whose `onAdopted` hook fires
+// synchronously inside the very same `dispatchLine` call. This test pins
+// down that ordering guarantee at the claude-tmux level: `onAdopted` (and
+// the background-task settle handler) provably complete before the OLD
+// run's `.then()` ever gets a turn, which is exactly the property
+// `dispatchLine`'s own comment relies on ("adopting first means the
+// orchestrator's release check sees task.runId already pointing at a
+// running continuation run and bails — no `review` flicker").
+//
+// NOTE: the deeper orchestrator-level assertion — that `attachDoneHandler`'s
+// `.then()` on the OLD run actually reads `task.runId` and bails because it
+// already points at the new continuation run — needs the real orchestrator
+// (DB-backed task.runId, attachDoneHandler), not this file's synthetic
+// SessionState harness. Checked `src/bun/orchestrator-continuation.test.ts`
+// for overlap: it covers the factory's DB effects (new run row, column
+// pull-back, the #92 hold, fold-while-busy) but has no test that races an
+// OLD run's done-resolution microtask against a notification-triggered
+// adoption on the same line. That combination is NOT covered anywhere
+// today — flagged in this file's owning task's summary as a gap for a
+// follow-up in orchestrator-continuation.test.ts (out of this file's
+// boundary).
+test("notification-triggered adoption (onAdopted, settle handler) runs synchronously ahead of the OLD run's done-promise microtask", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    // Stage (but do not fire) an OLD turn's end_turn — driving dispatchLine
+    // directly (not flushSync, which unconditionally fires any staged
+    // pendingEndTurn after its batch on the assumption a new prompt is about
+    // to be queued) reproduces the state a background-task auto-resume
+    // finds: the previous line ended the turn, but nothing has confirmed
+    // that yet, so the OLD slot is still the turnQueue head.
+    const old = recorder();
+    const oldDone = __forTest.pushTurnSlot(state, old.onChunk);
+    const order: string[] = [];
+    oldDone.then(() => order.push("old-run-then"));
+
+    __forTest.dispatchLine(state, endTurnLineId("old run's last line", "msg-old", "uuid-old"));
+    expect(state.turnQueue.length).toBe(1); // staged, not fired
+
+    const settleCalls: string[] = [];
+    const prevSettle = setBackgroundTaskSettledHandler((_tid, agentId) => {
+      settleCalls.push(agentId);
+      order.push("settle-handler");
+    });
+    const prevFactory = setContinuationRunFactory(() => ({
+      onChunk: () => {},
+      onAdopted: () => { order.push("adopted"); },
+    }));
+    try {
+      // ONE line both confirms the staged end_turn (staging block, fires
+      // synchronously, popping the OLD slot and scheduling its resolve as a
+      // microtask) AND is itself a fresh task-notification (adoption
+      // trigger, which dispatchLine runs BEFORE the settle block). All of
+      // that happens synchronously inside this single call.
+      __forTest.dispatchLine(state, taskNotificationLine("agent-interleave", "uuid-notif-interleave"));
+
+      // Synchronous work is done; the OLD run's .then() has NOT run yet —
+      // it's still sitting in the microtask queue behind this call.
+      expect(order).toEqual(["adopted", "settle-handler"]);
+      expect(settleCalls).toEqual(["agent-interleave"]);
+
+      // Now let microtasks drain.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(order).toEqual(["adopted", "settle-handler", "old-run-then"]);
+      await expect(oldDone).resolves.toBe(0);
+    } finally {
+      setContinuationRunFactory(prevFactory);
+      setBackgroundTaskSettledHandler(prevSettle);
+      clearArmedWatchdog(state);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("a task-notification breadcrumb immediately followed by genuine content in the same batch: adoption happens on the breadcrumb, the content line does not re-adopt", async () => {
+  // Previously (pre adopt-on-notification) this scenario adopted on the
+  // content line, since the breadcrumb alone wasn't eligible. Now the
+  // breadcrumb itself adopts — this test pins down that a content line
+  // arriving in the SAME flushSync batch right behind it is a no-op for the
+  // factory (maybeAdoptContinuation's `state.turnQueue.length !== 0` guard
+  // rejects it — the queue is already non-empty from the breadcrumb's
+  // adoption) while still delivering the content to the adopted slot and
+  // clearing its watchdog.
   const { taskId, jsonlPath } = freshSession();
   const state = __forTest.installSession(taskId, jsonlPath);
   try {
@@ -288,10 +654,15 @@ test("a status-only breadcrumb followed by genuine content still adopts on the c
       appendFileSync(jsonlPath, assistantLineId("resuming after the background task", "msg-3", "uuid-4"));
       __forTest.flushSync(state);
 
-      expect(calls).toEqual([taskId]); // adopted exactly once, on the content line
+      expect(calls).toEqual([taskId]); // adopted exactly once, not twice
+      expect(cont.out.some((r) => r.stream === "status" && r.data === "background task completed")).toBe(true);
       expect(cont.out.some((r) => r.data === "resuming after the background task")).toBe(true);
+      // The content line (dispatched to the same, already-adopted slot in
+      // this same batch) clears the watchdog the breadcrumb armed.
+      expect(__forTest.getContinuationWatchdog(state)).toBeNull();
     } finally {
       setContinuationRunFactory(prev);
+      clearArmedWatchdog(state);
     }
   } finally {
     __forTest.uninstallSession(taskId);

--- a/src/bun/claude-continuation.test.ts
+++ b/src/bun/claude-continuation.test.ts
@@ -741,6 +741,118 @@ test("dispatchLine's background-task settle block still fires for a normal (non-
   }
 });
 
+// ─── Phase 8: uuid-less queue-operation notifications (verified latent bug) ──
+//
+// `queue-operation` lines carry `uuid: null` by design — the PRIMARY shape
+// current claude uses for background-task completion. Before this fix,
+// `maybeAdoptContinuation`'s replay guard (`if (uuid && state.seenLineUuids
+// .has(uuid)) return;`) never blocked a falsy uuid, so a REPLAYED
+// queue-operation line (boot reattach re-reads the JSONL from offset 0)
+// dispatched onto an idle queue re-triggered the continuation factory —
+// spawning a phantom continuation run for activity that already happened.
+// `syntheticNotificationUuid` closes the hole by deriving a deterministic
+// key from the notification's own content.
+
+test("a replayed queue-operation notification line (uuid: null) adopts a continuation exactly once, not twice", () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    let calls = 0;
+    const prev = setContinuationRunFactory((tid) => {
+      calls++;
+      expect(tid).toBe(taskId);
+      return { onChunk: () => {}, onAdopted: () => {} };
+    });
+    try {
+      // No uuid arg — reproduces the real claude 2.1.x shape (`uuid: null`),
+      // not the earlier tests' explicit "uuid-qop" fixture uuid.
+      const line = queueOperationLine(
+        "<task-notification><task-id>agent-replay-dup</task-id></task-notification>",
+      );
+
+      __forTest.dispatchLine(state, line);
+      expect(calls).toBe(1);
+      expect(state.turnQueue.length).toBe(1);
+
+      // Boot reattach re-reads the JSONL from offset 0 — the exact same
+      // bytes are dispatched a second time. Without a synthetic uuid
+      // standing in for the null real uuid, this looked like a brand-new
+      // line and adopted a second, phantom continuation run.
+      __forTest.dispatchLine(state, line);
+
+      expect(calls).toBe(1); // still exactly one — the replay is a no-op
+      expect(state.turnQueue.length).toBe(1);
+    } finally {
+      setContinuationRunFactory(prev);
+      clearArmedWatchdog(state);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("reattach-style: pre-seeding seenLineUuids with a queue-operation line's synthetic uuid suppresses adoption but the settle signal still fires", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    await resolveFirstTurn(state, jsonlPath);
+
+    const content = "<task-notification><task-id>agent-reattach-seed</task-id></task-notification>";
+    // Mirrors how reattach seeds seenLineUuids from run_events.line_uuid —
+    // the synthetic key computed the same way `dispatchLine` derives it.
+    state.seenLineUuids.add(__forTest.syntheticNotificationUuid(content));
+
+    let calls = 0;
+    const prevFactory = setContinuationRunFactory(() => {
+      calls++;
+      return { onChunk: () => {}, onAdopted: () => {} };
+    });
+    const settleCalls: string[] = [];
+    const prevSettle = setBackgroundTaskSettledHandler((_tid, agentId) => {
+      settleCalls.push(agentId);
+    });
+    try {
+      __forTest.dispatchLine(state, queueOperationLine(content));
+
+      expect(calls).toBe(0); // adoption suppressed — this key is already "seen"
+      expect(state.turnQueue.length).toBe(0);
+      // The settle block runs BEFORE the dedup early-return by design (see
+      // dispatchLine's comment) — a reattach replay may be the only chance
+      // to learn a background agent settled while the process was down, and
+      // markSettledById is idempotent — so it must still fire here.
+      expect(settleCalls).toEqual(["agent-reattach-seed"]);
+    } finally {
+      setContinuationRunFactory(prevFactory);
+      setBackgroundTaskSettledHandler(prevSettle);
+    }
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("the status breadcrumb for a uuid-less queue-operation notification carries the synthetic uuid as its lineUuid", async () => {
+  const { taskId, jsonlPath } = freshSession();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  try {
+    // No factory installed → falls back to lastChunk routing (the first
+    // turn's own recorder), same convention as the "factory returning null"
+    // / "no factory installed" tests above.
+    const firstOut = await resolveFirstTurn(state, jsonlPath);
+
+    const content = "<task-notification><task-id>agent-breadcrumb</task-id></task-notification>";
+    const expectedUuid = __forTest.syntheticNotificationUuid(content);
+
+    appendFileSync(jsonlPath, queueOperationLine(content));
+    __forTest.flushSync(state);
+
+    const breadcrumb = firstOut.find((r) => r.stream === "status" && r.data === "background task completed");
+    expect(breadcrumb).toBeDefined();
+    expect(breadcrumb!.uuid).toBe(expectedUuid);
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
 test("with no factory installed at all, behavior is identical to pre-change: no calls, routes via lastChunk", async () => {
   const { taskId, jsonlPath } = freshSession();
   const state = __forTest.installSession(taskId, jsonlPath);

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -553,6 +553,43 @@ function extractTaskNotificationAgentId(content: string): string | null {
 }
 
 /**
+ * Deterministic stand-in uuid for a JSONL line that carries `uuid: null` —
+ * today this is only `queue-operation` notification lines (claude 2.1.x's
+ * PRIMARY shape for reporting a background command/agent's completion; see
+ * `taskNotificationContent`'s doc comment). A falsy real uuid never satisfies
+ * `dispatchLine`'s `uuid && state.seenLineUuids.has(uuid)` replay guard (nor
+ * `maybeAdoptContinuation`'s copy of it), so without a synthetic key a
+ * reattach replay (boot re-reads the JSONL from offset 0) looks exactly like
+ * a brand-new line: `maybeAdoptContinuation` re-adopts a phantom continuation
+ * run, and the status breadcrumb double-persists into `run_events` (its
+ * `uuid: undefined` third `onChunk` arg defeats both the in-memory dedup and
+ * the DB's `(run_id, line_uuid)` partial unique index).
+ *
+ * Hashing `content` (the notification's own XML payload, which is stable
+ * across re-reads of the same physical line) gives every caller — the
+ * seenLineUuids dedup check, `maybeAdoptContinuation`'s replay guard, and the
+ * breadcrumb chunk's persisted `line_uuid` — the identical key for the
+ * identical line, including across process restarts. MUST stay a pure
+ * function of `content` — no `Date.now()`/`Math.random()` — or reattach's
+ * offset-0 replay would mint a different key than the first pass and the
+ * whole point of this helper falls apart.
+ *
+ * Hand-rolled FNV-1a (32-bit) rather than `Bun.hash` — FNV-1a's algorithm is
+ * a tiny, permanently-fixed public spec, so a synthetic uuid computed by one
+ * agetor version matches one computed by the next; `Bun.hash`'s algorithm
+ * carries no such stability guarantee across Bun releases. Prefixed for
+ * greppability in `run_events.line_uuid`.
+ */
+function syntheticNotificationUuid(content: string): string {
+  let hash = 0x811c9dc5; // FNV-1a 32-bit offset basis
+  for (let i = 0; i < content.length; i++) {
+    hash ^= content.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193); // FNV-1a 32-bit prime
+  }
+  return `qnotif:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+/**
  * True when `evt`, once mapped, would emit genuine conversational content —
  * a `user` / `assistant` / `thinking` / `tool_use` / `tool_result` chunk —
  * rather than a bare status/heartbeat breadcrumb. One of two adoption
@@ -856,10 +893,14 @@ function mapParsedEventToChunks(
       // Older versions used a synthetic `user` event with
       // `origin.kind: "task-notification"` (the user branch above still
       // handles that for forward/backward compat). queue-operation lines
-      // carry `uuid: null` so they bypass the seenLineUuids dedup
-      // entirely — that's fine, each enqueue is broadcast once per
-      // process and reattach hits a different file offset.
+      // carry `uuid: null` by design — reattach re-reads the JSONL from
+      // offset 0, so a real uuid-less broadcast WOULD be re-dispatched on
+      // restart. Stand in a deterministic hash of the content
+      // (`syntheticNotificationUuid`) so the breadcrumb's persisted
+      // `line_uuid` still dedups a replay, mirroring the same substitution
+      // `dispatchLine` makes for `seenLineUuids`/`maybeAdoptContinuation`.
       if (evt.operation === "enqueue" && typeof evt.content === "string") {
+        const notifUuid = uuid ?? syntheticNotificationUuid(evt.content);
         const summary = /<summary>([\s\S]*?)<\/summary>/.exec(evt.content)?.[1]?.trim();
         // Mirror the existing user/origin.kind handler's fallback: when a
         // task-notification payload arrives without a `<summary>` (older
@@ -868,10 +909,11 @@ function mapParsedEventToChunks(
         // silently — something measurable happened, and the run panel
         // shouldn't go dark on it.
         if (summary) {
-          onChunk("status", `background task: ${summary}`, uuid);
+          onChunk("status", `background task: ${summary}`, notifUuid);
         } else if (evt.content.startsWith("<task-notification>")) {
-          onChunk("status", "background task completed", uuid);
+          onChunk("status", "background task completed", notifUuid);
         }
+        return { endOfTurn: false, lineUuid: notifUuid };
       }
       return { endOfTurn: false, lineUuid: uuid };
     }
@@ -2142,15 +2184,24 @@ function fireContinuationWatchdog(state: SessionState): void {
  *
  * Because this now runs ABOVE the `seenLineUuids` dedup return, it carries
  * its own replay guard reproducing that exact condition: a line only
- * reaches adoption when NOT (`uuid && state.seenLineUuids.has(uuid)`).
- * Uuid-less lines (e.g. `queue-operation` notifications, which carry
- * `uuid: null`) are never excluded by this guard — only a line whose uuid we
- * HAVE already seen is.
+ * reaches adoption when NOT (`uuid && state.seenLineUuids.has(uuid)`). This
+ * guard is what makes queue-operation notification replay-safe: `uuid` here
+ * is `dispatchLine`'s already-resolved key — the JSONL line's real uuid when
+ * it has one, else `syntheticNotificationUuid(notifContent)` — never the raw
+ * (possibly-null) `evt.uuid`, so a replayed uuid-less notification IS
+ * excluded by this guard just like any other already-seen line.
+ *
+ * `notifContent` is passed in by the caller (`dispatchLine` computes
+ * `taskNotificationContent(evt)` once and reuses it for the settle block and
+ * the synthetic-uuid derivation too) rather than recomputed here.
  */
-function maybeAdoptContinuation(state: SessionState, evt: ParsedJsonlEvent, uuid: string | undefined): void {
+function maybeAdoptContinuation(
+  state: SessionState,
+  evt: ParsedJsonlEvent,
+  uuid: string | undefined,
+  notifContent: string | null,
+): void {
   if (uuid && state.seenLineUuids.has(uuid)) return;
-
-  const notifContent = taskNotificationContent(evt);
 
   // A second (or later) task-notification while a notification-adopted turn
   // is still waiting for real content is itself a fresh "claude noticed
@@ -2208,7 +2259,23 @@ function dispatchLine(state: SessionState, line: string): void {
     handler?.("stderr", `jsonl parse error: ${(e as Error).message}`);
     return;
   }
-  const uuid = typeof evt.uuid === "string" ? evt.uuid : undefined;
+  const rawUuid = typeof evt.uuid === "string" ? evt.uuid : undefined;
+  // queue-operation notification lines carry `uuid: null` by design (claude
+  // 2.1.x's PRIMARY shape for a background command/agent completion — see
+  // `taskNotificationContent`). A falsy uuid never satisfies the
+  // seenLineUuids replay guard below (nor `maybeAdoptContinuation`'s copy of
+  // it), so a boot reattach replaying the JSONL from offset 0 would
+  // re-dispatch the SAME notification as if it were brand new: a second,
+  // phantom continuation run gets adopted, and the breadcrumb double-persists
+  // into run_events (its uuid:undefined third onChunk arg defeats both the
+  // in-memory dedup and the DB's `(run_id, line_uuid)` partial unique index).
+  // Deriving a deterministic stand-in from the notification's own content
+  // closes both holes with one key, computed once here and threaded through:
+  // this dedup check, `maybeAdoptContinuation`'s replay guard, and (via
+  // `mapParsedEventToChunks`, which independently derives the identical value
+  // from `evt.content`) the persisted `run_events.line_uuid`.
+  const notifContent = taskNotificationContent(evt);
+  const uuid = rawUuid ?? (notifContent ? syntheticNotificationUuid(notifContent) : undefined);
 
   // Mirror the latest mode-bearing JSONL event into SessionState.
   // IMPORTANT: this update MUST stay above the seenLineUuids early-return.
@@ -2254,7 +2321,7 @@ function dispatchLine(state: SessionState, line: string): void {
   // card snaps back to `running`. See `maybeAdoptContinuation` for the full
   // eligibility rules (content OR task-notification, plus the watchdog it
   // arms for the notification case).
-  maybeAdoptContinuation(state, evt, uuid);
+  maybeAdoptContinuation(state, evt, uuid, notifContent);
 
   // Background-task/agent settle signal. Deliberately runs BEFORE the dedup
   // early-return below (unlike `maybeAdoptContinuation` just above, which
@@ -2277,7 +2344,6 @@ function dispatchLine(state: SessionState, line: string): void {
   // eligibility check on its own), just made explicit here since this block
   // runs unconditionally rather than through a factory.
   if (state.taskId !== "__rebuild__") {
-    const notifContent = taskNotificationContent(evt);
     if (notifContent) {
       const agentId = extractTaskNotificationAgentId(notifContent);
       if (agentId) fireBackgroundTaskSettled(state.taskId, agentId);
@@ -4258,6 +4324,10 @@ export const __forTest = {
    *  null when not armed. Exposed so a test can assert arm/reset/clear
    *  transitions without reaching into module-private state another way. */
   getContinuationWatchdog(state: SessionState) { return state.continuationWatchdog; },
+  /** Deterministic stand-in uuid for a uuid-less notification line (see its
+   *  doc comment above). Exposed so tests can compute the expected key for a
+   *  given payload rather than hardcoding a hash literal. */
+  syntheticNotificationUuid,
 };
 
 /**

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -101,11 +101,12 @@ export type ContinuationHooks = {
 };
 
 /**
- * Factory the orchestrator installs to adopt a "stray" content line — one
- * that arrives on a session with no turn in flight and nothing queued to
- * receive it. This is exactly what happens after claude auto-resumes
- * following a background-task notification (see the call site in
- * `dispatchLine`): the prior run already resolved on its own `end_turn`, so
+ * Factory the orchestrator installs to adopt a "stray" line — one that
+ * arrives on a session with no turn in flight and nothing queued to receive
+ * it, either genuine content OR the task-notification line itself (see
+ * `maybeAdoptContinuation`, called from `dispatchLine`). This is exactly
+ * what happens after claude auto-resumes following a background-task
+ * notification: the prior run already resolved on its own `end_turn`, so
  * without this seam the resumed conversation would silently dispatch
  * through the stale `state.lastChunk` under the already-succeeded run.
  * Returns `null` for a task the orchestrator doesn't want to (or can't)
@@ -554,12 +555,14 @@ function extractTaskNotificationAgentId(content: string): string | null {
 /**
  * True when `evt`, once mapped, would emit genuine conversational content —
  * a `user` / `assistant` / `thinking` / `tool_use` / `tool_result` chunk —
- * rather than a bare status/heartbeat breadcrumb. Used by `dispatchLine` to
- * decide whether an unattributed line (no turn in flight, nothing queued) is
- * significant enough to adopt via `continuationRunFactory`: a status-only
- * line (a mode banner, a turn-duration footer, a task-notification
- * breadcrumb) must NOT open a new run on its own — only the human/agent
- * content that follows should.
+ * rather than a bare status/heartbeat breadcrumb. One of two adoption
+ * triggers `maybeAdoptContinuation` checks (the other is
+ * `taskNotificationContent`, handled separately since a task-notification is
+ * itself eligible to adopt — just with a watchdog attached, since it's only
+ * proof claude noticed the background work, not proof it will keep
+ * talking). A plain status-only line that is NEITHER of those two shapes (a
+ * mode banner, a turn-duration footer, an unrelated `isMeta` breadcrumb)
+ * must NOT open a new run on its own.
  */
 function isContinuationContentEvent(evt: ParsedJsonlEvent): boolean {
   if (evt.type === "assistant") return true;
@@ -1373,6 +1376,24 @@ interface SessionState {
    *  (and when AGETOR_TRACK_SUBAGENTS=0, `attachSubagentWatcher` returns a
    *  no-op handle). */
   subagentWatcher: SubagentWatcherHandle | null;
+  /**
+   * Armed by `maybeAdoptContinuation` ONLY when a continuation run was
+   * adopted off a task-notification line rather than genuine content — i.e.
+   * we don't yet know claude will actually keep talking after the
+   * background task settles, just that it noticed. `slot` is the adopted
+   * turn this watchdog is guarding, checked by identity at fire time so a
+   * stale timer callback (the turn already resolved a beat earlier through
+   * some other path) can't double-settle it. Reset (timer replaced, same
+   * slot) when another task-notification line arrives while still armed —
+   * a fresh wake signal earns a fresh window. Cleared — timer cancelled,
+   * field nulled — the moment real content reaches the adopted turn
+   * (`dispatchLine`), when that turn resolves through the normal end-turn
+   * machinery (`popEndOfTurn`), on an unexpected session death
+   * (`signalSessionDeath`), and on teardown (`disposeSessionState`), mirroring
+   * how `deathTimer` / `scrapeTimer` / `pollTimer` are handled in those same
+   * places. Content-triggered adoption arms nothing — real content already
+   * arrived, so there's nothing to wait for. Null when not armed. */
+  continuationWatchdog: { timer: ReturnType<typeof setTimeout>; slot: TurnSlot } | null;
 }
 
 interface TurnSlot {
@@ -1469,6 +1490,7 @@ function makeSessionState(o: MakeSessionStateOpts): SessionState {
     pendingEndTurn: null,
     holdUntilIdle: false,
     subagentWatcher: null,
+    continuationWatchdog: null,
   };
 }
 
@@ -1576,6 +1598,12 @@ function popEndOfTurn(state: SessionState): void {
   // The busy period (the active turn plus any folded follow-ups) is ending —
   // clear the hold so the next genuinely-sequential turn resolves normally.
   state.holdUntilIdle = false;
+  // A turn resolving through the normal end-turn machinery means any
+  // notification-triggered continuation watchdog has nothing left to guard
+  // against — cancel it. Safe unconditionally: the watchdog is only ever
+  // armed for the current queue head (see `maybeAdoptContinuation`), which
+  // is exactly the slot this call is about to pop below.
+  clearContinuationWatchdog(state);
   const slot = state.turnQueue[0];
   if (slot) {
     state.turnQueue.shift();
@@ -2021,6 +2049,156 @@ export function resolveAskCard(cardId: string, taskId: string): void {
   if (state && state.askCardId === cardId) state.askCardId = null;
 }
 
+/**
+ * Default wait after a notification-triggered continuation adoption (see
+ * `maybeAdoptContinuation`) before the watchdog gives up on ever seeing real
+ * content and settles the run as succeeded (`fireContinuationWatchdog`).
+ * Unlike `END_TURN_IDLE_FIRE_MS` — short enough that the 400ms `pollTimer`
+ * can just check elapsed time opportunistically on every tick — ten minutes
+ * is too long to poll for cheaply and too long for a unit test to wait out,
+ * so this is a real `setTimeout` (armed in `armContinuationWatchdog`) with a
+ * dedicated override seam, mirroring `setContinuationRunFactory` above
+ * rather than a bare unexported constant.
+ */
+export const CONTINUATION_WATCHDOG_MS = 10 * 60_000;
+let continuationWatchdogMs: number = CONTINUATION_WATCHDOG_MS;
+/** Test seam for `CONTINUATION_WATCHDOG_MS`. Pass `null` to restore the
+ *  default. Returns the previous value — save/restore like
+ *  `setContinuationRunFactory` so one test's override can't leak into the
+ *  next file's run. */
+export function setContinuationWatchdogMs(ms: number | null): number {
+  const prev = continuationWatchdogMs;
+  continuationWatchdogMs = ms ?? CONTINUATION_WATCHDOG_MS;
+  return prev;
+}
+
+/** Arm (or re-arm) the continuation watchdog for `slot` — the turn slot a
+ *  notification-triggered adoption just pushed. Cancels any existing timer
+ *  first so a re-arm (a second task-notification line while the first
+ *  window is still ticking — see `maybeAdoptContinuation`) restarts the full
+ *  window instead of stacking timers. */
+function armContinuationWatchdog(state: SessionState, slot: TurnSlot): void {
+  if (state.continuationWatchdog) clearTimeout(state.continuationWatchdog.timer);
+  const timer = setTimeout(() => fireContinuationWatchdog(state), continuationWatchdogMs);
+  state.continuationWatchdog = { timer, slot };
+}
+
+/** Cancel the continuation watchdog, if armed. Idempotent — safe to call
+ *  from every path that might settle the adopted turn, whether or not a
+ *  watchdog actually happens to be ticking. */
+function clearContinuationWatchdog(state: SessionState): void {
+  if (!state.continuationWatchdog) return;
+  clearTimeout(state.continuationWatchdog.timer);
+  state.continuationWatchdog = null;
+}
+
+/**
+ * Fires `continuationWatchdogMs` after a notification-triggered adoption
+ * with no real content ever landing on the adopted turn. Settles the run as
+ * succeeded through the exact same machinery the `flush` idle-fire uses for
+ * a genuine end_turn (`firePendingEndTurn` → `popEndOfTurn`) rather than a
+ * parallel resolve path, so the slot pops and `done` resolves with 0 just
+ * like a normal turn completion. If background subagents are still running,
+ * the orchestrator's hold gate (unrelated to this file) keeps the card in
+ * `running` regardless — this only resolves the RUN, not the task/column.
+ *
+ * `state.continuationWatchdog` is cleared everywhere content could prove the
+ * watch unnecessary (content dispatch, normal end-turn, session death,
+ * teardown), so by the time this timer callback actually runs, a non-null
+ * `armed` here means content genuinely never arrived. The `turnQueue[0]`
+ * identity check below is an extra belt-and-suspenders guard against a
+ * timer callback that was already queued on the event loop when one of
+ * those clears ran a beat too late to cancel it.
+ */
+function fireContinuationWatchdog(state: SessionState): void {
+  const armed = state.continuationWatchdog;
+  state.continuationWatchdog = null; // one-shot regardless of outcome below
+  if (!armed) return;
+  if (state.turnQueue[0] !== armed.slot) return;
+  armed.slot.onChunk("status", "no continuation followed the background task; settling");
+  state.pendingEndTurn = { messageId: null, uuid: undefined, emitBanner: false, stagedAt: Date.now() };
+  firePendingEndTurn(state);
+}
+
+/**
+ * Adopt a fresh continuation run for `evt` when it's the first provably-NEW
+ * line to arrive on a session with no turn in flight and nothing queued —
+ * the shape a post-end_turn background-task auto-resume produces. Two
+ * triggers:
+ *
+ *   - genuine content (`isContinuationContentEvent`) — claude is already
+ *     talking again; adopt immediately, no watchdog needed.
+ *   - a task-notification line (`taskNotificationContent`) — claude merely
+ *     NOTICED the background work finished, not proof it will keep talking.
+ *     Adopt anyway (so Stop/heartbeat/`running` are live for the whole
+ *     extended-thinking window that can precede the first content line) but
+ *     arm `CONTINUATION_WATCHDOG_MS` in case it never actually continues.
+ *
+ * Called from `dispatchLine` BEFORE the background-task settle block (which
+ * can release a task-notification's hold via `maybeReleaseHeldTask`) so a
+ * settle can never flip the card to `review` a beat before adoption pulls
+ * it back to `running` — see the settle block's comment for the ordering
+ * rationale.
+ *
+ * Because this now runs ABOVE the `seenLineUuids` dedup return, it carries
+ * its own replay guard reproducing that exact condition: a line only
+ * reaches adoption when NOT (`uuid && state.seenLineUuids.has(uuid)`).
+ * Uuid-less lines (e.g. `queue-operation` notifications, which carry
+ * `uuid: null`) are never excluded by this guard — only a line whose uuid we
+ * HAVE already seen is.
+ */
+function maybeAdoptContinuation(state: SessionState, evt: ParsedJsonlEvent, uuid: string | undefined): void {
+  if (uuid && state.seenLineUuids.has(uuid)) return;
+
+  const notifContent = taskNotificationContent(evt);
+
+  // A second (or later) task-notification while a notification-adopted turn
+  // is still waiting for real content is itself a fresh "claude noticed
+  // something" signal — reset the watchdog's clock instead of letting the
+  // window from the FIRST notification run out underneath a session that's
+  // still clearly alive. Does not re-adopt (the turn is already in flight —
+  // the eligibility guard below would reject it anyway).
+  if (notifContent && state.continuationWatchdog) {
+    armContinuationWatchdog(state, state.continuationWatchdog.slot);
+    return;
+  }
+
+  if (
+    !continuationRunFactory
+    || turnInFlight(state)
+    || state.turnQueue.length !== 0
+    || state.onEndOfTurn
+  ) {
+    return;
+  }
+  const isNotification = notifContent !== null;
+  if (!isContinuationContentEvent(evt) && !isNotification) return;
+
+  const hooks = continuationRunFactory(state.taskId);
+  // A null factory result (unknown/archived task) intentionally falls
+  // through to the pre-existing `lastChunk` routing in `dispatchLine` —
+  // unchanged.
+  if (!hooks) return;
+
+  const adopted: TurnSlot = { onChunk: hooks.onChunk, resolve: null, reject: null };
+  const done = new Promise<number>((resolve, reject) => {
+    adopted.resolve = resolve;
+    adopted.reject = reject;
+  });
+  state.turnQueue.push(adopted);
+  // Register the run with the orchestrator BEFORE the triggering line
+  // dispatches below — the caller must be able to observe "running" before
+  // the first chunk arrives, not after.
+  hooks.onAdopted(makeAgent(state.taskId, done));
+
+  // Content-triggered adoption needs no watchdog — real content already
+  // arrived, so there's nothing to wait for. Notification-triggered
+  // adoption is a bet that claude will keep talking; arm the watchdog so a
+  // continuation that never actually happens still settles instead of
+  // holding the card in `running` forever.
+  if (isNotification) armContinuationWatchdog(state, adopted);
+}
+
 function dispatchLine(state: SessionState, line: string): void {
   let evt: ParsedJsonlEvent;
   try {
@@ -2065,10 +2243,23 @@ function dispatchLine(state: SessionState, line: string): void {
     }
   }
 
+  // Continuation adoption: this line is provably NEW (`maybeAdoptContinuation`
+  // reproduces the dedup guard itself, since it runs above the early-return
+  // below). Runs BEFORE the background-task settle block on purpose: the
+  // settle block can release a held task via `maybeReleaseHeldTask`, and if
+  // this is a task-notification line that both settles the last background
+  // agent AND is itself the continuation trigger, adopting first means the
+  // orchestrator's release check sees `task.runId` already pointing at a
+  // running continuation run and bails — no `review` flicker before the
+  // card snaps back to `running`. See `maybeAdoptContinuation` for the full
+  // eligibility rules (content OR task-notification, plus the watchdog it
+  // arms for the notification case).
+  maybeAdoptContinuation(state, evt, uuid);
+
   // Background-task/agent settle signal. Deliberately runs BEFORE the dedup
-  // early-return below (unlike the continuation-adoption check further down,
-  // which must NOT fire on replayed lines): a reattach replay (offset-0
-  // re-read after an agetor restart) may be the only chance to learn that a
+  // early-return below (unlike `maybeAdoptContinuation` just above, which
+  // must NOT fire on replayed lines): a reattach replay (offset-0 re-read
+  // after an agetor restart) may be the only chance to learn that a
   // background agent settled while the process was down, and the consumer
   // (`subagents.markSettledById`) is idempotent, so re-firing for an
   // already-seen line is harmless.
@@ -2079,10 +2270,12 @@ function dispatchLine(state: SessionState, line: string): void {
   // on agentId alone with no taskId scoping, so firing here would settle a
   // REAL subagent/background-task row from a request that never touched a
   // live session — e.g. a rebuild racing a genuine resume could release a
-  // hold the live tailer still needs. Mirrors how the continuation-adoption
-  // check further down is naturally inert for `__rebuild__` (its factory
-  // looks the taskId up and finds no such task), just made explicit here
-  // since this block runs unconditionally rather than through a factory.
+  // hold the live tailer still needs. Mirrors how `maybeAdoptContinuation`
+  // just above is naturally inert for `__rebuild__` (its factory looks the
+  // taskId up and finds no such task; and `rebuildEventsFromJsonl` seeds a
+  // permanently non-empty `turnQueue`, which fails the empty-queue
+  // eligibility check on its own), just made explicit here since this block
+  // runs unconditionally rather than through a factory.
   if (state.taskId !== "__rebuild__") {
     const notifContent = taskNotificationContent(evt);
     if (notifContent) {
@@ -2107,40 +2300,16 @@ function dispatchLine(state: SessionState, line: string): void {
     return;
   }
 
-  // Continuation adoption: this line is provably NEW (it passed the dedup
-  // return above). If no turn is in flight and nothing is queued to receive
-  // it, yet it carries genuine content, claude has resumed talking with no
-  // run listening — the case a post-end_turn background-task auto-resume
-  // produces (the notification breadcrumb itself never reaches here; it's a
-  // status-only line filtered out by `isContinuationContentEvent`, and it
-  // already returned above via the dedup path on any replay). Ask the
-  // orchestrator to adopt a fresh run before this line is dispatched, so the
-  // run exists before its first chunk lands.
-  if (
-    continuationRunFactory
-    && !turnInFlight(state)
-    && state.turnQueue.length === 0
-    && !state.onEndOfTurn
-    && isContinuationContentEvent(evt)
-  ) {
-    const hooks = continuationRunFactory(state.taskId);
-    if (hooks) {
-      const adopted: TurnSlot = { onChunk: hooks.onChunk, resolve: null, reject: null };
-      const done = new Promise<number>((resolve, reject) => {
-        adopted.resolve = resolve;
-        adopted.reject = reject;
-      });
-      state.turnQueue.push(adopted);
-      // Register the run with the orchestrator BEFORE the triggering line
-      // dispatches below — the caller must be able to observe "running"
-      // before the first chunk arrives, not after.
-      hooks.onAdopted(makeAgent(state.taskId, done));
-    }
-    // A null factory result (unknown/archived task) intentionally falls
-    // through to the pre-existing `lastChunk` routing below — unchanged.
-  }
-
   const slot = state.turnQueue[0];
+  // A real content line reaching the adopted (still-active) turn means
+  // claude genuinely continued — the notification-triggered watchdog, if
+  // any, no longer needs to fire. Gated on slot identity: the watchdog is
+  // only ever armed for the current queue head (adoption always pushes to
+  // an empty queue), so this is really just "is a watchdog armed at all",
+  // spelled out defensively rather than assumed.
+  if (state.continuationWatchdog && state.continuationWatchdog.slot === slot && isContinuationContentEvent(evt)) {
+    clearContinuationWatchdog(state);
+  }
   // Active turn → its handler. No active turn → fall back to the most
   // recently popped slot's handler so trailing metadata still reaches the
   // correct run. If neither exists it's safe to drop.
@@ -2965,6 +3134,12 @@ function signalSessionDeath(state: SessionState): void {
   state.watcher = null;
   if (state.pollTimer) { clearInterval(state.pollTimer); state.pollTimer = null; }
   if (state.scrapeTimer) { clearInterval(state.scrapeTimer); state.scrapeTimer = null; }
+  // The session is gone, so a notification-triggered watchdog waiting on it
+  // will never see content or a normal end-turn either way — cancel rather
+  // than let it fire redundantly (harmlessly, since `fireContinuationWatchdog`
+  // would just find an empty/mismatched queue head — but there's nothing to
+  // gain by leaving it ticking on a dead session).
+  clearContinuationWatchdog(state);
   state.subagentWatcher?.detach();
   state.subagentWatcher = null;
   // The tmux session is provably gone, so nothing will ever write another
@@ -3898,6 +4073,7 @@ function disposeSessionState(state: SessionState | undefined, orphanSubagents = 
   state.scrapeTimer = null;
   if (state.deathTimer) clearInterval(state.deathTimer);
   state.deathTimer = null;
+  clearContinuationWatchdog(state);
   state.scrapeLastFingerprint = null;
   // Release the subagent watcher's fs.watch + poll timer. Read-only teardown:
   // this stops us TAILING the subagent files, never the agent itself.
@@ -4072,6 +4248,16 @@ export const __forTest = {
   pasteChains,
   queuePaste,
   queueTmuxOp,
+  /** Fire the continuation watchdog's settle logic directly — mirrors
+   *  `signalSessionDeath` above: real-timer tests would need to wait out
+   *  `CONTINUATION_WATCHDOG_MS` (or the `setContinuationWatchdogMs`
+   *  override), so exposing the destructive branch itself lets a test
+   *  drive "watchdog fires" deterministically without touching the timer. */
+  fireContinuationWatchdog,
+  /** Read-only accessor for the armed watchdog (timer + guarded slot), or
+   *  null when not armed. Exposed so a test can assert arm/reset/clear
+   *  transitions without reaching into module-private state another way. */
+  getContinuationWatchdog(state: SessionState) { return state.continuationWatchdog; },
 };
 
 /**

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -743,4 +743,16 @@ export const subagents = {
     ).all();
     return new Map(rows.map((r) => [r.task_id, r.n]));
   },
+  /** Distinct ids of every task with at least one `running` subagents row,
+   *  regardless of the task's own `column`. Boot reconciliation's held-task
+   *  pass used to source from `tasks WHERE column = 'running'`, which misses
+   *  a task whose terminal run already resolved and moved the card to
+   *  `review`/`done`/etc. before the crash — this is the wider source set
+   *  that also catches that case. */
+  taskIdsWithRunning(): string[] {
+    const rows = db.query<{ task_id: string }, []>(
+      `SELECT DISTINCT task_id FROM subagents WHERE status = 'running'`,
+    ).all();
+    return rows.map((r) => r.task_id);
+  },
 };

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -527,31 +527,73 @@ export function reconcileOrphans(): number {
     console.log(`[agetor] orphaned ${orphaned.length} run(s) with no recoverable session`);
   }
 
-  // Held tasks are invisible to the pass above: their terminal run is already
-  // `succeeded`, so it never appears in the `status='running'` scan and nothing
-  // re-arms the subagent watcher that would eventually release the card. Left
-  // alone, a restart strands a held task in `running` forever. Walk the
-  // `column='running'` tasks whose terminal run isn't running but that still
-  // have live subagent rows, and either re-arm the watcher (session still up,
-  // the background agent can finish and settle) or orphan the rows (session
-  // gone → settle hook lands the card in `review`).
+  // Held tasks — and, more generally, ANY task with a stuck `running`
+  // subagents row — are invisible to the pass above: their terminal run is
+  // already `succeeded`, so it never appears in the `status='running'` scan
+  // and nothing re-arms the subagent watcher that would eventually release
+  // the card. Left alone, a restart strands them forever. This used to only
+  // scan `tasks WHERE column = 'running'`, which covers the classic
+  // held-in-running case but has a blind spot: a `review`/`done`-column task
+  // whose subagents row is still `running` after a restart (the terminal run
+  // resolved and moved the card out of `running` *before* the crash, so the
+  // old scan skipped it entirely) was invisible here too — nothing ever
+  // re-armed its watcher or orphaned its rows, and the badge/tab dot stayed
+  // stuck forever. Source the wider set instead: every task with at least
+  // one `running` subagents row, regardless of column.
   let reArmed = 0;
   let released = 0;
-  const heldTaskIds = db.query<{ id: string }, []>(
-    `SELECT id FROM tasks WHERE "column" = 'running'`,
-  ).all();
-  for (const { id: heldId } of heldTaskIds) {
-    if (!isHeldByBackgroundAgents(heldId)) continue;
+  const heldTaskIds = subagents.taskIdsWithRunning();
+  for (const heldId of heldTaskIds) {
     const task = tasks.get(heldId);
     if (!task) continue;
     // Only claude-code writes subagent rows; a codex task can never be held, so
     // it never reaches here. Guard the session probe on kind for clarity.
     if (resolveHarness(task.agent)?.kind !== "claude-code") continue;
+
+    if (task.column === "running") {
+      // Classic held-task path, unchanged: only proceed when the terminal run
+      // has actually succeeded (i.e. this is a genuinely stuck "held for
+      // background agents" task, not an ordinary run still legitimately in
+      // progress that just happens to also have live subagent rows).
+      if (!isHeldByBackgroundAgents(heldId)) continue;
+      if (sessionExistsByName(sessionNameFor(heldId))) {
+        const run = task.runId ? runs.get(task.runId) : null;
+        // No JSONL session id means no watch directory to derive, so nothing will
+        // ever observe these agents finishing. Treat it exactly like a dead
+        // session and release, rather than leaving the card held forever.
+        if (!run?.claudeSessionId) {
+          orphanRunningSubagents(heldId);
+          released++;
+          continue;
+        }
+        const cwd = task.worktreePath ?? task.workdir;
+        const harness = resolveHarness(task.agent);
+        attachSubagentWatcher({
+          taskId: heldId,
+          jsonlPath: jsonlPathFor(cwd, run.claudeSessionId, harness?.home ?? null),
+        });
+        reArmed++;
+      } else {
+        // Session gone: no watcher could ever observe these agents finishing, so
+        // flip the rows now. `orphanRunningSubagents` fires the settle hook →
+        // `maybeReleaseHeldTask` → the card advances to `review`.
+        orphanRunningSubagents(heldId);
+        released++;
+      }
+      continue;
+    }
+
+    // Blind-spot path: any column other than `running` (review, done, ready,
+    // blocked, archived or not). `isHeldByBackgroundAgents` doesn't apply
+    // here — it only ever looks at `column === 'running'` rows — but the
+    // task's terminal run resolved normally (that's how the card got out of
+    // `running` before the crash), so `task.runId` still reliably points at
+    // that succeeded run and its `claudeSessionId`. Mirror the exact same
+    // session-alive / session-id-recoverable branch structure as above.
+    // HARD INVARIANT: never kill or create tmux sessions here — only re-arm
+    // watchers and flip DB rows.
     if (sessionExistsByName(sessionNameFor(heldId))) {
       const run = task.runId ? runs.get(task.runId) : null;
-      // No JSONL session id means no watch directory to derive, so nothing will
-      // ever observe these agents finishing. Treat it exactly like a dead
-      // session and release, rather than leaving the card held forever.
       if (!run?.claudeSessionId) {
         orphanRunningSubagents(heldId);
         released++;
@@ -565,15 +607,17 @@ export function reconcileOrphans(): number {
       });
       reArmed++;
     } else {
-      // Session gone: no watcher could ever observe these agents finishing, so
-      // flip the rows now. `orphanRunningSubagents` fires the settle hook →
-      // `maybeReleaseHeldTask` → the card advances to `review`.
+      // Session gone: orphan the rows. Unlike the held-in-running case, the
+      // settle hook's `maybeReleaseHeldTask` safely bails here (task.column
+      // isn't `running`), so this only clears the stale subagent rows — it
+      // does not move the card, which is already sitting wherever the user
+      // (or the earlier normal completion) left it.
       orphanRunningSubagents(heldId);
       released++;
     }
   }
   if (reArmed > 0 || released > 0) {
-    console.log(`[agetor] held tasks: re-armed ${reArmed} watcher(s), released ${released} to review`);
+    console.log(`[agetor] held tasks: re-armed ${reArmed} watcher(s), released ${released} background-agent row(s)`);
   }
 
   return orphaned.length;

--- a/src/bun/reconcile.test.ts
+++ b/src/bun/reconcile.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, beforeAll, afterAll, afterEach } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Task, Run, Subagent } from "../shared/types.ts";
@@ -15,7 +15,11 @@ process.env.AGETOR_DATA_DIR = DATA_DIR;
  *  in most files: `reconcileOrphans` now scans `tasks WHERE "column" =
  *  'running'` globally, so a leftover held-shaped row would keep getting
  *  re-visited (harmlessly, but wastefully) by every later call in this
- *  process, including from sibling test files in the combined `bun test`. */
+ *  process, including from sibling test files in the combined `bun test`.
+ *  Since the widened boot pass sources from `subagents.taskIdsWithRunning()`
+ *  (every task with a `running` subagent row, regardless of column — not
+ *  just `column = 'running'`), this hygiene now matters for ANY column a
+ *  test below parks a task in, not only `running`. */
 let cleanupTaskIds: string[] = [];
 afterEach(async () => {
   if (cleanupTaskIds.length === 0) return;
@@ -31,11 +35,17 @@ afterEach(async () => {
  *  deterministic without depending on a real tmux server or on whatever
  *  ambient AGETOR_TMUX_BIN a sibling test file left behind in this shared
  *  process. Mirrors the `fakeTmux` helper in claude-tmux-death.test.ts.
- *  Returns a restore fn; callers must call it (use try/finally). */
-function fakeTmux(code: number, stderr = "") {
+ *  Returns a restore fn; callers must call it (use try/finally).
+ *
+ *  Optional `logPath`: every invocation appends its full argv to that file
+ *  (one line per call) before exiting — used by the kill-safety test below
+ *  to assert `kill-session` never appears in the boot pass's tmux traffic,
+ *  without needing a real tmux server or a mocked module. */
+function fakeTmux(code: number, stderr = "", logPath?: string) {
   const dir = mkdtempSync(path.join(tmpdir(), "agetor-reconcile-faketmux-"));
   const bin = path.join(dir, "tmux");
-  writeFileSync(bin, `#!/bin/sh\n>&2 printf '%s' ${JSON.stringify(stderr)}\nexit ${code}\n`);
+  const logCmd = logPath ? `printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}\n` : "";
+  writeFileSync(bin, `#!/bin/sh\n${logCmd}>&2 printf '%s' ${JSON.stringify(stderr)}\nexit ${code}\n`);
   chmodSync(bin, 0o755);
   const prev = process.env.AGETOR_TMUX_BIN;
   process.env.AGETOR_TMUX_BIN = bin;
@@ -328,12 +338,24 @@ test("startTask honors cancel — exit handler records status 'cancelled'", asyn
 });
 
 /* ────────────────────────────────────────────────────────────────────────── *
- * Boot reconciliation of tasks held `running` by background agents
+ * Boot reconciliation of tasks with a dangling `running` subagents row
  * (orchestrator.ts's second `reconcileOrphans` pass, appended after the
  * runs-scan pass above). A held task's terminal run is already `succeeded`,
  * so the runs-scan pass never sees it — nothing would re-arm its subagent
  * watcher after a restart without this second pass. See
  * docs/plans/hold-task-running-while-background-agents-run.md §4/T4.
+ *
+ * This pass was later WIDENED (see
+ * docs/plans/adopt-continuation-on-task-notification.md §3/T2) to source
+ * from `subagents.taskIdsWithRunning()` — every task with a `running`
+ * subagent row, regardless of the task's own `column` — instead of just
+ * `tasks WHERE column = 'running'`. The old scan had a blind spot: a task
+ * whose terminal run resolved and moved the card to `review`/`done` before
+ * agetor crashed, but whose subagent row was still `running` at the moment
+ * of the crash, was invisible to both passes and stayed stuck forever. The
+ * tests below split into: (a) the classic `column = 'running'` path,
+ * unchanged; (b) the new any-other-column "blind spot" path this widening
+ * added.
  * ────────────────────────────────────────────────────────────────────────── */
 
 test("held-task boot pass: dead tmux session → subagent orphaned, task released to review", async () => {
@@ -364,45 +386,69 @@ test("held-task boot pass: dead tmux session → subagent orphaned, task release
   }
 });
 
-test("held-task boot pass: a task whose terminal run is still 'running' is left to the existing orphan pass, not double-handled", async () => {
-  // Guards against the two reconcile passes fighting: this task LOOKS
-  // held-shaped (column='running', a `running` subagent row) but its run
-  // hasn't actually finished, so `isHeldByBackgroundAgents` must be false
-  // and the FIRST pass (runs WHERE status='running') must own it instead —
-  // orphaning the run and dropping the column to `ready`, not `review`.
+test("held-task boot pass: a task whose terminal run is still 'running' has its run orphaned by the first pass, then its dangling subagent row orphaned by the widened second pass", async () => {
+  // This task LOOKS held-shaped (column='running', a `running` subagent
+  // row) but its run hasn't actually finished, so `isHeldByBackgroundAgents`
+  // is false and the FIRST pass (runs WHERE status='running') must own the
+  // run instead — orphaning it and dropping the column to `ready`, not
+  // `review`. That part of this test is UNCHANGED from before the widening.
+  //
+  // What changed: by the time the second (held-task) pass runs, the first
+  // pass has already flipped this task's column from 'running' to 'ready'
+  // (both passes execute inside the same `reconcileOrphans()` call, first
+  // pass first). Before the widening, the second pass only scanned
+  // `tasks WHERE column = 'running'` — so this task, now sitting in
+  // 'ready', was invisible to it, and its dangling `running` subagent row
+  // was left stranded forever (the exact blind-spot bug
+  // docs/plans/adopt-continuation-on-task-notification.md §3/T2 fixes).
+  // The widened pass sources from `subagents.taskIdsWithRunning()` instead,
+  // which doesn't filter by column, so it now reaches this task via its
+  // "blind spot" (any column other than 'running') branch and orphans the
+  // row. Session is forced dead here so that branch is deterministic.
   const { tasks, runs, subagents } = await import("./db.ts");
   const { reconcileOrphans } = await import("./orchestrator.ts");
 
-  const taskId = `task-notheld-running-${randomUUID()}`;
-  const runId = `run-notheld-running-${randomUUID()}`;
-  const subId = `sub-notheld-running-${randomUUID()}`;
-  cleanupTaskIds.push(taskId);
+  const restoreTmux = fakeTmux(1, "can't find session");
+  try {
+    const taskId = `task-notheld-running-${randomUUID()}`;
+    const runId = `run-notheld-running-${randomUUID()}`;
+    const subId = `sub-notheld-running-${randomUUID()}`;
+    cleanupTaskIds.push(taskId);
 
-  tasks.insert(heldTaskRow({ id: taskId, runId }));
-  // status:'running', no tmux_session/claude_session_id → the first pass's
-  // `canTryReattach` is false, so it falls straight to orphaning — no tmux
-  // dependency needed here, keeping this test fully deterministic.
-  runs.insert(succeededRun(runId, taskId, {
-    status: "running", endedAt: null, exitCode: null,
-    tmuxSession: null, claudeSessionId: null,
-  }));
-  subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
+    tasks.insert(heldTaskRow({ id: taskId, runId }));
+    // status:'running', no tmux_session/claude_session_id → the first pass's
+    // `canTryReattach` is false, so it falls straight to orphaning — no tmux
+    // dependency needed for the RUN outcome, keeping that half deterministic
+    // regardless of the fake tmux session state above.
+    runs.insert(succeededRun(runId, taskId, {
+      status: "running", endedAt: null, exitCode: null,
+      tmuxSession: null, claudeSessionId: null,
+    }));
+    subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
 
-  reconcileOrphans();
+    reconcileOrphans();
 
-  const run = runs.get(runId);
-  expect(run?.status).toBe("orphaned");
+    // Unchanged: the first pass still owns the run and the column drop.
+    const run = runs.get(runId);
+    expect(run?.status).toBe("orphaned");
+    const task = tasks.get(taskId);
+    expect(task?.column).toBe("ready");
 
-  const task = tasks.get(taskId);
-  expect(task?.column).toBe("ready");
+    // NEW: the widened second pass now reaches this task's dangling row
+    // (column is 'ready' by the time it scans, which the old
+    // `column = 'running'` source set would have missed entirely) and
+    // orphans it via the blind-spot branch.
+    const sub = subagents.get(subId);
+    expect(sub?.status).toBe("orphaned");
+    expect(sub?.endedAt).not.toBeNull();
 
-  // The new pass never gets a chance to touch this subagent row: the first
-  // pass's transaction already flipped the task out of `running` before the
-  // second pass's `tasks WHERE "column" = 'running'` scan runs (both passes
-  // execute inside the same `reconcileOrphans()` call), so the task is
-  // invisible to it. The row is left exactly as seeded.
-  const sub = subagents.get(subId);
-  expect(sub?.status).toBe("running");
+    // maybeReleaseHeldTask's settle hook fires from orphanRunningSubagents
+    // but bails immediately (task.column !== 'running'), so the column the
+    // first pass already set is left alone — it does not bounce to 'review'.
+    expect(tasks.get(taskId)?.column).toBe("ready");
+  } finally {
+    restoreTmux();
+  }
 });
 
 test("held-task boot pass: succeeded run with no running subagents is left untouched in running", async () => {
@@ -500,4 +546,204 @@ test("held-task boot pass: null claudeSessionId with a live tmux session is rele
   } finally {
     restoreTmux();
   }
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Blind-spot coverage: the widened source set reaches tasks OUTSIDE the
+ * `running` column. Each test below mirrors one of the `column = 'running'`
+ * cases above (dead session / live+recoverable session / live+no session /
+ * codex guard), but parks the task in `review` first — the exact shape that
+ * was invisible to the pre-widening boot pass. `maybeReleaseHeldTask`'s
+ * settle hook fires from every orphan in this branch too, but its own guard
+ * (`task.column !== 'running'`) must bail every time, so the column is
+ * asserted unchanged in each case, not just the subagent row's status.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("boot pass (blind spot): review-column task with a dead-session subagent row is orphaned; column is left alone", async () => {
+  const { tasks, runs, subagents } = await import("./db.ts");
+  const { reconcileOrphans, subscribeGlobal } = await import("./orchestrator.ts");
+
+  const restoreTmux = fakeTmux(1, "can't find session");
+  try {
+    const taskId = `task-review-dead-${randomUUID()}`;
+    const runId = `run-review-dead-${randomUUID()}`;
+    const subId = `sub-review-dead-${randomUUID()}`;
+    cleanupTaskIds.push(taskId);
+
+    tasks.insert(heldTaskRow({ id: taskId, runId, column: "review" }));
+    runs.insert(succeededRun(runId, taskId));
+    subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
+
+    // No `column` GlobalEvent should fire for this task: updateColumn only
+    // emits one when the column actually changes, and
+    // `maybeReleaseHeldTask` bails outright for a non-'running' column.
+    const columnEvents: unknown[] = [];
+    const unsub = subscribeGlobal((e) => {
+      if (e.kind === "column" && e.taskId === taskId) columnEvents.push(e);
+    });
+
+    reconcileOrphans();
+    unsub();
+
+    const sub = subagents.get(subId);
+    expect(sub?.status).toBe("orphaned");
+    expect(sub?.endedAt).not.toBeNull();
+
+    const task = tasks.get(taskId);
+    expect(task?.column).toBe("review");
+
+    expect(columnEvents).toEqual([]);
+  } finally {
+    restoreTmux();
+  }
+});
+
+test("boot pass (blind spot): review-column task with a live session + recoverable claudeSessionId re-arms the watcher instead of orphaning", async () => {
+  // Distinguishing observable from the dead-session and no-claudeSessionId
+  // cases (both of which orphan the row synchronously, inside
+  // `reconcileOrphans()` itself): a recoverable live session takes the
+  // re-arm branch — `attachSubagentWatcher` — which never touches the row
+  // at all, so it's still 'running' immediately after the call returns.
+  const { tasks, runs, subagents } = await import("./db.ts");
+  const { reconcileOrphans } = await import("./orchestrator.ts");
+  const { detachWatcherFor } = await import("./claude-subagents.ts");
+
+  const restoreTmux = fakeTmux(0, ""); // has-session always succeeds → "alive"
+  const taskId = `task-review-live-${randomUUID()}`;
+  try {
+    const runId = `run-review-live-${randomUUID()}`;
+    const subId = `sub-review-live-${randomUUID()}`;
+    cleanupTaskIds.push(taskId);
+
+    tasks.insert(heldTaskRow({ id: taskId, runId, column: "review" }));
+    runs.insert(succeededRun(runId, taskId)); // seeds a non-null claudeSessionId
+    subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
+
+    reconcileOrphans();
+
+    const sub = subagents.get(subId);
+    expect(sub?.status).toBe("running");
+
+    const task = tasks.get(taskId);
+    expect(task?.column).toBe("review");
+  } finally {
+    // Release the real watcher timer `attachSubagentWatcher` armed (it isn't
+    // called with `manual: true` from the boot pass) so it can't fire after
+    // this test moves on.
+    detachWatcherFor(taskId);
+    restoreTmux();
+  }
+});
+
+test("boot pass (blind spot): review-column task with a live session but no claudeSessionId is released, not stranded (mirrors the running-column case)", async () => {
+  const { tasks, runs, subagents } = await import("./db.ts");
+  const { reconcileOrphans } = await import("./orchestrator.ts");
+
+  const restoreTmux = fakeTmux(0, "");
+  try {
+    const taskId = `task-review-nosession-${randomUUID()}`;
+    const runId = `run-review-nosession-${randomUUID()}`;
+    const subId = `sub-review-nosession-${randomUUID()}`;
+    cleanupTaskIds.push(taskId);
+
+    tasks.insert(heldTaskRow({ id: taskId, runId, column: "review" }));
+    runs.insert(succeededRun(runId, taskId, { claudeSessionId: null }));
+    subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
+
+    reconcileOrphans();
+
+    const sub = subagents.get(subId);
+    expect(sub?.status).toBe("orphaned");
+
+    const task = tasks.get(taskId);
+    expect(task?.column).toBe("review");
+  } finally {
+    restoreTmux();
+  }
+});
+
+test("boot pass (blind spot): a codex task's stray running subagent row is skipped even outside the running column", async () => {
+  // Same guard as the running-column codex test above
+  // (`resolveHarness(task.agent)?.kind !== "claude-code"`), but pinned
+  // specifically against the NEW blind-spot branch: without this guard, a
+  // codex task parked in 'review' with a (synthetic — codex never really
+  // writes these) running subagent row would hit the dead-session path
+  // below and get orphaned. The guard fires before either branch runs.
+  const { tasks, runs, subagents } = await import("./db.ts");
+  const { reconcileOrphans } = await import("./orchestrator.ts");
+
+  const restoreTmux = fakeTmux(1, "can't find session"); // dead — would orphan if the guard were missing
+  try {
+    const taskId = `task-codex-review-${randomUUID()}`;
+    const runId = `run-codex-review-${randomUUID()}`;
+    const subId = `sub-codex-review-${randomUUID()}`;
+    cleanupTaskIds.push(taskId);
+
+    tasks.insert(heldTaskRow({ id: taskId, runId, column: "review", agent: "codex" }));
+    runs.insert(succeededRun(runId, taskId, {
+      agent: "codex", claudeSessionId: null, codexSessionId: `thread-${randomUUID()}`,
+    }));
+    subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
+
+    reconcileOrphans();
+
+    const task = tasks.get(taskId);
+    expect(task?.column).toBe("review");
+
+    const sub = subagents.get(subId);
+    expect(sub?.status).toBe("running");
+  } finally {
+    restoreTmux();
+  }
+});
+
+test("boot pass: never issues a tmux kill — dead and live review-column cases both leave kill-session absent from the tmux call log", async () => {
+  // HARD INVARIANT documented at the blind-spot branch in orchestrator.ts:
+  // the widened pass only ever re-arms a watcher or flips DB rows, never
+  // touches tmux beyond a has-session probe. `fakeTmux`'s optional logging
+  // captures every invocation's argv; asserting `kill-session` never
+  // appears is a direct, black-box check of that invariant across both the
+  // "orphan" and "re-arm" branches, without mocking any module.
+  const { tasks, runs, subagents } = await import("./db.ts");
+  const { reconcileOrphans } = await import("./orchestrator.ts");
+  const { detachWatcherFor } = await import("./claude-subagents.ts");
+
+  const logDir = mkdtempSync(path.join(tmpdir(), "agetor-reconcile-tmuxlog-"));
+  const logPath = path.join(logDir, "calls.log");
+
+  const deadTaskId = `task-nokill-dead-${randomUUID()}`;
+  const deadRunId = `run-nokill-dead-${randomUUID()}`;
+  const deadSubId = `sub-nokill-dead-${randomUUID()}`;
+  cleanupTaskIds.push(deadTaskId);
+  tasks.insert(heldTaskRow({ id: deadTaskId, runId: deadRunId, column: "review" }));
+  runs.insert(succeededRun(deadRunId, deadTaskId));
+  subagents.insertIfAbsent(subagentRow(deadSubId, deadTaskId, deadRunId));
+
+  let restoreTmux = fakeTmux(1, "can't find session", logPath);
+  try {
+    reconcileOrphans();
+  } finally {
+    restoreTmux();
+  }
+  expect(subagents.get(deadSubId)?.status).toBe("orphaned");
+
+  const liveTaskId = `task-nokill-live-${randomUUID()}`;
+  const liveRunId = `run-nokill-live-${randomUUID()}`;
+  const liveSubId = `sub-nokill-live-${randomUUID()}`;
+  cleanupTaskIds.push(liveTaskId);
+  tasks.insert(heldTaskRow({ id: liveTaskId, runId: liveRunId, column: "review" }));
+  runs.insert(succeededRun(liveRunId, liveTaskId));
+  subagents.insertIfAbsent(subagentRow(liveSubId, liveTaskId, liveRunId));
+
+  restoreTmux = fakeTmux(0, "", logPath);
+  try {
+    reconcileOrphans();
+  } finally {
+    detachWatcherFor(liveTaskId);
+    restoreTmux();
+  }
+  expect(subagents.get(liveSubId)?.status).toBe("running");
+
+  const log = existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
+  expect(log).not.toContain("kill-session");
 });

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -36,6 +36,7 @@ import { appendReferences } from "../../../shared/refs.ts";
 import { createEventDeduper } from "@/lib/event-dedup";
 import { createEventBuffer } from "@/lib/event-buffer";
 import { invalidatesRebuiltSnapshot } from "@/lib/rebuilt-mask";
+import { cleanPromptPane } from "@/lib/prompt-noise";
 import { AgentIcon } from "./AgentIcon";
 import {
   ReferencesPicker,
@@ -3151,27 +3152,11 @@ function AskQuestionsCard({
  * background) so the user recognises that they're looking at what's
  * actually on the tmux screen, not an agetor-synthesised question.
  */
-/** claude's TUI keyboard-shortcut footers — meaningless when answering through
- *  agetor's buttons, and they bury the actual prompt. Stripped from the scraped
- *  pane before display. Display-only; the parsed choices are unaffected. */
-const PROMPT_NOISE_RE = [
-  /^esc to cancel\b/i,
-  /^enter to (confirm|select|continue)\b/i,
-  /^↑\/↓/,
-  /^tab to amend\b/i,
-  /\bctrl\+e to explain\b/i,
-  /\(ctrl\+b ctrl\+b/i,
-  /to run in background\)/i,
-];
-function cleanPromptPane(text: string): string {
-  const out: string[] = [];
-  for (const line of text.split("\n")) {
-    if (PROMPT_NOISE_RE.some((re) => re.test(line.trim()))) continue;
-    if (out.length > 0 && out[out.length - 1] === line) continue; // repaint dup row
-    out.push(line);
-  }
-  return out.join("\n").replace(/^\n+|\n+$/g, "");
-}
+// claude's TUI keyboard-shortcut footers and working-spinner status line —
+// meaningless when answering through agetor's buttons, and they bury the
+// actual prompt. Stripped from the scraped pane before display via
+// `cleanPromptPane` (see `@/lib/prompt-noise` for the pattern list and the
+// rationale for each). Display-only; the parsed choices are unaffected.
 
 function TmuxPromptCard({
   req,

--- a/src/mainview/lib/prompt-noise.test.ts
+++ b/src/mainview/lib/prompt-noise.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import { cleanPromptPane, isPromptNoiseLine, PROMPT_NOISE_RE } from "./prompt-noise.ts";
+
+describe("isPromptNoiseLine — spinner/working-footer lines are noise", () => {
+  test("glyph + duration + token-count + esc-to-interrupt footer", () => {
+    expect(isPromptNoiseLine("✱ Scurrying… (1m 13s · ↓ 3.7k tokens)")).toBe(true);
+  });
+
+  test("asterisk glyph + short duration + esc-to-interrupt", () => {
+    expect(isPromptNoiseLine("* Reticulating… (3s · esc to interrupt)")).toBe(true);
+  });
+
+  test("glyph + duration + decimal-k token count + esc-to-interrupt", () => {
+    expect(
+      isPromptNoiseLine("✳ Simmering… (2m 4s · ↑ 1.2k tokens · esc to interrupt)"),
+    ).toBe(true);
+  });
+
+  test("ASCII ellipsis variant (three literal dots) still matches", () => {
+    expect(isPromptNoiseLine("Scurrying... (45s · esc to interrupt)")).toBe(true);
+  });
+
+  test("bare token count with no k/m suffix still matches (digit-led)", () => {
+    expect(isPromptNoiseLine("Working… (↓ 812 tokens)")).toBe(true);
+  });
+});
+
+describe("isPromptNoiseLine — legitimate modal content is not noise", () => {
+  test("a plain yes/no question", () => {
+    expect(isPromptNoiseLine("Do you want to proceed?")).toBe(false);
+  });
+
+  test("numbered choice lines", () => {
+    expect(isPromptNoiseLine("1. Yes, run it")).toBe(false);
+    expect(isPromptNoiseLine("2. No, and tell Claude what to do differently")).toBe(false);
+  });
+
+  test("an ellipsis with no parenthesized tail is not a footer", () => {
+    expect(isPromptNoiseLine("Reading files… please wait")).toBe(false);
+  });
+
+  test("a code snippet with a literal ellipsis inside a call's parens", () => {
+    expect(isPromptNoiseLine("callFunction(x, y, ...)")).toBe(false);
+  });
+
+  test("bare 'tokens' with no numeric count must NOT strip (security-relevant)", () => {
+    // A code-review tightened the pattern specifically so a permission
+    // excerpt describing what a tool does isn't silently swallowed just
+    // because it happens to end in "...(...tokens...)".
+    expect(isPromptNoiseLine("Read secrets… (rotates auth tokens)")).toBe(false);
+    expect(isPromptNoiseLine("Deploy… (production tokens required)")).toBe(false);
+  });
+});
+
+describe("isPromptNoiseLine — pre-existing keyboard-shortcut footers", () => {
+  test("esc to cancel, anchored at line start", () => {
+    expect(isPromptNoiseLine("Esc to cancel")).toBe(true);
+  });
+
+  test("enter to select, as rendered in the real AskUserQuestion footer", () => {
+    // Matches the fixture text in src/bun/fixtures/askuserquestion/*.txt —
+    // claude's TUI renders the whole hint bar as one line.
+    expect(
+      isPromptNoiseLine("Enter to select · ↑/↓ to navigate · Esc to cancel"),
+    ).toBe(true);
+  });
+
+  test("arrow-hint line anchored at line start", () => {
+    expect(isPromptNoiseLine("↑/↓ to navigate · n to add notes · Esc to cancel")).toBe(true);
+  });
+});
+
+describe("PROMPT_NOISE_RE — sanity on the exported list itself", () => {
+  test("is a non-empty array of RegExp", () => {
+    expect(Array.isArray(PROMPT_NOISE_RE)).toBe(true);
+    expect(PROMPT_NOISE_RE.length).toBeGreaterThan(0);
+    for (const re of PROMPT_NOISE_RE) {
+      expect(re).toBeInstanceOf(RegExp);
+    }
+  });
+});
+
+describe("cleanPromptPane — end-to-end on a realistic pane capture", () => {
+  // Mirrors the shape of a real scraped pane tail (see claude-tmux.ts,
+  // `lines.slice(-12)`): a boxed modal, its keyboard-shortcut footer, and
+  // the "is working" spinner line that sits right below it in the viewport.
+  const paneLines = [
+    "╭─ Plan ready ────────────────────────╮",
+    "│ I will refactor the auth module.    │",
+    "",
+    "│ Would you like to proceed?           │",
+    "",
+    "│ 1. Yes, and auto-accept edits        │",
+    "│ 2. Yes, and manually approve edits   │",
+    "│ 3. No, keep planning                 │",
+    "╰───────────────────────────────────────╯",
+    "Enter to select · ↑/↓ to navigate · Esc to cancel",
+    "",
+    "✱ Scurrying… (1m 13s · ↓ 3.7k tokens · esc to interrupt)",
+  ];
+
+  test("strips the footer and spinner lines, keeps the modal body/choices", () => {
+    const cleaned = cleanPromptPane(paneLines.join("\n"));
+
+    expect(cleaned).not.toMatch(/Enter to select/);
+    expect(cleaned).not.toMatch(/Scurrying/);
+    expect(cleaned).toContain("Would you like to proceed?");
+    expect(cleaned).toContain("1. Yes, and auto-accept edits");
+    expect(cleaned).toContain("2. Yes, and manually approve edits");
+    expect(cleaned).toContain("3. No, keep planning");
+  });
+
+  test("preserves the original line order of what's kept", () => {
+    const cleaned = cleanPromptPane(paneLines.join("\n"));
+    // The trailing blank line (index 10) has nothing after it once the
+    // spinner (index 11) is stripped, so it's trimmed off the end — the
+    // result is exactly the first 9 (non-noise) lines, untouched.
+    expect(cleaned).toBe(paneLines.slice(0, 9).join("\n"));
+  });
+});
+
+describe("cleanPromptPane — repaint duplicates and edge trimming", () => {
+  test("collapses an immediately-repeated line (tmux repaint) but not distant repeats", () => {
+    const pane = [
+      "│ Would you like to proceed?           │",
+      "│ Would you like to proceed?           │",
+      "1. Yes",
+      "│ Would you like to proceed?           │",
+    ].join("\n");
+    const cleaned = cleanPromptPane(pane);
+    expect(cleaned).toBe(
+      [
+        "│ Would you like to proceed?           │",
+        "1. Yes",
+        "│ Would you like to proceed?           │",
+      ].join("\n"),
+    );
+  });
+
+  test("trims leading/trailing blank lines left behind by stripped noise", () => {
+    const pane = [
+      "Enter to select · ↑/↓ to navigate · Esc to cancel",
+      "Do you want to proceed?",
+      "✱ Scurrying… (1m 13s · ↓ 3.7k tokens)",
+    ].join("\n");
+    expect(cleanPromptPane(pane)).toBe("Do you want to proceed?");
+  });
+});

--- a/src/mainview/lib/prompt-noise.ts
+++ b/src/mainview/lib/prompt-noise.ts
@@ -38,8 +38,11 @@ export const PROMPT_NOISE_RE = [
   // and/or "esc to interrupt". That combination doesn't occur in legitimate
   // modal body/choice text (e.g. "Do you want to proceed?", "1. Yes, run
   // it") or in a plain "please wait…" status line with no parenthesized
-  // tail, so it can't be tripped by those.
-  /(?:…|\.\.\.)\s*\([^)]*(?:\d+\s*[hms]\b|\btokens?\b|\besc to interrupt\b)[^)]*\)\s*$/i,
+  // tail, so it can't be tripped by those. The token branch requires the
+  // numeric count the real footer always carries ("3.7k tokens") — a bare
+  // "tokens" must NOT strip, or a permission excerpt like "Read secrets…
+  // (rotates auth tokens)" would silently lose approval context.
+  /(?:…|\.\.\.)\s*\([^)]*(?:\d+\s*[hms]\b|\d[\d.,]*\s*[km]?\s*tokens?\b|\besc to interrupt\b)[^)]*\)\s*$/i,
 ];
 
 /** Does `line` match one of the noise patterns above? */

--- a/src/mainview/lib/prompt-noise.ts
+++ b/src/mainview/lib/prompt-noise.ts
@@ -1,0 +1,62 @@
+// Noise filtering for `TmuxPromptCard`'s pane excerpt (RunPanel.tsx).
+//
+// Background: when the tmux pane scraper catches a REPL modal it hasn't
+// carved into a first-class card (plan-mode dialog aside), it registers a
+// `tmux_prompt` interaction whose `paneText` is the raw last-12-lines tail of
+// the pane (see `lines.slice(-12)` in `claude-tmux.ts`). That tail is
+// display-only chrome, not agetor's own copy, so it drags in whatever claude's
+// TUI happened to be drawing right next to the modal: keyboard-shortcut
+// footers ("esc to cancel", "↑/↓ to navigate", …) and — because the working
+// spinner footer sits directly above/below modals in the same viewport —
+// claude's "is working" status line too (e.g.
+// `"✱ Scurrying… (1m 13s · ↓ 3.7k tokens · esc to interrupt)"`). None of that
+// helps the user answer the prompt, so it's stripped before display. Purely
+// textual — no React/DOM dependency — so it's unit-testable on its own (see
+// the paired test task).
+
+/**
+ * Line-level noise patterns. Kept as small, independently testable regexes
+ * rather than one mega-pattern so a bad match is easy to isolate and a new
+ * footer variant is a one-line addition.
+ */
+export const PROMPT_NOISE_RE = [
+  /^esc to cancel\b/i,
+  /^enter to (confirm|select|continue)\b/i,
+  /^↑\/↓/,
+  /^tab to amend\b/i,
+  /\bctrl\+e to explain\b/i,
+  /\(ctrl\+b ctrl\+b/i,
+  /to run in background\)/i,
+  // claude's TUI "is working" spinner/status footer, e.g.
+  // "✱ Scurrying… (1m 13s · ↓ 3.7k tokens)" or
+  // "* Reticulating… (3s · esc to interrupt)". The leading glyph (✱ ✳ ✶ ✻ ✽
+  // · * +, or none) and the gerund verb both rotate freely across claude
+  // versions, so anchoring on either would be a whack-a-mole game. Instead
+  // this anchors on the one structural invariant: an ellipsis (either the
+  // single "…" glyph or "...") immediately followed by a parenthesized tail
+  // that carries a duration ("1m 13s", "3s"), a token count ("3.7k tokens"),
+  // and/or "esc to interrupt". That combination doesn't occur in legitimate
+  // modal body/choice text (e.g. "Do you want to proceed?", "1. Yes, run
+  // it") or in a plain "please wait…" status line with no parenthesized
+  // tail, so it can't be tripped by those.
+  /(?:…|\.\.\.)\s*\([^)]*(?:\d+\s*[hms]\b|\btokens?\b|\besc to interrupt\b)[^)]*\)\s*$/i,
+];
+
+/** Does `line` match one of the noise patterns above? */
+export function isPromptNoiseLine(line: string): boolean {
+  return PROMPT_NOISE_RE.some((re) => re.test(line));
+}
+
+/**
+ * Strips noise lines and collapses tmux repaint duplicates (the same line
+ * emitted twice in a row as the pane redraws) from a scraped pane excerpt.
+ */
+export function cleanPromptPane(text: string): string {
+  const out: string[] = [];
+  for (const line of text.split("\n")) {
+    if (isPromptNoiseLine(line.trim())) continue;
+    if (out.length > 0 && out[out.length - 1] === line) continue; // repaint dup row
+    out.push(line);
+  }
+  return out.join("\n").replace(/^\n+|\n+$/g, "");
+}


### PR DESCRIPTION
## Problem

A claude-code task whose background agents finished was moved to `Review` while the
claude session was visibly still working ("✱ Scurrying… (1m 13s · ↓ 3.7k tokens)").

Root cause: the last subagent settles ~1.5s after *its* JSONL goes idle, which releases
the #92 hold and flips the card to `review`. Claude then picks up the `<task-notification>`
and auto-continues — but continuation adoption (#95) only triggered on the first
*assistant content* line. During extended thinking, claude writes nothing to the JSONL
until the block completes, so for minutes the live session was tracked by no run row
and the card sat in `Review`.

## Fix

- **Adopt on the notification line itself** (`claude-tmux.ts`): `maybeAdoptContinuation`
  now also triggers on a provably-new `<task-notification>` line (both JSONL shapes),
  evaluated after `pendingEndTurn` staging and *before* the settle block — so the release
  check sees `task.runId` pointing at a running continuation and the card never flickers
  through `review`. The card stays `running` through the whole thinking window; Stop works.
- **10-minute watchdog**: if no content ever follows a notification-adopted run (claude
  interrupted / never continues), the run settles through the normal end-turn path and
  the card releases to `review`. Cleared by content or turn resolution, reset by another
  notification, torn down with the session.
- **Replay safety for uuid-less lines**: `queue-operation` notification lines carry
  `uuid: null`, which defeated every `seenLineUuids` guard — a boot-reattach replay could
  spawn a phantom continuation run (and double-persist the breadcrumb). They now get a
  deterministic FNV-1a content-hash `line_uuid` (`qnotif:`-prefixed) that persists to
  `run_events` and is re-seeded on reattach.

## Related fixes

- **Boot reconciliation blind spot** (`orchestrator.ts`/`db.ts`): the held-task pass only
  scanned `column='running'`, so a `Review`-column task with a stuck `running` subagent
  row after a restart kept its badge forever. The pass now sources from
  `subagents.taskIdsWithRunning()` (any column): re-arms the watcher if the session is
  alive, orphans the rows if not. Never kills or creates tmux sessions.
- **Spinner footer in prompt cards** (`RunPanel.tsx` → `lib/prompt-noise.ts`): the pane
  scraper's 12-line excerpt could include claude's `✱ Scurrying…` footer verbatim. The
  noise filter now strips it, anchored on ellipsis + parenthesized duration/token/esc
  tail (verbs and glyphs rotate across claude versions). The token branch requires a
  numeric count so a permission excerpt mentioning "tokens" is never stripped.

## Testing

- 50 new/updated tests: notification adoption + replay safety + watchdog lifecycle
  (arm/clear/reset/fire/stale-fire) in `claude-continuation.test.ts`; all widened
  boot-pass branches incl. a tmux-argv kill-safety log in `reconcile.test.ts`;
  spinner positives + security negatives + `cleanPromptPane` e2e in `prompt-noise.test.ts`.
- Full suite: **935 pass / 0 fail** (86 files); `tsc --noEmit` clean.
- Reviewed (0 must-fix; the one should-fix — the token-count anchor — is included).

## Accepted trade-off

Thinking silences longer than 10 minutes false-release to `Review`; the eventual content
line re-adopts a fresh continuation and pulls the card back (pre-fix behavior, not breakage).

Plan: `docs/plans/adopt-continuation-on-task-notification.md`