### PR TITLE
fix(github): resolve custom ssh host aliases in remote detection

### DIFF
--- a/docs/plans/github-remote-host-aliases.md
+++ b/docs/plans/github-remote-host-aliases.md
@@ -1,0 +1,74 @@
+# Plan — Resolve custom git-host aliases in GitHub remote detection
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-13 |
+| Source | /implement — "all projects show `project does not have a GitHub remote`" |
+| Config | AGENTS_CONFIG.yml (collapsed: single-file fix, phases run inline) |
+| Branch | fix/git-integration-error-no-project |
+| Base SHA | 5ec712a |
+| Mode | Autonomous — grill + plan-approval gates bypassed; assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+`GET /github/items?path=…` (and every other `repoForDir`-backed GitHub route) must
+recognize remotes that use custom SSH host aliases for per-identity keys, e.g.
+`git@github-alamops.com:alamops/agetor.git`, and resolve them to the canonical
+`github.com` `owner/repo`. Success: the GitHub panel loads PRs/issues for the
+user's projects instead of "project does not have a GitHub remote".
+
+## 2. Context & constraints
+
+- `parseGitHubRemote` (`src/bun/github.ts:558`) only matches literal `github.com`
+  in https and ssh forms. `repoForDir` (`github.ts:787`) walks `git remote
+  get-url` output through it; a null parse → the error on every route.
+- The user's `~/.ssh/config` defines per-identity aliases (`github-alamops.com`
+  and several other `github-*`/`bitbucket-*` hosts), so **every** project
+  remote uses a non-literal host → all projects fail.
+- The GitHub API integration is GitHub-only; gitlab/bitbucket appear only as a
+  negative test case. No other module parses remote URLs.
+
+## 3. Approach & key decisions
+
+Split parsing into a generic `parseGitRemote` (host + owner + name across https,
+`ssh://`, and scp-like syntaxes) plus a `canonicalGitHost` step that maps any
+host **containing** `github` → `github.com`, `gitlab` → `gitlab.com`,
+`bitbucket` → `bitbucket.org` (per the user's explicit instruction).
+`parseGitHubRemote` then accepts only canonical-host `github.com`. A
+gitlab/bitbucket remote still returns null for the GitHub API (correct — the
+API can't serve it), but the canonicalization is provider-generic so future
+gitlab/bitbucket integrations reuse it.
+
+Alternative considered: reading `HostName` out of `~/.ssh/config` — more exact
+(would handle GHE aliases) but heavier (fs + Include resolution) and not what
+the user asked for.
+
+## 4. Work breakdown — implementation
+
+- T1 — `src/bun/github.ts`: add `canonicalGitHost` + `parseGitRemote`, rewrite
+  `parseGitHubRemote` on top; export both via `__githubInternals`.
+
+## 5. Work breakdown — tests
+
+- T2 — `src/bun/github.test.ts`: alias ssh remotes (with and without `user@`),
+  `ssh://` alias form, gitlab/bitbucket alias canonicalization, gitlab remote
+  still null for GitHub, existing cases unchanged.
+
+## 6. Execution waves
+
+Single wave, inline (one file + its test — no fan-out).
+
+## 7. Blast radius & risks
+
+Every GitHub route funnels through `repoForDir` → behavior only *widens* (null →
+match); no existing match can regress since literal `github.com` contains
+`github`. Known tradeoff: a GitHub Enterprise host (`github.mycompany.com`)
+would now canonicalize to `github.com` and hit the wrong API — accepted per the
+user's explicit "if it has github, resolve to github.com".
+
+## 8. Open questions / assumptions
+
+- Assumed substring heuristic over `~/.ssh/config` `HostName` lookup (user's
+  explicit instruction; GHE misresolution accepted).
+- Assumed gitlab/bitbucket "the same" means canonicalization support in the
+  shared parser, not a full gitlab/bitbucket API integration (none exists).

--- a/src/bun/github.test.ts
+++ b/src/bun/github.test.ts
@@ -89,12 +89,48 @@ test("githubRepoFromRemoteForTest parses GitHub https remotes", () => {
 
 test("githubRepoFromRemoteForTest parses GitHub ssh remotes", () => {
   expect(githubRepoFromRemoteForTest("git@github.com:openai/codex.git")).toBe("openai/codex");
+  expect(githubRepoFromRemoteForTest("git@github.com:openai/codex.GIT")).toBe("openai/codex");
   expect(githubRepoFromRemoteForTest("ssh://git@github.com/openai/codex.git")).toBe("openai/codex");
 });
 
 test("githubRepoFromRemoteForTest ignores non-GitHub remotes", () => {
   expect(githubRepoFromRemoteForTest("git@gitlab.com:openai/codex.git")).toBeNull();
+  expect(githubRepoFromRemoteForTest("git@gitlab-work.com:openai/codex.git")).toBeNull();
+  expect(githubRepoFromRemoteForTest("/Users/me/repos/codex")).toBeNull();
   expect(githubRepoFromRemoteForTest("")).toBeNull();
+});
+
+test("githubRepoFromRemoteForTest resolves custom ssh host aliases containing github", () => {
+  expect(githubRepoFromRemoteForTest("git@github-alamops.com:alamops/agetor.git")).toBe("alamops/agetor");
+  expect(githubRepoFromRemoteForTest("git@github-work:openai/codex.git")).toBe("openai/codex");
+  expect(githubRepoFromRemoteForTest("github-work:openai/codex")).toBe("openai/codex");
+  expect(githubRepoFromRemoteForTest("ssh://git@github-work/openai/codex.git")).toBe("openai/codex");
+  expect(githubRepoFromRemoteForTest("https://github-mirror.example.com/openai/codex.git")).toBe("openai/codex");
+});
+
+test("canonicalGitHost maps alias hosts to provider hosts", () => {
+  const { canonicalGitHost } = __githubInternals;
+  expect(canonicalGitHost("github.com")).toBe("github.com");
+  expect(canonicalGitHost("GitHub-Alamops.com")).toBe("github.com");
+  expect(canonicalGitHost("gitlab-work.io")).toBe("gitlab.com");
+  expect(canonicalGitHost("bitbucket-work.org")).toBe("bitbucket.org");
+  expect(canonicalGitHost("git.internal.corp")).toBe("git.internal.corp");
+});
+
+test("parseGitRemote extracts host/owner/name across url syntaxes", () => {
+  const { parseGitRemote } = __githubInternals;
+  expect(parseGitRemote("git@bitbucket-work.org:acme/app.git")).toEqual({
+    host: "bitbucket.org",
+    owner: "acme",
+    name: "app",
+  });
+  expect(parseGitRemote("https://gitlab.com/group/project")).toEqual({
+    host: "gitlab.com",
+    owner: "group",
+    name: "project",
+  });
+  expect(parseGitRemote("../relative/path")).toBeNull();
+  expect(parseGitRemote("/absolute/path/repo.git")).toBeNull();
 });
 
 test("matchesFilters matches on assignee login (case-insensitive), rejects non-assignees", () => {

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -555,17 +555,37 @@ async function run(cmd: string[], cwd?: string, timeoutMs = 10_000): Promise<Com
   }
 }
 
-function parseGitHubRemote(raw: string): GitHubRepo | null {
+/** Map a remote's host to its canonical provider host. Users pin per-identity
+ *  SSH keys via `~/.ssh/config` host aliases (`github-work.com`, `bitbucket-x.org`,
+ *  …), so the host in a remote URL is often not the provider's real hostname.
+ *  Any host containing the provider's name resolves to that provider. */
+function canonicalGitHost(host: string): string {
+  const lower = host.toLowerCase();
+  if (lower.includes("github")) return "github.com";
+  if (lower.includes("gitlab")) return "gitlab.com";
+  if (lower.includes("bitbucket")) return "bitbucket.org";
+  return lower;
+}
+
+/** Extract host + owner/name from a git remote URL in https, ssh://, or
+ *  scp-like (`[user@]host:owner/repo`) form, canonicalizing the host via
+ *  canonicalGitHost. Returns null for local paths and anything unrecognized. */
+function parseGitRemote(raw: string): { host: string; owner: string; name: string } | null {
   const remote = raw.trim();
   if (!remote) return null;
 
-  const https = /^https?:\/\/github\.com\/([^/]+)\/([^/#?]+?)(?:\.git)?(?:[/?#].*)?$/i.exec(remote);
-  if (https) return { owner: https[1]!, name: https[2]! };
+  const https = /^https?:\/\/(?:[^@/]+@)?([^/:]+)(?::\d+)?\/([^/]+)\/([^/#?]+?)(?:\.git)?(?:[/?#].*)?$/i.exec(remote);
+  const ssh = /^ssh:\/\/(?:[^@/]+@)?([^/:]+)(?::\d+)?\/([^/]+)\/(.+?)(?:\.git)?$/i.exec(remote);
+  const scp = /^(?:[^@/\s]+@)?([^/:\s]+):([^/:]+)\/(.+?)(?:\.git)?$/i.exec(remote);
+  const m = https ?? ssh ?? scp;
+  if (!m) return null;
+  return { host: canonicalGitHost(m[1]!), owner: m[2]!, name: m[3]! };
+}
 
-  const ssh = /^(?:ssh:\/\/)?git@github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/i.exec(remote);
-  if (ssh) return { owner: ssh[1]!, name: ssh[2]! };
-
-  return null;
+function parseGitHubRemote(raw: string): GitHubRepo | null {
+  const parsed = parseGitRemote(raw);
+  if (!parsed || parsed.host !== "github.com") return null;
+  return { owner: parsed.owner, name: parsed.name };
 }
 
 export function githubRepoFromRemoteForTest(remote: string): string | null {
@@ -730,6 +750,8 @@ function buildIssueUpdatePatch(input: {
 
 // Internal helpers exposed for unit tests only — no other consumers.
 export const __githubInternals = {
+  canonicalGitHost,
+  parseGitRemote,
   matchesFilters,
   normalizeItem,
   normalizeComment,


### PR DESCRIPTION
Remotes like git@github-alamops.com:owner/repo.git (per-identity ssh keys via ~/.ssh/config host aliases) failed parseGitHubRemote's literal github.com match, so every GitHub route returned "project does not have a GitHub remote". Split parsing into a generic parseGitRemote (https,
ssh://, scp-like) plus canonicalGitHost: any host containing github ->
github.com, gitlab -> gitlab.com, bitbucket -> bitbucket.org.