### PR TITLE
feature: branch config button in the branch name field + realtime-resolved branch name

### DIFF
--- a/docs/plans/branch-config-modal-button.md
+++ b/docs/plans/branch-config-modal-button.md
@@ -1,0 +1,78 @@
+# Plan — Branch config button in the branch name field + realtime-resolved field
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-14 |
+| Source | /implement request (conversation) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/new-project-branch-config-window |
+| Base SHA | 7e798f51ef788e5cd69fc25ddcc7d144584be3a9 |
+| Mode | **Autonomous** — grill + plan-approval gates bypassed (headless run); assumptions in §8 |
+
+## 1. Objective & success criteria
+
+Three user asks:
+
+1. Move the branch-config entry point to an icon button **inside the right side of the branch name field** (replacing the gear button in the New Task form header).
+2. The branch name field shows the **resolved branch name, updated in realtime** as the configured pattern, title, task type, and project change.
+3. The **configured pattern display and the tags helper message move into the project branch-config modal** opened by that icon button.
+
+Done means: field live-updates while typing a title; clicking the in-field icon opens the config modal; the modal shows each task type's pattern and the tags helper; saving the modal immediately re-resolves the field; typecheck, vite build, and `bun test` green.
+
+## 2. Context & constraints (grounded)
+
+- `src/mainview/components/kanban/NewTaskForm.tsx` — field state: `branchConfig` (l.123), `branchOverride` (l.124, the input value, currently holds the RAW pattern), `branchDirty` (l.125), `branchToken` (l.126, 6-hex), `branchSettingsOpen` (l.127). `computedPattern = branchPattern(branchConfig, taskType)` (l.143-146, deliberately not keyed on title). Re-seed effect l.149-151 (`!branchDirty → setBranchOverride(computedPattern)`). `resolvedBranch = renderBranchTemplate(branchOverride, {title, projectName, taskType, token})` (l.164-172). Validation runs on the resolved name (l.177-180). JSX l.634-677: input, validation error / `→ resolved` preview (l.648-657), Reset-to-pattern button (l.658-666), helper `<p>` from `BRANCH_TEMPLATE_TAGS` (l.667-675). Header gear button l.501-511 (`SlidersHorizontal`). Dialog wiring l.841-846 (`onSaved={(c) => setBranchConfig(c)}`). Submit l.388 sends `branchOverride.trim()` verbatim (raw template).
+- `src/mainview/components/settings/BranchNamingDialog.tsx` — per-TaskType prefix inputs + `includeSlug` switch; static example per row via `buildBranchName(config, t.id, "Add login page", {token:"a1b2c3"})`; saves via `PUT /projects/settings`; sole call site is NewTaskForm.
+- **Server contract (fleet knowledge, must preserve):** client sends the UNRENDERED template; `orchestrator.createTask` is the authoritative resolver (task-id-derived token + creation-time Date). Rendering client-side at submit would freeze `<timestamp>` and change token semantics.
+- In-field trailing icon precedent: `RunPanel.tsx:2535-2554` — relative wrapper, `pr-9` padding, absolute-positioned right icon button.
+- No webview component-test harness exists; coverage lives in `src/shared/branch.test.ts`, `src/bun/branch-nomenclature.test.ts`, `src/bun/project-settings-endpoint.test.ts`.
+
+## 3. Approach & key decisions
+
+- **Field value becomes derived, not seeded.** Replace the "seed input with pattern + re-seed effect" model with: when clean, the input displays `renderBranchTemplate(computedPattern, {title, projectName, taskType, token: branchToken})` computed each render — realtime by construction. When dirty, it displays the user's literal `branchOverride`. The re-seed effect (l.149-151) is deleted.
+- **Submit:** clean → send `computedPattern` (raw template — server stays authoritative); dirty → send `branchOverride.trim()` verbatim (existing back-compat; server still resolves tags if the user typed any).
+- **Pure helper for testability:** extract `branchFieldState({dirty, override, pattern, title, projectName, taskType, token})` → `{ displayValue, submitValue, resolved }` into `src/mainview/lib/branch-field.ts` so the clean/dirty display+submit logic is unit-testable without a DOM harness.
+- **In-field button:** wrap the Input in a `relative` div with right padding; absolute icon `Button` (ghost, icon-size, `SlidersHorizontal`) on the right opens `branchSettingsOpen`; same `disabled` condition as today's header button (no workdir). Header button (l.501-511) removed.
+- **Form JSX cleanup:** helper `<p>` (l.667-675) removed from the form. The `→ resolved` preview line is kept ONLY for the dirty-with-tags case (`branchDirty && hasBranchTemplateTags(branchOverride)`) — when clean the field itself already shows the resolved name. Reset-to-pattern button kept.
+- **Modal gains:** (a) per-row pattern display — `branchPattern(config, t.id)` rendered as code text alongside each type's static example; (b) the tags helper paragraph (generated from `BRANCH_TEMPLATE_TAGS`, never hardcoded) at the bottom; (c) optional `activeTaskType?: TaskType` prop from NewTaskForm to visually highlight the row that drives the current field.
+- Alternatives rejected: making the field read-only (regresses #90's override feature); free-form template editing in the modal (schema change + migration, out of scope — noted as future work, consistent with the prior workdone's note).
+
+## 4. Work breakdown — implementation tasks
+
+| ID | Goal | Files owned | Deps | Acceptance |
+| --- | --- | --- | --- | --- |
+| I1 | Extract pure field-state helper | `src/mainview/lib/branch-field.ts` (new) | — | Pure, no React imports; handles clean/dirty; unknown tags pass through (delegated to renderBranchTemplate) |
+| I2 | Rework NewTaskForm field + in-field config button; remove header gear + helper text; wire helper from I1 | `src/mainview/components/kanban/NewTaskForm.tsx` | I1 | Field realtime-resolves when clean; dirty edit freezes it; Reset restores; submit sends template when clean, literal when dirty; icon button opens dialog |
+| I3 | Extend BranchNamingDialog: per-type pattern display, tags helper, activeTaskType highlight | `src/mainview/components/settings/BranchNamingDialog.tsx` | — | Pattern shown per row from `branchPattern`; helper generated from `BRANCH_TEMPLATE_TAGS`; save still echoes config via `onSaved` |
+
+I1+I2+I3 go to **one agent in one wave** — I2 renders I3 and imports I1; splitting a props contract across parallel agents invites drift, and the total surface is small.
+
+## 5. Work breakdown — test tasks
+
+| ID | Goal | Files owned | Covers |
+| --- | --- | --- | --- |
+| T1 | Unit tests for `branchFieldState` (clean realtime resolution, dirty freeze, submitValue template-vs-literal, empty title fallback, tags-in-override) | `src/mainview/lib/branch-field.test.ts` (new) | I1, I2's submit contract |
+
+No webview component harness exists; UI-level behavior is verified by typecheck + vite build + the existing server/shared suites (unchanged).
+
+## 6. Execution waves
+
+- Wave 1: one implementation agent (I1+I2+I3). Barrier: typecheck + build + commit.
+- Phase 5: review agent (opus) on the diff.
+- Phase 6: one test agent (T1).
+- Phase 7: test-run agent (`bun test` + `bun run typecheck` + vite build).
+
+## 7. Blast radius & risks
+
+- Contained to `NewTaskForm.tsx` internals — investigation confirmed no external reader of the form's in-progress branch value; everything else reads `task.branch` (server-resolved).
+- Client preview token ≠ server token (already true today); with the field showing the resolved name, the created branch can differ from the display when patterns use `<token>`/`<timestamp>` — existing rename toast in `App.tsx:645-646` already covers this.
+- Deleting the re-seed effect: ensure dirty-reset (`Reset to pattern`) and post-submit reset still leave the field following the pattern (dirty=false ⇒ derived display takes over automatically — simpler than before).
+- Server routes, shared helpers, migrations: untouched.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+1. Field remains **editable** with dirty-freeze + Reset (assumed; read-only would regress the override feature).
+2. Clean submit sends the **raw template**, not the displayed resolved string (assumed, to honor the server-authoritative contract).
+3. "New project branch config modal" = **existing `BranchNamingDialog` extended**, not a second dialog (assumed; avoids duplicating the config surface).
+4. Header gear button is **removed**, not duplicated (assumed from "move").
+5. Free-form pattern/template editing inside the modal stays out of scope (no schema change).

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -7,9 +7,9 @@ import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { taskTypeIcon } from "@/lib/task-type-icon";
+import { branchFieldState } from "@/lib/branch-field";
 import {
   AGENT_OPTIONS,
-  BRANCH_TEMPLATE_TAGS,
   CODE_PLAN_MODE,
   DEFAULT_BRANCH_CONFIG,
   DEFAULT_EFFORT,
@@ -18,7 +18,6 @@ import {
   TASK_TYPES,
   branchPattern,
   hasBranchTemplateTags,
-  renderBranchTemplate,
   supportedEfforts,
   supportedModes,
   validateBranchName,
@@ -113,13 +112,14 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
   const [isolate, setIsolate] = useState(true);
   const [baseRef, setBaseRef] = useState("");
   // Branch nomenclature for the selected project (loaded from the server;
-  // falls back to the built-in defaults). `branchOverride` is the value shown
-  // in the editable field; it auto-tracks the tag-visible PATTERN (e.g.
-  // `feature/<slug>`) until the user edits it (`branchDirty`), at which point
-  // their value wins and is sent to the server verbatim — tags and all, the
-  // server resolves them authoritatively at create time. `branchToken` seeds
-  // the client-side preview/validation fallback (used when `<slug>` would
-  // otherwise render empty).
+  // falls back to the built-in defaults). While clean (`!branchDirty`), the
+  // field DERIVES its display from the tag-visible PATTERN (e.g.
+  // `feature/<slug>`) rendered live against the current title/type/config —
+  // realtime by construction, no seeding effect required. Once the user edits
+  // it (`branchDirty`), `branchOverride` holds their literal text, sent to the
+  // server verbatim — tags and all, the server resolves them authoritatively
+  // at create time. `branchToken` seeds the client-side preview/validation
+  // fallback (used when `<slug>` would otherwise render empty).
   const [branchConfig, setBranchConfig] = useState<BranchNamingConfig>(DEFAULT_BRANCH_CONFIG);
   const [branchOverride, setBranchOverride] = useState("");
   const [branchDirty, setBranchDirty] = useState(false);
@@ -144,11 +144,6 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
     () => branchPattern(branchConfig, taskType),
     [branchConfig, taskType],
   );
-  // Keep the editable field in sync with the pattern until the user takes it
-  // over; once dirty, their value (tags and all) is preserved as the override.
-  useEffect(() => {
-    if (!branchDirty) setBranchOverride(computedPattern);
-  }, [computedPattern, branchDirty]);
 
   // Last path segment of the workdir, used as `<project_name>` in the live
   // preview — mirrors the server's own resolution so the preview matches what
@@ -158,25 +153,30 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
     return parts[parts.length - 1] ?? "";
   }, [workdir]);
 
-  // Live resolved name shown under the field when the override still contains
-  // tags — purely a preview; the server re-resolves at create time with the
-  // real task id and creation timestamp.
-  const resolvedBranch = useMemo(
-    () => renderBranchTemplate(branchOverride, {
+  // Derived clean/dirty projection of the branch field — see
+  // `src/mainview/lib/branch-field.ts`. Clean: `displayValue`/`resolved`
+  // live-render the pattern each render (realtime as title/type/config
+  // change), and `submitValue` is the raw un-rendered pattern so the server
+  // stays the authoritative resolver. Dirty: the user's literal text wins.
+  const branchField = useMemo(
+    () => branchFieldState({
+      dirty: branchDirty,
+      override: branchOverride,
+      pattern: computedPattern,
       title,
       projectName,
       taskType,
       token: branchToken,
     }),
-    [branchOverride, title, projectName, taskType, branchToken],
+    [branchDirty, branchOverride, computedPattern, title, projectName, taskType, branchToken],
   );
 
   // Validation gates on the RESOLVED name (a template like `feature/<slug>` is
   // always git-legal since `<`/`>` are allowed in ref names, but we want the
   // error — and canSubmit — to reflect what will actually be created).
   const branchValidation = useMemo(
-    () => validateBranchName(resolvedBranch.trim()),
-    [resolvedBranch],
+    () => validateBranchName(branchField.resolved.trim()),
+    [branchField.resolved],
   );
   const [mode, setMode] = useState<string>(initialMode("claude-code"));
   const [model, setModel] = useState<string>(DEFAULT_MODEL["claude-code"]);
@@ -382,10 +382,11 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
         workdir: workdir.trim(),
         isolation: isolate ? "worktree" : "none",
         baseRef: isolate && baseRef.trim() ? baseRef.trim() : undefined,
-        // The branch is only meaningful under worktree isolation. Sending the
-        // field value verbatim makes the sidebar preview the source of truth;
-        // the server validates it and guarantees uniqueness.
-        branch: isolate && branchOverride.trim() ? branchOverride.trim() : undefined,
+        // The branch is only meaningful under worktree isolation. Clean →
+        // the raw pattern (server resolves authoritatively at create time);
+        // dirty → the user's literal text, trimmed. The server validates it
+        // and guarantees uniqueness either way.
+        branch: isolate && branchField.submitValue ? branchField.submitValue : undefined,
         // model is always an explicit option id. effort is too, except for
         // the Haiku-style "model doesn't accept effort" case which sends null.
         mode,
@@ -498,16 +499,6 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
               {selectedStatus.version}
             </span>
           )}
-          <button
-            type="button"
-            onClick={() => setBranchSettingsOpen(true)}
-            disabled={!workdir.trim()}
-            title="Branch naming settings for this project"
-            aria-label="Branch naming settings"
-            className="text-muted-foreground transition-colors hover:text-foreground disabled:opacity-40"
-          >
-            <SlidersHorizontal className="size-3.5" />
-          </button>
         </div>
       </div>
 
@@ -634,25 +625,37 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
         {isolate && (
           <div className="space-y-1">
             <label className="text-muted-foreground">Branch name</label>
-            <Input
-              value={branchOverride}
-              onChange={(e) => { setBranchOverride(e.target.value); setBranchDirty(true); }}
-              spellCheck={false}
-              placeholder="feature/my-task"
-              className={cn(
-                "font-mono text-[11px]",
-                !branchValidation.ok && "border-destructive focus-visible:ring-destructive",
-              )}
-              title="Git branch the worktree will use. Supports tags like <slug>, <project_name>, <type>, <date>, <timestamp>, and <token>, resolved when the task is created. Auto-generated from this project's nomenclature; edit to override, or use the settings button in the header to change the pattern."
-            />
+            <div className="relative">
+              <Input
+                value={branchField.displayValue}
+                onChange={(e) => { setBranchOverride(e.target.value); setBranchDirty(true); }}
+                spellCheck={false}
+                placeholder="feature/my-task"
+                className={cn(
+                  "pr-9 font-mono text-[11px]",
+                  !branchValidation.ok && "border-destructive focus-visible:ring-destructive",
+                )}
+                title="Git branch the worktree will use. Live-resolved from this project's nomenclature (title, type, project name); edit to override, or use the settings button to change the pattern."
+              />
+              <button
+                type="button"
+                onClick={() => setBranchSettingsOpen(true)}
+                disabled={!workdir.trim()}
+                title="Branch naming settings for this project"
+                aria-label="Configure branch naming"
+                className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-40"
+              >
+                <SlidersHorizontal className="size-3.5" />
+              </button>
+            </div>
             {!branchValidation.ok ? (
               <p className="text-[10px] text-destructive">{branchValidation.reason}</p>
-            ) : hasBranchTemplateTags(branchOverride) ? (
+            ) : branchDirty && hasBranchTemplateTags(branchOverride) ? (
               <p
                 className="text-[10px] font-mono text-muted-foreground truncate"
-                title={resolvedBranch}
+                title={branchField.resolved}
               >
-                → {resolvedBranch}
+                → {branchField.resolved}
               </p>
             ) : null}
             {branchDirty && (
@@ -664,15 +667,6 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
                 Reset to pattern
               </button>
             )}
-            <p className="text-[10px] text-muted-foreground">
-              Tags are replaced when the task is created:{" "}
-              {BRANCH_TEMPLATE_TAGS.map(({ tag, description }, i) => (
-                <span key={tag}>
-                  <span className="font-mono">{tag}</span> {description}
-                  {i < BRANCH_TEMPLATE_TAGS.length - 1 ? " · " : "."}
-                </span>
-              ))}
-            </p>
           </div>
         )}
 
@@ -841,6 +835,7 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
       <BranchNamingDialog
         open={branchSettingsOpen}
         projectPath={workdir.trim()}
+        activeTaskType={taskType}
         onClose={() => setBranchSettingsOpen(false)}
         onSaved={(c) => setBranchConfig(c)}
       />

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -493,13 +493,11 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
     >
       <div className="flex shrink-0 items-center justify-between border-b border-border/60 px-4 py-3">
         <span className="text-sm font-semibold">New task</span>
-        <div className="flex items-center gap-2">
-          {selectedStatus?.available && selectedStatus.version && (
-            <span className="text-[11px] text-muted-foreground">
-              {selectedStatus.version}
-            </span>
-          )}
-        </div>
+        {selectedStatus?.available && selectedStatus.version && (
+          <span className="text-[11px] text-muted-foreground">
+            {selectedStatus.version}
+          </span>
+        )}
       </div>
 
       <div className="flex-1 space-y-3 overflow-y-auto px-4 py-3 text-xs">

--- a/src/mainview/components/settings/BranchNamingDialog.tsx
+++ b/src/mainview/components/settings/BranchNamingDialog.tsx
@@ -141,16 +141,19 @@ export function BranchNamingDialog({ open, onClose, projectPath, projectName, ac
                     spellCheck={false}
                     className="h-8 font-mono text-xs"
                   />
-                  <p className="font-mono text-[10px] text-muted-foreground">
-                    {pattern}
+                  <p className="text-[10px] text-muted-foreground">
+                    pattern{" "}
+                    <span className="font-mono text-foreground/70">
+                      {pattern}
+                    </span>
                   </p>
                   <p
                     className={cn(
-                      "font-mono text-[10px]",
+                      "text-[10px]",
                       legal ? "text-muted-foreground" : "text-destructive",
                     )}
                   >
-                    {example}
+                    e.g. <span className="font-mono">{example}</span>
                   </p>
                 </div>
               </div>

--- a/src/mainview/components/settings/BranchNamingDialog.tsx
+++ b/src/mainview/components/settings/BranchNamingDialog.tsx
@@ -8,11 +8,14 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import {
+  BRANCH_TEMPLATE_TAGS,
   DEFAULT_BRANCH_CONFIG,
   TASK_TYPES,
+  branchPattern,
   buildBranchName,
   validateBranchConfig,
   validateBranchName,
+  type TaskType,
 } from "../../../shared/types.ts";
 
 interface Props {
@@ -22,6 +25,9 @@ interface Props {
   projectPath: string;
   /** Display name for the header (defaults to the path basename). */
   projectName?: string;
+  /** The task type driving the field that opened this dialog, if any — its
+   *  row is visually highlighted so the user sees which rule is in play. */
+  activeTaskType?: TaskType;
   /** Called with the saved config so the parent can refresh its preview. */
   onSaved: (config: BranchNamingConfig) => void;
 }
@@ -31,10 +37,11 @@ const EXAMPLE_TITLE = "Add login page";
 
 /**
  * Per-project branch nomenclature editor. One prefix field per task type plus a
- * global "include card slug" toggle, with a live example and git-legal
- * validation. Opened from the gear button in the New Task sidebar header.
+ * global "include card slug" toggle, with the configured pattern + a live
+ * example and git-legal validation per row, plus a tags-legend footer. Opened
+ * from the config icon button inside the New Task form's branch-name field.
  */
-export function BranchNamingDialog({ open, onClose, projectPath, projectName, onSaved }: Props) {
+export function BranchNamingDialog({ open, onClose, projectPath, projectName, activeTaskType, onSaved }: Props) {
   const [config, setConfig] = useState<BranchNamingConfig>(DEFAULT_BRANCH_CONFIG);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -109,10 +116,18 @@ export function BranchNamingDialog({ open, onClose, projectPath, projectName, on
         <section className="space-y-2.5">
           {TASK_TYPES.map((t, i) => {
             const prefix = config.rules[t.id]?.prefix ?? "";
+            const pattern = branchPattern(config, t.id);
             const example = buildBranchName(config, t.id, EXAMPLE_TITLE, { token: "a1b2c3" });
             const legal = validateBranchName(example).ok;
+            const active = activeTaskType === t.id;
             return (
-              <div key={t.id} className="grid grid-cols-[4.5rem_1fr] items-center gap-2">
+              <div
+                key={t.id}
+                className={cn(
+                  "grid grid-cols-[4.5rem_1fr] items-center gap-2 rounded-md p-1 -m-1",
+                  active && "ring-1 ring-primary/50 bg-primary/5",
+                )}
+              >
                 <label className="text-xs text-muted-foreground" htmlFor={`prefix-${t.id}`}>
                   {t.label}
                 </label>
@@ -126,6 +141,9 @@ export function BranchNamingDialog({ open, onClose, projectPath, projectName, on
                     spellCheck={false}
                     className="h-8 font-mono text-xs"
                   />
+                  <p className="font-mono text-[10px] text-muted-foreground">
+                    {pattern}
+                  </p>
                   <p
                     className={cn(
                       "font-mono text-[10px]",
@@ -152,6 +170,16 @@ export function BranchNamingDialog({ open, onClose, projectPath, projectName, on
             onCheckedChange={(v) => setConfig((c) => ({ ...c, includeSlug: v }))}
           />
         </label>
+
+        <p className="text-[10px] text-muted-foreground">
+          Tags are replaced when the task is created:{" "}
+          {BRANCH_TEMPLATE_TAGS.map(({ tag, description }, i) => (
+            <span key={tag}>
+              <span className="font-mono">{tag}</span> {description}
+              {i < BRANCH_TEMPLATE_TAGS.length - 1 ? " · " : "."}
+            </span>
+          ))}
+        </p>
 
         {!validation.ok && (
           <p className="text-xs text-destructive">{validation.reason}</p>

--- a/src/mainview/lib/branch-field.test.ts
+++ b/src/mainview/lib/branch-field.test.ts
@@ -1,0 +1,107 @@
+import { test, expect, describe } from "bun:test";
+import { branchFieldState, type BranchFieldInput } from "./branch-field.ts";
+
+const TOKEN = "a1b2c3";
+
+function input(overrides: Partial<BranchFieldInput> = {}): BranchFieldInput {
+  return {
+    dirty: false,
+    override: "",
+    pattern: "feature/<slug>",
+    title: "Add login page",
+    projectName: "my-cool-app",
+    taskType: "task",
+    token: TOKEN,
+    ...overrides,
+  };
+}
+
+describe("branchFieldState — clean", () => {
+  test("displayValue is the rendered pattern, resolved matches, submitValue is the raw pattern", () => {
+    const state = branchFieldState(input());
+    expect(state.displayValue).toBe("feature/add-login-page");
+    expect(state.resolved).toBe(state.displayValue);
+    // Server-authoritative contract: submitValue is the UNRENDERED template,
+    // not the resolved display string.
+    expect(state.submitValue).toBe("feature/<slug>");
+  });
+
+  test("follows the title in realtime — a different title yields a different displayValue", () => {
+    const first = branchFieldState(input({ title: "Add login page" }));
+    const second = branchFieldState(input({ title: "Fix broken nav" }));
+    expect(first.displayValue).toBe("feature/add-login-page");
+    expect(second.displayValue).toBe("feature/fix-broken-nav");
+    expect(first.displayValue).not.toBe(second.displayValue);
+    // submitValue stays the raw pattern regardless of title.
+    expect(first.submitValue).toBe("feature/<slug>");
+    expect(second.submitValue).toBe("feature/<slug>");
+  });
+
+  test("empty title falls back to the token — no dangling prefix", () => {
+    const state = branchFieldState(input({ title: "" }));
+    expect(state.displayValue).toBe(`feature/${TOKEN}`);
+    expect(state.resolved).toBe(`feature/${TOKEN}`);
+  });
+});
+
+describe("branchFieldState — dirty", () => {
+  test("displayValue is the verbatim override, submitValue is trimmed, and stale pattern/title don't leak", () => {
+    const state = branchFieldState(
+      input({
+        dirty: true,
+        override: "  my-manual-branch  ",
+        // Deliberately stale/mismatched pattern + title — must not appear anywhere in the output.
+        pattern: "feature/<slug>",
+        title: "Some Other Title",
+      }),
+    );
+    expect(state.displayValue).toBe("  my-manual-branch  ");
+    expect(state.submitValue).toBe("my-manual-branch");
+    expect(state.displayValue).not.toContain("feature/");
+    expect(state.displayValue).not.toContain("some-other-title");
+    expect(state.submitValue).not.toContain("feature/");
+  });
+
+  test("tags in the override still resolve, but displayValue stays the raw override", () => {
+    const state = branchFieldState(
+      input({
+        dirty: true,
+        override: "bugfix/<slug>-<type>",
+        title: "Add login page",
+        taskType: "bug",
+      }),
+    );
+    expect(state.displayValue).toBe("bugfix/<slug>-<type>");
+    expect(state.resolved).toBe("bugfix/add-login-page-bug");
+  });
+
+  test("a tag-free override resolves to itself (identity)", () => {
+    const state = branchFieldState(input({ dirty: true, override: "bugfix/my-manual-branch" }));
+    expect(state.resolved).toBe("bugfix/my-manual-branch");
+    expect(state.displayValue).toBe("bugfix/my-manual-branch");
+  });
+
+  test("empty/whitespace override yields an empty submitValue", () => {
+    const empty = branchFieldState(input({ dirty: true, override: "" }));
+    expect(empty.submitValue).toBe("");
+
+    const whitespace = branchFieldState(input({ dirty: true, override: "   " }));
+    expect(whitespace.submitValue).toBe("");
+  });
+});
+
+describe("branchFieldState — <project_name> tag wiring", () => {
+  test("renders from projectName when clean", () => {
+    const state = branchFieldState(
+      input({ pattern: "<project_name>/<slug>", projectName: "my-cool-app" }),
+    );
+    expect(state.displayValue).toBe("my-cool-app/add-login-page");
+  });
+
+  test("falls back per renderBranchTemplate's rules when projectName is empty", () => {
+    const state = branchFieldState(
+      input({ pattern: "<project_name>/<slug>", projectName: "" }),
+    );
+    expect(state.displayValue).toBe("project/add-login-page");
+  });
+});

--- a/src/mainview/lib/branch-field.ts
+++ b/src/mainview/lib/branch-field.ts
@@ -1,0 +1,54 @@
+import { renderBranchTemplate, type TaskType } from "../../shared/types.ts";
+
+/** Inputs to {@link branchFieldState} — mirrors what the New Task form tracks
+ *  for the branch-name field. `override` only matters while `dirty`. */
+export interface BranchFieldInput {
+  /** Whether the user has taken the field over with their own text. */
+  dirty: boolean;
+  /** The user's literal text — meaningful only when `dirty`. */
+  override: string;
+  /** The tag-visible pattern for the current config + task type, e.g.
+   *  `feature/<slug>` — see {@link import("../../shared/types.ts").branchPattern}. */
+  pattern: string;
+  title: string;
+  projectName: string;
+  taskType: TaskType;
+  token: string;
+}
+
+/** Derived view of the branch-name field, computed fresh each render. */
+export interface BranchFieldState {
+  /** What the input shows. */
+  displayValue: string;
+  /** What gets sent to the server on submit (raw template when clean, so the
+   *  server stays the authoritative resolver; the trimmed literal when dirty). */
+  submitValue: string;
+  /** The fully-resolved name — used for validation and the `→ resolved`
+   *  preview line while dirty. */
+  resolved: string;
+}
+
+/**
+ * Pure clean/dirty projection of the branch-name field. Clean: the field
+ * tracks the live-rendered pattern (realtime as title/type/config change) and
+ * submits the raw, un-rendered pattern — the server resolves it authoritatively
+ * at task-creation time (task-id-derived token, creation timestamp). Dirty:
+ * the user's literal text wins for both display and submit (trimmed), and is
+ * still run through {@link renderBranchTemplate} to produce `resolved` for
+ * validation/preview — a template-free override renders as itself (identity).
+ */
+export function branchFieldState(input: BranchFieldInput): BranchFieldState {
+  const { dirty, override, pattern, title, projectName, taskType, token } = input;
+  const ctx = { title, projectName, taskType, token };
+
+  if (!dirty) {
+    const rendered = renderBranchTemplate(pattern, ctx);
+    return { displayValue: rendered, submitValue: pattern, resolved: rendered };
+  }
+
+  return {
+    displayValue: override,
+    submitValue: override.trim(),
+    resolved: renderBranchTemplate(override, ctx),
+  };
+}


### PR DESCRIPTION
## What

Reworks the New Task form's branch name field and the per-project branch config entry point:

- **In-field config button** — the branch naming config is now opened by an icon button
  inside the right side of the branch name field (replacing the gear button in the form
  header). Disabled until a project is selected.
- **Realtime-resolved branch name** — the field now displays the *resolved* branch name
  (e.g. `feature/add-login-page`) instead of the raw pattern, updating live as you type
  the title, switch task type, change project, or save the config dialog. Manually
  editing the field freezes it (your text wins); "Reset to pattern" resumes live updates.
- **Pattern + helper moved into the config modal** — `BranchNamingDialog` now shows each
  task type's configured pattern (`pattern feature/<slug>`), a resolved example
  (`e.g. feature/add-login-page`), and the template-tags legend that previously sat under
  the field. The row matching the current task type is highlighted.

## How

- New pure helper `src/mainview/lib/branch-field.ts` (`branchFieldState`) owns the
  clean/dirty display + submit logic, keeping it unit-testable without a DOM harness.
- **Server contract unchanged**: when the field is untouched, the form still submits the
  raw unrendered template so `orchestrator.createTask` remains the authoritative resolver
  (fresh timestamp/token, uniqueness suffixing). User-edited text is sent verbatim, as
  before. No server, shared-types, or schema changes.
- The old "seed the input with the pattern + re-seed effect" model is gone — the display
  value is derived each render, so realtime updates fall out by construction.

## Testing

- New `src/mainview/lib/branch-field.test.ts` (9 tests): clean realtime resolution,
  dirty freeze + trim, template-vs-literal submit contract, empty-title token fallback,
  tag wiring.
- `bun test`: 1232 pass / 3 fail — all 3 are the known pre-existing sandbox baseline
  (daemon-handoff, daemon-boot, claude-followup-restart), unrelated to this branch.
- `bun run typecheck` and `vite build` green.

Plan: `docs/plans/branch-config-modal-button.md`