### PR TITLE
feature: cleanup worktree on task archive, keep AI history restorable

### DIFF
--- a/docs/plans/archive-worktree-cleanup.md
+++ b/docs/plans/archive-worktree-cleanup.md
@@ -1,0 +1,89 @@
+# Plan — Worktree cleanup on archive, with restorable AI session
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-13 |
+| Source | /implement task: "Once archiving a task, we must also cleanup the associated worktree but keeping the AI history for restoration of the session later if the user decides to send a message to an archived task or if they decide to unarchive that." |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/cleaning-up-worktrees |
+| Base SHA | 5ec712ab5ea8cfae618170fec7f4db99748d30b9 |
+| Mode | **Autonomous** — grill + plan-approval gates bypassed; all assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+When a task is archived, its git worktree directory is removed from disk (reclaiming space and reducing `~/.agetor/worktrees/` clutter), while everything needed to resume the agent conversation is preserved. The session is restored — worktree re-materialized on the same branch at the same path, conversation resumed via `claude --resume <sessionId>` / `codex exec resume <thread_id>` — when the user unarchives the task or sends a message to it.
+
+Success criteria:
+- `archiveTask` removes the worktree dir but **keeps the branch**, `task.worktreePath`/`branch`/`baseRef` in the DB, all `runs`/`run_events` rows (incl. `claude_session_id`/`codex_session_id`), and claude's external JSONL history.
+- `unarchiveTask` re-materializes the worktree (best-effort) so the card is immediately usable.
+- Sending a message to an archived task auto-unarchives it, restores the worktree, and resumes the prior conversation.
+- A dirty worktree (uncommitted changes) is **not** removed on archive — no silent data loss.
+- `bun run typecheck` green; `bun test` green.
+
+## 2. Context & constraints (from investigation)
+
+- `archiveTask` (`orchestrator.ts:1729`) today: done-column only, kills tmux sessions (`dropSession`/`dropCodexSession`), fire-and-forgets `killTerminalsForTask`, **keeps the worktree** (doc comment says so explicitly).
+- `removeWorktree` (`worktree.ts:756`) is delete-only: `git worktree remove --force` **plus `git branch -D`** — unusable for archive as-is (would destroy the work). Owned-prefix `rmSync` fallback for paths under `dataDir/worktrees/`.
+- `prepareWorkdir` (`worktree.ts:536`) already has the exact restore mechanic: when `task.worktreePath` is recorded but the dir is gone and the branch exists, it re-attaches via `git worktree add <wt> <branch>` (no reset — prior commits preserved). Path is deterministic: `dataDir/worktrees/<task-id>`. Tested at `worktree.test.ts:154-174` and `:316-345`.
+- Claude AI history = `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl` — encoded from the **cwd path string** (`claude-tmux.ts:302,1555`), stored outside the worktree. Deleting the worktree never touches it, but `task.worktreePath` must stay **non-null and verbatim** in the DB or the JSONL lookup (`/runs/:id/rebuild-events`, resume) resolves the wrong encoded path. Also the PATCH workdir-lock (`server.ts:2962`) keys off `worktreePath !== null`.
+- Codex history = thread id in `runs.codex_session_id`, replayed via `codex exec resume <thread_id>`; not cwd-encoded.
+- **Gap:** `spawnResumedSession` (`orchestrator.ts:1490`) and `spawnCodexTurnNow` (`orchestrator.ts:1196`) compute `cwd = task.worktreePath ?? task.workdir` with no existence check and never call `prepareWorkdir` — spawning into a missing dir fails (30s boot-timeout at best).
+- `sendInput` (`orchestrator.ts:1134`) is sync; its only production callers are async route handlers (`server.ts:3419`, `:3618`). `archiveTask`/`unarchiveTask` callers: `server.ts:3054`, `:3063`. Going async is safe.
+- Diff/git-status/open-path routes already degrade gracefully when the dir is missing (`worktree.ts:63,91,681`; `server.ts:3198,3248`). `createTerminal` already calls `prepareWorkdir` (rematerializes).
+- UI: archived RunPanel replaces the composer with a static "Unarchive it to send messages" notice (`RunPanel.tsx:1307-1310`); backlog tray renders `readOnly`. Archive/Unarchive buttons at `TaskCard.tsx:182-191`, `RunPanel.tsx:1173-1182`.
+- Tests: `orchestrator.test.ts` (top-level mkdtemp `AGETOR_DATA_DIR`, fake driver env, per-test dynamic imports, manual row cleanup); `worktree.test.ts` (`makeRepo()`/`fakeTask()` helpers, real temp git repos). Existing archive tests only cover `isolation: "none"`.
+- Latest migration: `026` — **this plan needs no migration** (no schema change).
+
+## 3. Approach & key decisions
+
+1. **New `detachWorktree(task)` in `worktree.ts`** — branch-preserving teardown: `git worktree remove --force` + `prune` + owned-prefix `rmSync` fallback, **no `git branch -D`**. Idempotent (no-op when dir already absent). Skips removal when the worktree has uncommitted changes (returns `{ removed: false, reason: "dirty" }`) — `--force` would permanently destroy uncommitted work. Never throws.
+2. **Keep `task.worktreePath` non-null across archive** — required by the JSONL path encoding, the PATCH workdir-lock, and `prepareWorkdir`'s re-attach key. State "dir missing on disk" is detected via `existsSync`, matching existing patterns. No new column, no migration.
+3. **Restore = `prepareWorkdir`** — its existing re-attach path is exactly "same absolute path, same branch". Triggers:
+   - `unarchiveTask` → eager best-effort re-materialize (failure logged to console, does not block unarchive; next send/start/terminal retries lazily).
+   - `sendInput` → auto-unarchive if archived, then restore the worktree if `worktreePath` set but dir missing, then dispatch as today. Hard failure (e.g. branch deleted by user, or checked out elsewhere) returns `{ delivered: false, reason }`.
+   - `startTask` → already calls `prepareWorkdir`; add auto-unarchive so a started archived task can't become a hidden moving card.
+4. **Ordering in `archiveTask`**: stamp `archivedAt` → drop tmux sessions → **await** `killTerminalsForTask` (a live shell cwd'd in the worktree blocks `git worktree remove`; mirrors `deleteTask`'s ordering) → await `detachWorktree`. `archiveTask` becomes async.
+5. **`sendInput` (and `archiveTask`/`unarchiveTask`) become async** — awaited at the 4 server.ts call sites. HTTP CLI unaffected.
+6. **UI**: archived RunPanel shows the normal composer (same `canSend`/`resumableRunId` capability rules as an idle task) with an inline hint that sending will unarchive the task and restore its worktree. Backlog tray stays `readOnly` while archived (server freezes backlog mutations; unchanged).
+
+Alternatives considered: (a) new `worktreeRemovedAt` column — rejected, `existsSync` is the established pattern and no consumer needs the distinction; (b) restore at the server-route layer — rejected, orchestrator owns process side effects in this codebase; (c) sync git rematerialization to keep `sendInput` sync — rejected, duplicates `prepareWorkdir` logic and the async ripple is contained.
+
+## 4. Work breakdown — implementation tasks
+
+| ID | Goal | Files owned | Deps | Acceptance |
+| --- | --- | --- | --- | --- |
+| T1 | Backend: `detachWorktree`; async `archiveTask` with detach; eager-restore `unarchiveTask`; auto-unarchive + lazy-restore in `sendInput`; auto-unarchive in `startTask`; await at server call sites; update stale doc comments | `src/bun/worktree.ts`, `src/bun/orchestrator.ts`, `src/bun/server.ts` | — | typecheck green; behavior per §3 |
+| T2 | Frontend: unlock composer on archived tasks with unarchive-on-send hint; keep backlog tray readOnly | `src/mainview/components/RunPanel.tsx` | — | typecheck green; archived task shows enabled composer + hint |
+
+## 5. Work breakdown — test tasks
+
+| ID | Goal | Files owned | Covers |
+| --- | --- | --- | --- |
+| T3 | `detachWorktree` unit tests: removes dir + keeps branch/commits; dirty worktree skipped; idempotent on missing dir; `prepareWorkdir` re-attach after detach round-trip | `src/bun/worktree.test.ts` | T1 (worktree.ts) |
+| T4 | Orchestrator archive-lifecycle tests: archive removes worktree dir, keeps branch + runs rows + session ids; unarchive re-materializes; `sendInput` on archived task auto-unarchives (fake driver); startTask auto-unarchives | `src/bun/orchestrator.test.ts` | T1 (orchestrator.ts) |
+
+## 6. Execution waves
+
+- **Wave 1 (parallel):** T1, T2 — disjoint file sets. Barrier: typecheck + commit.
+- **Review** (Phase 5, opus) on `git diff 5ec712a...HEAD`.
+- **Wave 2 (parallel):** T3, T4 — disjoint test files. Barrier: `bun test` + typecheck.
+- **Phase 7:** run `bun test` + `bun run typecheck` (haiku background agent).
+
+## 7. Blast radius & risks
+
+- `archiveTask`/`unarchiveTask`/`sendInput` signature change (sync → async): callers are server routes + tests only; CLI talks HTTP. Tests referencing these must be updated to await.
+- `git worktree remove --force` on a dirty tree destroys uncommitted work → mitigated by the dirty-skip.
+- Branch checked out elsewhere / deleted by user before restore → `prepareWorkdir` re-attach is a hard error; surfaced as `sendInput` failure reason / console warning on unarchive. Acceptable.
+- Archived tasks created **before** this change already have live worktrees — unaffected (archive-time detach only fires on newly-archived tasks; old ones behave as today).
+- `RunPanel` "Open"/"Diff" buttons on archived tasks: `/open-path` 404s cleanly and diff returns a friendly note when the dir is missing (pre-existing degradation). Not changing them.
+- Dogfooding hazard: this very session runs inside `~/.agetor/worktrees/…` — tests must keep using temp repos + temp `AGETOR_DATA_DIR` (existing convention) so they never touch real worktrees.
+
+## 8. Open questions / assumptions (autonomous mode — decisions taken without owner input)
+
+1. **Message-to-archived-task auto-unarchives** (server-side in `sendInput`) rather than requiring an explicit unarchive first. UI hints at this before sending.
+2. **Dirty worktrees are kept** on archive (removal skipped) rather than force-removed or auto-committed. Archive still succeeds.
+3. **Unarchive eagerly restores** the worktree, best-effort; failures don't block unarchive.
+4. **No confirmation dialog added** for archive — the operation is now reversible-by-design (branch + history kept).
+5. **No new DB column** to distinguish "removed by archive" from "never created"/"manually deleted" — `existsSync` state is sufficient for all current consumers.
+6. **Backlog stays frozen** on archived tasks (existing server guard untouched); only the composer gains send-with-unarchive.
+7. Claude `--resume` is assumed to work when the worktree is re-created at the identical absolute path (deterministic `dataDir/worktrees/<task-id>`), matching how agetor already derives JSONL paths from the cwd string.

--- a/src/bun/claude-followup-restart.test.ts
+++ b/src/bun/claude-followup-restart.test.ts
@@ -118,7 +118,7 @@ test("follow-up to a task whose session outlived the process resumes instead of 
       codexSessionId: null,
     });
 
-    const result = sendInput(priorRunId, "please continue");
+    const result = await sendInput(priorRunId, "please continue");
     expect(result.delivered).toBe(true);
     if (!result.delivered) throw new Error(result.reason);
 

--- a/src/bun/claude-turn-routing.test.ts
+++ b/src/bun/claude-turn-routing.test.ts
@@ -144,7 +144,7 @@ test("a transient/unreachable tmux probe routes a follow-up through the existing
       codexSessionId: null,
     });
 
-    const result = sendInput(priorRunId, "still there?");
+    const result = await sendInput(priorRunId, "still there?");
     expect(result.delivered).toBe(true);
 
     // Let the fire-and-forget paste chain (queuePaste) run its course.
@@ -248,7 +248,7 @@ test("an unambiguous 'gone' probe routes a follow-up through the resume path (ki
       codexSessionId: null,
     });
 
-    const result = sendInput(priorRunId, "please continue");
+    const result = await sendInput(priorRunId, "please continue");
     expect(result.delivered).toBe(true);
 
     const entries = readLog(logPath);

--- a/src/bun/orchestrator-codex.test.ts
+++ b/src/bun/orchestrator-codex.test.ts
@@ -75,7 +75,7 @@ test("sendInput (codex, idle) spawns a NEW run row that resumes the same thread"
   await settle(); // let the first turn resolve (fake done at ~20ms)
 
   const firstRunId = "runId" in started ? started.runId : "";
-  const res = sendInput(firstRunId, "turn two");
+  const res = await sendInput(firstRunId, "turn two");
   expect(res.delivered).toBe(true);
   await settle();
 
@@ -115,7 +115,7 @@ test("sendInput (codex, busy) queues the follow-up; it spawns after the active t
 
   // Send immediately — the first turn's fake hasn't resolved yet, so this
   // folds into the queue and reports the still-active run id.
-  const res = sendInput(firstRunId, "queued turn");
+  const res = await sendInput(firstRunId, "queued turn");
   expect(res.delivered).toBe(true);
   if (res.delivered) expect(res.runId).toBe(firstRunId); // attached to active run
 

--- a/src/bun/orchestrator-continuation.test.ts
+++ b/src/bun/orchestrator-continuation.test.ts
@@ -327,7 +327,7 @@ test("a follow-up sent while the continuation run is in flight folds into it (bu
   claudeTmux.__forTest.installSession(taskId, jsonlPath);
   try {
     const { sendInput } = await import("./orchestrator.ts");
-    const sent = sendInput(newRunId, "follow-up while continuation is in flight");
+    const sent = await sendInput(newRunId, "follow-up while continuation is in flight");
     expect(sent.delivered).toBe(true);
     if (sent.delivered) expect(sent.runId).toBe(newRunId);
 

--- a/src/bun/orchestrator.test.ts
+++ b/src/bun/orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -15,6 +15,27 @@ process.env.AGETOR_CLAUDE_DRIVER = "fake";
 process.env.AGETOR_CLAUDE_BIN = "/bin/echo";
 process.env.AGETOR_TMUX_BIN = "/bin/echo"; // tmux probe in agent-status passes
 process.env.AGETOR_CLAUDE_ARGS = "";
+
+// Standalone helper: run git in a directory (mirrors worktree.test.ts's
+// `git` helper — kept local here since this file owns no shared test util).
+async function git(args: string[], cwd: string) {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+}
+
+// Standalone helper: a real temp git repo for worktree-isolation tests. Never
+// point a task at a real repo in these tests — always mkdtemp (see worktree
+// isolation warning in CLAUDE.md).
+async function makeRepo(): Promise<string> {
+  const repo = mkdtempSync(path.join(tmpdir(), "agetor-orch-repo-"));
+  await git(["init", "-b", "main"], repo);
+  await git(["config", "user.email", "test@example.com"], repo);
+  await git(["config", "user.name", "test"], repo);
+  writeFileSync(path.join(repo, "README"), "hi\n");
+  await git(["add", "."], repo);
+  await git(["commit", "-m", "init"], repo);
+  return repo;
+}
 
 test("startTask refuses to run when the harness is disabled", async () => {
   const { createTask, startTask } = await import("./orchestrator.ts");
@@ -151,7 +172,7 @@ test("sendInput folds a follow-up into the in-flight run instead of stranding a 
     // `rows.length === 1` assertion below fails loudly rather than silently
     // passing for the wrong reason.
     // R1 is still in flight → this must fold into it.
-    const sent = sendInput(r1, "second message while busy");
+    const sent = await sendInput(r1, "second message while busy");
     expect(sent.delivered).toBe(true);
     if (sent.delivered) expect(sent.runId).toBe(r1);
 
@@ -190,7 +211,7 @@ test("archiveTask refuses tasks that aren't in the Done column", async () => {
   });
   if ("error" in created) throw new Error(created.error);
   try {
-    const res = archiveTask(created.task.id);
+    const res = await archiveTask(created.task.id);
     expect("error" in res).toBe(true);
     if ("error" in res) expect(res.error).toMatch(/done/i);
   } finally {
@@ -218,7 +239,7 @@ test("archiveTask stamps archivedAt and unarchiveTask clears it", async () => {
     const before = tasks.get(created.task.id);
     expect(before?.archivedAt).toBeNull();
 
-    const archived = archiveTask(created.task.id);
+    const archived = await archiveTask(created.task.id);
     expect("task" in archived).toBe(true);
     if ("task" in archived) {
       expect(archived.task.archivedAt).not.toBeNull();
@@ -226,15 +247,244 @@ test("archiveTask stamps archivedAt and unarchiveTask clears it", async () => {
     }
 
     // Idempotent: archiving twice is a no-op success.
-    const archivedAgain = archiveTask(created.task.id);
+    const archivedAgain = await archiveTask(created.task.id);
     expect("task" in archivedAgain).toBe(true);
 
-    const restored = unarchiveTask(created.task.id);
+    const restored = await unarchiveTask(created.task.id);
     expect("task" in restored).toBe(true);
     if ("task" in restored) {
       expect(restored.task.archivedAt).toBeNull();
     }
   } finally {
     db.run(`DELETE FROM tasks WHERE id = ?`, [created.task.id]);
+  }
+});
+
+test("archiveTask detaches the worktree from disk but keeps branch + DB pointers", async () => {
+  const { createTask, archiveTask } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "archive detaches worktree",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    // Materialize the worktree directly (mirrors what startTask does) without
+    // spawning an agent — this test is about archive's disk bookkeeping, not
+    // the run lifecycle.
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+    const branch = prepared.branch!;
+    expect(existsSync(worktreePath)).toBe(true);
+
+    const archived = await archiveTask(taskId);
+    expect("task" in archived).toBe(true);
+    if (!("task" in archived)) throw new Error(archived.error);
+    expect(archived.task.archivedAt).not.toBeNull();
+
+    // Checkout gone from disk…
+    expect(existsSync(worktreePath)).toBe(false);
+
+    // …but the branch (and its commits) survive in the source repo.
+    const proc = Bun.spawn(["git", "branch", "--list", branch], { cwd: repo, stdout: "pipe" });
+    const out = (await new Response(proc.stdout).text()).trim();
+    await proc.exited;
+    expect(out).toContain(branch);
+
+    // The DB row keeps worktreePath/branch non-null — required for the JSONL
+    // path encoding and the re-attach key `prepareWorkdir` uses on restore.
+    const after = tasks.get(taskId);
+    expect(after?.worktreePath).toBe(worktreePath);
+    expect(after?.branch).toBe(branch);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("archiveTask keeps a dirty worktree on disk instead of discarding uncommitted work", async () => {
+  const { createTask, archiveTask } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "archive skips dirty worktree",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+    // Uncommitted change — `git worktree remove --force` would otherwise
+    // silently destroy it, so detach must skip removal.
+    writeFileSync(path.join(worktreePath, "uncommitted.txt"), "work in progress\n");
+
+    const archived = await archiveTask(taskId);
+    expect("task" in archived).toBe(true);
+    if (!("task" in archived)) throw new Error(archived.error);
+    expect(archived.task.archivedAt).not.toBeNull();
+
+    // Dirty-skip: the checkout stays on disk.
+    expect(existsSync(worktreePath)).toBe(true);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("unarchiveTask rematerializes a worktree that archive detached", async () => {
+  const { createTask, archiveTask, unarchiveTask } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "unarchive restores worktree",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+    const archived = await archiveTask(taskId);
+    if (!("task" in archived)) throw new Error(archived.error);
+    expect(existsSync(worktreePath)).toBe(false);
+
+    const restored = await unarchiveTask(taskId);
+    expect("task" in restored).toBe(true);
+    if (!("task" in restored)) throw new Error(restored.error);
+    expect(restored.task.archivedAt).toBeNull();
+    // Eager best-effort restore rematerializes at the same deterministic path.
+    expect(existsSync(worktreePath)).toBe(true);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("sendInput to an archived task auto-unarchives it and restores the worktree", async () => {
+  const { createTask, archiveTask, sendInput } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks, runs } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "sendInput restores archived worktree",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+
+    // Seed a run row directly (mirrors how the orchestrator's own resume
+    // paths insert one) so sendInput has a runId to resolve back to this
+    // task, without needing a live worktree to go through startTask first —
+    // that worktree is exactly what we're about to detach via archiveTask.
+    const runId = randomUUID();
+    runs.insert({
+      id: runId,
+      taskId,
+      agent: "claude-code",
+      status: "succeeded",
+      startedAt: Date.now(),
+      endedAt: Date.now(),
+      exitCode: 0,
+      tmuxSession: null,
+      claudeSessionId: null,
+      codexSessionId: null,
+    });
+
+    const archived = await archiveTask(taskId);
+    if (!("task" in archived)) throw new Error(archived.error);
+    expect(existsSync(worktreePath)).toBe(false);
+
+    // sendInput must (1) auto-unarchive, (2) restore the worktree via
+    // prepareWorkdir's re-attach path, THEN (3) dispatch to the fake claude
+    // driver — which doesn't touch cwd at all, so this exercises steps 1-2
+    // regardless of the driver's own behavior.
+    const sent = await sendInput(runId, "hello");
+    expect(sent.delivered).toBe(true);
+
+    const after = tasks.get(taskId);
+    expect(after?.archivedAt).toBeNull();
+    expect(existsSync(worktreePath)).toBe(true);
+
+    // Let the fake driver's turn resolve so its ~20ms timer doesn't fire
+    // after this test's cleanup deletes the task row.
+    await new Promise((r) => setTimeout(r, 100));
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("startTask auto-unarchives an archived task before running it", async () => {
+  const { createTask, archiveTask, startTask } = await import("./orchestrator.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const created = await createTask({
+    title: "startTask auto-unarchives",
+    prompt: "hello",
+    agent: "claude-code",
+    workdir: process.cwd(),
+    isolation: "none",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+  tasks.update(taskId, { column: "done" });
+
+  try {
+    const archived = await archiveTask(taskId);
+    expect("task" in archived).toBe(true);
+    if (!("task" in archived)) throw new Error(archived.error);
+    expect(archived.task.archivedAt).not.toBeNull();
+
+    const res = await startTask(taskId);
+    expect("runId" in res).toBe(true);
+
+    const after = tasks.get(taskId);
+    expect(after?.archivedAt).toBeNull();
+
+    // Let the fake driver resolve the turn before cleanup deletes the row.
+    await new Promise((r) => setTimeout(r, 100));
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
   }
 });

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
 import { basename } from "node:path";
 import { db, tasks, runs, harnesses, projects, subagents } from "./db.ts";
 import { spawnAgent, toClaudeModelArg } from "./agents.ts";
@@ -71,7 +72,7 @@ import {
   orphanRunningSubagents,
   attachSubagentWatcher,
 } from "./claude-subagents.ts";
-import { prepareWorkdir, removeWorktree, repoRoot, resolveRef, branchName, ensureUniqueBranch } from "./worktree.ts";
+import { prepareWorkdir, removeWorktree, detachWorktree, repoRoot, resolveRef, branchName, ensureUniqueBranch } from "./worktree.ts";
 import { killTerminalsForTask } from "./terminals.ts";
 import { ensureInstalledForCwd } from "./hook-installer.ts";
 import type {
@@ -630,9 +631,16 @@ export function reconcileOrphans(): number {
 
 
 export async function startTask(taskId: string): Promise<{ runId: string } | { error: string }> {
-  const task = tasks.get(taskId);
+  let task = tasks.get(taskId);
   if (!task) return { error: "task not found" };
   if (task.runId && active.has(task.runId)) return { error: "task already running" };
+
+  // Starting an archived task auto-unarchives it — otherwise the card would
+  // move through columns (running → review/ready) while hidden behind the
+  // archive filter, which is confusing at best.
+  if (task.archivedAt != null) {
+    task = tasks.update(taskId, { archivedAt: null }) ?? task;
+  }
 
   const harness = resolveHarness(task.agent);
   if (!harness) {
@@ -1130,12 +1138,45 @@ export type SendInputResult =
  *     `sendTurnInExistingSession`.
  *
  *   • codex: writes to the active run's stdin (single-run model unchanged).
+ *
+ * Archived / detached-worktree restore: a message to an archived task
+ * auto-unarchives it (sending is an unambiguous signal of continued
+ * interest), and if the task's worktree was detached (by archive) or is
+ * otherwise missing on disk, it's rematerialized via `prepareWorkdir` before
+ * dispatch — same deterministic path, branch, and history, so the resumed
+ * turn lands in the same place the agent left off. A hard restore failure
+ * (e.g. the branch was deleted or checked out elsewhere) is surfaced as a
+ * `delivered: false` result rather than silently falling back to an
+ * unisolated cwd.
  */
-export function sendInput(runId: string, line: string): SendInputResult {
+export async function sendInput(runId: string, line: string): Promise<SendInputResult> {
   const row = db.query<{ task_id: string; agent: string }, [string]>(
     `SELECT task_id, agent FROM runs WHERE id = ?`,
   ).get(runId);
   if (!row) return { delivered: false, reason: "run not found" };
+
+  const task = tasks.get(row.task_id);
+  if (!task) return { delivered: false, reason: "task not found" };
+
+  if (task.archivedAt != null) {
+    tasks.update(row.task_id, { archivedAt: null });
+  }
+
+  if (task.worktreePath && !existsSync(task.worktreePath)) {
+    // Re-fetch so the restore sees the just-cleared archivedAt (prepareWorkdir
+    // doesn't care about it, but keeping the object fresh avoids acting on a
+    // stale snapshot).
+    const fresh = tasks.get(row.task_id) ?? task;
+    try {
+      const restored = await prepareWorkdir(fresh);
+      if ("error" in restored) {
+        return { delivered: false, reason: `worktree restore failed: ${restored.error}` };
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { delivered: false, reason: `worktree restore failed: ${msg}` };
+    }
+  }
 
   const kind = resolveHarness(row.agent)?.kind;
   if (kind === "claude-code") {
@@ -1720,13 +1761,18 @@ export async function createTask(
  * Archive a finished task: stamp `archivedAt`, kill its claude tmux session
  * AND any open terminal tabs (both best-effort) so no background shell outlives
  * the user's interest in the task — once archived the card is hidden, so the
- * user can no longer reach those shells to close them. Worktree, run history,
- * and prompt stay intact for later reference.
+ * user can no longer reach those shells to close them — then **detach** the
+ * worktree from disk (`detachWorktree`): the checkout is removed to reclaim
+ * space, but the branch, every commit, the run/run_events history, and
+ * claude's external JSONL transcript all survive untouched. Sending a
+ * follow-up message or unarchiving later rematerializes the worktree at the
+ * same deterministic path (`prepareWorkdir`'s re-attach path) and resumes the
+ * conversation right where it left off.
  *
  * Only allowed when the task is in the `done` column — archive is the
  * terminal step of the explicit review → done → archive flow.
  */
-export function archiveTask(taskId: string): { task: Task } | { error: string } {
+export async function archiveTask(taskId: string): Promise<{ task: Task } | { error: string }> {
   const task = tasks.get(taskId);
   if (!task) return { error: "task not found" };
   if (task.column !== "done") {
@@ -1752,24 +1798,37 @@ export function archiveTask(taskId: string): { task: Task } | { error: string } 
   if (archiveKind === "claude-code") dropSession(taskId);
   else if (archiveKind === "codex") dropCodexSession(taskId);
   codexTurnQueue.delete(taskId);
-  // Tear down terminal tabs too — same rationale as the tmux session above.
-  // Fire-and-forget (archive keeps the worktree, so there's no removal race);
-  // the synchronous part of killTerminalsForTask drops the tabs immediately,
-  // the awaited part just reaps the shells. `.catch` keeps the async function's
-  // best-effort failures from surfacing as an unhandled rejection.
-  void killTerminalsForTask(taskId).catch(() => { /* best-effort */ });
+  // Tear down terminal tabs before detaching the worktree — a live shell
+  // cwd'd inside the worktree would block `git worktree remove`, exactly like
+  // deleteTask's ordering. Awaited (not fire-and-forget) so the shells are
+  // actually gone before detachWorktree runs.
+  await killTerminalsForTask(taskId);
+  await detachWorktree(updated);
   return { task: updated };
 }
 
-/** Reverse of `archiveTask`: clear the timestamp. No tmux work — sending a
- *  follow-up message on a non-archived task already spawns a fresh session via
- *  the resume path. */
-export function unarchiveTask(taskId: string): { task: Task } | { error: string } {
+/**
+ * Reverse of `archiveTask`: clear the timestamp and, best-effort, restore the
+ * worktree if `archiveTask` detached it (or it's otherwise missing on disk).
+ * Restore failure doesn't block the unarchive — the card comes back either
+ * way; a later send/start/terminal-open retries the restore lazily.
+ */
+export async function unarchiveTask(taskId: string): Promise<{ task: Task } | { error: string }> {
   const task = tasks.get(taskId);
   if (!task) return { error: "task not found" };
   if (task.archivedAt == null) return { task };
   const updated = tasks.update(taskId, { archivedAt: null });
   if (!updated) return { error: "task not found" };
+  if (updated.worktreePath && updated.branch && !existsSync(updated.worktreePath)) {
+    try {
+      const restored = await prepareWorkdir(updated);
+      if ("error" in restored) {
+        console.warn(`[agetor] unarchiveTask: worktree restore failed for ${taskId}: ${restored.error}`);
+      }
+    } catch (err) {
+      console.warn(`[agetor] unarchiveTask: worktree restore failed for ${taskId}:`, err);
+    }
+  }
   return { task: updated };
 }
 

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -3050,8 +3050,8 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       },
 
       "/tasks/:id/archive": {
-        POST: authed((req) => {
-          const result = archiveTask(req.params.id);
+        POST: authed(async (req) => {
+          const result = await archiveTask(req.params.id);
           return "error" in result
             ? json(result, { status: 400, headers: corsHeaders(req) })
             : json(withRunningSubagents(result.task), { headers: corsHeaders(req) });
@@ -3059,8 +3059,8 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       },
 
       "/tasks/:id/unarchive": {
-        POST: authed((req) => {
-          const result = unarchiveTask(req.params.id);
+        POST: authed(async (req) => {
+          const result = await unarchiveTask(req.params.id);
           return "error" in result
             ? json(result, { status: 400, headers: corsHeaders(req) })
             : json(withRunningSubagents(result.task), { headers: corsHeaders(req) });
@@ -3416,7 +3416,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
               // REPL prompt before the paste lands, so it isn't eaten by the
               // dismissing modal.
               await Bun.sleep(150);
-              ok = sendInput(pending.runId, plan.text).delivered;
+              ok = (await sendInput(pending.runId, plan.text)).delivered;
             }
             // Drop the card. `resolveAskCard` also clears the session's
             // `askCardId` tracker, so if a drive FAILED and the modal is still
@@ -3615,7 +3615,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             );
           }
           return json(
-            sendInput(req.params.id, line),
+            await sendInput(req.params.id, line),
             { headers: corsHeaders(req) },
           );
         }),

--- a/src/bun/task-events.test.ts
+++ b/src/bun/task-events.test.ts
@@ -189,7 +189,7 @@ test("sendInput on a finished claude-code task inserts a NEW run row with status
   // through spawnResumedSession deterministically (regardless of whether a
   // stray tmux session with this name exists), which uses the fake driver
   // (AGETOR_CLAUDE_DRIVER=fake) and inserts a fresh run row.
-  const result = sendInput(firstRunId, "follow-up");
+  const result = await sendInput(firstRunId, "follow-up");
   if (!result.delivered) throw new Error(`sendInput failed: ${result.reason}`);
   expect(result.runId).not.toBe(firstRunId);
 

--- a/src/bun/terminals.test.ts
+++ b/src/bun/terminals.test.ts
@@ -148,11 +148,11 @@ test("archiving a task closes its terminals", async () => {
   expect(countTerminals(task.id)).toBe(2);
 
   const { archiveTask } = await import("./orchestrator.ts");
-  const res = archiveTask(task.id);
+  const res = await archiveTask(task.id);
   expect("task" in res).toBe(true);
 
-  // killTerminalsForTask runs its teardown synchronously (only the shell-reap
-  // is deferred), so the tabs are gone the moment archiveTask returns.
+  // archiveTask awaits killTerminalsForTask (a live shell would block the
+  // worktree detach), so the tabs are gone once it resolves.
   expect(countTerminals(task.id)).toBe(0);
   expect(tasks.get(task.id)!.openTerminalCount).toBe(0);
 });

--- a/src/bun/worktree.test.ts
+++ b/src/bun/worktree.test.ts
@@ -879,3 +879,129 @@ describe("getAheadCount", () => {
     expect(await getAheadCount(repo, "no-such-ref")).toBeNull();
   });
 });
+
+describe("detachWorktree", () => {
+  test("removes the checkout but keeps the branch and its commits", async () => {
+    const { prepareWorkdir, detachWorktree } = await import("./worktree.ts");
+    const repo = await makeRepo();
+    const task = fakeTask({ workdir: repo });
+    const created = await prepareWorkdir(task);
+    if ("error" in created) throw new Error(created.error);
+
+    writeFileSync(path.join(created.cwd, "work.txt"), "agent output\n");
+    await git(["add", "."], created.cwd);
+    await git(["commit", "-m", "agent work"], created.cwd);
+
+    const live = { ...task, worktreePath: created.worktreePath, branch: created.branch };
+    const result = await detachWorktree(live);
+    expect(result).toEqual({ removed: true });
+    expect(existsSync(created.cwd)).toBe(false);
+
+    // The branch must survive in the source repo — that's the whole point of
+    // detach vs removeWorktree.
+    const branchProc = Bun.spawn(["git", "branch", "--list", created.branch!], {
+      cwd: repo,
+      stdout: "pipe",
+    });
+    const branchOut = (await new Response(branchProc.stdout).text()).trim();
+    await branchProc.exited;
+    expect(branchOut).toContain(created.branch!);
+
+    // The commit made inside the (now-removed) worktree is still reachable on
+    // the branch in the source repo.
+    const logProc = Bun.spawn(["git", "log", "--oneline", created.branch!], {
+      cwd: repo,
+      stdout: "pipe",
+    });
+    const log = (await new Response(logProc.stdout).text()).trim();
+    await logProc.exited;
+    expect(log).toContain("agent work");
+  });
+
+  test("round-trip: prepareWorkdir re-materializes the checkout at the same path with the prior commit intact", async () => {
+    const { prepareWorkdir, detachWorktree } = await import("./worktree.ts");
+    const repo = await makeRepo();
+    const task = fakeTask({ workdir: repo });
+    const created = await prepareWorkdir(task);
+    if ("error" in created) throw new Error(created.error);
+
+    writeFileSync(path.join(created.cwd, "work.txt"), "agent output\n");
+    await git(["add", "."], created.cwd);
+    await git(["commit", "-m", "agent work"], created.cwd);
+
+    // The orchestrator keeps worktreePath + branch on the task row across
+    // detach (that's what makes the later re-attach deterministic).
+    const live = { ...task, worktreePath: created.worktreePath, branch: created.branch };
+    const detached = await detachWorktree(live);
+    expect(detached).toEqual({ removed: true });
+    expect(existsSync(created.cwd)).toBe(false);
+
+    const restored = await prepareWorkdir(live);
+    if ("error" in restored) throw new Error(restored.error);
+    expect(restored.cwd).toBe(created.cwd);
+    expect(restored.worktreePath).toBe(created.worktreePath);
+    expect(restored.branch).toBe(created.branch);
+    expect(existsSync(path.join(restored.cwd, "work.txt"))).toBe(true);
+  });
+
+  test("skips removal when the worktree has uncommitted changes", async () => {
+    const { prepareWorkdir, detachWorktree } = await import("./worktree.ts");
+    const repo = await makeRepo();
+    const task = fakeTask({ workdir: repo });
+    const created = await prepareWorkdir(task);
+    if ("error" in created) throw new Error(created.error);
+
+    writeFileSync(path.join(created.cwd, "dirty.txt"), "uncommitted\n");
+
+    const live = { ...task, worktreePath: created.worktreePath, branch: created.branch };
+    const result = await detachWorktree(live);
+    expect(result).toEqual({ removed: false, reason: "dirty" });
+    expect(existsSync(created.cwd)).toBe(true);
+    expect(existsSync(path.join(created.cwd, "dirty.txt"))).toBe(true);
+  });
+
+  test("no-op when the task never materialized a worktree", async () => {
+    const { detachWorktree } = await import("./worktree.ts");
+    const repo = await makeRepo();
+    const task = fakeTask({ workdir: repo, worktreePath: null, branch: null });
+    const result = await detachWorktree(task);
+    expect(result).toEqual({ removed: false, reason: "no-worktree" });
+  });
+
+  test("no-op when the worktree dir is already gone", async () => {
+    const { prepareWorkdir, detachWorktree } = await import("./worktree.ts");
+    const repo = await makeRepo();
+    const task = fakeTask({ workdir: repo });
+    const created = await prepareWorkdir(task);
+    if ("error" in created) throw new Error(created.error);
+    rmSync(created.cwd, { recursive: true, force: true });
+
+    const live = { ...task, worktreePath: created.worktreePath, branch: created.branch };
+    const result = await detachWorktree(live);
+    expect(result).toEqual({ removed: false, reason: "already-absent" });
+  });
+
+  test("detaching twice is idempotent — second call reports already-absent without throwing", async () => {
+    const { prepareWorkdir, detachWorktree } = await import("./worktree.ts");
+    const repo = await makeRepo();
+    const task = fakeTask({ workdir: repo });
+    const created = await prepareWorkdir(task);
+    if ("error" in created) throw new Error(created.error);
+
+    const live = { ...task, worktreePath: created.worktreePath, branch: created.branch };
+    const first = await detachWorktree(live);
+    expect(first).toEqual({ removed: true });
+
+    const second = await detachWorktree(live);
+    expect(second).toEqual({ removed: false, reason: "already-absent" });
+
+    // Branch still exists throughout — detach never deletes it.
+    const branchProc = Bun.spawn(["git", "branch", "--list", created.branch!], {
+      cwd: repo,
+      stdout: "pipe",
+    });
+    const branchOut = (await new Response(branchProc.stdout).text()).trim();
+    await branchProc.exited;
+    expect(branchOut).toContain(created.branch!);
+  });
+});

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -772,3 +772,52 @@ export async function removeWorktree(task: Task): Promise<void> {
     catch { /* best-effort */ }
   }
 }
+
+/**
+ * Branch-preserving teardown for archive. Unlike `removeWorktree`, this keeps
+ * the branch (and thus every commit on it) intact — it only removes the
+ * worktree *checkout* from disk, so `prepareWorkdir`'s re-attach path
+ * (`task.worktreePath` recorded but the dir is gone, branch still exists) can
+ * rematerialize it later at the same deterministic path. This is what lets an
+ * archived task's session (claude JSONL, run history, codex thread id — none
+ * of which live inside the worktree) be resumed after unarchiving or after a
+ * follow-up message.
+ *
+ * No-op when there's nothing to detach: `task.worktreePath` is null, or the
+ * directory is already gone (idempotent — safe to call repeatedly).
+ *
+ * Skips removal when the worktree has uncommitted changes — `git worktree
+ * remove --force` would otherwise permanently discard them with no way back
+ * (the branch only has what was committed). `hasUncommittedChanges` returns
+ * null whenever it can't get an answer — dir gone (vanished between the two
+ * checks), path not a git repo, or `git status` failing on a broken/pruned
+ * registration; all of those are "can't confirm clean" → skip removal.
+ *
+ * Never throws — best-effort, mirroring `removeWorktree`.
+ */
+export async function detachWorktree(
+  task: Task,
+): Promise<{ removed: boolean; reason?: string }> {
+  if (!task.worktreePath) return { removed: false, reason: "no-worktree" };
+  if (!existsSync(task.worktreePath)) return { removed: false, reason: "already-absent" };
+
+  const dirty = await hasUncommittedChanges(task.worktreePath);
+  if (dirty !== false) return { removed: false, reason: "dirty" };
+
+  const root = await repoRoot(task.workdir);
+  if (root) {
+    await git(["worktree", "remove", "--force", task.worktreePath], root);
+    // Deliberately no `git branch -D` — the whole point of detach is to keep
+    // the branch around for a later re-attach.
+    await git(["worktree", "prune"], root, 10_000);
+  }
+  const ownedPrefix = WORKTREES_DIR + path.sep;
+  if (
+    task.worktreePath.startsWith(ownedPrefix)
+    && existsSync(task.worktreePath)
+  ) {
+    try { rmSync(task.worktreePath, { recursive: true, force: true }); }
+    catch { /* best-effort */ }
+  }
+  return { removed: !existsSync(task.worktreePath) };
+}

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -1303,10 +1303,14 @@ function RunPanelBody({
           height as the textarea so they baseline together. The whole dock is
           one drop zone so dragging a screenshot anywhere over the input area
           (chips, textarea, send button gap) routes through the same capture
-          path. */}
-      {archived ? (
+          path. An archived task with a resumable run gets the same composer as
+          an idle one — the backend auto-unarchives and rematerializes the
+          worktree on send (see the inline hint below); only a genuinely
+          non-sendable archived task (no resumable run) falls back to the
+          static notice. */}
+      {archived && !canSend ? (
         <div className="shrink-0 border-t border-border/60 p-3 text-[11px] text-muted-foreground">
-          This task is archived. Unarchive it to send messages.
+          This task is archived. Unarchive it to interact.
         </div>
       ) : activeStream !== "main" ? (
         // Background-agent streams are read-only — you can watch them but not
@@ -1343,6 +1347,16 @@ function RunPanelBody({
             onChange={setSendRefs}
             startingFolder={task.worktreePath ?? task.workdir}
           />
+          {/* Archived-but-sendable: the task has a resumable run, so the
+              composer above is fully live — but sending here has a side
+              effect (auto-unarchive + worktree restore) that a non-archived
+              idle task doesn't have, so call it out inline rather than
+              silently. */}
+          {archived && (
+            <p className="text-[10px] text-muted-foreground">
+              Sending will unarchive this task and restore its worktree.
+            </p>
+          )}
           {/* Shown once the task is sendable, OR as soon as there's something to
               stash — that's what lets "Save for later" work pre-run. */}
           {(canSend || input.trim() || sendRefs.length > 0) && (
@@ -1365,7 +1379,10 @@ function RunPanelBody({
                 <span />
               )}
               <div className="flex items-center gap-2">
-                {(input.trim() || sendRefs.length > 0) && (
+                {/* Backlog mutations are frozen server-side while archived
+                    (`backlogGuard`) — only Send (which auto-unarchives) is
+                    offered on an archived task. */}
+                {!archived && (input.trim() || sendRefs.length > 0) && (
                   <Button
                     size="sm"
                     variant="ghost"
@@ -1415,7 +1432,9 @@ function RunPanelBody({
                     // user means: stash the draft. `send()` guards both states
                     // too, so this is the only place that decides.
                     if (!canSend || modalPending) {
-                      void saveForLater();
+                      // Archived tasks can't stash drafts (server freezes the
+                      // backlog) — swallow Enter instead of surfacing a 400.
+                      if (!archived) void saveForLater();
                       return;
                     }
                     void send();


### PR DESCRIPTION
Archiving a task now detaches its git worktree from disk while preserving everything needed to resume the agent session later:

- worktree.ts: new detachWorktree — branch-preserving teardown (git worktree remove + prune, never git branch -D); skips dirty trees so uncommitted work is never destroyed; idempotent and best-effort like removeWorktree
- orchestrator.ts: archiveTask (async) awaits terminal teardown then detaches the worktree; unarchiveTask eagerly rematerializes it via prepareWorkdir (best-effort); sendInput auto-unarchives and restores a missing worktree before resuming (claude --resume / codex exec resume); startTask auto-unarchives so a hidden card can't move through columns
- task.worktreePath/branch/baseRef and all runs/run_events stay in the DB — claude's JSONL history is keyed by the cwd path string, so the path must survive archive verbatim for restore to find it
- server.ts: await the now-async archive/unarchive/sendInput call sites
- RunPanel.tsx: archived tasks show the normal composer with an unarchive-on-send hint; Save-for-later stays gated (backlog is frozen server-side while archived); scrollback remains readable without unarchiving
- tests: detachWorktree unit tests (worktree.test.ts) + archive lifecycle integration tests (orchestrator.test.ts); async ripple fixed across test files
- plan: docs/plans/archive-worktree-cleanup.md