### PR TITLE
fix(github): authenticate API calls per ssh-alias identity so private…

### DIFF
--- a/docs/plans/github-multi-identity-tokens.md
+++ b/docs/plans/github-multi-identity-tokens.md
@@ -1,0 +1,180 @@
+# Plan — GitHub multi-identity tokens (fix "Not Found" on alias-host origins)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-14 |
+| Source | /implement — "projects that have @github-<something>.com in their origin are showing as `not found`" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/git-integration-not-found |
+| Base SHA | 7e798f51ef788e5cd69fc25ddcc7d144584be3a9 |
+
+## 1. Objective & success criteria
+
+Projects whose `origin` uses an ssh host alias (`git@github-<identity>.com:owner/repo.git`) must work
+in the GitHub integration even when the repo is private and belongs to a different GitHub identity.
+
+Success:
+- A user can store one PAT per ssh host alias in Settings; the GitHub dialog then lists
+  issues/PRs/etc. for private repos reached through that alias.
+- Repos on plain `github.com` keep working exactly as before (env token / `gh auth token`).
+- When no usable token exists for a private repo, the UI shows an actionable message pointing at
+  Settings instead of GitHub's bare `Not Found`.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- **Parsing is not the bug.** PR #101 (`7e798f5`) already resolves alias hosts:
+  `parseGitRemote` (`src/bun/github.ts:573`) + `canonicalGitHost` (`:562`) map
+  `github-work.com` → `github.com`. Verified empirically against every alias shape.
+- **The "not found" is GitHub's 404 body**, surfaced verbatim by `apiError()`
+  (`src/bun/github.ts:1245`). GitHub answers 404 (not 403) for private repos the caller cannot see.
+- **All API calls are unauthenticated on the affected machine**: `githubToken()`
+  (`src/bun/github.ts:824`) only checks `GITHUB_TOKEN`/`GH_TOKEN` env and `gh auth token`;
+  neither exists. Verified live: the public repo → HTTP 200 (works), a private alias-host repo → 404.
+- **Multiple identities are structural**: the user has 3+ GitHub identities via ssh aliases —
+  one token can never cover all of them. Tokens must be routed **per remote host alias**
+  (owner decision, Phase 2).
+- The raw (pre-canonicalization) host is currently discarded at `parseGitRemote` (`:582`) and
+  `GitHubRepo` (`src/shared/types.ts`) carries no host — it must be preserved and threaded.
+- `githubToken()` has **76 call sites**, all with `repo` (from `repoForDir(input.dir)`) in scope,
+  and no resolution choke point. Making the new `host` parameter **required** turns every missed
+  site into a compile error.
+- Token store template: `src/bun/core-creds.ts` — lazy `resolveDataDir()` (`:48`), atomic
+  tmp+rename write with `mode: 0o600` plus best-effort `chmodSync` (`:62-72`), validating reader,
+  **no `db.ts` import**.
+- Settings precedent: generic preferences flow (`SettingsDialog.tsx` → `api.ts:938` →
+  `server.ts:2397` routes). Sub-dialog precedent: `BranchNamingDialog.tsx`.
+- Test harness: `github-test-util.ts` `makeGitHubRepo` (github.com https only — needs an
+  alias-remote variant) + `mockGitHubFetch`; network tests assert the `authorization` header;
+  `github.test.ts` tests pure helpers via `__githubInternals`.
+
+## 3. Approach & key decisions
+
+Owner decisions (Phase 2, 2026-07-14):
+1. **Auth source**: agetor-managed PATs with env/`gh` fallback (no hard dependency on `gh`).
+2. **Routing**: tokens keyed by **ssh host alias** (deterministic; the alias *is* the identity).
+3. **Storage**: JSON file in dataDir, `0600`, core-creds pattern. Never returned raw to the webview.
+4. **Error UX**: enrich 404s with an actionable message + Settings pointer.
+
+**Token resolution order** for a repo whose origin host (raw, lowercased) is `H`:
+1. stored token for `H` (exact match),
+2. stored token for `github.com` (acts as the default entry),
+3. `GITHUB_TOKEN` / `GH_TOKEN` env,
+4. `gh auth token`.
+
+Alternatives considered: try-each-token with per-owner caching (rejected by owner — prefers
+deterministic mapping); gh multi-account enumeration (rejected — requires gh installed and logged
+into every identity); macOS Keychain storage (rejected — macOS-only, finicky from a background Bun
+process, harder to test).
+
+## 4. Work breakdown — implementation tasks
+
+### Wave 1
+
+**T1 — token store module.** Owns: `src/bun/github-tokens.ts` (new).
+Mirror `core-creds.ts` exactly (lazy dataDir, atomic tmp+rename `0o600` write, best-effort chmod,
+validating reader, no db import). File: `<dataDir>/github-tokens.json`, shape
+`{ "tokens": [{ "host": "github-x.com", "token": "ghp_…", "label": "optional" }] }`.
+Exports:
+- `type GitHubTokenEntry = { host: string; token: string; label: string | null }`
+- `listGitHubTokens(): GitHubTokenEntry[]` (hosts lowercased on read)
+- `setGitHubToken(host: string, token: string, label?: string | null): void` (upsert by host)
+- `deleteGitHubToken(host: string): boolean`
+- `tokenForHost(host: string | null): string | null` — implements steps 1–2 of the resolution
+  order only (exact host, then `github.com`); env/gh fallback stays in `github.ts`.
+Acceptance: pure module, no imports from `db.ts`/`github.ts`; malformed/missing file → `[]`.
+
+### Wave 2 (parallel, file-disjoint)
+
+**T2 — backend threading + routes.** Owns: `src/bun/github.ts`, `src/shared/types.ts`,
+`src/bun/server.ts`.
+- `parseGitRemote` returns `{ host, rawHost, owner, name }` (`rawHost` = lowercased `m[1]`,
+  pre-canonicalization).
+- `GitHubRepo` (shared/types.ts) gains `remoteHost?: string | null` (optional — UI consumers of
+  `GitHubRepo` keep compiling). `parseGitHubRemote` and `repoForDir` populate it.
+- `githubToken(host: string | null)` — **required parameter**: resolution order §3 (calls
+  `tokenForHost(host)` first, then env, then gh). Update all 76 call sites to
+  `githubToken(repo.remoteHost ?? null)` (compiler enforces completeness). The few pre-`repoForDir`
+  or repo-less contexts, if any surface, pass `null`.
+- Error enrichment: helper `privateRepoHint(status: number, message: string, repo: GitHubRepo,
+  hadToken: boolean): string` — when `status === 404`, returns
+  `"<owner>/<name> was not found on GitHub — if the repo is private, add a token for
+  <remoteHost> in Settings → GitHub tokens"` (mention which source authenticated the request when
+  one existed). Apply it in the primary user-facing lookups: `listGitHubItems`,
+  the aggregate list path, `getGitHubViewer`, and repo-permissions. Export via `__githubInternals`.
+- New exported helper `remoteHostsForDirs(dirs: string[]): Promise<string[]>` — distinct raw
+  GitHub hosts across project dirs (drives Settings suggestions).
+- Routes (object-style, token-gated like all others):
+  - `GET /github/tokens` → `{ tokens: [{ host, label, tokenPreview }], detectedHosts: string[] }`
+    where `tokenPreview` = `"…" + last 4 chars`; `detectedHosts` = `remoteHostsForDirs(all
+    registered project paths)`. **Never returns the raw token.**
+  - `PUT /github/tokens` body `{ host, token, label? }` — validates non-empty host/token, host
+    lowercased, 400 on bad body.
+  - `DELETE /github/tokens/:host` — 404 if absent.
+- Add `canonicalGitHost`/`parseGitRemote` internals exports already exist; add `privateRepoHint`.
+Acceptance: `bun run typecheck` green; no call site left calling arg-less `githubToken`.
+
+**T3 — Settings UI.** Owns: `src/mainview/lib/api.ts`,
+`src/mainview/components/settings/GitHubTokensSection.tsx` (new),
+`src/mainview/components/settings/SettingsDialog.tsx`.
+- `api.ts`: `listGitHubTokens()`, `setGitHubToken({host, token, label?})`,
+  `deleteGitHubToken(host)` matching the wire contract above (define the wire types locally in
+  api.ts, matching T2's route payloads exactly as written in this plan).
+- `GitHubTokensSection`: rendered inside SettingsDialog as a new "GitHub tokens" section following
+  the dialog's existing section idiom. Lists stored tokens (host, label, `tokenPreview`, delete
+  button); add-form with host input (datalist fed by `detectedHosts`, so the user's real alias
+  hosts are one click away), token input (`type="password"`), optional label. Saving refreshes the
+  list; token input is cleared after save and never re-populated.
+- Copy under the section title: one line explaining ssh-alias identities ("Repos reached through an
+  ssh host alias (git@github-work.com:…) authenticate with the token stored for that alias;
+  github.com is the default").
+Acceptance: section renders in SettingsDialog, add/delete round-trips against the routes, no raw
+token ever displayed after save.
+
+## 5. Work breakdown — test tasks
+
+**T5 — store + pure-helper tests.** Owns: `src/bun/github-tokens.test.ts` (new),
+`src/bun/github.test.ts`.
+- Store: round-trip, upsert-by-host, delete, host lowercasing, malformed file → `[]`, file mode
+  0600 (skip mode assert if platform-flaky), `tokenForHost` exact-alias > github.com-default > null.
+  Uses `AGETOR_DATA_DIR` mkdtemp per existing convention.
+- Pure helpers via `__githubInternals`: `parseGitRemote` now yields `rawHost` (alias preserved,
+  canonical host unchanged); `privateRepoHint` wording for 404 with/without token; non-404 passthrough.
+
+**T6 — network/integration tests.** Owns: `src/bun/github-network.test.ts`,
+`src/bun/github-test-util.ts`.
+- `makeGitHubRepo` variant (new option or sibling helper) whose origin is
+  `git@github-testalias.com:owner/name.git`.
+- With a stored token for `github-testalias.com` (write via `setGitHubToken` under the test's
+  `AGETOR_DATA_DIR`): request carries `Bearer <alias-token>` even when `GITHUB_TOKEN` is also set
+  (alias beats env). With only env set and no stored entry: env token used (regression).
+  With nothing: 404 response surfaces the enriched settings-pointer message.
+
+## 6. Execution waves
+
+- Wave 1: T1 (alone — T2 imports its exports).
+- Wave 2: T2 ∥ T3 (file-disjoint; wire contract pinned in §4). Typecheck at wave end.
+- Phase 5: code review (opus) of `git diff 7e798f5...HEAD`.
+- Phase 6: T5 ∥ T6 (file-disjoint).
+- Phase 7: `bun run typecheck` + `bun test` (haiku, background).
+- Phase 8: fixes if needed, re-run to green.
+
+## 7. Blast radius & risks
+
+- `githubToken` signature change touches all 76 GitHub API functions — mitigated by the required
+  parameter (compile-time completeness) and by regression tests keeping env-token behavior.
+- `GitHubRepo` type widening is optional-field only; webview consumers unaffected.
+- The token file contains secrets: 0600, never logged, never sent to the webview raw, and excluded
+  from any knowledge-base capture (fleet rule). It lives in dataDir — dev (`~/.agetor-dev`) and
+  prod (`~/.agetor`) stores are naturally separate.
+- `gh`-based flow and `GITHUB_TOKEN` users: unchanged behavior when no stored tokens exist
+  (resolution steps 3–4 preserved).
+- Bitbucket-alias projects: out of scope — integration is GitHub-only today (non-goal).
+
+## 8. Open questions / assumptions
+
+- Assumption: keying strictly by host alias means a repo reached via a *new* alias needs a new
+  Settings entry; `detectedHosts` in the Settings UI keeps that discoverable.
+- Assumption: no "verify token" button in v1 (can be added later as `POST /github/tokens/verify`
+  → `GET /user`); kept out to limit scope.
+- Assumption: token file is intentionally plain JSON (not Keychain) per owner decision; acceptable
+  because agents already run unsandboxed with user privileges (see CLAUDE.md security note).

--- a/src/bun/github-network.test.ts
+++ b/src/bun/github-network.test.ts
@@ -6,7 +6,8 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test, expect, beforeAll } from "bun:test";
-import { makeGitHubRepo, mockGitHubFetch } from "./github-test-util.ts";
+import { makeAliasGitHubRepo, makeGitHubRepo, mockGitHubFetch } from "./github-test-util.ts";
+import { setGitHubToken } from "./github-tokens.ts";
 import {
   addGitHubDiscussionComment,
   addGitHubProjectItem,
@@ -2490,4 +2491,120 @@ test("addGitHubDiscussionComment / setGitHubDiscussionAnswer / deleteGitHubDiscu
     if (priorToken !== undefined) process.env.GITHUB_TOKEN = priorToken;
     if (priorGhToken !== undefined) process.env.GH_TOKEN = priorGhToken;
   }
+});
+
+// ---------------------------------------------------------------------------
+// Multi-identity token resolution — end-to-end through the request layer
+// (docs/plans/github-multi-identity-tokens.md, T6). These exercise the same
+// `githubToken()` resolution order §3 the pure-helper tests in
+// github-tokens.test.ts cover in isolation, but here via a real API function
+// (`getGitHubViewer`) hitting the fetch mock, so the whole chain — remote
+// parsing → token resolution → request header → error enrichment — is proven
+// together.
+//
+// The token store file lives under `AGETOR_DATA_DIR`, resolved lazily at call
+// time by github-tokens.ts. This file's `beforeAll` never sets that var, so
+// each test below points it at its own throwaway directory for the duration
+// of the test and restores the prior value afterwards — never touching a
+// real dataDir (dev or prod).
+async function withGitHubTokenStore<T>(fn: () => Promise<T>): Promise<T> {
+  const priorDataDir = process.env.AGETOR_DATA_DIR;
+  process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-gh-tokenstore-"));
+  try {
+    return await fn();
+  } finally {
+    if (priorDataDir !== undefined) process.env.AGETOR_DATA_DIR = priorDataDir;
+    else delete process.env.AGETOR_DATA_DIR;
+  }
+}
+
+test("githubToken resolution: a stored alias-host token beats GITHUB_TOKEN env", async () => {
+  // beforeAll already set process.env.GITHUB_TOKEN = "test-token", so this
+  // exercises the "alias beats env" ordering directly — no need to touch it.
+  await withGitHubTokenStore(async () => {
+    const aliasDir = await makeAliasGitHubRepo("acme", "widgets", "github-testalias.com");
+    setGitHubToken("github-testalias.com", "alias-token-abc");
+    const mock = mockGitHubFetch([{ match: "https://api.github.com/user", json: { login: "octocat" } }]);
+    try {
+      const res = await getGitHubViewer({ dir: aliasDir });
+      expect(res).toEqual({ ok: true, login: "octocat" });
+      expect(mock.calls).toHaveLength(1);
+      expect(mock.calls[0]!.url).toBe("https://api.github.com/user");
+      expect(mock.calls[0]!.headers.authorization).toBe("Bearer alias-token-abc");
+    } finally {
+      mock.restore();
+    }
+  });
+});
+
+test("githubToken resolution: an alias-host repo with no stored token falls back to GITHUB_TOKEN env (regression)", async () => {
+  await withGitHubTokenStore(async () => {
+    // Fresh AGETOR_DATA_DIR for this test → no stored tokens exist at all, so
+    // resolution must fall through to the env var, exactly as it did before
+    // per-host token storage existed.
+    const aliasDir = await makeAliasGitHubRepo("acme", "widgets", "github-testalias-env.com");
+    const mock = mockGitHubFetch([{ match: "https://api.github.com/user", json: { login: "octocat" } }]);
+    try {
+      const res = await getGitHubViewer({ dir: aliasDir });
+      expect(res).toEqual({ ok: true, login: "octocat" });
+      expect(mock.calls).toHaveLength(1);
+      // Still the canonical github.com API host — only the token routing
+      // keys off the raw alias, requests always go to api.github.com.
+      expect(mock.calls[0]!.url).toBe("https://api.github.com/user");
+      expect(mock.calls[0]!.headers.authorization).toBe("Bearer test-token");
+    } finally {
+      mock.restore();
+    }
+  });
+});
+
+test("githubToken resolution: a stored github.com entry is used as the default for a plain github.com repo", async () => {
+  const priorToken = process.env.GITHUB_TOKEN;
+  const priorGhToken = process.env.GH_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_TOKEN;
+  try {
+    await withGitHubTokenStore(async () => {
+      setGitHubToken("github.com", "default-token-xyz");
+      const mock = mockGitHubFetch([{ match: "https://api.github.com/user", json: { login: "octocat" } }]);
+      try {
+        // REPO_DIR's origin is a plain https://github.com/acme/widgets.git
+        // remote (set up in this file's top-level beforeAll) — remoteHost
+        // resolves to "github.com" itself, so the stored default entry (not
+        // an alias) is what should be picked up here.
+        const res = await getGitHubViewer({ dir: REPO_DIR });
+        expect(res).toEqual({ ok: true, login: "octocat" });
+        expect(mock.calls).toHaveLength(1);
+        expect(mock.calls[0]!.headers.authorization).toBe("Bearer default-token-xyz");
+      } finally {
+        mock.restore();
+      }
+    });
+  } finally {
+    if (priorToken !== undefined) process.env.GITHUB_TOKEN = priorToken;
+    if (priorGhToken !== undefined) process.env.GH_TOKEN = priorGhToken;
+  }
+});
+
+test("a 404 on an alias-host repo is enriched with the Settings pointer, naming that host", async () => {
+  // beforeAll's GITHUB_TOKEN stays set, so a request is attempted (hadToken
+  // === true) and the 404 hint includes the "doesn't work here" clause on top
+  // of the base "add a token" pointer.
+  await withGitHubTokenStore(async () => {
+    const aliasDir = await makeAliasGitHubRepo("acme", "secret-repo", "github-testalias-404.com");
+    const mock = mockGitHubFetch([
+      { match: "https://api.github.com/user", status: 404, json: { message: "Not Found" } },
+    ]);
+    try {
+      const res = await getGitHubViewer({ dir: aliasDir });
+      expect(res.ok).toBe(false);
+      if (res.ok) throw new Error("expected getGitHubViewer to fail on a 404");
+      expect(res.error).toContain(
+        "add a token for github-testalias-404.com in Settings → GitHub tokens",
+      );
+      expect(res.error).toContain("configured token cannot access it");
+    } finally {
+      mock.restore();
+    }
+  });
 });

--- a/src/bun/github-test-util.ts
+++ b/src/bun/github-test-util.ts
@@ -30,6 +30,20 @@ export async function makeGitHubRepo(owner = "o", name = "r"): Promise<string> {
   return dir;
 }
 
+/** A throwaway git repo whose `origin` is an ssh host-alias remote
+ *  (`git@<aliasHost>:<owner>/<name>.git`), e.g. `git@github-work.com:acme/widgets.git`.
+ *  `repoForDir(dir)` still resolves this to the canonical `github.com` API host
+ *  (via `canonicalGitHost`), but `repo.remoteHost` carries the raw alias — the
+ *  identity that per-host token routing (`github-tokens.ts`) keys on. Mirrors
+ *  `makeGitHubRepo` but for exercising the multi-identity token resolution
+ *  paths end-to-end. */
+export async function makeAliasGitHubRepo(owner = "o", name = "r", aliasHost = "github-alias.com"): Promise<string> {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-gh-repo-alias-"));
+  await git(["init", "-b", "main"], dir);
+  await git(["remote", "add", "origin", `git@${aliasHost}:${owner}/${name}.git`], dir);
+  return dir;
+}
+
 export interface MockRoute {
   /** HTTP method to match (case-insensitive). Omit to match any method. */
   method?: string;

--- a/src/bun/github-tokens.test.ts
+++ b/src/bun/github-tokens.test.ts
@@ -1,0 +1,122 @@
+import { test, expect, beforeEach, afterEach, afterAll } from "bun:test";
+import { mkdtempSync, existsSync, writeFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  listGitHubTokens,
+  setGitHubToken,
+  deleteGitHubToken,
+  tokenForHost,
+  githubTokensPath,
+} from "./github-tokens.ts";
+
+// github-tokens.ts resolves AGETOR_DATA_DIR lazily at call time (not at module
+// load), so — unlike db.ts/orchestrator.ts tests — it's safe to swap the env
+// var per-test rather than once in beforeAll. Each test gets its own mkdtemp
+// dir so parallel-file test isolation holds and nothing leaks into a real
+// ~/.agetor or ~/.agetor-dev store.
+const ORIGINAL_DATA_DIR = process.env.AGETOR_DATA_DIR;
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(path.join(tmpdir(), "agetor-gh-tokens-"));
+  process.env.AGETOR_DATA_DIR = dataDir;
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.AGETOR_DATA_DIR;
+  else process.env.AGETOR_DATA_DIR = ORIGINAL_DATA_DIR;
+});
+
+test("setGitHubToken then listGitHubTokens round-trips, host lowercased/trimmed", () => {
+  setGitHubToken("  GitHub-Work.COM  ", "tok_1", "work");
+  expect(listGitHubTokens()).toEqual([
+    { host: "github-work.com", token: "tok_1", label: "work" },
+  ]);
+});
+
+test("setGitHubToken upserts by host — same host twice yields one entry, latest wins", () => {
+  setGitHubToken("github-work.com", "tok_1", "first label");
+  setGitHubToken("GitHub-Work.com", "tok_2", "second label");
+  const tokens = listGitHubTokens();
+  expect(tokens).toHaveLength(1);
+  expect(tokens[0]).toEqual({ host: "github-work.com", token: "tok_2", label: "second label" });
+});
+
+test("deleteGitHubToken returns true when an entry was removed, false otherwise", () => {
+  setGitHubToken("github.com", "tok_1");
+  expect(deleteGitHubToken("github.com")).toBe(true);
+  expect(listGitHubTokens()).toEqual([]);
+  expect(deleteGitHubToken("github.com")).toBe(false);
+  expect(deleteGitHubToken("never-stored.example.com")).toBe(false);
+});
+
+test("malformed file content degrades to an empty list", () => {
+  writeFileSync(githubTokensPath(), "{ not valid json ][");
+  expect(listGitHubTokens()).toEqual([]);
+});
+
+test("missing file degrades to an empty list", () => {
+  expect(existsSync(githubTokensPath())).toBe(false);
+  expect(listGitHubTokens()).toEqual([]);
+});
+
+test("entries with non-string/empty host or token are dropped on read", () => {
+  writeFileSync(
+    githubTokensPath(),
+    JSON.stringify({
+      tokens: [
+        { host: "github.com", token: "good" },
+        { host: "", token: "bad-empty-host" },
+        { host: 42, token: "bad-nonstring-host" },
+        { host: "github-work.com", token: "" },
+        { host: "github-other.com", token: 42 },
+        { host: "github-null-label.com", token: "ok", label: null },
+        "not-an-object",
+        null,
+      ],
+    }),
+  );
+  expect(listGitHubTokens()).toEqual([
+    { host: "github.com", token: "good", label: null },
+    { host: "github-null-label.com", token: "ok", label: null },
+  ]);
+});
+
+test("tokenForHost: exact alias match beats the github.com fallback entry", () => {
+  setGitHubToken("github.com", "default-tok");
+  setGitHubToken("github-work.com", "alias-tok");
+  expect(tokenForHost("github-work.com")).toBe("alias-tok");
+  expect(tokenForHost("GitHub-Work.com")).toBe("alias-tok");
+});
+
+test("tokenForHost: falls back to the github.com entry for an unknown host", () => {
+  setGitHubToken("github.com", "default-tok");
+  expect(tokenForHost("gitlab-work.io")).toBe("default-tok");
+});
+
+test("tokenForHost: null when nothing is stored", () => {
+  expect(tokenForHost("github.com")).toBeNull();
+  expect(tokenForHost(null)).toBeNull();
+});
+
+test("tokenForHost: null host still resolves to the github.com entry", () => {
+  setGitHubToken("github.com", "default-tok");
+  expect(tokenForHost(null)).toBe("default-tok");
+});
+
+test("setGitHubToken throws on empty host or empty token", () => {
+  expect(() => setGitHubToken("", "tok")).toThrow();
+  expect(() => setGitHubToken("   ", "tok")).toThrow();
+  expect(() => setGitHubToken("github.com", "")).toThrow();
+});
+
+test("token file is written with mode 0600", () => {
+  setGitHubToken("github.com", "tok_1");
+  const mode = statSync(githubTokensPath()).mode & 0o777;
+  expect(mode).toBe(0o600);
+});

--- a/src/bun/github-tokens.ts
+++ b/src/bun/github-tokens.ts
@@ -1,0 +1,160 @@
+import { homedir } from "node:os";
+import path from "node:path";
+import { readFileSync, writeFileSync, renameSync, chmodSync } from "node:fs";
+
+/**
+ * Per-host GitHub personal-access-token store. This exists because a single
+ * machine can have several GitHub identities reachable only through distinct
+ * ssh host aliases (`git@github-work.com:owner/repo.git`), and one env var
+ * (`GITHUB_TOKEN`) or `gh auth token` can never cover more than one of them.
+ * Tokens here are keyed by the raw (pre-canonicalization) remote host, which
+ * *is* the identity — see docs/plans/github-multi-identity-tokens.md.
+ *
+ * This module deliberately imports nothing from `db.ts` (which opens SQLite
+ * on import) or `github.ts` (which calls `tokenForHost` from here as one step
+ * of its own resolution order) — keeping it a leaf module makes it trivial to
+ * unit test and avoids any import cycle with github.ts.
+ */
+export type GitHubTokenEntry = {
+  host: string;
+  token: string;
+  label: string | null;
+};
+
+interface GitHubTokensFile {
+  tokens: GitHubTokenEntry[];
+}
+
+export const GITHUB_TOKENS_FILENAME = "github-tokens.json";
+
+/**
+ * Resolve the data dir the same way `db.ts` / `core-creds.ts` do, but lazily
+ * (at call time) rather than once at module load. Reading `AGETOR_DATA_DIR`
+ * at call time keeps this in agreement with `db.ts` even under the test
+ * auto-allocate path (which sets the env var before any store call runs).
+ */
+export function resolveDataDir(): string {
+  return process.env.AGETOR_DATA_DIR ?? path.join(homedir(), ".agetor");
+}
+
+export function githubTokensPath(dataDir: string = resolveDataDir()): string {
+  return path.join(dataDir, GITHUB_TOKENS_FILENAME);
+}
+
+/** Lowercase + trim so lookups and storage never diverge on case/whitespace. */
+function normalizeHost(host: string): string {
+  return host.trim().toLowerCase();
+}
+
+/**
+ * Read + validate the store file. Missing file, corrupt JSON, or a
+ * malformed shape all degrade to an empty list rather than throwing — a
+ * broken token file must never block the rest of the app from starting.
+ * Entries with an empty or non-string `host`/`token` are dropped rather than
+ * surfaced, since they can never be resolved against by `tokenForHost`.
+ */
+function readTokensFile(): GitHubTokenEntry[] {
+  let raw: string;
+  try {
+    raw = readFileSync(githubTokensPath(), "utf8");
+  } catch {
+    return []; // missing file → no tokens
+  }
+  try {
+    const v = JSON.parse(raw) as Partial<GitHubTokensFile>;
+    if (!v || !Array.isArray(v.tokens)) return [];
+    const out: GitHubTokenEntry[] = [];
+    for (const entry of v.tokens) {
+      if (!entry || typeof entry !== "object") continue;
+      const e = entry as Partial<GitHubTokenEntry>;
+      if (typeof e.host !== "string" || e.host.trim() === "") continue;
+      if (typeof e.token !== "string" || e.token === "") continue;
+      const label =
+        typeof e.label === "string" ? e.label : e.label === null ? null : null;
+      out.push({ host: normalizeHost(e.host), token: e.token, label });
+    }
+    return out;
+  } catch {
+    return []; // corrupt JSON → treat as no tokens
+  }
+}
+
+/**
+ * Write the store atomically at mode 0600 (write a tmp sibling, then rename
+ * over the target) so a reader never sees a half-written or world-readable
+ * file. Best-effort chmod afterwards in case the umask or an existing file
+ * left looser bits. Mirrors `writeCoreCreds` in core-creds.ts.
+ */
+function writeTokensFile(tokens: GitHubTokenEntry[]): void {
+  const file = githubTokensPath();
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify({ tokens }), { mode: 0o600 });
+  renameSync(tmp, file);
+  try {
+    chmodSync(file, 0o600);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** List all stored tokens. Never throws; malformed/missing file → `[]`. */
+export function listGitHubTokens(): GitHubTokenEntry[] {
+  return readTokensFile();
+}
+
+/**
+ * Upsert a token by (normalized) host. Throws on empty host/token so a
+ * caller-side validation bug fails loudly instead of silently writing a
+ * dead entry that `tokenForHost` can never match.
+ */
+export function setGitHubToken(
+  host: string,
+  token: string,
+  label?: string | null,
+): void {
+  const normalized = normalizeHost(host);
+  if (normalized === "") throw new Error("host must not be empty");
+  if (token === "") throw new Error("token must not be empty");
+
+  const tokens = readTokensFile();
+  const entry: GitHubTokenEntry = {
+    host: normalized,
+    token,
+    label: label ?? null,
+  };
+  const idx = tokens.findIndex((t) => t.host === normalized);
+  if (idx === -1) {
+    tokens.push(entry);
+  } else {
+    tokens[idx] = entry;
+  }
+  writeTokensFile(tokens);
+}
+
+/** Remove the entry for `host`. Returns true iff an entry was removed. */
+export function deleteGitHubToken(host: string): boolean {
+  const normalized = normalizeHost(host);
+  const tokens = readTokensFile();
+  const next = tokens.filter((t) => t.host !== normalized);
+  if (next.length === tokens.length) return false;
+  writeTokensFile(next);
+  return true;
+}
+
+/**
+ * Resolve a stored token for `host`, implementing only steps 1–2 of the
+ * full resolution order (exact host match, then the `github.com` entry as
+ * default) — env var and `gh auth token` fallback live in github.ts, which
+ * calls this as its first step. `host` is expected pre-lowercased by the
+ * caller's parsing, but is normalized again here defensively.
+ */
+export function tokenForHost(host: string | null): string | null {
+  const tokens = readTokensFile();
+  if (host !== null) {
+    const normalized = normalizeHost(host);
+    const exact = tokens.find((t) => t.host === normalized);
+    if (exact) return exact.token;
+  }
+  const fallback = tokens.find((t) => t.host === "github.com");
+  return fallback ? fallback.token : null;
+}

--- a/src/bun/github.test.ts
+++ b/src/bun/github.test.ts
@@ -54,9 +54,10 @@ const {
   parseDiscussionDetail,
   createdDiscussionFromGraphql,
   addedDiscussionCommentIdFromGraphql,
+  privateRepoHint,
 } = __githubInternals;
 
-const REPO = { owner: "o", name: "r" };
+const REPO = { owner: "o", name: "r", remoteHost: "github.com" };
 
 function makeItem(overrides: Partial<GitHubListItem> = {}): GitHubListItem {
   return {
@@ -101,7 +102,7 @@ test("githubRepoFromRemoteForTest ignores non-GitHub remotes", () => {
 });
 
 test("githubRepoFromRemoteForTest resolves custom ssh host aliases containing github", () => {
-  expect(githubRepoFromRemoteForTest("git@github-alamops.com:alamops/agetor.git")).toBe("alamops/agetor");
+  expect(githubRepoFromRemoteForTest("git@github-acme.com:acme/widgets.git")).toBe("acme/widgets");
   expect(githubRepoFromRemoteForTest("git@github-work:openai/codex.git")).toBe("openai/codex");
   expect(githubRepoFromRemoteForTest("github-work:openai/codex")).toBe("openai/codex");
   expect(githubRepoFromRemoteForTest("ssh://git@github-work/openai/codex.git")).toBe("openai/codex");
@@ -121,11 +122,13 @@ test("parseGitRemote extracts host/owner/name across url syntaxes", () => {
   const { parseGitRemote } = __githubInternals;
   expect(parseGitRemote("git@bitbucket-work.org:acme/app.git")).toEqual({
     host: "bitbucket.org",
+    rawHost: "bitbucket-work.org",
     owner: "acme",
     name: "app",
   });
   expect(parseGitRemote("https://gitlab.com/group/project")).toEqual({
     host: "gitlab.com",
+    rawHost: "gitlab.com",
     owner: "group",
     name: "project",
   });
@@ -1243,4 +1246,42 @@ test("addedDiscussionCommentIdFromGraphql digs data.addDiscussionComment.comment
   expect(addedDiscussionCommentIdFromGraphql({})).toBeNull();
   expect(addedDiscussionCommentIdFromGraphql({ data: { addDiscussionComment: null } })).toBeNull();
   expect(addedDiscussionCommentIdFromGraphql({ data: { addDiscussionComment: { comment: {} } } })).toBeNull();
+});
+
+test("privateRepoHint on a 404 with no token points at Settings for the remote host", () => {
+  const msg = privateRepoHint(404, "Not Found", REPO, false);
+  expect(msg).toContain("o/r");
+  expect(msg).toContain("private");
+  expect(msg).toContain(REPO.remoteHost);
+  expect(msg).toContain("Settings");
+});
+
+test("privateRepoHint on a 404 with a token mentions the configured token can't access it", () => {
+  const msg = privateRepoHint(404, "Not Found", REPO, true);
+  expect(msg).toContain("o/r");
+  expect(msg).toContain(REPO.remoteHost);
+  expect(msg).toContain("Settings");
+  expect(msg).toContain("cannot access it");
+});
+
+test("privateRepoHint uses the repo's own remoteHost (alias), not github.com, in the Settings pointer", () => {
+  const aliasRepo = { owner: "o", name: "r", remoteHost: "github-work.com" };
+  const msg = privateRepoHint(404, "Not Found", aliasRepo, false);
+  expect(msg).toContain("github-work.com");
+});
+
+test("privateRepoHint returns the input message unchanged for non-404 statuses", () => {
+  expect(privateRepoHint(500, "Internal Server Error", REPO, false)).toBe("Internal Server Error");
+  expect(privateRepoHint(403, "rate limited", REPO, true)).toBe("rate limited");
+  expect(privateRepoHint(401, "bad credentials", REPO, false)).toBe("bad credentials");
+});
+
+test("parseGitRemote preserves rawHost for a github ssh host alias while canonicalizing host", () => {
+  const { parseGitRemote } = __githubInternals;
+  expect(parseGitRemote("git@github-work.com:o/r.git")).toEqual({
+    host: "github.com",
+    rawHost: "github-work.com",
+    owner: "o",
+    name: "r",
+  });
 });

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -63,6 +63,7 @@ import type {
   TaskDiff,
 } from "../shared/types.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
+import { tokenForHost } from "./github-tokens.ts";
 
 interface CommandResult {
   ok: boolean;
@@ -81,6 +82,11 @@ interface PipedProcess {
 interface GitHubRepo {
   owner: string;
   name: string;
+  /** Raw (pre-canonicalization) remote host — e.g. `github-work.com` for an
+   *  ssh host alias, or `github.com` for a plain remote. This is the identity
+   *  key tokens are stored under (see github-tokens.ts) since one env var or
+   *  `gh auth token` can't cover more than one GitHub identity. */
+  remoteHost: string;
 }
 
 interface ListGitHubItemsInput {
@@ -568,9 +574,12 @@ function canonicalGitHost(host: string): string {
 }
 
 /** Extract host + owner/name from a git remote URL in https, ssh://, or
- *  scp-like (`[user@]host:owner/repo`) form, canonicalizing the host via
- *  canonicalGitHost. Returns null for local paths and anything unrecognized. */
-function parseGitRemote(raw: string): { host: string; owner: string; name: string } | null {
+ *  scp-like (`[user@]host:owner/repo`) form. `host` is canonicalized via
+ *  canonicalGitHost; `rawHost` is the lowercased pre-canonicalization host
+ *  (the ssh alias itself, when one is in play) — callers that need to route a
+ *  per-identity token use `rawHost`, not `host`. Returns null for local paths
+ *  and anything unrecognized. */
+function parseGitRemote(raw: string): { host: string; rawHost: string; owner: string; name: string } | null {
   const remote = raw.trim();
   if (!remote) return null;
 
@@ -579,13 +588,14 @@ function parseGitRemote(raw: string): { host: string; owner: string; name: strin
   const scp = /^(?:[^@/\s]+@)?([^/:\s]+):([^/:]+)\/(.+?)(?:\.git)?$/i.exec(remote);
   const m = https ?? ssh ?? scp;
   if (!m) return null;
-  return { host: canonicalGitHost(m[1]!), owner: m[2]!, name: m[3]! };
+  const rawHost = m[1]!.toLowerCase();
+  return { host: canonicalGitHost(rawHost), rawHost, owner: m[2]!, name: m[3]! };
 }
 
 function parseGitHubRemote(raw: string): GitHubRepo | null {
   const parsed = parseGitRemote(raw);
   if (!parsed || parsed.host !== "github.com") return null;
-  return { owner: parsed.owner, name: parsed.name };
+  return { owner: parsed.owner, name: parsed.name, remoteHost: parsed.rawHost };
 }
 
 export function githubRepoFromRemoteForTest(remote: string): string | null {
@@ -804,6 +814,7 @@ export const __githubInternals = {
   parseDiscussionDetail,
   createdDiscussionFromGraphql,
   addedDiscussionCommentIdFromGraphql,
+  privateRepoHint,
 };
 
 async function repoForDir(dir: string): Promise<GitHubRepo | null> {
@@ -821,7 +832,30 @@ async function repoForDir(dir: string): Promise<GitHubRepo | null> {
   return null;
 }
 
-async function githubToken(): Promise<string | null> {
+/** Distinct raw GitHub hosts (the ssh-alias identity, or `github.com` for a
+ *  plain remote) across the given project dirs, sorted — drives the Settings
+ *  "detected hosts" suggestion list so a user's real aliases are one click
+ *  away instead of hand-typed. Dirs with no GitHub remote (or that aren't a
+ *  repo at all) are tolerated silently, same as `repoForDir`. */
+export async function remoteHostsForDirs(dirs: string[]): Promise<string[]> {
+  const repos = await Promise.all(dirs.map((dir) => repoForDir(dir)));
+  const hosts = new Set<string>();
+  for (const repo of repos) {
+    if (repo) hosts.add(repo.remoteHost);
+  }
+  return Array.from(hosts).sort();
+}
+
+/** Resolve the token to authenticate a GitHub request with, for a repo whose
+ *  raw remote host is `host` (null when there's no repo in scope). Order:
+ *  (1) a stored token for `host` (or the `github.com` default entry —
+ *  `tokenForHost` implements that fallback), (2) `GITHUB_TOKEN`/`GH_TOKEN`
+ *  env, (3) `gh auth token`. `host` is a required parameter (not optional) so
+ *  every call site has to thread it through explicitly rather than silently
+ *  falling back to the single-identity env/gh behavior this replaces. */
+async function githubToken(host: string | null): Promise<string | null> {
+  const stored = tokenForHost(host);
+  if (stored) return stored;
   const envToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (envToken) return envToken;
   const gh = await run(["gh", "auth", "token"], undefined, 5_000);
@@ -1248,6 +1282,21 @@ function apiError(body: unknown, status: number, statusText: string): string {
     : `${status} ${statusText}`;
 }
 
+/** Enriches a plain 404 with an actionable pointer to Settings. GitHub answers
+ *  404 — not 403 — for a private repo the caller can't see, so an unadorned
+ *  passthrough of `message` reads as "this repo doesn't exist" even when it's
+ *  just an auth gap. Any other status is returned unchanged. Pure — the
+ *  `hadToken` flag (was a request even attempted with a token?) picks between
+ *  "add a token" and "the token you have doesn't work here". */
+function privateRepoHint(status: number, message: string, repo: GitHubRepo, hadToken: boolean): string {
+  if (status !== 404) return message;
+  const host = repo.remoteHost || "github.com";
+  const base = `${repo.owner}/${repo.name} was not found on GitHub — if the repo is private, add a token for ${host} in Settings → GitHub tokens`;
+  return hadToken
+    ? `${base} (the configured token cannot access it — check it belongs to the right account)`
+    : base;
+}
+
 async function pullHeadSha(repo: GitHubRepo, token: string | null, number: number): Promise<string | GitHubListError> {
   const prUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${number}`;
   const prRes = await fetchGitHub(prUrl, token, "application/vnd.github+json");
@@ -1293,7 +1342,7 @@ export async function listGitHubItems(input: ListGitHubItemsInput): Promise<GitH
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const slug = repoSlug(repo);
   const labels = input.labels?.map((s) => s.trim()).filter(Boolean) ?? [];
   const assignee = input.assignee?.trim() ?? "";
@@ -1382,7 +1431,7 @@ export async function listGitHubItems(input: ListGitHubItemsInput): Promise<GitH
         // GitHub's own "Validation Failed" is opaque — the query syntax is the fault.
         msg = "Invalid GitHub search query — check your qualifiers (e.g. is:open label:bug sort:updated).";
       }
-      return { ok: false, error: msg };
+      return { ok: false, error: privateRepoHint(res.status, msg, repo, !!token) };
     }
     // The list endpoints return a bare array; search wraps items in `.items`.
     const raws = useSearch
@@ -1566,7 +1615,7 @@ export async function createGitHubPull(input: CreateGitHubPullInput): Promise<Gi
   if (!head) return { ok: false, error: "head branch required" };
   if (!base) return { ok: false, error: "base branch required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to create a pull request" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls`;
   const res = await fetchGitHub(
@@ -1623,7 +1672,7 @@ export async function getGitHubPullDiff(input: GetGitHubPullDiffInput): Promise<
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   const res = await fetchGitHub(url, token, "application/vnd.github.v3.diff");
   if (!("status" in res)) return res;
@@ -1677,7 +1726,7 @@ export async function listGitHubComments(input: GitHubItemNumberInput): Promise<
     return { ok: false, error: "item number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const url = new URL(`https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}/comments`);
   url.searchParams.set("per_page", "100");
   const res = await fetchGitHub(url.toString(), token, "application/vnd.github+json");
@@ -1707,7 +1756,7 @@ export async function createGitHubComment(input: CreateGitHubCommentInput): Prom
   const body = input.body.trim();
   if (!body) return { ok: false, error: "comment body required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to comment" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}/comments`;
   const res = await fetchGitHub(
@@ -1748,7 +1797,7 @@ export async function createGitHubPullLineComment(
     return { ok: false, error: "comment side must be LEFT or RIGHT" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to comment on a line" };
   const sha = await pullHeadSha(repo, token, input.number);
   if (typeof sha !== "string") return sha;
@@ -1786,7 +1835,7 @@ export async function listGitHubPullReviewComments(
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const url = new URL(`https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/comments`);
   url.searchParams.set("per_page", "100");
   const res = await fetchGitHub(url.toString(), token, "application/vnd.github+json");
@@ -1816,7 +1865,7 @@ export async function replyGitHubPullLineComment(
   const body = input.body.trim();
   if (!body) return { ok: false, error: "reply body required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to reply" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/comments/${input.commentId}/replies`;
   const res = await fetchGitHub(
@@ -1854,7 +1903,7 @@ export async function applyGitHubSuggestion(input: ApplyGitHubSuggestionInput): 
     return { ok: false, error: "review comment id must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to apply a suggestion" };
 
   const reviewCommentUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/comments/${input.commentId}`;
@@ -1949,7 +1998,7 @@ export async function getGitHubPullChecks(input: GitHubItemNumberInput): Promise
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const sha = await pullHeadSha(repo, token, input.number);
   if (typeof sha !== "string") return sha;
 
@@ -1987,7 +2036,7 @@ export async function getGitHubCommitStatus(input: GetGitHubCommitStatusInput): 
   const ref = input.ref.trim();
   if (!ref) return { ok: false, error: "commit ref required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/commits/${encodeURIComponent(ref)}/status`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json");
   if (!("status" in res)) return res;
@@ -2007,7 +2056,7 @@ export async function listGitHubPullCommits(input: GitHubItemNumberInput): Promi
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const commits: GitHubPullCommit[] = [];
   let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/commits?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
@@ -2036,7 +2085,7 @@ export async function reviewGitHubPull(input: ReviewGitHubPullInput): Promise<Gi
   const invalid = reviewValidationError(input.event, body, comments.length > 0);
   if (invalid) return { ok: false, error: invalid };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to review" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/reviews`;
   const res = await fetchGitHub(
@@ -2076,7 +2125,7 @@ export async function mergeGitHubPull(input: MergeGitHubPullInput): Promise<GitH
     return { ok: false, error: "unsupported merge method" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to merge" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/merge`;
   const res = await fetchGitHub(
@@ -2111,7 +2160,7 @@ export async function closeGitHubPull(input: CloseGitHubPullInput): Promise<GitH
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to close a pull request" };
   const comment = input.comment?.trim() ?? "";
 
@@ -2151,7 +2200,7 @@ export async function createGitHubIssue(input: CreateGitHubIssueInput): Promise<
   const title = input.title.trim();
   if (!title) return { ok: false, error: "issue title required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to create an issue" };
   const labels = input.labels?.map((s) => s.trim()).filter(Boolean) ?? [];
   const assignees = input.assignees?.map((s) => s.trim()).filter(Boolean) ?? [];
@@ -2189,7 +2238,7 @@ export async function updateGitHubIssue(input: UpdateGitHubIssueInput): Promise<
     return { ok: false, error: "unsupported issue state" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to update an issue" };
   const kind = input.kind === "pulls" ? "pulls" : "issues";
   const noun = kind === "pulls" ? "pull request" : "issue";
@@ -2225,7 +2274,7 @@ export async function requestGitHubPullReviewers(
     return { ok: false, error: "at least one reviewer or team is required" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to request reviewers" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/requested_reviewers`;
   const res = await fetchGitHub(
@@ -2281,7 +2330,7 @@ export async function getGitHubPullMergeability(input: GitHubItemNumberInput): P
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   // GitHub computes `mergeable` asynchronously — the first read after a push can
   // return null. Poll a couple of times before giving up so the UI usually gets
@@ -2309,7 +2358,7 @@ export async function updateGitHubPullBranch(input: GitHubItemNumberInput): Prom
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to update the branch" };
   // Merges the base branch into the PR head. 202 Accepted with a message body.
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/update-branch`;
@@ -2330,7 +2379,7 @@ export async function reopenGitHubPull(input: GitHubItemNumberInput): Promise<Gi
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to reopen a pull request" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   const res = await fetchGitHub(
@@ -2745,7 +2794,7 @@ export async function setGitHubPullDraft(input: SetGitHubPullDraftInput): Promis
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to change draft state" };
   const prUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   const prRes = await fetchGitHub(prUrl, token, "application/vnd.github+json");
@@ -2789,7 +2838,7 @@ export async function setGitHubPullAutoMerge(input: SetGitHubPullAutoMergeInput)
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to change auto-merge" };
   const prUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   const prRes = await fetchGitHub(prUrl, token, "application/vnd.github+json");
@@ -2837,7 +2886,7 @@ export async function setGitHubIssueLock(input: SetGitHubIssueLockInput): Promis
     return { ok: false, error: "item number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to lock/unlock" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}/lock`;
 
@@ -2874,7 +2923,7 @@ export async function setGitHubIssuePinned(input: SetGitHubIssuePinnedInput): Pr
     return { ok: false, error: "issue number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to pin/unpin" };
   const issueUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}`;
   const issueRes = await fetchGitHub(issueUrl, token, "application/vnd.github+json");
@@ -2920,7 +2969,7 @@ export async function getGitHubIssuePinned(input: GitHubItemNumberInput): Promis
     return { ok: false, error: "issue number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: true, pinned: false };
   const query = `query($owner:String!,$name:String!,$number:Int!){`
     + `repository(owner:$owner,name:$name){issue(number:$number){isPinned}}}`;
@@ -2958,7 +3007,7 @@ export async function listGitHubSubIssues(input: GitHubItemNumberInput): Promise
     return { ok: false, error: "issue number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const subIssues: GitHubSubIssue[] = [];
   let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}/sub_issues?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
@@ -2989,7 +3038,7 @@ export async function addGitHubSubIssue(input: AddGitHubSubIssueInput): Promise<
     return { ok: false, error: "child issue number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to add a sub-issue" };
 
   const childUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.childNumber}`;
@@ -3031,7 +3080,7 @@ export async function removeGitHubSubIssue(input: RemoveGitHubSubIssueInput): Pr
     return { ok: false, error: "child issue id must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to remove a sub-issue" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}/sub_issue`;
   const res = await fetchGitHub(
@@ -3062,7 +3111,7 @@ export async function transferGitHubIssue(input: TransferGitHubIssueInput): Prom
   const target = parseTargetRepo(input.targetRepo);
   if (!target) return { ok: false, error: "target repo must be in the form owner/name" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to transfer an issue" };
 
   const issueUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}`;
@@ -3117,7 +3166,7 @@ export async function transferGitHubIssue(input: TransferGitHubIssueInput): Prom
 export async function listGitHubProjectsV2(input: { dir: string }): Promise<GitHubProjectsV2Response> {
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to view projects" };
 
   const query = `query($owner:String!,$name:String!){repository(owner:$owner,name:$name){projectsV2(first:20){nodes{id number title url}}}}`;
@@ -3145,7 +3194,7 @@ export async function getGitHubProjectItems(input: GetGitHubProjectItemsInput): 
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!input.projectId.trim()) return { ok: false, error: "project id required" };
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to view project items" };
 
   const query = `query($id:ID!){ node(id:$id){ ... on ProjectV2 {`
@@ -3182,7 +3231,7 @@ export async function addGitHubProjectItem(input: AddGitHubProjectItemInput): Pr
   if (!Number.isInteger(input.contentNumber) || input.contentNumber <= 0) {
     return { ok: false, error: "issue/PR number must be positive" };
   }
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to add a project item" };
 
   const segment = input.contentKind === "pr" ? "pulls" : "issues";
@@ -3220,7 +3269,7 @@ export async function removeGitHubProjectItem(input: RemoveGitHubProjectItemInpu
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!input.projectId.trim()) return { ok: false, error: "project id required" };
   if (!input.itemId.trim()) return { ok: false, error: "item id required" };
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to remove a project item" };
 
   const query = `mutation($p:ID!,$i:ID!){ deleteProjectV2Item(input:{ projectId:$p, itemId:$i }){ deletedItemId } }`;
@@ -3250,7 +3299,7 @@ export async function setGitHubProjectItemStatus(input: SetGitHubProjectItemStat
   if (!input.itemId.trim()) return { ok: false, error: "item id required" };
   if (!input.fieldId.trim()) return { ok: false, error: "field id required" };
   if (!input.optionId.trim()) return { ok: false, error: "option id required" };
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to update a project item" };
 
   const query = `mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){ updateProjectV2ItemFieldValue(input:{ projectId:$p, itemId:$i, fieldId:$f, value:{ singleSelectOptionId:$o } }){ projectV2Item { id } } }`;
@@ -3279,7 +3328,7 @@ export async function setGitHubProjectItemStatus(input: SetGitHubProjectItemStat
 export async function listGitHubDiscussions(input: { dir: string }): Promise<GitHubDiscussionsResponse> {
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
 
   const query = `query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){`
     + `discussions(first:25, orderBy:{field:UPDATED_AT, direction:DESC}){ nodes{ id number title url createdAt isAnswered category{ name } author{ login } } }`
@@ -3313,7 +3362,7 @@ export async function getGitHubDiscussion(input: GetGitHubDiscussionInput): Prom
   if (!Number.isInteger(input.number) || input.number <= 0) {
     return { ok: false, error: "discussion number must be positive" };
   }
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
 
   const query = `query($owner:String!,$name:String!,$number:Int!){ repository(owner:$owner,name:$name){`
     + `discussion(number:$number){ id title body category{ isAnswerable } comments(first:50){ nodes{ id body createdAt isAnswer author{ login } } } }`
@@ -3347,7 +3396,7 @@ export async function createGitHubDiscussion(input: CreateGitHubDiscussionInput)
   const body = input.body.trim();
   if (!body) return { ok: false, error: "discussion body required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to create a discussion" };
 
   const repoIdQuery = `query($owner:String!,$name:String!){repository(owner:$owner,name:$name){id}}`;
@@ -3390,7 +3439,7 @@ export async function addGitHubDiscussionComment(input: AddGitHubDiscussionComme
   if (!input.discussionId.trim()) return { ok: false, error: "discussion id required" };
   const body = input.body.trim();
   if (!body) return { ok: false, error: "comment body required" };
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to comment" };
 
   const query = `mutation($d:ID!,$b:String!){ addDiscussionComment(input:{ discussionId:$d, body:$b }){ comment{ id } } }`;
@@ -3419,7 +3468,7 @@ export async function setGitHubDiscussionAnswer(input: SetGitHubDiscussionAnswer
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!input.commentId.trim()) return { ok: false, error: "comment id required" };
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to mark an answer" };
 
   const field = input.answer ? "markDiscussionCommentAsAnswer" : "unmarkDiscussionCommentAsAnswer";
@@ -3446,7 +3495,7 @@ export async function deleteGitHubDiscussion(input: DeleteGitHubDiscussionInput)
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!input.discussionId.trim()) return { ok: false, error: "discussion id required" };
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to delete a discussion" };
 
   const query = `mutation($id:ID!){ deleteDiscussion(input:{ id:$id }){ clientMutationId } }`;
@@ -3470,7 +3519,7 @@ export async function deleteGitHubDiscussionComment(input: DeleteGitHubDiscussio
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!input.commentId.trim()) return { ok: false, error: "comment id required" };
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to delete a comment" };
 
   const query = `mutation($id:ID!){ deleteDiscussionComment(input:{ id:$id }){ clientMutationId } }`;
@@ -3494,12 +3543,12 @@ export async function deleteGitHubDiscussionComment(input: DeleteGitHubDiscussio
 export async function getGitHubViewer(input: { dir: string }): Promise<GitHubViewerResponse> {
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: true, login: "" };
   const res = await fetchGitHub("https://api.github.com/user", token, "application/vnd.github+json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiError(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: privateRepoHint(res.status, apiError(json, res.status, res.statusText), repo, !!token) };
   const login = json && typeof json === "object" && typeof (json as { login?: unknown }).login === "string"
     ? (json as { login: string }).login
     : "";
@@ -3514,13 +3563,13 @@ export async function getGitHubViewer(input: { dir: string }): Promise<GitHubVie
 export async function getGitHubRepoPermissions(input: { dir: string }): Promise<GitHubRepoPermissionsResponse> {
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: true, push: false, admin: false, maintain: false };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiError(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: privateRepoHint(res.status, apiError(json, res.status, res.statusText), repo, !!token) };
   const perms = json && typeof json === "object" && (json as { permissions?: unknown }).permissions
     && typeof (json as { permissions?: unknown }).permissions === "object"
     ? (json as { permissions: Record<string, unknown> }).permissions
@@ -3549,7 +3598,7 @@ export async function updateGitHubComment(input: UpdateGitHubCommentInput): Prom
   const body = input.body.trim();
   if (!body) return { ok: false, error: "comment body required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to edit a comment" };
   const res = await fetchGitHub(
     commentUrl(repo, input.kind, input.commentId),
@@ -3572,7 +3621,7 @@ export async function deleteGitHubComment(input: DeleteGitHubCommentInput): Prom
     return { ok: false, error: "comment id must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to delete a comment" };
   const res = await fetchGitHub(
     commentUrl(repo, input.kind, input.commentId),
@@ -3644,7 +3693,7 @@ export async function getGitHubPullReviewThreads(input: GitHubItemNumberInput): 
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: true, repo: repoSlug(repo), pullNumber: input.number, threads: [], truncated: false };
   // `comments(first:1)` is the thread's ROOT comment — GitHub returns a review
   // thread's comments oldest-first, so the first is the one that started the
@@ -3683,7 +3732,7 @@ export async function getGitHubPullLinkedIssues(input: GitHubItemNumberInput): P
     return { ok: false, error: "pull request number must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: true, repo: repoSlug(repo), pullNumber: input.number, issues: [] };
   const query = `query($owner:String!,$name:String!,$number:Int!){`
     + `repository(owner:$owner,name:$name){pullRequest(number:$number){`
@@ -3709,7 +3758,7 @@ export async function setGitHubReviewThreadResolved(
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!input.threadId) return { ok: false, error: "review thread id required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to resolve a thread" };
   const field = input.resolved ? "resolveReviewThread" : "unresolveReviewThread";
   const query = `mutation($id:ID!){ ${field}(input:{threadId:$id}){ thread { isResolved } } }`;
@@ -3762,7 +3811,7 @@ export async function listGitHubLabels(input: { dir: string }): Promise<GitHubLa
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const labels: GitHubRepoLabel[] = [];
   let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/labels?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
@@ -3785,7 +3834,7 @@ export async function listGitHubAssignees(input: { dir: string }): Promise<GitHu
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const assignees: GitHubUser[] = [];
   let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/assignees?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
@@ -3811,7 +3860,7 @@ export async function createGitHubLabel(input: CreateGitHubLabelInput): Promise<
   if (!name) return { ok: false, error: "label name required" };
   const color = normalizeColor(input.color) ?? "";
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to create a label" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/labels`;
   const res = await fetchGitHub(
@@ -3840,7 +3889,7 @@ export async function updateGitHubLabel(input: UpdateGitHubLabelInput): Promise<
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!input.name.trim()) return { ok: false, error: "label name required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to edit a label" };
   const patch: { new_name?: string; color?: string; description?: string } = {};
   if (input.newName !== undefined) {
@@ -3874,7 +3923,7 @@ export async function deleteGitHubLabel(input: DeleteGitHubLabelInput): Promise<
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!input.name.trim()) return { ok: false, error: "label name required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to delete a label" };
   const res = await fetchGitHub(labelUrl(repo, input.name), token, "application/vnd.github+json", { method: "DELETE" });
   if (!("status" in res)) return res;
@@ -3920,7 +3969,7 @@ export async function listGitHubMilestones(input: { dir: string }): Promise<GitH
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const milestones: GitHubRepoMilestone[] = [];
   let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/milestones?state=all&per_page=100&sort=due_on&direction=asc`;
   for (let page = 0; next && page < 3; page++) {
@@ -3944,7 +3993,7 @@ export async function createGitHubMilestone(input: CreateGitHubMilestoneInput): 
   const title = input.title.trim();
   if (!title) return { ok: false, error: "milestone title required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to create a milestone" };
   const dueOn = normalizeDueOn(input.dueOn);
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/milestones`;
@@ -3974,7 +4023,7 @@ export async function updateGitHubMilestone(input: UpdateGitHubMilestoneInput): 
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!Number.isInteger(input.number) || input.number <= 0) return { ok: false, error: "valid milestone number required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to edit a milestone" };
   const patch: { title?: string; description?: string; due_on?: string; state?: "open" | "closed" } = {};
   if (input.title !== undefined) {
@@ -4062,7 +4111,7 @@ export async function listGitHubReactions(input: ListGitHubReactionsInput): Prom
     return { ok: false, error: "reaction subject id must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const raw: unknown[] = [];
   let next: string | null = `${reactionSubjectPath(repo, input.subject)}?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
@@ -4087,7 +4136,7 @@ export async function addGitHubReaction(input: AddGitHubReactionInput): Promise<
     return { ok: false, error: "unsupported reaction content" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to react" };
   const res = await fetchGitHub(
     reactionSubjectPath(repo, input.subject),
@@ -4115,7 +4164,7 @@ export async function removeGitHubReaction(input: RemoveGitHubReactionInput): Pr
     return { ok: false, error: "reaction id must be positive" };
   }
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to remove a reaction" };
   const res = await fetchGitHub(
     `${reactionSubjectPath(repo, input.subject)}/${input.reactionId}`,
@@ -4136,7 +4185,7 @@ export async function deleteGitHubMilestone(input: DeleteGitHubMilestoneInput): 
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!Number.isInteger(input.number) || input.number <= 0) return { ok: false, error: "valid milestone number required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to delete a milestone" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/milestones/${input.number}`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json", { method: "DELETE" });
@@ -4155,7 +4204,7 @@ export async function listGitHubReleases(input: { dir: string }): Promise<GitHub
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const releases: GitHubRelease[] = [];
   let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/releases?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
@@ -4180,7 +4229,7 @@ export async function listGitHubTags(input: { dir: string }): Promise<GitHubTags
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const tags: GitHubTag[] = [];
   let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/tags?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
@@ -4204,7 +4253,7 @@ export async function createGitHubRelease(input: CreateGitHubReleaseInput): Prom
   const tagName = input.tagName.trim();
   if (!tagName) return { ok: false, error: "tag name required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to create a release" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/releases`;
   const res = await fetchGitHub(
@@ -4236,7 +4285,7 @@ export async function updateGitHubRelease(input: UpdateGitHubReleaseInput): Prom
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!Number.isInteger(input.id) || input.id <= 0) return { ok: false, error: "valid release id required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to edit a release" };
   const patch: { tag_name?: string; name?: string; body?: string; draft?: boolean; prerelease?: boolean } = {};
   if (input.tagName !== undefined) {
@@ -4267,7 +4316,7 @@ export async function deleteGitHubRelease(input: DeleteGitHubReleaseInput): Prom
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!Number.isInteger(input.id) || input.id <= 0) return { ok: false, error: "valid release id required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to delete a release" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/releases/${input.id}`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json", { method: "DELETE" });
@@ -4328,7 +4377,7 @@ export async function listGitHubNotifications(input: ListGitHubNotificationsInpu
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to view notifications" };
 
   const notifications: GitHubNotification[] = [];
@@ -4357,7 +4406,7 @@ export async function markGitHubNotificationRead(input: GitHubThreadInput): Prom
   const threadId = input.threadId.trim();
   if (!threadId) return { ok: false, error: "thread id required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to mark a notification read" };
   const res = await fetchGitHub(
     `https://api.github.com/notifications/threads/${encodeURIComponent(threadId)}`,
@@ -4380,7 +4429,7 @@ export async function markAllGitHubNotificationsRead(input: { dir: string }): Pr
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to mark notifications read" };
   const res = await fetchGitHub(
     `https://api.github.com/repos/${repo.owner}/${repo.name}/notifications`,
@@ -4406,7 +4455,7 @@ export async function getGitHubThreadSubscription(input: GitHubThreadInput): Pro
   const threadId = input.threadId.trim();
   if (!threadId) return { ok: false, error: "thread id required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to view thread subscription" };
   const res = await fetchGitHub(
     `https://api.github.com/notifications/threads/${encodeURIComponent(threadId)}/subscription`,
@@ -4430,7 +4479,7 @@ export async function setGitHubThreadSubscription(input: SetGitHubThreadSubscrip
   const threadId = input.threadId.trim();
   if (!threadId) return { ok: false, error: "thread id required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to update thread subscription" };
   const res = await fetchGitHub(
     `https://api.github.com/notifications/threads/${encodeURIComponent(threadId)}/subscription`,
@@ -4454,7 +4503,7 @@ export async function unsubscribeGitHubThread(input: GitHubThreadInput): Promise
   const threadId = input.threadId.trim();
   if (!threadId) return { ok: false, error: "thread id required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to unsubscribe from a thread" };
   const res = await fetchGitHub(
     `https://api.github.com/notifications/threads/${encodeURIComponent(threadId)}/subscription`,
@@ -4479,7 +4528,7 @@ export async function listGitHubWorkflowRuns(input: { dir: string }): Promise<Gi
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/runs?per_page=30`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json");
   if (!("status" in res)) return res;
@@ -4500,7 +4549,7 @@ export async function listGitHubWorkflows(input: { dir: string }): Promise<GitHu
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/workflows?per_page=100`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json");
   if (!("status" in res)) return res;
@@ -4522,7 +4571,7 @@ export async function rerunGitHubWorkflowRun(input: RerunGitHubWorkflowRunInput)
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!Number.isInteger(input.runId) || input.runId <= 0) return { ok: false, error: "valid run id required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to re-run a workflow" };
   const segment = input.failedOnly ? "rerun-failed-jobs" : "rerun";
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/runs/${input.runId}/${segment}`;
@@ -4542,7 +4591,7 @@ export async function cancelGitHubWorkflowRun(input: CancelGitHubWorkflowRunInpu
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   if (!Number.isInteger(input.runId) || input.runId <= 0) return { ok: false, error: "valid run id required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to cancel a workflow run" };
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/runs/${input.runId}/cancel`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json", { method: "POST" });
@@ -4569,7 +4618,7 @@ export async function dispatchGitHubWorkflow(input: DispatchGitHubWorkflowInput)
   const ref = input.ref.trim();
   if (!ref) return { ok: false, error: "ref required" };
 
-  const token = await githubToken();
+  const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to dispatch a workflow" };
   const inputs = input.inputs && Object.keys(input.inputs).length > 0 ? input.inputs : undefined;
   const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/workflows/${input.workflowId}/dispatches`;

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -19,6 +19,7 @@ import {
 } from "./db.ts";
 import { archiveTask, createTask, deleteTask, startTask, cancelRun, reconcileTaskSession, sendInput, subscribe, subscribeGlobal, unarchiveTask } from "./orchestrator.ts";
 import { checkAllHarnesses } from "./agent-status.ts";
+import { listGitHubTokens, setGitHubToken, deleteGitHubToken } from "./github-tokens.ts";
 import {
   buildHarnessTerminalCommand,
   harnessEnv,
@@ -148,6 +149,7 @@ import {
   updateGitHubMilestone,
   updateGitHubPullBranch,
   updateGitHubRelease,
+  remoteHostsForDirs,
 } from "./github.ts";
 import { getDiscoveredModels, refreshDiscoveredModels } from "./agent-discovery.ts";
 import { getMainWindow } from "./window.ts";
@@ -330,6 +332,17 @@ function backlogGuard(req: { params: { id: string } } & Request): Response | nul
  * back to the built-in default). Returns `{ error }` when the shape is
  * unusable or a prefix wouldn't produce a legal branch.
  */
+/** Wire shape for a stored GitHub PAT: the raw token never leaves the Bun
+ *  process — only a last-4-chars preview, and even that is withheld when the
+ *  token is so short the suffix would be the entire secret. */
+function sanitizedTokenInfo(t: { host: string; label: string | null; token: string }) {
+  return {
+    host: t.host,
+    label: t.label,
+    tokenPreview: t.token.length > 4 ? `…${t.token.slice(-4)}` : "…",
+  };
+}
+
 function coerceBranchConfig(raw: unknown): { config: BranchNamingConfig } | { error: string } {
   if (!raw || typeof raw !== "object") return { error: "config (object) required" };
   const src = raw as { rules?: unknown; includeSlug?: unknown };
@@ -2387,6 +2400,39 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }
           return json(result, { headers: corsHeaders(req) });
+        }),
+      },
+
+      // Per-host GitHub PATs (github-tokens.ts), keyed by the raw ssh-alias
+      // remote host — see docs/plans/github-multi-identity-tokens.md. The raw
+      // token is write-only from the webview's perspective: GET/PUT both
+      // reply with a `tokenPreview` (last 4 chars — withheld entirely for
+      // tokens so short the suffix would be the whole secret), never the
+      // token itself.
+      "/github/tokens": {
+        GET: authed(async (req) => {
+          const tokens = listGitHubTokens().map(sanitizedTokenInfo);
+          const detectedHosts = await remoteHostsForDirs(projects.list().map((p) => p.path));
+          return json({ tokens, detectedHosts }, { headers: corsHeaders(req) });
+        }),
+        PUT: authed(async (req) => {
+          const body = (await req.json().catch(() => ({}))) as { host?: unknown; token?: unknown; label?: unknown };
+          const host = typeof body.host === "string" ? body.host.trim().toLowerCase() : "";
+          const token = typeof body.token === "string" ? body.token.trim() : "";
+          if (!host) return json({ error: "host required" }, { status: 400, headers: corsHeaders(req) });
+          if (!token) return json({ error: "token required" }, { status: 400, headers: corsHeaders(req) });
+          const label = typeof body.label === "string" && body.label.trim() ? body.label.trim() : null;
+          setGitHubToken(host, token, label);
+          const tokens = listGitHubTokens().map(sanitizedTokenInfo);
+          const detectedHosts = await remoteHostsForDirs(projects.list().map((p) => p.path));
+          return json({ tokens, detectedHosts }, { headers: corsHeaders(req) });
+        }),
+      },
+      "/github/tokens/:host": {
+        DELETE: authed((req) => {
+          const removed = deleteGitHubToken(req.params.host);
+          if (!removed) return json({ error: "token not found" }, { status: 404, headers: corsHeaders(req) });
+          return json({ ok: true }, { headers: corsHeaders(req) });
         }),
       },
 

--- a/src/mainview/components/settings/GitHubTokensSection.tsx
+++ b/src/mainview/components/settings/GitHubTokensSection.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useState } from "react";
+import { Trash2 } from "lucide-react";
+import { api, type GitHubTokensResult } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const DATALIST_ID = "github-token-hosts";
+
+const EMPTY: GitHubTokensResult = { tokens: [], detectedHosts: [] };
+
+/**
+ * "GitHub tokens" Settings section — lists stored per-host PATs and lets the
+ * user add/replace or delete one. Tokens are keyed by the raw ssh remote host
+ * (e.g. `github-work.com`); `github.com` acts as the default entry used when
+ * no alias-specific token exists. The raw token is never returned by the API
+ * — only a redacted `tokenPreview` — so the add-form input is always cleared
+ * (never re-populated) after a successful save.
+ */
+export function GitHubTokensSection() {
+  const [data, setData] = useState<GitHubTokensResult>(EMPTY);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [host, setHost] = useState("");
+  const [token, setToken] = useState("");
+  const [label, setLabel] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [deletingHost, setDeletingHost] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const result = await api.listGitHubTokens();
+      setData(result);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const storedHosts = new Set(data.tokens.map((t) => t.host));
+  const hostsWithoutToken = data.detectedHosts.filter((h) => !storedHosts.has(h));
+
+  const save = async () => {
+    const trimmedHost = host.trim().toLowerCase();
+    if (!trimmedHost) {
+      setSaveError("Host is required");
+      return;
+    }
+    if (!token.trim()) {
+      setSaveError("Token is required");
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const result = await api.setGitHubToken({
+        host: trimmedHost,
+        token: token.trim(),
+        label: label.trim() || null,
+      });
+      setData(result);
+      setHost("");
+      setToken("");
+      setLabel("");
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (h: string) => {
+    setDeletingHost(h);
+    setDeleteError(null);
+    try {
+      const result = await api.deleteGitHubToken(h);
+      if (result.ok) {
+        await refresh();
+      }
+    } catch (e) {
+      setDeleteError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setDeletingHost(null);
+    }
+  };
+
+  return (
+    <section className="space-y-2">
+      <div>
+        <label className="text-xs text-muted-foreground">GitHub tokens</label>
+        <p className="text-[11px] leading-snug text-muted-foreground">
+          Repos reached through an ssh host alias (git@github-work.com:…) authenticate with the
+          token stored for that alias; github.com acts as the default.
+        </p>
+      </div>
+
+      {loadError && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
+          {loadError}
+        </div>
+      )}
+
+      {!loading && (
+        <div className="space-y-1.5">
+          {data.tokens.map((t) => (
+            <div
+              key={t.host}
+              className="flex items-center gap-2 rounded-md border border-border/60 px-3 py-2"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate font-medium">{t.host}</span>
+                  {t.label && (
+                    <span className="truncate text-[11px] text-muted-foreground">{t.label}</span>
+                  )}
+                </div>
+                <div className="truncate font-mono text-[11px] text-muted-foreground">
+                  {t.tokenPreview}
+                </div>
+              </div>
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={() => void remove(t.host)}
+                disabled={deletingHost === t.host}
+                aria-label={`Delete token for ${t.host}`}
+              >
+                <Trash2 className="size-4" />
+              </Button>
+            </div>
+          ))}
+          {data.tokens.length === 0 && (
+            <p className="text-xs text-muted-foreground">No tokens stored yet.</p>
+          )}
+          {hostsWithoutToken.map((h) => (
+            <div
+              key={h}
+              className="flex items-center gap-2 rounded-md border border-dashed border-border/40 px-3 py-2 opacity-60"
+            >
+              <div className="min-w-0 flex-1 truncate">{h}</div>
+              <span className="text-[10px] uppercase text-muted-foreground">no token yet</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {deleteError && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
+          {deleteError}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-2 pt-1">
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">Host</label>
+          <Input
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+            placeholder="github.com"
+            list={DATALIST_ID}
+            spellCheck={false}
+          />
+          <datalist id={DATALIST_ID}>
+            {data.detectedHosts.map((h) => (
+              <option key={h} value={h} />
+            ))}
+          </datalist>
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">Label (optional)</label>
+          <Input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Work account"
+          />
+        </div>
+      </div>
+      <div className="space-y-1">
+        <label className="text-xs text-muted-foreground">Token</label>
+        <Input
+          type="password"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="ghp_…"
+          autoComplete="off"
+        />
+      </div>
+
+      {saveError && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
+          {saveError}
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <Button size="sm" onClick={() => void save()} disabled={saving}>
+          {saving ? "Saving…" : "Save token"}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -10,6 +10,7 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useConfirm } from "@/components/ui/confirm";
 import { AgentIcon } from "@/components/kanban/AgentIcon";
+import { GitHubTokensSection } from "@/components/settings/GitHubTokensSection";
 import { abbreviateHome, cn } from "@/lib/utils";
 import {
   HARNESS_TEMPLATES,
@@ -495,6 +496,8 @@ function ListView({
           binary if you don't want to install tmux system-wide.
         </p>
       </section>
+
+      <GitHubTokensSection />
 
       <section className="space-y-2">
         <div className="flex items-center justify-between">

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -207,6 +207,22 @@ export type PendingInteraction =
   | PendingAskQuestions
   | PendingTmuxPrompt;
 
+/** One stored per-host GitHub PAT, as surfaced to the webview. The raw token
+ *  is never returned — `tokenPreview` is a redacted tail (e.g. "…abcd"). */
+export interface GitHubTokenInfo {
+  host: string;
+  label: string | null;
+  tokenPreview: string;
+}
+
+/** Response shape for the GitHub tokens routes. `detectedHosts` are the
+ *  distinct raw remote hosts (including ssh aliases) seen across registered
+ *  project dirs — used to suggest hosts that don't have a token yet. */
+export interface GitHubTokensResult {
+  tokens: GitHubTokenInfo[];
+  detectedHosts: string[];
+}
+
 // Read api port + token, preferring globals injected by the Bun side via
 // BrowserWindow's `preload` option — that path works under the native
 // views:// scheme, which rejects URLs carrying a fragment or query.
@@ -923,6 +939,18 @@ export const api = {
       method: "POST",
       body: JSON.stringify(input),
     }),
+  /** Stored per-host GitHub tokens + hosts detected across registered
+   *  projects (drives the "GitHub tokens" Settings section). */
+  listGitHubTokens: () => j<GitHubTokensResult>("/github/tokens"),
+  /** Upsert the token for `input.host`. Returns the refreshed list — never
+   *  the raw token. */
+  setGitHubToken: (input: { host: string; token: string; label?: string | null }) =>
+    j<GitHubTokensResult>("/github/tokens", {
+      method: "PUT",
+      body: JSON.stringify(input),
+    }),
+  deleteGitHubToken: (host: string) =>
+    j<{ ok: true }>(`/github/tokens/${encodeURIComponent(host)}`, { method: "DELETE" }),
   getTmuxSource: () =>
     j<{
       source: "system" | "bundled";


### PR DESCRIPTION
… repos stop showing "Not Found"

Projects whose origin uses an ssh host alias (git@github-<x>.com:owner/repo) parsed correctly since #101 but still surfaced GitHub's literal 404 body "Not Found": the API calls ran with a single token source (GITHUB_TOKEN or the active gh account) — or none at all — and GitHub answers 404 for private repos the caller can't see. One token can never cover multiple ssh-alias identities.

- github-tokens.ts: PAT store keyed by the raw alias host; JSON in dataDir, 0600 atomic writes (core-creds pattern), github.com entry as the default.
- github.ts: parseGitRemote preserves the pre-canonicalization rawHost; githubToken(host) is now a required-arg resolver (stored alias token → stored github.com token → env → gh auth token) threaded through all 77 call sites; 404s at the list/viewer/permissions surfaces now explain the repo may be private and point at Settings → GitHub tokens.
- server.ts: GET/PUT /github/tokens + DELETE /github/tokens/:host; responses carry a last-4 tokenPreview only — the raw token never reaches the webview.
- Settings UI: new GitHub tokens section with alias hosts auto-detected from registered projects, password-style input never re-populated after save.
- Tests: token store round-trip/precedence, alias-beats-env resolution via the request auth header, enriched-404 wording, alias-origin repo fixture; a real ssh alias left in a #101 fixture replaced with a synthetic host.

Plan: docs/plans/github-multi-identity-tokens.md