### PR TITLE
fix: support GitLab and Bitbucket in the PRs/issues modal alongside G…

### DIFF
--- a/docs/plans/multi-provider-git-modal.md
+++ b/docs/plans/multi-provider-git-modal.md
@@ -1,0 +1,111 @@
+# Plan — Multi-provider (GitHub / GitLab / Bitbucket) PRs & issues modal
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-14 |
+| Source | /implement: "besides the modal name be Github, we're only supporting github there, we must support bitbucket and gitlab as well" + screenshot (modal shows "project does not have a GitHub remote") |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/support-bitbucket-and-gitlab |
+| Base SHA | dfb16bb7cfe107633aa905d48a04655675854a91 |
+| Mode | **Autonomous** — grill + plan-approval gates bypassed; all owner decisions logged in §8 |
+
+## 1. Objective & success criteria
+
+A project whose remote points at GitLab or Bitbucket Cloud (including via `~/.ssh/config` host aliases like `git@gitlab-work.io:group/app.git`) gets a working PRs/MRs + issues modal instead of "project does not have a GitHub remote".
+
+Success criteria:
+- Modal title/terminology follows the selected project's provider (GitHub / GitLab "Merge requests" / Bitbucket).
+- Core flow works on all three providers: list + filter PRs/MRs and issues, expand detail, view diff, list/create comments, inline line comments + replies, CI status, create PR/MR (incl. push-head), merge, close/decline, approve, create/update issue.
+- GitHub-exclusive panels and actions are hidden (not broken) for non-GitHub projects.
+- Existing GitHub behavior is unchanged; full test suite green (modulo the pre-existing `claude-followup-restart.test.ts` flake on base).
+
+## 2. Context & constraints (grounded)
+
+- `src/bun/github.ts` (~4,635 lines, ~80 exports). `canonicalGitHost` (github.ts:568) **already** maps any host containing github/gitlab/bitbucket → `github.com`/`gitlab.com`/`bitbucket.org`; `parseGitRemote` (582) is provider-agnostic; `parseGitHubRemote` (595) hard-filters to `github.com` — the single gate producing the error. `repoForDir` (820) returns a GitHub-only repo. **None of these three are exported** (only via `__githubInternals`) — they need real exports.
+- Auth: `githubToken(host)` (856) resolves raw-ssh-alias host → `github-tokens.ts` store (`~/.agetor/github-tokens.json`, `{host, token, label}[]`, keyed by RAW pre-canonicalization host) → `GITHUB_TOKEN`/`GH_TOKEN` env → `gh auth token`. The store is host-keyed so it can hold gitlab/bitbucket alias hosts with **zero schema change**.
+- Routes: ~70 `/github/*` routes in `src/bun/server.ts` (640–2447), 1:1 to github.ts exports, `authed(...)`, `{ok:false,error}` result convention.
+- UI: `src/mainview/components/kanban/GitHubDialog.tsx` (8,427 lines). Trigger in `App.tsx:605-613`. Subtitle "Pull requests and issues" at GitHubDialog.tsx:2642. Provider identity is hardcoded strings, no badge component.
+- Diff parsing is already provider-neutral: `git-diff.ts` `parseGitDiff` + `src/mainview/lib/diff-rows.ts` parse raw unified diffs; GitLab (`/raw_diffs`) and Bitbucket (`/diff`) both return raw unified diffs.
+- Test conventions: `github-test-util.ts` (`makeGitHubRepo`/`makeAliasGitHubRepo` real git-init repos; `mockGitHubFetch` ordered route table over `globalThis.fetch`); `github-network.test.ts` exercises URL/headers/pagination end-to-end.
+- Provider API facts (researched 2026-07, doc URLs in the research brief):
+  - GitLab v4: project id = `encodeURIComponent("owner/name")`. MRs `GET /projects/:id/merge_requests` (`state=opened|closed|merged|all`, `labels`, `search`, `scope=created_by_me|assigned_to_me|reviews_for_me`, `order_by`, `sort`). Issues analogous. Detail `GET .../merge_requests/:iid`; raw diff `GET .../merge_requests/:iid/raw_diffs`; notes API for comments; discussions API + `position{base_sha,start_sha,head_sha,old_path,new_path,old_line,new_line}` for line comments (SHAs from `.../versions`); `PUT .../merge` (`squash`); `state_event=close|reopen`; `POST .../approve`; pipelines + `GET /projects/:id/repository/commits/:sha/statuses` for CI; `POST/PUT /projects/:id/issues`. Auth header `PRIVATE-TOKEN`. Pagination `page`/`per_page` + `Link rel=next`. Viewer: `GET /user`.
+  - Bitbucket 2.0: `GET /2.0/repositories/{ws}/{slug}/pullrequests` (states OPEN/MERGED/DECLINED/SUPERSEDED, repeatable `state` param; BBQL `q=` for filters, `sort=-updated_on`); detail `GET .../pullrequests/:id`; raw diff `GET .../pullrequests/:id/diff`; comments `GET/POST .../comments` (inline `{path,to,from}`, replies via `parent.id`); `POST .../merge` (`merge_strategy: merge_commit|squash|fast_forward`); `POST .../decline`; `POST .../approve` + `POST .../request-changes`; commit build statuses `GET /2.0/repositories/{ws}/{slug}/commit/{sha}/statuses`; issues `GET/POST/PUT /2.0/.../issues` (**no labels**; states new/open/resolved/...; tracker optional per-repo and sunsets 2026-08-20 — best-effort with friendly 404 error). Auth: Basic (email + API token) or Bearer (access token). Pagination: body `next` URL. Viewer: `GET /2.0/user`. NO app passwords (dead 2026-06-09).
+  - No official Bitbucket CLI; `glab` exists for GitLab (`GITLAB_TOKEN` env, `~/.config/glab-cli/config.yml`).
+
+## 3. Approach & key decisions
+
+1. **Adapter modules + thin dispatch facade; reuse existing wire types.** New `src/bun/gitlab.ts` and `src/bun/bitbucket.ts` implement the core subset, normalizing into the **existing** `GitHub*` shared types (`GitHubListItem`, `GitHubComment`, `GitHubPullLineComment`, `GitHubCheckRun`, …) so the UI/wire contract barely moves. No mass type rename (rejected: churn across 13k lines for zero behavior).
+2. **Provider detection** in new `src/bun/git-provider.ts`: `providerRepoForDir(dir)` → `{ provider: "github"|"gitlab"|"bitbucket", host (canonical), remoteHost (raw alias), owner, name }`, built on the now-exported `parseGitRemote` + `canonicalGitHost`. GitHub path keeps using `repoForDir` internally — behavior identical.
+3. **Dispatch at the route layer via facade** `src/bun/git-host.ts`: for the ~22 core operations, server.ts handlers call `gitHost.listItems(...)` etc., which detects the provider and dispatches to github/gitlab/bitbucket modules. Non-core routes keep calling github.ts directly (they are GitHub-only features). Route paths stay `/github/*` (no client URL churn); one new route `GET /github/provider-info?path=` returns provider + repo identity for the UI.
+4. **Auth reuses the per-host token store as-is** (raw-host keyed). Resolution: store → env (`GITLAB_TOKEN` / `BITBUCKET_TOKEN` [+`BITBUCKET_EMAIL`]) → CLI (`glab` for GitLab; none for Bitbucket). Bitbucket credential convention: token value containing `:` → Basic (`email:api_token`, base64); otherwise Bearer (workspace/repo access token). Settings hint text updated.
+5. **CI status collapses to the CheckRuns UI**: GitLab pipelines/statuses and Bitbucket build statuses are mapped into `GitHubCheckRun` shape; the separate CommitStatus panel stays GitHub-only.
+6. **Feature gating in the dialog, driven by provider-info**: a `ProviderCaps` map (in shared/types.ts) declares which features each provider supports; the dialog hides unsupported affordances. GitHub loses nothing.
+7. **Aggregate "All repositories" mode** dispatches per `sourcePath` through the facade, so mixed-provider aggregation works; items already carry `sourcePath`.
+
+## 4. Work breakdown — implementation tasks
+
+**T1 — Foundation: provider detection + shared types + auth plumbing** (Wave 1)
+Files owned: `src/shared/types.ts`, `src/bun/git-provider.ts` (new), `src/bun/github.ts` (export-only edits), `src/bun/github-tokens.ts` (doc/label tweaks only).
+- Export `parseGitRemote`, `canonicalGitHost`, `repoForDir`, `githubToken` (keep `__githubInternals` intact).
+- `git-provider.ts`: `GitProvider` dispatch on canonical host; `providerRepoForDir(dir)` (mirrors `repoForDir`'s remote iteration: `origin` first, then others, first parseable wins); `gitlabToken(host)` (store → `GITLAB_TOKEN` → `glab config get token --host <canonical>` best-effort 5s timeout); `bitbucketCreds(host)` (store → `BITBUCKET_TOKEN`+`BITBUCKET_EMAIL`; `email:token` → Basic, else Bearer). Reuse `tokenForHost` from github-tokens.ts.
+- types.ts: `GitProvider = "github"|"gitlab"|"bitbucket"`, `ProviderRepoInfo`, `ProviderCaps` + `PROVIDER_CAPS` const (flags: labels, milestones, searchSyntax, reviewRequested, checks, commitStatus, reactions, draft, autoMerge, suggestions, subIssues, projects, discussions, actions, notifications, releases, issueTracker, requestChanges, mergeMethods list, terminology strings {pullNoun:"Pull request"|"Merge request", pullAbbrev:"PR"|"MR"}).
+- Acceptance: typecheck green; `providerRepoForDir` resolves alias hosts (`git@gitlab-work.io:acme/app.git` → gitlab) exactly like the github path does.
+
+**T2 — GitLab adapter** (Wave 2, parallel with T3)
+Files owned: `src/bun/gitlab.ts` (new only).
+Implements (all returning existing `{ok:true …}|{ok:false,error}` unions with existing shared types): `listGitLabItems` (MRs+issues, filters: state/labels/search/scope/order_by; maps `iid`→number, `description`→body, state opened→open, merged→merged flag semantics matching `GitHubListItem`), `getGitLabPullDefaults` (default_branch from `GET /projects/:id`), `createGitLabPull`, `getGitLabPullDiff` (raw_diffs → `parseGitDiff`), `listGitLabComments`/`createGitLabComment` (notes), `listGitLabPullLineComments` (discussions w/ position → `GitHubPullLineComment`, old_line→LEFT, new_line→RIGHT), `createGitLabPullLineComment` (fetch versions for SHAs; side RIGHT→new_line, LEFT→old_line), `replyGitLabLineComment` (discussion notes), `getGitLabPullChecks` (latest MR head pipeline + commit statuses → `GitHubCheckRun[]`; status map: running→in_progress, pending→queued, success/failed/canceled/skipped→completed+conclusion), `mergeGitLabPull` (merge|squash), `closeGitLabPull`/`reopenGitLabPull` (state_event), `approveGitLabPull`, `createGitLabIssue`, `updateGitLabIssue`, `getGitLabViewer` (`GET /user` → login=username), `listGitLabLabels` (for the labels filter/triage). Internal: `fetchGitLab` (PRIVATE-TOKEN header, 30s abort, api base `https://<canonical-or-raw?>/api/v4` — use canonical host `gitlab.com` for cloud; self-hosted out of scope, §8), `encodeProjectId(owner,name)`, pagination via `page/per_page` + Link header, `__gitlabInternals` export for tests.
+Acceptance: typecheck green; no imports from server.ts/db.ts; mirrors github.ts error-string style ("project does not have a supported git remote" is produced by the facade, not here — adapter assumes a resolved repo arg `{remoteHost, owner, name}`).
+
+**T3 — Bitbucket adapter** (Wave 2, parallel with T2)
+Files owned: `src/bun/bitbucket.ts` (new only).
+Same contract style: `listBitbucketItems` (PRs via repeatable `state` params + BBQL `q=` for query/author/reviewer; issues via issue tracker; state map OPEN→open, MERGED→merged, DECLINED/SUPERSEDED→closed; sort `-updated_on`/`-created_on`; "best match" degrades to `-updated_on`), `getBitbucketPullDefaults` (`mainbranch.name` from repo GET), `createBitbucketPull`, `getBitbucketPullDiff` (raw diff → `parseGitDiff`), `listBitbucketComments`/`createBitbucketComment` (non-inline comments; `content.raw`), `listBitbucketPullLineComments` (inline `{path,to,from}` → side to→RIGHT/from→LEFT), `createBitbucketPullLineComment`, `replyBitbucketLineComment` (`parent.id`), `getBitbucketPullChecks` (PR commit statuses → `GitHubCheckRun[]`: INPROGRESS→in_progress, SUCCESSFUL→success, FAILED→failure, STOPPED→cancelled), `mergeBitbucketPull` (merge_strategy map: merge→merge_commit, squash→squash, rebase→fast_forward exposure per caps), `closeBitbucketPull` (decline), `approveBitbucketPull`, `requestChangesBitbucketPull`, `createBitbucketIssue`, `updateBitbucketIssue` (issue state machine: open/new→open, resolved/closed/etc→closed; 404 → friendly "issue tracker is not enabled for this repository"), `getBitbucketViewer` (`GET /2.0/user` → login=username). Internal: `fetchBitbucket` (Basic when creds contain email, else Bearer; base `https://api.bitbucket.org`), pagination follows body `next` URL, `__bitbucketInternals` for tests.
+Acceptance: typecheck green; standalone module.
+
+**T4 — Facade + routes + client API** (Wave 3)
+Files owned: `src/bun/git-host.ts` (new), `src/bun/server.ts`, `src/mainview/lib/api.ts`.
+- `git-host.ts`: `providerInfoForDir(dir)` → `{ok, provider, owner, name, host}|{ok:false,error}`; dispatch wrappers for the core ops (listItems incl. aggregate-across-repos per-sourcePath dispatch, pullDefaults, pullCreate, pullDiff, comments list/create, line comments list/create/reply, pullChecks, pullMerge, pullClose, pullReopen, pullReview/approve+requestChanges, issueCreate, issueUpdate, viewer, labels). GitHub branch delegates to existing github.ts functions untouched. Non-supported op on a provider → `{ok:false, error:"not supported on <provider>"}` (defense; UI hides these anyway). Unknown provider → `{ok:false, error:"project does not have a supported git remote (GitHub, GitLab, or Bitbucket)"}`.
+- server.ts: repoint ONLY the core routes listed above to git-host.ts; add `GET /github/provider-info`. All other `/github/*` routes untouched.
+- api.ts: add `getProviderInfo(path)`; existing wrappers unchanged (same URLs).
+- Acceptance: typecheck green; GitHub requests flow through identical code paths as before (github.ts functions unchanged).
+
+**T5 — Dialog UI: provider awareness** (Wave 4, single agent)
+Files owned: `src/mainview/components/kanban/GitHubDialog.tsx`, `src/mainview/App.tsx`.
+- Fetch provider-info when `projectPath` changes (aggregate mode → provider "mixed": generic labels, GitHub-only panels hidden unless all selected repos are GitHub — simplest: hidden in aggregate unless every project resolves github; acceptable v1: hide in aggregate mode when any non-GitHub project present, existing behavior otherwise).
+- Title header: provider display name ("GitHub"/"GitLab"/"Bitbucket"; aggregate → "Git"); subtitle stays "Pull requests and issues" (GitLab: "Merge requests and issues"). Tab label "PRs"→"MRs" for GitLab. "New PR"→"New MR". App.tsx toolbar `aria-label`/`title` → "Git pull requests and issues".
+- Gate via `PROVIDER_CAPS[provider]`: hide labels filter+triage (bitbucket), milestones (bitbucket), search-syntax GH toggle (non-github), "Review requested" mine-filter (bitbucket keeps it → maps server-side to reviewers; keep visible), comments sort option (non-github → drop "comments" from sort fields), reactions/sub-issues/pin/lock/transfer/suggestions/auto-merge/draft-toggle/update-branch/CommitStatus panel/linked-issues (github-only), manager panels: Labels/Milestones/Releases/Notifications/Actions/Projects/Discussions buttons (github-only), merge-method options from caps (gitlab: merge+squash; bitbucket: merge+squash+fast-forward), review verdicts (gitlab: approve+comment; bitbucket: approve+request-changes+comment).
+- Error copy: surface backend errors as-is (backend now says "supported git remote").
+- Acceptance: typecheck + vite build green; GitHub project renders identically to today.
+
+## 5. Work breakdown — test tasks (Phase 6)
+
+**TT1** — `src/bun/git-provider.test.ts` + facade tests (`git-host.test.ts`): provider detection across https/ssh/scp/alias hosts; dispatch routing; unsupported-op errors; token resolution order (env manipulation à la github-tokens tests). Owns those two new files only.
+**TT2** — `src/bun/gitlab.test.ts` + `src/bun/gitlab-network.test.ts` + `src/bun/gitlab-test-util.ts`: normalizers (item/comment/line-comment/check mapping, state maps, LEFT/RIGHT↔old/new), URL/header (PRIVATE-TOKEN)/pagination via mock-fetch harness patterned on github-test-util.ts (makeAliasRepo with gitlab alias host). Owns those three new files.
+**TT3** — `src/bun/bitbucket.test.ts` + `src/bun/bitbucket-network.test.ts` + `src/bun/bitbucket-test-util.ts`: BBQL building, state maps, inline to/from↔side, Basic-vs-Bearer header choice, `next`-URL pagination, issue-tracker-404 friendly error. Owns those three new files.
+
+## 6. Execution waves
+
+- Wave 1: T1 (blocks everything — types + exports).
+- Wave 2: T2 ∥ T3 (disjoint new files).
+- Wave 3: T4.
+- Wave 4: T5.
+- Review (Phase 5) → Tests Wave: TT1 ∥ TT2 ∥ TT3 (disjoint) → run suite → fixes.
+
+## 7. Blast radius & risks
+
+- github.ts edits limited to adding `export` keywords — regression risk near zero; full github test suite is the guard.
+- server.ts core-route repointing is the riskiest edit (route bodies rewritten to call the facade) — mitigated by keeping request/response shapes identical and by github-network.test.ts exercising GitHub flows end-to-end through routes? (they exercise github.ts directly — the facade's GitHub branch is a pass-through, low risk).
+- GitHubDialog.tsx is 8.4k lines — gating must be additive (`caps.x && …`) to avoid layout regressions for GitHub.
+- Bitbucket issue tracker sunsets 2026-08-20 — implemented best-effort with friendly errors; noted for roadmap.
+- Bitbucket diff truncation limits (8000 lines/200 files) — raw diff may be truncated server-side; parser tolerates it.
+- Self-hosted GitLab/Bitbucket Server are OUT of scope (canonical-host heuristic maps any *gitlab* host to gitlab.com cloud API).
+
+## 8. Open questions / assumptions (autonomous mode — logged, not asked)
+
+1. **Scope cut**: "support bitbucket and gitlab" = core PR/MR+issue flow only; the 15 GitHub-exclusive panels (Projects, Discussions, Actions, Notifications, Releases, Reactions, Sub-issues, …) stay GitHub-only and hidden elsewhere. Full parity is structurally impossible (Bitbucket has no such APIs).
+2. **Cloud only**: gitlab.com and bitbucket.org (API v2 cloud). Self-hosted instances deferred (the ssh-alias canonicalization heuristic can't distinguish them anyway).
+3. **Types**: reuse `GitHub*` shared types as neutral wire shapes rather than renaming — smallest diff, zero UI churn.
+4. **Routes stay under `/github/*`** + new `/github/provider-info`; renaming the namespace would churn the client for no behavior.
+5. **Token store shared**: gitlab/bitbucket tokens live in the existing `github-tokens.json` per-raw-host store (it's host-keyed already). Bitbucket Basic credentials stored as `email:api_token` in the token field.
+6. **Aggregate mode**: mixed providers aggregate core items; GitHub-only panels hidden in aggregate when any selected repo is non-GitHub.
+7. **Bitbucket "Review requested"** approximated with `reviewers.username="<me>"` BBQL (no request-state machine exists there).
+8. **App passwords not supported** (dead as of 2026-06-09) — API tokens / access tokens only.

--- a/src/bun/bitbucket-network.test.ts
+++ b/src/bun/bitbucket-network.test.ts
@@ -1,0 +1,540 @@
+// Network-level tests for bitbucket.ts, exercising the real request/response
+// path (URL, method, headers, body, pagination, error mapping) via the
+// fetch-mock harness in bitbucket-test-util.ts. Complements bitbucket.test.ts,
+// which unit-tests the pure helpers in isolation.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { makeBitbucketRepo, mockGitHubFetch } from "./bitbucket-test-util.ts";
+import {
+  closeBitbucketPull,
+  createBitbucketComment,
+  createBitbucketIssue,
+  createBitbucketPull,
+  createBitbucketPullLineComment,
+  getBitbucketPullDefaults,
+  getBitbucketPullDiff,
+  getBitbucketViewer,
+  listBitbucketComments,
+  listBitbucketItems,
+  listBitbucketPullReviewComments,
+  mergeBitbucketPull,
+  replyBitbucketLineComment,
+  reopenBitbucketPull,
+  reviewBitbucketPull,
+  updateBitbucketIssue,
+} from "./bitbucket.ts";
+
+const ORIGINAL_DATA_DIR = process.env.AGETOR_DATA_DIR;
+const ORIGINAL_TOKEN = process.env.BITBUCKET_TOKEN;
+const ORIGINAL_EMAIL = process.env.BITBUCKET_EMAIL;
+let dataDir: string;
+
+beforeAll(() => {
+  // Hermetic AGETOR_DATA_DIR so `bitbucketCreds`'s stored-token lookup
+  // (`tokenForHost` → `~/.agetor/github-tokens.json`) never touches a real
+  // store — mirrors github-tokens.test.ts's mkdtemp convention.
+  dataDir = mkdtempSync(path.join(tmpdir(), "agetor-bb-tokens-"));
+  process.env.AGETOR_DATA_DIR = dataDir;
+  // Deterministic bearer token so bitbucketCreds() doesn't need a stored
+  // credential to resolve. Individual basic-auth tests set BITBUCKET_EMAIL
+  // themselves and restore it afterward.
+  process.env.BITBUCKET_TOKEN = "test-token";
+  delete process.env.BITBUCKET_EMAIL;
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.AGETOR_DATA_DIR;
+  else process.env.AGETOR_DATA_DIR = ORIGINAL_DATA_DIR;
+  if (ORIGINAL_TOKEN === undefined) delete process.env.BITBUCKET_TOKEN;
+  else process.env.BITBUCKET_TOKEN = ORIGINAL_TOKEN;
+  if (ORIGINAL_EMAIL === undefined) delete process.env.BITBUCKET_EMAIL;
+  else process.env.BITBUCKET_EMAIL = ORIGINAL_EMAIL;
+});
+
+const REPO = makeBitbucketRepo("acme", "app");
+
+// ---------------------------------------------------------------------------
+// listBitbucketItems
+// ---------------------------------------------------------------------------
+
+test("listBitbucketItems hits the pull requests endpoint with pagelen and repeats state= for closed", async () => {
+  const mock = mockGitHubFetch([{ match: "/pullrequests", json: { values: [] } }]);
+  try {
+    const res = await listBitbucketItems(REPO, { kind: "pulls", state: "closed" });
+    expect(res.ok).toBe(true);
+    expect(mock.calls).toHaveLength(1);
+    const url = new URL(mock.calls[0]!.url);
+    expect(url.pathname).toBe("/2.0/repositories/acme/app/pullrequests");
+    expect(url.searchParams.getAll("state")).toEqual(["MERGED", "DECLINED", "SUPERSEDED"]);
+    expect(url.searchParams.get("pagelen")).toBe("30");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listBitbucketItems only sets q= when filters are present", async () => {
+  const mock = mockGitHubFetch([{ match: "/pullrequests", json: { values: [] } }]);
+  try {
+    await listBitbucketItems(REPO, { kind: "pulls", state: "open" });
+    expect(new URL(mock.calls[0]!.url).searchParams.has("q")).toBe(false);
+
+    await listBitbucketItems(REPO, { kind: "pulls", state: "open", query: "bug" });
+    expect(new URL(mock.calls[1]!.url).searchParams.get("q")).toBe('(title ~ "bug" OR description ~ "bug")');
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listBitbucketItems maps sort/direction to Bitbucket's sort= param", async () => {
+  const mock = mockGitHubFetch([{ match: "/pullrequests", json: { values: [] } }]);
+  try {
+    await listBitbucketItems(REPO, { kind: "pulls", state: "open" });
+    expect(new URL(mock.calls[0]!.url).searchParams.get("sort")).toBe("-updated_on");
+
+    await listBitbucketItems(REPO, { kind: "pulls", state: "open", sort: "created", direction: "asc" });
+    expect(new URL(mock.calls[1]!.url).searchParams.get("sort")).toBe("created_on");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listBitbucketItems resolves the viewer uuid via GET /2.0/user only when createdByMe/assignedToMe/reviewRequested is set", async () => {
+  const mockPlain = mockGitHubFetch([{ match: "/pullrequests", json: { values: [] } }]);
+  try {
+    await listBitbucketItems(REPO, { kind: "pulls", state: "open" });
+    expect(mockPlain.calls.some((c) => c.url.includes("/2.0/user"))).toBe(false);
+  } finally {
+    mockPlain.restore();
+  }
+
+  const mockMe = mockGitHubFetch([
+    { match: "/2.0/user", json: { uuid: "{me-uuid}" } },
+    { match: "/pullrequests", json: { values: [] } },
+  ]);
+  try {
+    await listBitbucketItems(REPO, { kind: "pulls", state: "open", createdByMe: true });
+    expect(mockMe.calls).toHaveLength(2);
+    expect(mockMe.calls[0]!.url).toContain("/2.0/user");
+    expect(new URL(mockMe.calls[1]!.url).searchParams.get("q")).toBe('author.uuid="{me-uuid}"');
+  } finally {
+    mockMe.restore();
+  }
+});
+
+test("listBitbucketItems (issues) maps a 404 to the issue-tracker-disabled friendly error", async () => {
+  const mock = mockGitHubFetch([{ match: "/issues", status: 404, json: { error: { message: "Not Found" } } }]);
+  try {
+    const res = await listBitbucketItems(REPO, { kind: "issues", state: "open" });
+    expect(res).toEqual({ ok: false, error: "issue tracker is not enabled for this repository" });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listBitbucketItems maps a 401 to a friendly error mentioning credential configuration", async () => {
+  const mock = mockGitHubFetch([
+    { match: "/pullrequests", status: 401, json: { error: { message: "Access token expired" } } },
+  ]);
+  try {
+    const res = await listBitbucketItems(REPO, { kind: "pulls", state: "open" });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toContain("configure credentials in Settings");
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Auth headers
+// ---------------------------------------------------------------------------
+
+test("bearer-token credentials send Authorization: Bearer <token>", async () => {
+  const mock = mockGitHubFetch([{ match: "/2.0/user", json: { nickname: "octo" } }]);
+  try {
+    const res = await getBitbucketViewer(REPO);
+    expect(res).toEqual({ ok: true, login: "octo" });
+    expect(mock.calls[0]!.headers.authorization).toBe("Bearer test-token");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("email:token credentials send Authorization: Basic base64(email:token)", async () => {
+  process.env.BITBUCKET_TOKEN = "apitoken123";
+  process.env.BITBUCKET_EMAIL = "user@example.com";
+  const mock = mockGitHubFetch([{ match: "/2.0/user", json: { nickname: "octo" } }]);
+  try {
+    await getBitbucketViewer(REPO);
+    const expected = `Basic ${Buffer.from("user@example.com:apitoken123").toString("base64")}`;
+    expect(mock.calls[0]!.headers.authorization).toBe(expected);
+  } finally {
+    mock.restore();
+    process.env.BITBUCKET_TOKEN = "test-token";
+    delete process.env.BITBUCKET_EMAIL;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// getBitbucketPullDefaults / createBitbucketPull
+// ---------------------------------------------------------------------------
+
+test("getBitbucketPullDefaults reads base from mainbranch.name and always reports head as empty", async () => {
+  const mock = mockGitHubFetch([
+    { match: "/2.0/repositories/acme/app", json: { mainbranch: { name: "develop" } } },
+  ]);
+  try {
+    const res = await getBitbucketPullDefaults(REPO);
+    expect(res).toEqual({ ok: true, repo: "acme/app", head: "", base: "develop" });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("createBitbucketPull POSTs title/description nested under source.branch/destination.branch", async () => {
+  const mock = mockGitHubFetch([
+    {
+      method: "POST",
+      match: "/pullrequests",
+      json: {
+        id: 11,
+        title: "New PR",
+        state: "OPEN",
+        description: "desc",
+        created_on: "2026-01-01T00:00:00Z",
+        updated_on: "2026-01-01T00:00:00Z",
+        links: { html: { href: "https://bitbucket.org/acme/app/pull-requests/11" } },
+      },
+    },
+  ]);
+  try {
+    const res = await createBitbucketPull(REPO, { title: "New PR", body: "desc", base: "main", head: "feature" });
+    expect(res.ok).toBe(true);
+    const body = JSON.parse(mock.calls[0]!.body!);
+    expect(body).toEqual({
+      title: "New PR",
+      description: "desc",
+      source: { branch: { name: "feature" } },
+      destination: { branch: { name: "main" } },
+      draft: false,
+    });
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// getBitbucketPullDiff
+// ---------------------------------------------------------------------------
+
+test("getBitbucketPullDiff fetches the /diff endpoint as raw text and parses it into files", async () => {
+  const diffText = [
+    "diff --git a/src/a.ts b/src/a.ts",
+    "index abc123..def456 100644",
+    "--- a/src/a.ts",
+    "+++ b/src/a.ts",
+    "@@ -1,1 +1,1 @@",
+    "-old line",
+    "+new line",
+    "",
+  ].join("\n");
+  const mock = mockGitHubFetch([
+    { match: "/pullrequests/7/diff", text: diffText },
+  ]);
+  try {
+    const res = await getBitbucketPullDiff(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.files).toHaveLength(1);
+    expect(res.files[0]!.path).toBe("src/a.ts");
+    expect(res.files[0]!.status).toBe("modified");
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Comments — pagination follows body `next`, cap, exclude inline/deleted
+// ---------------------------------------------------------------------------
+
+test("listBitbucketComments excludes inline and soft-deleted comments", async () => {
+  const mock = mockGitHubFetch([
+    {
+      match: "/pullrequests/7/comments",
+      json: {
+        values: [
+          { id: 1, content: { raw: "top-level" }, links: { html: { href: "https://x/1" } } },
+          { id: 2, content: { raw: "inline" }, inline: { path: "a.ts", to: 1 }, links: { html: { href: "https://x/2" } } },
+          { id: 3, content: { raw: "" }, deleted: true, links: { html: { href: "https://x/3" } } },
+        ],
+      },
+    },
+  ]);
+  try {
+    const res = await listBitbucketComments(REPO, 7, "pulls");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.comments.map((c) => c.id)).toEqual([1]);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listBitbucketComments follows the body `next` URL across pages and stops at the page cap", async () => {
+  const base = "https://api.bitbucket.org/2.0/repositories/acme/app/pullrequests/7/comments";
+  const page = (id: number, next?: string) => ({
+    values: [{ id, content: { raw: `c${id}` }, links: { html: { href: `https://x/${id}` } } }],
+    ...(next ? { next } : {}),
+  });
+  const mock = mockGitHubFetch([
+    { match: new RegExp(`^${base}\\?pagelen=30$`), json: page(1, `${base}?pagelen=30&page=2`) },
+    { match: /page=2$/, json: page(2, `${base}?pagelen=30&page=3`) },
+    { match: /page=3$/, json: page(3, `${base}?pagelen=30&page=4`) },
+    { match: /page=4$/, json: page(4, `${base}?pagelen=30&page=5`) },
+    { match: /page=5$/, json: page(5, `${base}?pagelen=30&page=6`) },
+    // Deliberately no route for page=6 — if the walk didn't stop at the cap
+    // (BITBUCKET_MAX_EXTRA_PAGES=4 beyond the first page), this would throw
+    // "no route for ..." and fail the test loudly.
+  ]);
+  try {
+    const res = await listBitbucketComments(REPO, 7, "pulls");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.comments.map((c) => c.id)).toEqual([1, 2, 3, 4, 5]);
+    expect(mock.calls).toHaveLength(5); // 1 first page + 4 extra pages, capped
+  } finally {
+    mock.restore();
+  }
+});
+
+test("createBitbucketComment POSTs {content:{raw}}", async () => {
+  const mock = mockGitHubFetch([
+    {
+      method: "POST",
+      match: "/pullrequests/7/comments",
+      json: { id: 99, content: { raw: "hello" }, links: { html: { href: "https://x/99" } } },
+    },
+  ]);
+  try {
+    const res = await createBitbucketComment(REPO, 7, "pulls", "hello");
+    expect(res.ok).toBe(true);
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ content: { raw: "hello" } });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("createBitbucketPullLineComment POSTs inline.to for RIGHT and inline.from for LEFT", async () => {
+  const mock = mockGitHubFetch([
+    {
+      method: "POST",
+      match: "/pullrequests/7/comments",
+      json: { id: 100, content: { raw: "nit" }, inline: { path: "a.ts", to: 5 }, links: { html: { href: "https://x/100" } } },
+    },
+  ]);
+  try {
+    await createBitbucketPullLineComment(REPO, 7, { path: "a.ts", line: 5, side: "RIGHT", body: "nit" });
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ content: { raw: "nit" }, inline: { path: "a.ts", to: 5 } });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("createBitbucketPullLineComment POSTs inline.from for a LEFT-side comment", async () => {
+  const mock = mockGitHubFetch([
+    {
+      method: "POST",
+      match: "/pullrequests/7/comments",
+      json: { id: 101, content: { raw: "nit" }, inline: { path: "a.ts", from: 3 }, links: { html: { href: "https://x/101" } } },
+    },
+  ]);
+  try {
+    await createBitbucketPullLineComment(REPO, 7, { path: "a.ts", line: 3, side: "LEFT", body: "nit" });
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ content: { raw: "nit" }, inline: { path: "a.ts", from: 3 } });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("replyBitbucketLineComment POSTs parent.id alongside the reply body", async () => {
+  const mock = mockGitHubFetch([
+    {
+      method: "POST",
+      match: "/pullrequests/7/comments",
+      json: { id: 102, content: { raw: "reply" }, inline: { path: "a.ts", to: 5 }, links: { html: { href: "https://x/102" } } },
+    },
+  ]);
+  try {
+    await replyBitbucketLineComment(REPO, 7, 100, "reply");
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ content: { raw: "reply" }, parent: { id: 100 } });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listBitbucketPullReviewComments keeps ONLY inline comments and follows the `next` link", async () => {
+  const base = "https://api.bitbucket.org/2.0/repositories/acme/app/pullrequests/7/comments";
+  const mock = mockGitHubFetch([
+    {
+      match: new RegExp(`^${base}\\?pagelen=30$`),
+      json: {
+        values: [
+          { id: 1, content: { raw: "top-level" }, links: { html: { href: "https://x/1" } } },
+          { id: 2, content: { raw: "inline1" }, inline: { path: "a.ts", to: 1 }, links: { html: { href: "https://x/2" } } },
+        ],
+        next: `${base}?pagelen=30&page=2`,
+      },
+    },
+    {
+      match: /page=2$/,
+      json: {
+        values: [
+          { id: 3, content: { raw: "inline2" }, inline: { path: "a.ts", to: 2 }, links: { html: { href: "https://x/3" } } },
+        ],
+      },
+    },
+  ]);
+  try {
+    const res = await listBitbucketPullReviewComments(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.comments.map((c) => c.id)).toEqual([2, 3]);
+    expect(mock.calls).toHaveLength(2);
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// merge / close / reopen / review
+// ---------------------------------------------------------------------------
+
+test("mergeBitbucketPull maps 'rebase' to merge_strategy: fast_forward", async () => {
+  const mock = mockGitHubFetch([
+    {
+      method: "POST",
+      match: "/pullrequests/7/merge",
+      json: { merge_commit: { hash: "abc123" } },
+    },
+  ]);
+  try {
+    const res = await mergeBitbucketPull(REPO, 7, "rebase");
+    expect(res).toEqual({ ok: true, merged: true, sha: "abc123", message: "Pull request merged." });
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ merge_strategy: "fast_forward" });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("closeBitbucketPull POSTs /decline", async () => {
+  const mock = mockGitHubFetch([
+    {
+      method: "POST",
+      match: "/pullrequests/7/decline",
+      json: {
+        id: 7,
+        title: "PR",
+        state: "DECLINED",
+        links: { html: { href: "https://x/7" } },
+      },
+    },
+  ]);
+  try {
+    const res = await closeBitbucketPull(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.message).toBe("Pull request declined.");
+    expect(mock.calls[0]!.method).toBe("POST");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("reopenBitbucketPull always errors 'cannot be reopened' with NO network call", async () => {
+  const mock = mockGitHubFetch([]);
+  try {
+    const res = await reopenBitbucketPull(REPO, 7);
+    expect(res).toEqual({ ok: false, error: "declined pull requests cannot be reopened on Bitbucket" });
+    expect(mock.calls).toHaveLength(0);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("reviewBitbucketPull APPROVE POSTs /approve and, with a body, also posts a comment", async () => {
+  const mock = mockGitHubFetch([
+    { method: "POST", match: "/pullrequests/7/approve", json: {} },
+    {
+      method: "POST",
+      match: "/pullrequests/7/comments",
+      json: { id: 5, content: { raw: "LGTM" }, links: { html: { href: "https://x/5" } } },
+    },
+  ]);
+  try {
+    const res = await reviewBitbucketPull(REPO, 7, "APPROVE", "LGTM");
+    expect(res).toEqual({ ok: true, message: "Pull request approved." });
+    expect(mock.calls.some((c) => c.method === "POST" && c.url.includes("/approve"))).toBe(true);
+    const commentCall = mock.calls.find((c) => c.url.includes("/comments"));
+    expect(commentCall).toBeDefined();
+    expect(JSON.parse(commentCall!.body!)).toEqual({ content: { raw: "LGTM" } });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("reviewBitbucketPull REQUEST_CHANGES POSTs /request-changes", async () => {
+  const mock = mockGitHubFetch([
+    { method: "POST", match: "/pullrequests/7/request-changes", json: {} },
+  ]);
+  try {
+    const res = await reviewBitbucketPull(REPO, 7, "REQUEST_CHANGES");
+    expect(res).toEqual({ ok: true, message: "Changes requested." });
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// create/update issue bodies
+// ---------------------------------------------------------------------------
+
+test("createBitbucketIssue POSTs title + content.raw only when a body is given", async () => {
+  const mock = mockGitHubFetch([
+    {
+      method: "POST",
+      match: "/issues",
+      json: { id: 3, title: "Bug", state: "new", content: {}, links: { html: { href: "https://x/3" } } },
+    },
+  ]);
+  try {
+    await createBitbucketIssue(REPO, { title: "Bug", body: "steps" });
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ title: "Bug", content: { raw: "steps" } });
+
+    await createBitbucketIssue(REPO, { title: "Bug2" });
+    expect(JSON.parse(mock.calls[1]!.body!)).toEqual({ title: "Bug2" });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("updateBitbucketIssue maps state:'closed' to 'resolved' and state:'open' passes through", async () => {
+  const mock = mockGitHubFetch([
+    {
+      method: "PUT",
+      match: "/issues/3",
+      json: { id: 3, title: "Bug", state: "resolved", content: {}, links: { html: { href: "https://x/3" } } },
+    },
+  ]);
+  try {
+    await updateBitbucketIssue(REPO, 3, { state: "closed" });
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ state: "resolved" });
+
+    await updateBitbucketIssue(REPO, 3, { state: "open" });
+    expect(JSON.parse(mock.calls[1]!.body!)).toEqual({ state: "open" });
+  } finally {
+    mock.restore();
+  }
+});

--- a/src/bun/bitbucket-test-util.ts
+++ b/src/bun/bitbucket-test-util.ts
@@ -1,0 +1,42 @@
+// Test-only helpers for exercising `src/bun/bitbucket.ts` (TT3).
+//
+// Unlike github.ts, every bitbucket.ts function takes an already-resolved
+// `ProviderRepoInfo` directly (the facade resolves it once via
+// `providerRepoForDir` before dispatching) — this module does no local git
+// work of its own, so there's no throwaway-repo builder to write here, unlike
+// github-test-util.ts's `makeGitHubRepo`. `makeBitbucketRepo` below just
+// constructs that plain object.
+//
+// The fetch-mock harness itself (`mockGitHubFetch`) is host-agnostic — it
+// stubs `globalThis.fetch` against an ordered route table keyed on
+// method + URL substring/regex, with no GitHub-specific assumptions baked in
+// — so it's reused as-is rather than forked.
+import type { GitProvider, ProviderRepoInfo } from "../shared/types.ts";
+
+export { mockGitHubFetch } from "./github-test-util.ts";
+export type { MockRoute, FetchMock, FetchCall } from "./github-test-util.ts";
+
+/**
+ * A resolved Bitbucket Cloud repo, matching the shape `providerRepoForDir`
+ * would produce for `git@bitbucket.org:acme/app.git` (or an ssh-alias host
+ * like `git@bitbucket-work.com:acme/app.git`, when `remoteHost` is overridden
+ * to something other than the canonical `bitbucket.org`). `host` is always
+ * the canonical API host `bitbucket.org` — that's what `repoBasePath`/
+ * `fetchBitbucket` resolve against; `remoteHost` is the raw pre-
+ * canonicalization host, which is what `bitbucketCreds` keys credential
+ * lookup on.
+ */
+export function makeBitbucketRepo(
+  owner = "acme",
+  name = "app",
+  remoteHost = "bitbucket.org",
+): ProviderRepoInfo {
+  const provider: GitProvider = "bitbucket";
+  return {
+    provider,
+    host: "bitbucket.org",
+    remoteHost,
+    owner,
+    name,
+  };
+}

--- a/src/bun/bitbucket.test.ts
+++ b/src/bun/bitbucket.test.ts
@@ -1,0 +1,455 @@
+// Pure-function unit tests for `src/bun/bitbucket.ts`, exercised entirely
+// through `__bitbucketInternals` (no network, no filesystem). Complements
+// bitbucket-network.test.ts, which drives the exported functions end-to-end
+// through a mocked `fetch`.
+import { test, expect } from "bun:test";
+import { __bitbucketInternals } from "./bitbucket.ts";
+import { makeBitbucketRepo } from "./bitbucket-test-util.ts";
+
+const {
+  repoBasePath,
+  resolveUrl,
+  apiErrorMessage,
+  normalizeBitbucketUser,
+  normalizeBitbucketPull,
+  normalizeBitbucketIssue,
+  normalizeBitbucketComment,
+  normalizeBitbucketLineComment,
+  normalizeBitbucketCheckRun,
+  escapeBBQLString,
+  prStateParams,
+  issueStateBBQL,
+  buildPullsBBQL,
+  buildIssuesBBQL,
+  sortParam,
+  bitbucketViewerUuid,
+  BITBUCKET_OPEN_ISSUE_STATES,
+  BITBUCKET_CHECK_STATE_MAP,
+  BITBUCKET_MERGE_STRATEGY,
+} = __bitbucketInternals;
+
+// ---------------------------------------------------------------------------
+// repoBasePath / resolveUrl
+// ---------------------------------------------------------------------------
+
+test("repoBasePath builds /2.0/repositories/{workspace}/{repo_slug}, URL-encoding segments", () => {
+  expect(repoBasePath(makeBitbucketRepo("acme", "app"))).toBe("/2.0/repositories/acme/app");
+  expect(repoBasePath(makeBitbucketRepo("a c/me", "app"))).toBe("/2.0/repositories/a%20c%2Fme/app");
+});
+
+test("resolveUrl passes an absolute URL through and prefixes a relative path with the API base", () => {
+  expect(resolveUrl("/2.0/repositories/acme/app")).toBe("https://api.bitbucket.org/2.0/repositories/acme/app");
+  expect(resolveUrl("https://api.bitbucket.org/2.0/repositories/acme/app?page=2")).toBe(
+    "https://api.bitbucket.org/2.0/repositories/acme/app?page=2",
+  );
+  expect(resolveUrl("HTTP://example.com/next")).toBe("HTTP://example.com/next");
+});
+
+// ---------------------------------------------------------------------------
+// apiErrorMessage
+// ---------------------------------------------------------------------------
+
+test("apiErrorMessage reads body.error.message when present", () => {
+  expect(apiErrorMessage({ type: "error", error: { message: "Repository not found" } }, 404, "Not Found")).toBe(
+    "Repository not found",
+  );
+});
+
+test("apiErrorMessage falls back to `status statusText` for a malformed/absent body", () => {
+  expect(apiErrorMessage(null, 500, "Internal Server Error")).toBe("500 Internal Server Error");
+  expect(apiErrorMessage({}, 502, "Bad Gateway")).toBe("502 Bad Gateway");
+  expect(apiErrorMessage({ error: "not an object" }, 400, "Bad Request")).toBe("400 Bad Request");
+});
+
+test("apiErrorMessage gives a 401 an actionable credentials hint, wrapping the underlying message", () => {
+  const msg = apiErrorMessage({ error: { message: "Invalid credentials" } }, 401, "Unauthorized");
+  expect(msg).toContain("Invalid credentials");
+  expect(msg).toContain("configure credentials in Settings");
+  expect(msg).toContain("Basic auth: email:api_token");
+});
+
+// ---------------------------------------------------------------------------
+// escapeBBQLString — recent fix: backslashes doubled BEFORE quotes escaped
+// ---------------------------------------------------------------------------
+
+test("escapeBBQLString doubles a trailing backslash without touching a closing BBQL quote", () => {
+  expect(escapeBBQLString("foo\\")).toBe("foo\\\\");
+});
+
+test("escapeBBQLString escapes a bare double quote", () => {
+  expect(escapeBBQLString('"')).toBe('\\"');
+});
+
+test("escapeBBQLString doubles backslashes BEFORE escaping quotes (order matters)", () => {
+  // If quotes were escaped first, this input's escaped `\"` would itself get
+  // its backslash doubled again, corrupting the escape. Doubling backslashes
+  // first is what keeps a trailing `\` from swallowing the closing `"`.
+  expect(escapeBBQLString('a"b\\')).toBe('a\\"b\\\\');
+  expect(escapeBBQLString('a\\"b')).toBe('a\\\\\\"b');
+});
+
+test("escapeBBQLString leaves a plain string untouched", () => {
+  expect(escapeBBQLString("plain query")).toBe("plain query");
+});
+
+// ---------------------------------------------------------------------------
+// normalizeBitbucketUser
+// ---------------------------------------------------------------------------
+
+test("normalizeBitbucketUser prefers nickname over display_name for login", () => {
+  const user = normalizeBitbucketUser({
+    nickname: "octocat",
+    display_name: "The Octocat",
+    links: { avatar: { href: "https://x/avatar.png" }, html: { href: "https://x/octocat" } },
+  });
+  expect(user).toEqual({ login: "octocat", avatarUrl: "https://x/avatar.png", htmlUrl: "https://x/octocat" });
+});
+
+test("normalizeBitbucketUser falls back to display_name when nickname is absent/empty", () => {
+  expect(normalizeBitbucketUser({ display_name: "Jane Doe" })).toEqual({
+    login: "Jane Doe",
+    avatarUrl: null,
+    htmlUrl: null,
+  });
+  expect(normalizeBitbucketUser({ nickname: "", display_name: "Jane Doe" })).toEqual({
+    login: "Jane Doe",
+    avatarUrl: null,
+    htmlUrl: null,
+  });
+});
+
+test("normalizeBitbucketUser returns null with neither nickname nor display_name, or a non-object input", () => {
+  expect(normalizeBitbucketUser({})).toBeNull();
+  expect(normalizeBitbucketUser(null)).toBeNull();
+  expect(normalizeBitbucketUser("nope")).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// normalizeBitbucketPull
+// ---------------------------------------------------------------------------
+
+function bbPull(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 7,
+    title: "Add feature",
+    state: "OPEN",
+    description: "body text",
+    comment_count: 3,
+    created_on: "2026-01-01T00:00:00Z",
+    updated_on: "2026-01-02T00:00:00Z",
+    links: { html: { href: "https://bitbucket.org/acme/app/pull-requests/7" } },
+    author: { nickname: "octocat" },
+    ...overrides,
+  };
+}
+
+test("normalizeBitbucketPull maps OPEN state, defaults draft to false, and carries sourcePath", () => {
+  const item = normalizeBitbucketPull(bbPull(), "/repo/a");
+  expect(item).toEqual({
+    kind: "pulls",
+    number: 7,
+    title: "Add feature",
+    state: "open",
+    draft: false,
+    htmlUrl: "https://bitbucket.org/acme/app/pull-requests/7",
+    author: { login: "octocat", avatarUrl: null, htmlUrl: null },
+    assignees: [],
+    milestone: null,
+    body: "body text",
+    labels: [],
+    comments: 3,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-02T00:00:00Z",
+    closedAt: null,
+    mergedAt: null,
+    locked: false,
+    sourcePath: "/repo/a",
+  });
+});
+
+test("normalizeBitbucketPull respects an explicit draft:true", () => {
+  const item = normalizeBitbucketPull(bbPull({ draft: true }), null);
+  expect(item?.draft).toBe(true);
+});
+
+test("normalizeBitbucketPull approximates mergedAt/closedAt from updated_on for a MERGED pull", () => {
+  const item = normalizeBitbucketPull(bbPull({ state: "MERGED" }), null);
+  expect(item?.state).toBe("closed");
+  expect(item?.mergedAt).toBe("2026-01-02T00:00:00Z");
+  expect(item?.closedAt).toBe("2026-01-02T00:00:00Z");
+});
+
+test.each(["DECLINED", "SUPERSEDED"])("normalizeBitbucketPull maps %s to closed with no mergedAt", (state) => {
+  const item = normalizeBitbucketPull(bbPull({ state }), null);
+  expect(item?.state).toBe("closed");
+  expect(item?.mergedAt).toBeNull();
+  expect(item?.closedAt).toBe("2026-01-02T00:00:00Z");
+});
+
+test("normalizeBitbucketPull returns null when required fields are missing", () => {
+  expect(normalizeBitbucketPull({ id: 1 }, null)).toBeNull(); // no title
+  expect(normalizeBitbucketPull({ title: "x" }, null)).toBeNull(); // no id
+  expect(normalizeBitbucketPull(bbPull({ links: {} }), null)).toBeNull(); // no html url
+  expect(normalizeBitbucketPull(null, null)).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// normalizeBitbucketIssue
+// ---------------------------------------------------------------------------
+
+function bbIssue(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 9,
+    title: "Bug report",
+    state: "new",
+    content: { raw: "steps to reproduce" },
+    comment_count: 1,
+    created_on: "2026-02-01T00:00:00Z",
+    updated_on: "2026-02-02T00:00:00Z",
+    links: { html: { href: "https://bitbucket.org/acme/app/issues/9" } },
+    reporter: { nickname: "reporter1" },
+    assignee: { nickname: "assignee1" },
+    ...overrides,
+  };
+}
+
+test("normalizeBitbucketIssue maps content.raw to body and reporter to author", () => {
+  const item = normalizeBitbucketIssue(bbIssue(), null);
+  expect(item).toMatchObject({
+    kind: "issues",
+    number: 9,
+    title: "Bug report",
+    body: "steps to reproduce",
+    author: { login: "reporter1", avatarUrl: null, htmlUrl: null },
+    assignees: [{ login: "assignee1", avatarUrl: null, htmlUrl: null }],
+    mergedAt: null,
+    draft: false,
+    labels: [],
+  });
+});
+
+test.each(["new", "open"])("normalizeBitbucketIssue treats state=%s as open", (state) => {
+  expect(normalizeBitbucketIssue(bbIssue({ state }), null)?.state).toBe("open");
+});
+
+test.each(["resolved", "closed", "duplicate", "invalid", "wontfix", "on hold"])(
+  "normalizeBitbucketIssue treats state=%s as closed",
+  (state) => {
+    const item = normalizeBitbucketIssue(bbIssue({ state }), null);
+    expect(item?.state).toBe("closed");
+    expect(item?.closedAt).toBe("2026-02-02T00:00:00Z");
+  },
+);
+
+test("normalizeBitbucketIssue has no assignees when the issue is unassigned", () => {
+  const item = normalizeBitbucketIssue(bbIssue({ assignee: null }), null);
+  expect(item?.assignees).toEqual([]);
+});
+
+test("normalizeBitbucketIssue returns null when id/title/html url is missing", () => {
+  expect(normalizeBitbucketIssue({ title: "x" }, null)).toBeNull();
+  expect(normalizeBitbucketIssue(bbIssue({ links: {} }), null)).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// normalizeBitbucketComment / normalizeBitbucketLineComment
+// ---------------------------------------------------------------------------
+
+function bbComment(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 55,
+    content: { raw: "a comment" },
+    created_on: "2026-03-01T00:00:00Z",
+    updated_on: "2026-03-01T00:00:00Z",
+    links: { html: { href: "https://bitbucket.org/acme/app/pull-requests/7#comment-55" } },
+    user: { nickname: "octocat" },
+    ...overrides,
+  };
+}
+
+test("normalizeBitbucketComment maps content.raw to body", () => {
+  expect(normalizeBitbucketComment(bbComment())).toEqual({
+    id: 55,
+    body: "a comment",
+    htmlUrl: "https://bitbucket.org/acme/app/pull-requests/7#comment-55",
+    author: { login: "octocat", avatarUrl: null, htmlUrl: null },
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+  });
+});
+
+test("normalizeBitbucketComment returns null without a numeric id or an html url", () => {
+  expect(normalizeBitbucketComment({ content: { raw: "x" } })).toBeNull();
+  expect(normalizeBitbucketComment(bbComment({ links: {} }))).toBeNull();
+});
+
+test("normalizeBitbucketLineComment maps inline.to to side RIGHT", () => {
+  const comment = normalizeBitbucketLineComment(bbComment({ inline: { path: "src/a.ts", to: 5 } }));
+  expect(comment).toMatchObject({ path: "src/a.ts", line: 5, side: "RIGHT" });
+});
+
+test("normalizeBitbucketLineComment maps inline.from to side LEFT", () => {
+  const comment = normalizeBitbucketLineComment(bbComment({ inline: { path: "src/a.ts", from: 3 } }));
+  expect(comment).toMatchObject({ path: "src/a.ts", line: 3, side: "LEFT" });
+});
+
+test("normalizeBitbucketLineComment prefers `to` over `from` when both are present", () => {
+  const comment = normalizeBitbucketLineComment(bbComment({ inline: { path: "src/a.ts", to: 5, from: 3 } }));
+  expect(comment).toMatchObject({ line: 5, side: "RIGHT" });
+});
+
+test("normalizeBitbucketLineComment returns null for a non-inline (top-level) comment", () => {
+  expect(normalizeBitbucketLineComment(bbComment())).toBeNull();
+});
+
+test("normalizeBitbucketLineComment returns null when inline has no path", () => {
+  expect(normalizeBitbucketLineComment(bbComment({ inline: { to: 5 } }))).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// normalizeBitbucketCheckRun / BITBUCKET_CHECK_STATE_MAP
+// ---------------------------------------------------------------------------
+
+test("BITBUCKET_CHECK_STATE_MAP maps every Bitbucket build-status state to the GitHub check-run vocabulary", () => {
+  expect(BITBUCKET_CHECK_STATE_MAP).toEqual({
+    INPROGRESS: { status: "in_progress", conclusion: null },
+    SUCCESSFUL: { status: "completed", conclusion: "success" },
+    FAILED: { status: "completed", conclusion: "failure" },
+    STOPPED: { status: "completed", conclusion: "cancelled" },
+  });
+});
+
+test("normalizeBitbucketCheckRun maps state and uses a 1-based page-local index as id", () => {
+  const raw = { name: "ci/build", state: "SUCCESSFUL", url: "https://ci/1", created_on: "2026-01-01T00:00:00Z", updated_on: "2026-01-01T00:05:00Z" };
+  expect(normalizeBitbucketCheckRun(raw, 0)).toEqual({
+    id: 1,
+    name: "ci/build",
+    status: "completed",
+    conclusion: "success",
+    htmlUrl: "https://ci/1",
+    startedAt: "2026-01-01T00:00:00Z",
+    completedAt: "2026-01-01T00:05:00Z",
+  });
+  expect(normalizeBitbucketCheckRun(raw, 4)?.id).toBe(5);
+});
+
+test("normalizeBitbucketCheckRun falls back to `key` for name and to unknown/null for an unrecognized state", () => {
+  const raw = { key: "ci-build-key", state: "SOMETHING_NEW" };
+  expect(normalizeBitbucketCheckRun(raw, 0)).toMatchObject({ name: "ci-build-key", status: "unknown", conclusion: null });
+});
+
+test("normalizeBitbucketCheckRun leaves completedAt null for an in-progress run even though updated_on is present", () => {
+  const raw = { name: "ci/build", state: "INPROGRESS", updated_on: "2026-01-01T00:05:00Z" };
+  expect(normalizeBitbucketCheckRun(raw, 0)).toMatchObject({ status: "in_progress", conclusion: null, completedAt: null });
+});
+
+test("normalizeBitbucketCheckRun returns null without a name or a key", () => {
+  expect(normalizeBitbucketCheckRun({ state: "SUCCESSFUL" }, 0)).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// escaping / BBQL builders
+// ---------------------------------------------------------------------------
+
+test("prStateParams maps open/closed/all to Bitbucket's repeatable state values", () => {
+  expect(prStateParams("open")).toEqual(["OPEN"]);
+  expect(prStateParams("closed")).toEqual(["MERGED", "DECLINED", "SUPERSEDED"]);
+  expect(prStateParams("all")).toEqual(["OPEN", "MERGED", "DECLINED", "SUPERSEDED"]);
+});
+
+test("issueStateBBQL: open→new/open, closed→every non-open state, all→null", () => {
+  expect(issueStateBBQL("open")).toBe('(state="new" OR state="open")');
+  expect(issueStateBBQL("closed")).toBe(
+    '(state="resolved" OR state="closed" OR state="duplicate" OR state="invalid" OR state="wontfix" OR state="on hold")',
+  );
+  expect(issueStateBBQL("all")).toBeNull();
+});
+
+test("buildPullsBBQL: a free-text query produces a title/description OR clause", () => {
+  expect(buildPullsBBQL({ query: "fix bug", state: "open" }, null)).toBe(
+    '(title ~ "fix bug" OR description ~ "fix bug")',
+  );
+});
+
+test("buildPullsBBQL: createdByMe adds author.uuid, only when meUuid is resolved", () => {
+  expect(buildPullsBBQL({ createdByMe: true, state: "open" }, "{me-uuid}")).toBe('author.uuid="{me-uuid}"');
+  expect(buildPullsBBQL({ createdByMe: true, state: "open" }, null)).toBeNull();
+});
+
+test("buildPullsBBQL: reviewRequested and assignedToMe both fold into the same reviewers.uuid clause", () => {
+  expect(buildPullsBBQL({ reviewRequested: true, state: "open" }, "{me-uuid}")).toBe('reviewers.uuid="{me-uuid}"');
+  expect(buildPullsBBQL({ assignedToMe: true, state: "open" }, "{me-uuid}")).toBe('reviewers.uuid="{me-uuid}"');
+});
+
+test("buildPullsBBQL ANDs every active clause together", () => {
+  expect(buildPullsBBQL({ query: "q", createdByMe: true, reviewRequested: true, state: "open" }, "{me-uuid}")).toBe(
+    '(title ~ "q" OR description ~ "q") AND author.uuid="{me-uuid}" AND reviewers.uuid="{me-uuid}"',
+  );
+});
+
+test("buildPullsBBQL returns null with no active clauses", () => {
+  expect(buildPullsBBQL({ state: "open" }, null)).toBeNull();
+  expect(buildPullsBBQL({ state: "open" }, "{me-uuid}")).toBeNull();
+});
+
+test("buildIssuesBBQL combines the state clause, free-text query, and assignee.nickname", () => {
+  expect(buildIssuesBBQL({ state: "open", query: "q", assignee: "octocat" })).toBe(
+    '(state="new" OR state="open") AND (title ~ "q" OR content.raw ~ "q") AND assignee.nickname="octocat"',
+  );
+});
+
+test("buildIssuesBBQL returns null for state=all with no query/assignee", () => {
+  expect(buildIssuesBBQL({ state: "all" })).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// sortParam
+// ---------------------------------------------------------------------------
+
+test("sortParam: created + asc/desc", () => {
+  expect(sortParam("created", "asc")).toBe("created_on");
+  expect(sortParam("created", "desc")).toBe("-created_on");
+});
+
+test("sortParam: updated is the default field", () => {
+  expect(sortParam("updated", "asc")).toBe("updated_on");
+  expect(sortParam(undefined, undefined)).toBe("-updated_on");
+});
+
+test("sortParam: comments (no Bitbucket field) degrades to the updated_on field", () => {
+  expect(sortParam("comments", "asc")).toBe("updated_on");
+  expect(sortParam("comments", "desc")).toBe("-updated_on");
+});
+
+// ---------------------------------------------------------------------------
+// misc internal tables
+// ---------------------------------------------------------------------------
+
+test("BITBUCKET_OPEN_ISSUE_STATES contains exactly new/open", () => {
+  expect(BITBUCKET_OPEN_ISSUE_STATES).toEqual(new Set(["new", "open"]));
+});
+
+test("BITBUCKET_MERGE_STRATEGY maps the shared merge-method enum to Bitbucket's merge_strategy values", () => {
+  expect(BITBUCKET_MERGE_STRATEGY).toEqual({
+    merge: "merge_commit",
+    squash: "squash",
+    rebase: "fast_forward",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bitbucketViewerUuid — the no-creds short-circuit only (network-mocked
+// resolution paths live in bitbucket-network.test.ts)
+// ---------------------------------------------------------------------------
+
+test("bitbucketViewerUuid resolves to null without any network call when there are no credentials", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("bitbucketViewerUuid must not fetch without credentials");
+  }) as unknown as typeof fetch;
+  try {
+    expect(await bitbucketViewerUuid(null)).toBeNull();
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -1,0 +1,1132 @@
+import type {
+  GitHubCheckRun,
+  GitHubChecksResult,
+  GitHubComment,
+  GitHubCommentsResult,
+  GitHubItemKind,
+  GitHubItemState,
+  GitHubListItem,
+  GitHubListResult,
+  GitHubPullDefaultsResult,
+  GitHubPullLineComment,
+  GitHubPullMergeMethod,
+  GitHubPullMergeResult,
+  GitHubPullReviewCommentsResult,
+  GitHubPullReviewEvent,
+  GitHubUser,
+  ProviderRepoInfo,
+  TaskDiff,
+} from "../shared/types.ts";
+import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
+import { bitbucketCreds, type BitbucketCreds } from "./git-provider.ts";
+
+/**
+ * Bitbucket Cloud (api.bitbucket.org, REST 2.0) adapter
+ * (docs/plans/multi-provider-git-modal.md, T3).
+ *
+ * Mirrors `src/bun/github.ts`'s shape as closely as the two APIs allow, so the
+ * facade (`git-host.ts`, T4) can dispatch to whichever provider a repo
+ * resolves to without special-casing return shapes: every exported function
+ * here returns the SAME shared `GitHub*` wire types as its github.ts
+ * counterpart (`{ok:true} & X | {ok:false;error}`), just normalized from
+ * Bitbucket's JSON instead of GitHub's. `src/bun/gitlab.ts` is the sibling
+ * adapter for GitLab (owned by a different task/agent in this wave).
+ *
+ * Key shape difference from github.ts: every github.ts function takes a
+ * `dir` and resolves the repo (and does local git work like reading the
+ * current branch) itself via `repoForDir`. This adapter instead takes an
+ * already-resolved `repo: ProviderRepoInfo` (the facade resolves it once via
+ * `providerRepoForDir`, T1) — this module does no local git/filesystem work
+ * at all, only Bitbucket HTTP calls. The one place that matters is
+ * `getBitbucketPullDefaults`: unlike `getGitHubPullDefaults`, it cannot read
+ * the local checkout's current branch (no `dir`), so `head` is always `""`
+ * here — the facade is expected to fill it in from local git the same way
+ * for every provider, since "current branch" is a local-checkout concept,
+ * not a provider concept.
+ *
+ * Bitbucket API facts this file leans on (see plan §2/§3 and Bitbucket's own
+ * docs):
+ *  - Base URL `https://api.bitbucket.org`; a repo is addressed as
+ *    `/2.0/repositories/{workspace}/{repo_slug}` — `owner`/`name` on
+ *    `ProviderRepoInfo` map to workspace/repo_slug respectively.
+ *  - Auth is Basic (email + API token) or Bearer (workspace/repo access
+ *    token) — `bitbucketCreds` (git-provider.ts) resolves which.
+ *  - List responses page as `{values, next, page, pagelen, size}`; `next` is
+ *    an absolute URL to the following page — this module's `fetchBitbucket`
+ *    passes an absolute URL straight through instead of re-prefixing it.
+ *  - Bitbucket Query Language (`q=`) expresses server-side filters; multiple
+ *    clauses combine with ` AND `. There is no Bitbucket equivalent of
+ *    GitHub labels, so `labels` is accepted (for interface parity with
+ *    call sites shared across providers) but always ignored.
+ *
+ * Leaf module: does not import `db.ts`, `server.ts`, or `github.ts`. May
+ * import from `git-provider.ts`, `git-diff.ts`, and `../shared/types.ts`.
+ */
+
+const BITBUCKET_API_BASE = "https://api.bitbucket.org";
+const BITBUCKET_FETCH_TIMEOUT_MS = 30_000;
+const BITBUCKET_DIFF_BODY_CAP_BYTES = 8_000_000;
+const BITBUCKET_PAGELEN = 30;
+
+interface BitbucketError {
+  ok: false;
+  error: string;
+}
+
+// Local response unions, mirroring the shape of github.ts's (unexported)
+// `GitHub*Response` types but built from the shared, exported `GitHub*`
+// interfaces so this module can compile without any github.ts import.
+type BitbucketListResponse = ({ ok: true } & GitHubListResult) | BitbucketError;
+type BitbucketDiffResponse = ({ ok: true } & TaskDiff) | BitbucketError;
+type BitbucketCommentsResponse = ({ ok: true } & GitHubCommentsResult) | BitbucketError;
+type BitbucketCommentResponse = ({ ok: true; comment: GitHubComment }) | BitbucketError;
+type BitbucketPullLineCommentResponse = ({ ok: true; comment: GitHubPullLineComment }) | BitbucketError;
+type BitbucketPullReviewCommentsResponse = ({ ok: true } & GitHubPullReviewCommentsResult) | BitbucketError;
+type BitbucketChecksResponse = ({ ok: true } & GitHubChecksResult) | BitbucketError;
+type BitbucketPullMergeResponse = GitHubPullMergeResult | BitbucketError;
+type BitbucketPullDefaultsResponse = ({ ok: true } & GitHubPullDefaultsResult) | BitbucketError;
+type BitbucketIssueResponse = ({ ok: true; item: GitHubListItem; message?: string }) | BitbucketError;
+type BitbucketActionResponse =
+  | ({ ok: true; message?: string; item?: GitHubListItem; commentPosted?: boolean })
+  | BitbucketError;
+type BitbucketViewerResponse = ({ ok: true; login: string }) | BitbucketError;
+
+/** `/2.0/repositories/{workspace}/{repo_slug}` for a resolved repo. Segments
+ *  are URL-encoded defensively even though workspace/repo slugs are normally
+ *  URL-safe already. */
+function repoBasePath(repo: ProviderRepoInfo): string {
+  return `/2.0/repositories/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}`;
+}
+
+/** Absolute-URL passthrough: a `next` pagination link (or any other
+ *  already-absolute URL a caller builds via `new URL(...)`) is used as-is;
+ *  anything else is treated as a path relative to the Bitbucket API base. */
+function resolveUrl(pathOrUrl: string): string {
+  return /^https?:\/\//i.test(pathOrUrl) ? pathOrUrl : `${BITBUCKET_API_BASE}${pathOrUrl}`;
+}
+
+/** How many extra pages a comment listing follows beyond the first — 5 pages
+ *  of `pagelen=30` covers 150 comments, matching gitlab.ts's paging bound. */
+const BITBUCKET_MAX_EXTRA_PAGES = 4;
+
+/**
+ * Follows a paginated collection's absolute `next` URLs (Bitbucket puts
+ * pagination in the response body, not headers), accumulating each page's
+ * `values`. `firstBody` is the already-fetched, already-error-checked page-1
+ * body. A fetch/parse failure mid-pagination stops the walk and returns what
+ * has accumulated so far — partial results beat failing a listing whose first
+ * page already succeeded.
+ */
+async function collectRemainingValues(firstBody: unknown, creds: BitbucketCreds | null): Promise<unknown[]> {
+  const extra: unknown[] = [];
+  let next = firstBody && typeof firstBody === "object" ? (firstBody as { next?: unknown }).next : null;
+  for (let i = 0; i < BITBUCKET_MAX_EXTRA_PAGES && typeof next === "string" && next; i++) {
+    const res = await fetchBitbucket(next, creds, "application/json");
+    if (!("status" in res) || !res.ok) break;
+    const body = await res.json().catch(() => null);
+    const values = body && typeof body === "object" && Array.isArray((body as { values?: unknown }).values)
+      ? (body as { values: unknown[] }).values
+      : null;
+    if (!values) break;
+    extra.push(...values);
+    next = (body as { next?: unknown }).next;
+  }
+  return extra;
+}
+
+function authHeader(creds: BitbucketCreds | null): Record<string, string> {
+  if (!creds) return {};
+  if (creds.kind === "basic") {
+    const encoded = Buffer.from(`${creds.username}:${creds.password}`).toString("base64");
+    return { authorization: `Basic ${encoded}` };
+  }
+  return { authorization: `Bearer ${creds.token}` };
+}
+
+function fetchErrorMessage(e: unknown): string {
+  if (e instanceof DOMException && e.name === "AbortError") {
+    return "Bitbucket request timed out";
+  }
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** Internal fetch wrapper: absolute-URL passthrough (for pagination `next`
+ *  links), 30s abort, `user-agent: agetor`, and the resolved
+ *  Basic/Bearer auth header. `accept` is caller-supplied since the diff
+ *  endpoint wants a permissive/plain accept rather than `application/json`. */
+async function fetchBitbucket(
+  pathOrUrl: string,
+  creds: BitbucketCreds | null,
+  accept: string,
+  init?: { method?: string; body?: string },
+): Promise<Response | BitbucketError> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), BITBUCKET_FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(resolveUrl(pathOrUrl), {
+      method: init?.method,
+      signal: controller.signal,
+      headers: {
+        accept,
+        ...(init?.body ? { "content-type": "application/json" } : {}),
+        "user-agent": "agetor",
+        ...authHeader(creds),
+      },
+      body: init?.body,
+    });
+  } catch (e) {
+    return { ok: false, error: fetchErrorMessage(e) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Extract a friendly error message from a non-2xx Bitbucket response body
+ *  (`{type:"error", error:{message}}`), falling back to `status statusText`.
+ *  A 401 gets an actionable hint pointing at where credentials are
+ *  configured, mirroring github.ts's `privateRepoHint` — a bare 401 passthrough
+ *  otherwise reads as "this doesn't exist" rather than "you're not authed". */
+function apiErrorMessage(body: unknown, status: number, statusText: string): string {
+  const message = body && typeof body === "object" && (body as { error?: unknown }).error
+    && typeof (body as { error?: unknown }).error === "object"
+    && typeof ((body as { error: Record<string, unknown> }).error.message) === "string"
+    ? (body as { error: { message: string } }).error.message
+    : `${status} ${statusText}`;
+  if (status === 401) {
+    return `Bitbucket authentication failed (${message}) — configure credentials in Settings → API tokens (Basic auth: email:api_token).`;
+  }
+  return message;
+}
+
+function normalizeBitbucketUser(raw: unknown): GitHubUser | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const links = obj.links && typeof obj.links === "object" ? obj.links as Record<string, unknown> : {};
+  const html = links.html && typeof links.html === "object" ? (links.html as Record<string, unknown>).href : undefined;
+  const avatar = links.avatar && typeof links.avatar === "object"
+    ? (links.avatar as Record<string, unknown>).href
+    : undefined;
+  // login prefers `nickname` (Bitbucket's stable handle-like field) and falls
+  // back to `display_name` — Bitbucket deprecated the old `username` field for
+  // most accounts, and not every user object carries a nickname.
+  const login = typeof obj.nickname === "string" && obj.nickname
+    ? obj.nickname
+    : typeof obj.display_name === "string" && obj.display_name
+      ? obj.display_name
+      : null;
+  if (!login) return null;
+  return {
+    login,
+    avatarUrl: typeof avatar === "string" ? avatar : null,
+    htmlUrl: typeof html === "string" ? html : null,
+  };
+}
+
+/** Normalize a Bitbucket pull request object into `GitHubListItem`.
+ *  `mergedAt` is approximated: Bitbucket pull requests have no dedicated
+ *  `merged_at`/similar field, so `updated_on` is used when `state === "MERGED"`
+ *  — in practice the merge is the terminal update to a PR, so this is accurate
+ *  for the vast majority of cases (a rare post-merge metadata edit, if the API
+ *  even allows one, would shift it slightly). `closedAt` uses the same
+ *  approximation for any non-open state. */
+function normalizeBitbucketPull(raw: unknown, sourcePath: string | null): GitHubListItem | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== "number" || typeof obj.title !== "string") return null;
+  const links = obj.links && typeof obj.links === "object" ? obj.links as Record<string, unknown> : {};
+  const html = links.html && typeof links.html === "object" ? (links.html as Record<string, unknown>).href : undefined;
+  if (typeof html !== "string") return null;
+  const rawState = typeof obj.state === "string" ? obj.state : "";
+  const state: "open" | "closed" = rawState === "OPEN" ? "open" : "closed";
+  const updatedAt = typeof obj.updated_on === "string" ? obj.updated_on : "";
+  return {
+    kind: "pulls",
+    number: obj.id,
+    title: obj.title,
+    state,
+    // Bitbucket added draft PRs after the initial 2.0 API — read defensively
+    // since older responses (and some SDKs) may omit the field entirely.
+    draft: typeof obj.draft === "boolean" ? obj.draft : false,
+    htmlUrl: html,
+    author: normalizeBitbucketUser(obj.author),
+    assignees: [], // Bitbucket pull requests have no assignee concept.
+    milestone: null,
+    body: typeof obj.description === "string" ? obj.description : "",
+    labels: [], // Bitbucket has no labels.
+    comments: typeof obj.comment_count === "number" ? obj.comment_count : 0,
+    createdAt: typeof obj.created_on === "string" ? obj.created_on : "",
+    updatedAt,
+    closedAt: state === "closed" ? (updatedAt || null) : null,
+    mergedAt: rawState === "MERGED" ? (updatedAt || null) : null,
+    locked: false, // Bitbucket has no conversation-lock concept.
+    sourcePath,
+  };
+}
+
+// Bitbucket issue states that count as "open" for state filtering / mapping —
+// everything else (resolved, closed, duplicate, invalid, wontfix, on hold)
+// counts as "closed". Kept as a Set (not a switch) so `buildIssuesBBQL`'s BBQL
+// clause and `normalizeBitbucketIssue`'s state mapping stay in lockstep.
+const BITBUCKET_OPEN_ISSUE_STATES = new Set(["new", "open"]);
+
+function normalizeBitbucketIssue(raw: unknown, sourcePath: string | null): GitHubListItem | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== "number" || typeof obj.title !== "string") return null;
+  const links = obj.links && typeof obj.links === "object" ? obj.links as Record<string, unknown> : {};
+  const html = links.html && typeof links.html === "object" ? (links.html as Record<string, unknown>).href : undefined;
+  if (typeof html !== "string") return null;
+  const rawState = typeof obj.state === "string" ? obj.state : "";
+  const state: "open" | "closed" = BITBUCKET_OPEN_ISSUE_STATES.has(rawState) ? "open" : "closed";
+  const content = obj.content && typeof obj.content === "object" ? obj.content as Record<string, unknown> : {};
+  const assignee = obj.assignee ? normalizeBitbucketUser(obj.assignee) : null;
+  const updatedAt = typeof obj.updated_on === "string" ? obj.updated_on : "";
+  return {
+    kind: "issues",
+    number: obj.id,
+    title: obj.title,
+    state,
+    draft: false, // Issues have no draft concept.
+    htmlUrl: html,
+    author: normalizeBitbucketUser(obj.reporter),
+    assignees: assignee ? [assignee] : [],
+    milestone: null,
+    body: typeof content.raw === "string" ? content.raw : "",
+    labels: [],
+    comments: typeof obj.comment_count === "number" ? obj.comment_count : 0,
+    createdAt: typeof obj.created_on === "string" ? obj.created_on : "",
+    updatedAt,
+    closedAt: state === "closed" ? (updatedAt || null) : null,
+    mergedAt: null, // Issues never merge.
+    locked: false,
+    sourcePath,
+  };
+}
+
+function normalizeBitbucketComment(raw: unknown): GitHubComment | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== "number") return null;
+  const links = obj.links && typeof obj.links === "object" ? obj.links as Record<string, unknown> : {};
+  const html = links.html && typeof links.html === "object" ? (links.html as Record<string, unknown>).href : undefined;
+  if (typeof html !== "string") return null;
+  const content = obj.content && typeof obj.content === "object" ? obj.content as Record<string, unknown> : {};
+  return {
+    id: obj.id,
+    body: typeof content.raw === "string" ? content.raw : "",
+    htmlUrl: html,
+    author: normalizeBitbucketUser(obj.user),
+    createdAt: typeof obj.created_on === "string" ? obj.created_on : "",
+    updatedAt: typeof obj.updated_on === "string" ? obj.updated_on : "",
+  };
+}
+
+/** A comment carrying an `inline` position is a line (review) comment. Note:
+ *  `GitHubPullLineComment` (shared/types.ts) has no field for reply-threading
+ *  — and neither does github.ts's own `normalizeLineComment` (it never reads
+ *  GitHub's `in_reply_to_id`). So Bitbucket's `parent.id` on a reply is
+ *  likewise not carried into the normalized shape here; this is a limitation
+ *  of the current shared wire type, not something bitbucket.ts drops that
+ *  github.ts otherwise preserves. */
+function normalizeBitbucketLineComment(raw: unknown): GitHubPullLineComment | null {
+  const comment = normalizeBitbucketComment(raw);
+  if (!comment || !raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const inline = obj.inline && typeof obj.inline === "object" ? obj.inline as Record<string, unknown> : null;
+  if (!inline || typeof inline.path !== "string") return null;
+  const to = typeof inline.to === "number" ? inline.to : null;
+  const from = typeof inline.from === "number" ? inline.from : null;
+  const side: "LEFT" | "RIGHT" | null = to != null ? "RIGHT" : from != null ? "LEFT" : null;
+  const line = to ?? from;
+  if (!side || line == null) return null;
+  return { ...comment, path: inline.path, line, side };
+}
+
+/** Maps a Bitbucket commit-status `state` to the `{status, conclusion}` pair
+ *  `GitHubCheckRun` expects (GitHub's check-runs vocabulary). */
+const BITBUCKET_CHECK_STATE_MAP: Record<string, { status: string; conclusion: string | null }> = {
+  INPROGRESS: { status: "in_progress", conclusion: null },
+  SUCCESSFUL: { status: "completed", conclusion: "success" },
+  FAILED: { status: "completed", conclusion: "failure" },
+  STOPPED: { status: "completed", conclusion: "cancelled" },
+};
+
+/** Bitbucket build-status entries have no numeric id (only a string
+ *  `key`/`uuid`), unlike GitHub's check runs — `GitHubCheckRun.id` is `number`,
+ *  so the entry's 1-based position in the page is used as a stand-in. It's
+ *  only used as a React/table row key by the UI, never round-tripped back
+ *  into a Bitbucket API call, so a page-local synthetic id is safe. */
+function normalizeBitbucketCheckRun(raw: unknown, index: number): GitHubCheckRun | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const name = typeof obj.name === "string" && obj.name
+    ? obj.name
+    : typeof obj.key === "string" && obj.key
+      ? obj.key
+      : null;
+  if (!name) return null;
+  const rawState = typeof obj.state === "string" ? obj.state : "";
+  const mapped = BITBUCKET_CHECK_STATE_MAP[rawState] ?? { status: "unknown", conclusion: null };
+  return {
+    id: index + 1,
+    name,
+    status: mapped.status,
+    conclusion: mapped.conclusion,
+    htmlUrl: typeof obj.url === "string" ? obj.url : null,
+    startedAt: typeof obj.created_on === "string" ? obj.created_on : null,
+    completedAt: mapped.status === "completed" && typeof obj.updated_on === "string" ? obj.updated_on : null,
+  };
+}
+
+/** Escape a double quote in a BBQL string literal — the only character in a
+ *  free-text query that needs escaping for a `"…"` BBQL string to stay valid. */
+function escapeBBQLString(s: string): string {
+  // Backslash is BBQL's own escape character, so it must be doubled BEFORE
+  // quotes are escaped — otherwise a trailing `\` in the search term turns
+  // the closing `"` into an escaped quote and the whole `q=` fails with 400.
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/** Bitbucket's pull-request list endpoint takes a repeatable `state` query
+ *  param rather than a single value — `closed` and `all` expand to every
+ *  terminal (or all) PR state. */
+function prStateParams(state: GitHubItemState): string[] {
+  if (state === "open") return ["OPEN"];
+  if (state === "closed") return ["MERGED", "DECLINED", "SUPERSEDED"];
+  return ["OPEN", "MERGED", "DECLINED", "SUPERSEDED"];
+}
+
+/** BBQL clause for issue state filtering — Bitbucket issues have a richer
+ *  state machine (new/open/resolved/closed/duplicate/invalid/wontfix/on hold)
+ *  than the open/closed binary the UI exposes, so `closed` expands to every
+ *  non-open state. `null` for `state === "all"` (no filter needed). */
+function issueStateBBQL(state: GitHubItemState): string | null {
+  if (state === "open") return '(state="new" OR state="open")';
+  if (state === "closed") {
+    return '(state="resolved" OR state="closed" OR state="duplicate" OR state="invalid" OR state="wontfix" OR state="on hold")';
+  }
+  return null;
+}
+
+interface BitbucketQueryFilters {
+  query?: string;
+  assignee?: string;
+  createdByMe?: boolean;
+  assignedToMe?: boolean;
+  reviewRequested?: boolean;
+  state: GitHubItemState;
+}
+
+/** Builds the `q=` BBQL string for the pull-requests list endpoint from the
+ *  "involvement" filters, ANDing every active clause together. Bitbucket pull
+ *  requests have no assignee concept, so `assignedToMe` is treated the same as
+ *  `reviewRequested` (documented on `listBitbucketItems`). `meUuid` is null
+ *  when the involvement filters can't be resolved (no credentials, or the
+ *  `/2.0/user` lookup failed) — those clauses are silently dropped rather than
+ *  erroring, matching a plain unauthenticated list. */
+function buildPullsBBQL(input: BitbucketQueryFilters, meUuid: string | null): string | null {
+  const clauses: string[] = [];
+  const q = input.query?.trim();
+  if (q) clauses.push(`(title ~ "${escapeBBQLString(q)}" OR description ~ "${escapeBBQLString(q)}")`);
+  if (input.createdByMe && meUuid) clauses.push(`author.uuid="${meUuid}"`);
+  if ((input.reviewRequested || input.assignedToMe) && meUuid) clauses.push(`reviewers.uuid="${meUuid}"`);
+  return clauses.length > 0 ? clauses.join(" AND ") : null;
+}
+
+/** Builds the `q=` BBQL string for the issues list endpoint. `assignee` is
+ *  matched by nickname (best-effort — Bitbucket's issue-tracker BBQL schema
+ *  for assignee is thinner than the pull-request one). */
+function buildIssuesBBQL(input: BitbucketQueryFilters): string | null {
+  const clauses: string[] = [];
+  const stateClause = issueStateBBQL(input.state);
+  if (stateClause) clauses.push(stateClause);
+  const q = input.query?.trim();
+  if (q) clauses.push(`(title ~ "${escapeBBQLString(q)}" OR content.raw ~ "${escapeBBQLString(q)}")`);
+  const assignee = input.assignee?.trim();
+  if (assignee) clauses.push(`assignee.nickname="${escapeBBQLString(assignee)}"`);
+  return clauses.length > 0 ? clauses.join(" AND ") : null;
+}
+
+/** Maps the shared sort/direction input to Bitbucket's `sort=` param.
+ *  "best-match" (search-relevance sort, GitHub-only) and "comments" (no
+ *  Bitbucket field backs a comment-count sort) both degrade to `-updated_on` —
+ *  the plan's documented fallback. `direction: "asc"` drops the leading `-`. */
+function sortParam(sort: "created" | "updated" | "comments" | undefined, direction: "asc" | "desc" | undefined): string {
+  const field = sort === "created" ? "created_on" : "updated_on";
+  return direction === "asc" ? field : `-${field}`;
+}
+
+/** Resolves the authenticated viewer's Bitbucket `uuid` (needed for BBQL
+ *  `author.uuid="…"` / `reviewers.uuid="…"` clauses) alongside a display
+ *  login. Returns null on no credentials or any failure — callers treat that
+ *  as "the me-scoped filter can't be applied" rather than a hard error. */
+async function bitbucketViewerUuid(creds: BitbucketCreds | null): Promise<{ uuid: string; login: string } | null> {
+  if (!creds) return null;
+  const res = await fetchBitbucket("/2.0/user", creds, "application/json");
+  if (!("status" in res) || !res.ok) return null;
+  const json = await res.json().catch(() => null);
+  const obj = json && typeof json === "object" ? json as Record<string, unknown> : {};
+  const uuid = typeof obj.uuid === "string" ? obj.uuid : null;
+  if (!uuid) return null;
+  const login = typeof obj.nickname === "string" && obj.nickname
+    ? obj.nickname
+    : typeof obj.username === "string"
+      ? obj.username
+      : "";
+  return { uuid, login };
+}
+
+export interface ListBitbucketItemsOptions {
+  kind: GitHubItemKind;
+  state: GitHubItemState;
+  query?: string;
+  /** Bitbucket has no labels — accepted only for interface parity with
+   *  callers shared across providers (the facade); always ignored. */
+  labels?: string[];
+  assignee?: string;
+  createdByMe?: boolean;
+  /** PRs: no Bitbucket assignee concept — treated as `reviewRequested`
+   *  (see `buildPullsBBQL`). Issues: matched via `assignee.nickname=`. */
+  assignedToMe?: boolean;
+  reviewRequested?: boolean;
+  page?: number;
+  sort?: "created" | "updated" | "comments";
+  direction?: "asc" | "desc";
+}
+
+/** Lists pull requests or issues for a repo. Mirrors `listGitHubItems`'s
+ *  option surface and `GitHubListResult` return shape. `rateLimit` is always
+ *  null — Bitbucket's REST API doesn't expose a GitHub-style rate-limit
+ *  header trio. `hasMore` reflects whether the response body's `next` link is
+ *  present (Bitbucket's own pagination cursor), and `page` echoes back the
+ *  requested page the same way `listGitHubItems` does. */
+export async function listBitbucketItems(
+  repo: ProviderRepoInfo,
+  opts: ListBitbucketItemsOptions,
+): Promise<BitbucketListResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  const page = Number.isInteger(opts.page) && (opts.page as number) > 0 ? (opts.page as number) : 1;
+
+  const needsMe = !!(opts.createdByMe || opts.assignedToMe || opts.reviewRequested);
+  const viewer = needsMe ? await bitbucketViewerUuid(creds) : null;
+  const meUuid = viewer?.uuid ?? null;
+
+  const url = new URL(`${BITBUCKET_API_BASE}${repoBasePath(repo)}/${opts.kind === "pulls" ? "pullrequests" : "issues"}`);
+  url.searchParams.set("pagelen", String(BITBUCKET_PAGELEN));
+  url.searchParams.set("page", String(page));
+  url.searchParams.set("sort", sortParam(opts.sort, opts.direction));
+
+  if (opts.kind === "pulls") {
+    for (const s of prStateParams(opts.state)) url.searchParams.append("state", s);
+    const q = buildPullsBBQL(opts, meUuid);
+    if (q) url.searchParams.set("q", q);
+  } else {
+    const q = buildIssuesBBQL(opts);
+    if (q) url.searchParams.set("q", q);
+  }
+
+  const res = await fetchBitbucket(url.toString(), creds, "application/json");
+  if (!("status" in res)) return res;
+  const body = await res.json().catch(() => null);
+  if (!res.ok) {
+    if (opts.kind === "issues" && res.status === 404) {
+      return { ok: false, error: "issue tracker is not enabled for this repository" };
+    }
+    return { ok: false, error: apiErrorMessage(body, res.status, res.statusText) };
+  }
+  const values = body && typeof body === "object" && Array.isArray((body as { values?: unknown }).values)
+    ? (body as { values: unknown[] }).values
+    : null;
+  if (!values) return { ok: false, error: "Bitbucket returned an unexpected response" };
+  const normalize = opts.kind === "pulls" ? normalizeBitbucketPull : normalizeBitbucketIssue;
+  const items = values.map((v) => normalize(v, null)).filter((x): x is GitHubListItem => !!x);
+  const next = body && typeof body === "object" ? (body as { next?: unknown }).next : undefined;
+
+  return {
+    ok: true,
+    repo: `${repo.owner}/${repo.name}`,
+    webUrl: `https://bitbucket.org/${repo.owner}/${repo.name}`,
+    auth: creds ? "token" : "none",
+    items,
+    page,
+    hasMore: typeof next === "string" && next.length > 0,
+    rateLimit: null,
+  };
+}
+
+/** Matches `getGitHubPullDefaults`'s return shape. `base` comes from the
+ *  repo's `mainbranch.name`; `head` is always `""` here since this adapter
+ *  has no working directory to read a current branch from (see the module
+ *  doc comment) — the facade fills it in from local git the same way for
+ *  every provider. */
+export async function getBitbucketPullDefaults(repo: ProviderRepoInfo): Promise<BitbucketPullDefaultsResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  const res = await fetchBitbucket(repoBasePath(repo), creds, "application/json");
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  const obj = json && typeof json === "object" ? json as Record<string, unknown> : {};
+  const mainbranch = obj.mainbranch && typeof obj.mainbranch === "object" ? obj.mainbranch as Record<string, unknown> : {};
+  const base = typeof mainbranch.name === "string" && mainbranch.name ? mainbranch.name : "main";
+  return { ok: true, repo: `${repo.owner}/${repo.name}`, head: "", base };
+}
+
+export interface CreateBitbucketPullInput {
+  title: string;
+  body?: string;
+  base: string;
+  head: string;
+  draft?: boolean;
+}
+
+export async function createBitbucketPull(
+  repo: ProviderRepoInfo,
+  input: CreateBitbucketPullInput,
+): Promise<BitbucketIssueResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  const title = input.title.trim();
+  const head = input.head.trim();
+  const base = input.base.trim();
+  if (!title) return { ok: false, error: "pull request title required" };
+  if (!head) return { ok: false, error: "head branch required" };
+  if (!base) return { ok: false, error: "base branch required" };
+  if (!creds) return { ok: false, error: "Bitbucket authentication required to create a pull request" };
+
+  const res = await fetchBitbucket(
+    `${repoBasePath(repo)}/pullrequests`,
+    creds,
+    "application/json",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        title,
+        ...(input.body?.trim() ? { description: input.body.trim() } : {}),
+        source: { branch: { name: head } },
+        destination: { branch: { name: base } },
+        draft: input.draft === true,
+      }),
+    },
+  );
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  const item = normalizeBitbucketPull(json, null);
+  if (!item) return { ok: false, error: "Bitbucket returned an unexpected pull request response" };
+  return { ok: true, item, message: "Pull request created." };
+}
+
+/** Fetches the raw unified diff for a pull request. Mirrors
+ *  `getGitHubPullDiff`'s 8MB content-length/byte-size guard and
+ *  `MAX_DIFF_FILES` truncation exactly (same constants, same shape). Bitbucket
+ *  itself also truncates very large diffs server-side (its own 8000-line /
+ *  200-file caps) — `parseGitDiff` tolerates a truncated unified diff either
+ *  way (it just yields fewer/partial hunks). */
+export async function getBitbucketPullDiff(repo: ProviderRepoInfo, number: number): Promise<BitbucketDiffResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
+
+  const res = await fetchBitbucket(`${repoBasePath(repo)}/pullrequests/${number}/diff`, creds, "*/*");
+  if (!("status" in res)) return res;
+  const contentLength = Number(res.headers.get("content-length") ?? 0);
+  if (contentLength > BITBUCKET_DIFF_BODY_CAP_BYTES) {
+    return {
+      ok: false,
+      error: `Pull request diff is too large to display in Agetor (${Math.ceil(contentLength / 1_000_000)} MB).`,
+    };
+  }
+  const body = await res.text().catch(() => "");
+  if (!res.ok) {
+    let msg = body;
+    try {
+      const parsed = JSON.parse(body) as { error?: { message?: unknown } };
+      if (parsed.error && typeof parsed.error.message === "string") msg = parsed.error.message;
+    } catch { /* the diff endpoint returns plain text on success, not JSON */ }
+    return { ok: false, error: msg || `${res.status} ${res.statusText}` };
+  }
+  const bodyBytes = Buffer.byteLength(body, "utf8");
+  if (bodyBytes > BITBUCKET_DIFF_BODY_CAP_BYTES) {
+    return {
+      ok: false,
+      error: `Pull request diff is too large to display in Agetor (${Math.ceil(bodyBytes / 1_000_000)} MB).`,
+    };
+  }
+  const files = parseGitDiff(body);
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  if (files.length > MAX_DIFF_FILES) {
+    const total = files.length;
+    return {
+      ok: true,
+      base: null,
+      files: files.slice(0, MAX_DIFF_FILES),
+      note: `Showing the first ${MAX_DIFF_FILES} of ${total} changed files — the rest are omitted to keep the viewer responsive.`,
+    };
+  }
+  return {
+    ok: true,
+    base: null,
+    files,
+    note: files.length === 0 ? "No diff returned for this pull request." : undefined,
+  };
+}
+
+/** Lists non-inline comments on a pull request or issue. Inline (line)
+ *  comments and soft-deleted comments are excluded here — inline ones belong
+ *  to `listBitbucketPullReviewComments`, and Bitbucket never removes a deleted
+ *  comment from the list, it just flips `deleted: true` and blanks the body. */
+export async function listBitbucketComments(
+  repo: ProviderRepoInfo,
+  number: number,
+  kind: GitHubItemKind,
+): Promise<BitbucketCommentsResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "item number must be positive" };
+  const endpoint = kind === "pulls" ? "pullrequests" : "issues";
+  const url = new URL(`${BITBUCKET_API_BASE}${repoBasePath(repo)}/${endpoint}/${number}/comments`);
+  url.searchParams.set("pagelen", String(BITBUCKET_PAGELEN));
+
+  const res = await fetchBitbucket(url.toString(), creds, "application/json");
+  if (!("status" in res)) return res;
+  const body = await res.json().catch(() => null);
+  if (!res.ok) {
+    if (kind === "issues" && res.status === 404) {
+      return { ok: false, error: "issue tracker is not enabled for this repository" };
+    }
+    return { ok: false, error: apiErrorMessage(body, res.status, res.statusText) };
+  }
+  const values = body && typeof body === "object" && Array.isArray((body as { values?: unknown }).values)
+    ? (body as { values: unknown[] }).values
+    : null;
+  if (!values) return { ok: false, error: "Bitbucket returned an unexpected comments response" };
+  values.push(...await collectRemainingValues(body, creds));
+  const comments: GitHubComment[] = [];
+  for (const raw of values) {
+    const obj = raw && typeof raw === "object" ? raw as Record<string, unknown> : null;
+    if (!obj || obj.deleted === true || obj.inline) continue;
+    const comment = normalizeBitbucketComment(obj);
+    if (comment) comments.push(comment);
+  }
+  return { ok: true, repo: `${repo.owner}/${repo.name}`, itemNumber: number, comments };
+}
+
+export async function createBitbucketComment(
+  repo: ProviderRepoInfo,
+  number: number,
+  kind: GitHubItemKind,
+  body: string,
+): Promise<BitbucketCommentResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "item number must be positive" };
+  const trimmed = body.trim();
+  if (!trimmed) return { ok: false, error: "comment body required" };
+  if (!creds) return { ok: false, error: "Bitbucket authentication required to comment" };
+  const endpoint = kind === "pulls" ? "pullrequests" : "issues";
+  const res = await fetchBitbucket(
+    `${repoBasePath(repo)}/${endpoint}/${number}/comments`,
+    creds,
+    "application/json",
+    { method: "POST", body: JSON.stringify({ content: { raw: trimmed } }) },
+  );
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) {
+    if (kind === "issues" && res.status === 404) {
+      return { ok: false, error: "issue tracker is not enabled for this repository" };
+    }
+    return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  }
+  const comment = normalizeBitbucketComment(json);
+  if (!comment) return { ok: false, error: "Bitbucket returned an unexpected comment response" };
+  return { ok: true, comment };
+}
+
+/** Lists inline (line) review comments on a pull request — the same
+ *  `/comments` endpoint as `listBitbucketComments`, but keeping ONLY entries
+ *  that carry an `inline` position (excluding soft-deleted ones too). */
+export async function listBitbucketPullReviewComments(
+  repo: ProviderRepoInfo,
+  number: number,
+): Promise<BitbucketPullReviewCommentsResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
+  const url = new URL(`${BITBUCKET_API_BASE}${repoBasePath(repo)}/pullrequests/${number}/comments`);
+  url.searchParams.set("pagelen", String(BITBUCKET_PAGELEN));
+
+  const res = await fetchBitbucket(url.toString(), creds, "application/json");
+  if (!("status" in res)) return res;
+  const body = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(body, res.status, res.statusText) };
+  const values = body && typeof body === "object" && Array.isArray((body as { values?: unknown }).values)
+    ? (body as { values: unknown[] }).values
+    : null;
+  if (!values) return { ok: false, error: "Bitbucket returned an unexpected review comments response" };
+  values.push(...await collectRemainingValues(body, creds));
+  const comments = values
+    .filter((raw) => {
+      const obj = raw && typeof raw === "object" ? raw as Record<string, unknown> : null;
+      return !!obj && !!obj.inline && obj.deleted !== true;
+    })
+    .map(normalizeBitbucketLineComment)
+    .filter((x): x is GitHubPullLineComment => !!x);
+  return { ok: true, repo: `${repo.owner}/${repo.name}`, pullNumber: number, comments };
+}
+
+export interface CreateBitbucketPullLineCommentInput {
+  path: string;
+  line: number;
+  side: "LEFT" | "RIGHT";
+  body: string;
+}
+
+export async function createBitbucketPullLineComment(
+  repo: ProviderRepoInfo,
+  number: number,
+  input: CreateBitbucketPullLineCommentInput,
+): Promise<BitbucketPullLineCommentResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
+  const body = input.body.trim();
+  const path = input.path.trim();
+  if (!body) return { ok: false, error: "comment body required" };
+  if (!path) return { ok: false, error: "comment path required" };
+  if (!Number.isInteger(input.line) || input.line <= 0) {
+    return { ok: false, error: "comment line must be positive" };
+  }
+  if (input.side !== "LEFT" && input.side !== "RIGHT") {
+    return { ok: false, error: "comment side must be LEFT or RIGHT" };
+  }
+  if (!creds) return { ok: false, error: "Bitbucket authentication required to comment on a line" };
+
+  // RIGHT (added/context line, head file) → `inline.to`; LEFT (base-file
+  // deletion line) → `inline.from` — Bitbucket's own to/from vocabulary for
+  // which side of the diff a line number refers to.
+  const lineKey = input.side === "RIGHT" ? "to" : "from";
+  const res = await fetchBitbucket(
+    `${repoBasePath(repo)}/pullrequests/${number}/comments`,
+    creds,
+    "application/json",
+    { method: "POST", body: JSON.stringify({ content: { raw: body }, inline: { path, [lineKey]: input.line } }) },
+  );
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  const comment = normalizeBitbucketLineComment(json);
+  if (!comment) return { ok: false, error: "Bitbucket returned an unexpected line comment response" };
+  return { ok: true, comment };
+}
+
+export async function replyBitbucketLineComment(
+  repo: ProviderRepoInfo,
+  number: number,
+  commentId: number,
+  body: string,
+): Promise<BitbucketPullLineCommentResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
+  if (!Number.isInteger(commentId) || commentId <= 0) return { ok: false, error: "review comment id must be positive" };
+  const trimmed = body.trim();
+  if (!trimmed) return { ok: false, error: "reply body required" };
+  if (!creds) return { ok: false, error: "Bitbucket authentication required to reply" };
+
+  const res = await fetchBitbucket(
+    `${repoBasePath(repo)}/pullrequests/${number}/comments`,
+    creds,
+    "application/json",
+    { method: "POST", body: JSON.stringify({ content: { raw: trimmed }, parent: { id: commentId } }) },
+  );
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  const comment = normalizeBitbucketLineComment(json);
+  if (!comment) return { ok: false, error: "Bitbucket returned an unexpected reply response" };
+  return { ok: true, comment };
+}
+
+/** `GET .../pullrequests/:id/statuses` — Bitbucket's commit build statuses
+ *  scoped directly to the pull request (unlike GitHub, no separate head-sha
+ *  resolution + check-runs call is needed for the listing itself). The head
+ *  sha for `GitHubChecksResult.sha` is still fetched via the PR detail call,
+ *  purely to fill that field — same two-request shape as
+ *  `getGitHubPullChecks`, just for a different reason. */
+export async function getBitbucketPullChecks(repo: ProviderRepoInfo, number: number): Promise<BitbucketChecksResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
+
+  const prRes = await fetchBitbucket(`${repoBasePath(repo)}/pullrequests/${number}`, creds, "application/json");
+  if (!("status" in prRes)) return prRes;
+  const prJson = await prRes.json().catch(() => null);
+  if (!prRes.ok) return { ok: false, error: apiErrorMessage(prJson, prRes.status, prRes.statusText) };
+  const prObj = prJson && typeof prJson === "object" ? prJson as Record<string, unknown> : {};
+  const source = prObj.source && typeof prObj.source === "object" ? prObj.source as Record<string, unknown> : {};
+  const commit = source.commit && typeof source.commit === "object" ? source.commit as Record<string, unknown> : {};
+  const sha = typeof commit.hash === "string" ? commit.hash : "";
+
+  const statusesUrl = new URL(`${BITBUCKET_API_BASE}${repoBasePath(repo)}/pullrequests/${number}/statuses`);
+  statusesUrl.searchParams.set("pagelen", String(BITBUCKET_PAGELEN));
+  const res = await fetchBitbucket(statusesUrl.toString(), creds, "application/json");
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  const values = json && typeof json === "object" && Array.isArray((json as { values?: unknown }).values)
+    ? (json as { values: unknown[] }).values
+    : [];
+  const checkRuns = values.map((v, i) => normalizeBitbucketCheckRun(v, i)).filter((x): x is GitHubCheckRun => !!x);
+
+  return { ok: true, repo: `${repo.owner}/${repo.name}`, pullNumber: number, sha, checkRuns };
+}
+
+/** The shared `GitHubPullMergeMethod` enum ("merge"|"squash"|"rebase") maps to
+ *  Bitbucket's three `merge_strategy` values. There is no fast-forward entry
+ *  in the shared enum, so Bitbucket's `fast_forward` (a linear, no-merge-
+ *  commit history — the same end result GitHub's "rebase and merge" produces)
+ *  is exposed to the UI as `"rebase"`; see the `PROVIDER_CAPS` doc comment in
+ *  `shared/types.ts` for the authoritative statement of this mapping. */
+const BITBUCKET_MERGE_STRATEGY: Record<GitHubPullMergeMethod, string> = {
+  merge: "merge_commit",
+  squash: "squash",
+  rebase: "fast_forward",
+};
+
+export async function mergeBitbucketPull(
+  repo: ProviderRepoInfo,
+  number: number,
+  method: GitHubPullMergeMethod,
+): Promise<BitbucketPullMergeResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
+  const strategy = BITBUCKET_MERGE_STRATEGY[method];
+  if (!strategy) return { ok: false, error: "unsupported merge method" };
+  if (!creds) return { ok: false, error: "Bitbucket authentication required to merge" };
+
+  const res = await fetchBitbucket(
+    `${repoBasePath(repo)}/pullrequests/${number}/merge`,
+    creds,
+    "application/json",
+    { method: "POST", body: JSON.stringify({ merge_strategy: strategy }) },
+  );
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  const obj = json && typeof json === "object" ? json as Record<string, unknown> : {};
+  const mergeCommit = obj.merge_commit && typeof obj.merge_commit === "object"
+    ? obj.merge_commit as Record<string, unknown>
+    : null;
+  const sha = mergeCommit && typeof mergeCommit.hash === "string" ? mergeCommit.hash : null;
+  return { ok: true, merged: true, sha, message: "Pull request merged." };
+}
+
+/** Bitbucket has no distinct "close without merging" action — declining is
+ *  the only terminal non-merge state a pull request can reach via the API,
+ *  so this is what `closeGitHubPull`'s call sites map onto. */
+export async function closeBitbucketPull(repo: ProviderRepoInfo, number: number): Promise<BitbucketActionResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
+  if (!creds) return { ok: false, error: "Bitbucket authentication required to decline a pull request" };
+
+  const res = await fetchBitbucket(
+    `${repoBasePath(repo)}/pullrequests/${number}/decline`,
+    creds,
+    "application/json",
+    { method: "POST" },
+  );
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  const item = normalizeBitbucketPull(json, null);
+  return { ok: true, message: "Pull request declined.", ...(item ? { item } : {}) };
+}
+
+/** Bitbucket has no API to move a declined pull request back to OPEN — unlike
+ *  GitHub (`reopenGitHubPull`, a plain `state: "closed"` → back to `"open"`
+ *  PATCH), a decline is terminal. Always returns a friendly, actionable error
+ *  rather than attempting a request that Bitbucket would reject anyway. */
+export async function reopenBitbucketPull(_repo: ProviderRepoInfo, _number: number): Promise<BitbucketActionResponse> {
+  return { ok: false, error: "declined pull requests cannot be reopened on Bitbucket" };
+}
+
+/** Approve / request-changes / comment on a pull request. Reuses the shared
+ *  `GitHubPullReviewEvent` enum ("APPROVE"|"REQUEST_CHANGES"|"COMMENT") as the
+ *  verdict vocabulary — rather than inventing Bitbucket-specific literal
+ *  strings — so the facade (T4) can pass the same value through to whichever
+ *  provider a repo resolves to. `body` is optional for approve/request-changes
+ *  (posted as a trailing plain comment when present) but required for a bare
+ *  "comment" verdict, matching `reviewValidationError`'s COMMENT rule in
+ *  github.ts. */
+export async function reviewBitbucketPull(
+  repo: ProviderRepoInfo,
+  number: number,
+  verdict: GitHubPullReviewEvent,
+  body?: string,
+): Promise<BitbucketActionResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
+  const trimmedBody = body?.trim() ?? "";
+  if (verdict === "COMMENT" && !trimmedBody) {
+    return { ok: false, error: "a review comment requires a body" };
+  }
+  if (verdict !== "APPROVE" && verdict !== "REQUEST_CHANGES" && verdict !== "COMMENT") {
+    return { ok: false, error: "unsupported review event" };
+  }
+  if (!creds) return { ok: false, error: "Bitbucket authentication required to review" };
+
+  if (verdict === "COMMENT") {
+    const commentRes = await createBitbucketComment(repo, number, "pulls", trimmedBody);
+    if (!commentRes.ok) return commentRes;
+    return { ok: true, message: "Review submitted." };
+  }
+
+  const endpoint = verdict === "APPROVE" ? "approve" : "request-changes";
+  const res = await fetchBitbucket(
+    `${repoBasePath(repo)}/pullrequests/${number}/${endpoint}`,
+    creds,
+    "application/json",
+    { method: "POST" },
+  );
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+
+  const verdictLabel = verdict === "APPROVE" ? "Pull request approved" : "Changes requested";
+  if (trimmedBody) {
+    const commentRes = await createBitbucketComment(repo, number, "pulls", trimmedBody);
+    if (!commentRes.ok) {
+      return { ok: true, message: `${verdictLabel}, but the comment was not posted: ${commentRes.error}` };
+    }
+  }
+  return { ok: true, message: `${verdictLabel}.` };
+}
+
+export interface CreateBitbucketIssueInput {
+  title: string;
+  body?: string;
+}
+
+/** Labels/assignees/milestone are silently ignored — Bitbucket's issue
+ *  creation endpoint doesn't support labels at all, and while it technically
+ *  accepts an `assignee`/`milestone` object, the plan scopes this adapter to
+ *  the portable title/body subset (matching `updateBitbucketIssue` below). */
+export async function createBitbucketIssue(
+  repo: ProviderRepoInfo,
+  input: CreateBitbucketIssueInput,
+): Promise<BitbucketIssueResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  const title = input.title.trim();
+  if (!title) return { ok: false, error: "issue title required" };
+  if (!creds) return { ok: false, error: "Bitbucket authentication required to create an issue" };
+
+  const res = await fetchBitbucket(
+    `${repoBasePath(repo)}/issues`,
+    creds,
+    "application/json",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        title,
+        ...(input.body?.trim() ? { content: { raw: input.body.trim() } } : {}),
+      }),
+    },
+  );
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) {
+    if (res.status === 404) return { ok: false, error: "issue tracker is not enabled for this repository" };
+    return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  }
+  const item = normalizeBitbucketIssue(json, null);
+  if (!item) return { ok: false, error: "Bitbucket returned an unexpected issue response" };
+  return { ok: true, item, message: "Issue created." };
+}
+
+export interface UpdateBitbucketIssueInput {
+  title?: string;
+  body?: string;
+  state?: "open" | "closed";
+}
+
+/** Portable patch surface matching `updateGitHubIssue`'s (title/body/state) —
+ *  labels/assignees/milestone aren't part of this adapter's issue-update
+ *  surface (see `createBitbucketIssue`). `state: "closed"` maps to Bitbucket's
+ *  `"resolved"` (the canonical closed-ish state a fresh issue transitions to
+ *  via a plain "close" action; a caller wanting `wontfix`/`duplicate`/etc.
+ *  would need a Bitbucket-specific affordance this adapter doesn't expose). */
+export async function updateBitbucketIssue(
+  repo: ProviderRepoInfo,
+  number: number,
+  patch: UpdateBitbucketIssueInput,
+): Promise<BitbucketIssueResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "issue number must be positive" };
+  if (patch.state && patch.state !== "open" && patch.state !== "closed") {
+    return { ok: false, error: "unsupported issue state" };
+  }
+  const body: Record<string, unknown> = {};
+  if (patch.title !== undefined) {
+    const title = patch.title.trim();
+    if (!title) return { ok: false, error: "issue title cannot be empty" };
+    body.title = title;
+  }
+  if (patch.body !== undefined) body.content = { raw: patch.body };
+  if (patch.state === "closed") body.state = "resolved";
+  else if (patch.state === "open") body.state = "open";
+  if (Object.keys(body).length === 0) {
+    return { ok: false, error: "issue update requires title, body, or state" };
+  }
+  if (!creds) return { ok: false, error: "Bitbucket authentication required to update an issue" };
+
+  const res = await fetchBitbucket(
+    `${repoBasePath(repo)}/issues/${number}`,
+    creds,
+    "application/json",
+    { method: "PUT", body: JSON.stringify(body) },
+  );
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) {
+    if (res.status === 404) return { ok: false, error: "issue tracker is not enabled for this repository" };
+    return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  }
+  const item = normalizeBitbucketIssue(json, null);
+  if (!item) return { ok: false, error: "Bitbucket returned an unexpected issue response" };
+  return { ok: true, item, message: "Issue updated." };
+}
+
+/** Matches `getGitHubViewer`'s shape (`{ok:true; login}` only — no token
+ *  means an anonymous "" login rather than an error, same no-token behavior
+ *  as the GitHub counterpart). */
+export async function getBitbucketViewer(repo: ProviderRepoInfo): Promise<BitbucketViewerResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!creds) return { ok: true, login: "" };
+  const res = await fetchBitbucket("/2.0/user", creds, "application/json");
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  const obj = json && typeof json === "object" ? json as Record<string, unknown> : {};
+  const login = typeof obj.nickname === "string" && obj.nickname
+    ? obj.nickname
+    : typeof obj.username === "string"
+      ? obj.username
+      : "";
+  return { ok: true, login };
+}
+
+// Internal helpers exposed for unit tests only (TT3) — no other consumers.
+export const __bitbucketInternals = {
+  repoBasePath,
+  resolveUrl,
+  apiErrorMessage,
+  normalizeBitbucketUser,
+  normalizeBitbucketPull,
+  normalizeBitbucketIssue,
+  normalizeBitbucketComment,
+  normalizeBitbucketLineComment,
+  normalizeBitbucketCheckRun,
+  escapeBBQLString,
+  prStateParams,
+  issueStateBBQL,
+  buildPullsBBQL,
+  buildIssuesBBQL,
+  sortParam,
+  bitbucketViewerUuid,
+  BITBUCKET_OPEN_ISSUE_STATES,
+  BITBUCKET_CHECK_STATE_MAP,
+  BITBUCKET_MERGE_STRATEGY,
+};

--- a/src/bun/git-host.test.ts
+++ b/src/bun/git-host.test.ts
@@ -1,0 +1,286 @@
+import { test, expect, beforeEach, afterEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  providerInfoForDir,
+  listItems,
+  pullDefaults,
+  labels,
+  pullReopen,
+} from "./git-host.ts";
+import { makeGitHubRepo } from "./github-test-util.ts";
+import { mockGitHubFetch, type FetchMock } from "./github-test-util.ts";
+
+// git-host.ts dispatches through git-provider.ts's providerRepoForDir (a real
+// `git remote` shellout against a temp repo) and, for gitlab/bitbucket, through
+// gitlabToken/bitbucketCreds (github-tokens.ts), which are lazy-AGETOR_DATA_DIR
+// like github-tokens.test.ts. GITHUB_TOKEN/GITLAB_TOKEN are forced in
+// beforeEach so githubToken()/gitlabToken() never fall through to a real `gh`/
+// `glab` CLI shellout (mirrors github-network.test.ts's convention) —
+// bitbucketCreds has no CLI fallback tier, so it's fine to leave unset.
+const ORIGINAL_DATA_DIR = process.env.AGETOR_DATA_DIR;
+const ENV_KEYS = ["GITHUB_TOKEN", "GH_TOKEN", "GITLAB_TOKEN", "BITBUCKET_TOKEN", "BITBUCKET_EMAIL"] as const;
+let dataDir: string;
+let savedEnv: Record<string, string | undefined> = {};
+let createdDirs: string[] = [];
+let fetchMock: FetchMock | null = null;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(path.join(tmpdir(), "agetor-git-host-tokens-"));
+  process.env.AGETOR_DATA_DIR = dataDir;
+  savedEnv = {};
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.GITHUB_TOKEN = "gh-test-token";
+  process.env.GITLAB_TOKEN = "glab-test-token";
+});
+
+afterEach(() => {
+  fetchMock?.restore();
+  fetchMock = null;
+  rmSync(dataDir, { recursive: true, force: true });
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  for (const dir of createdDirs) rmSync(dir, { recursive: true, force: true });
+  createdDirs = [];
+});
+
+afterAll(() => {
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.AGETOR_DATA_DIR;
+  else process.env.AGETOR_DATA_DIR = ORIGINAL_DATA_DIR;
+});
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+}
+
+async function makeRepo(remoteUrl: string): Promise<string> {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-git-host-repo-"));
+  createdDirs.push(dir);
+  await git(["init", "-b", "main"], dir);
+  await git(["remote", "add", "origin", remoteUrl], dir);
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// providerInfoForDir
+// ---------------------------------------------------------------------------
+
+test("providerInfoForDir resolves a github repo", async () => {
+  const dir = await makeGitHubRepo("acme", "app");
+  createdDirs.push(dir);
+  expect(await providerInfoForDir(dir)).toEqual({
+    ok: true,
+    provider: "github",
+    owner: "acme",
+    name: "app",
+    host: "github.com",
+    remoteHost: "github.com",
+  });
+});
+
+test("providerInfoForDir resolves a gitlab repo", async () => {
+  const dir = await makeRepo("https://gitlab.com/acme/app.git");
+  expect(await providerInfoForDir(dir)).toEqual({
+    ok: true,
+    provider: "gitlab",
+    owner: "acme",
+    name: "app",
+    host: "gitlab.com",
+    remoteHost: "gitlab.com",
+  });
+});
+
+test("providerInfoForDir resolves a bitbucket repo", async () => {
+  const dir = await makeRepo("https://bitbucket.org/acme/app.git");
+  expect(await providerInfoForDir(dir)).toEqual({
+    ok: true,
+    provider: "bitbucket",
+    owner: "acme",
+    name: "app",
+    host: "bitbucket.org",
+    remoteHost: "bitbucket.org",
+  });
+});
+
+test("providerInfoForDir errors on an unsupported git remote", async () => {
+  const dir = await makeRepo("git@example.com:acme/app.git");
+  expect(await providerInfoForDir(dir)).toEqual({
+    ok: false,
+    error: "project does not have a supported git remote (GitHub, GitLab, or Bitbucket)",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatch: listItems
+// ---------------------------------------------------------------------------
+
+test("listItems dispatches a gitlab repo to the GitLab API and stitches sourcePath", async () => {
+  const dir = await makeRepo("https://gitlab.com/acme/app.git");
+  fetchMock = mockGitHubFetch([
+    {
+      match: "gitlab.com/api/v4/projects/acme%2Fapp/merge_requests",
+      json: [
+        {
+          iid: 5,
+          title: "Add feature",
+          state: "opened",
+          web_url: "https://gitlab.com/acme/app/-/merge_requests/5",
+          author: { username: "alice" },
+          assignees: [],
+          milestone: null,
+          description: "body text",
+          labels: [],
+          user_notes_count: 0,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-02T00:00:00Z",
+        },
+      ],
+    },
+  ]);
+
+  const res = await listItems({ dir, kind: "pulls", state: "open" });
+  expect(res.ok).toBe(true);
+  if (!res.ok) return;
+  expect(res.items).toHaveLength(1);
+  expect(res.items[0]).toMatchObject({ number: 5, title: "Add feature", sourcePath: dir });
+
+  const call = fetchMock.calls.find((c) => c.url.includes("merge_requests"));
+  expect(call?.url).toContain("/projects/acme%2Fapp/merge_requests");
+});
+
+test("listItems dispatches a bitbucket repo to the Bitbucket API and stitches sourcePath", async () => {
+  const dir = await makeRepo("https://bitbucket.org/acme/app.git");
+  fetchMock = mockGitHubFetch([
+    {
+      match: "api.bitbucket.org/2.0/repositories/acme/app/pullrequests",
+      json: {
+        values: [
+          {
+            id: 7,
+            title: "Fix bug",
+            state: "OPEN",
+            links: { html: { href: "https://bitbucket.org/acme/app/pull-requests/7" } },
+            author: { nickname: "bob" },
+            description: "desc",
+            comment_count: 0,
+            created_on: "2026-01-01T00:00:00Z",
+            updated_on: "2026-01-02T00:00:00Z",
+          },
+        ],
+      },
+    },
+  ]);
+
+  const res = await listItems({ dir, kind: "pulls", state: "open" });
+  expect(res.ok).toBe(true);
+  if (!res.ok) return;
+  expect(res.items).toHaveLength(1);
+  expect(res.items[0]).toMatchObject({ number: 7, title: "Fix bug", sourcePath: dir });
+
+  const call = fetchMock.calls.find((c) => c.url.includes("pullrequests"));
+  expect(call?.url).toContain("/2.0/repositories/acme/app/pullrequests");
+});
+
+test("listItems dispatches a github repo to the GitHub API (existing behavior preserved)", async () => {
+  const dir = await makeGitHubRepo("acme", "app");
+  createdDirs.push(dir);
+  fetchMock = mockGitHubFetch([
+    {
+      match: "api.github.com/repos/acme/app/pulls",
+      json: [
+        {
+          number: 3,
+          title: "Add thing",
+          state: "open",
+          draft: false,
+          html_url: "https://github.com/acme/app/pull/3",
+          user: { login: "alice" },
+          assignees: [],
+          milestone: null,
+          body: "body",
+          labels: [],
+          comments: 0,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-02T00:00:00Z",
+          closed_at: null,
+          merged_at: null,
+          locked: false,
+        },
+      ],
+    },
+  ]);
+
+  const res = await listItems({ dir, kind: "pulls", state: "open" });
+  expect(res.ok).toBe(true);
+  if (!res.ok) return;
+  expect(res.items).toHaveLength(1);
+  expect(res.items[0]).toMatchObject({ number: 3, title: "Add thing", sourcePath: dir });
+
+  const call = fetchMock.calls.find((c) => c.url.includes("api.github.com"));
+  expect(call?.url).toContain("api.github.com/repos/acme/app/pulls");
+});
+
+// ---------------------------------------------------------------------------
+// labels
+// ---------------------------------------------------------------------------
+
+test("labels on a bitbucket repo returns an empty list without any fetch", async () => {
+  const dir = await makeRepo("https://bitbucket.org/acme/app.git");
+  fetchMock = mockGitHubFetch([]); // any fetch call would throw — asserting none happens
+
+  const res = await labels({ dir });
+  expect(res).toEqual({ ok: true, repo: "acme/app", labels: [] });
+  expect(fetchMock.calls).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// pullDefaults
+// ---------------------------------------------------------------------------
+
+test("pullDefaults on a gitlab repo fills head from the local current branch", async () => {
+  const dir = await makeRepo("https://gitlab.com/acme/app.git");
+  fetchMock = mockGitHubFetch([
+    {
+      match: /gitlab\.com\/api\/v4\/projects\/acme%2Fapp$/,
+      json: { default_branch: "develop" },
+    },
+  ]);
+
+  const res = await pullDefaults({ dir });
+  expect(res).toEqual({ ok: true, repo: "acme/app", head: "main", base: "develop" });
+});
+
+test("pullDefaults on a bitbucket repo fills head from the local current branch", async () => {
+  const dir = await makeRepo("https://bitbucket.org/acme/app.git");
+  fetchMock = mockGitHubFetch([
+    {
+      match: /api\.bitbucket\.org\/2\.0\/repositories\/acme\/app$/,
+      json: { mainbranch: { name: "trunk" } },
+    },
+  ]);
+
+  const res = await pullDefaults({ dir });
+  expect(res).toEqual({ ok: true, repo: "acme/app", head: "main", base: "trunk" });
+});
+
+// ---------------------------------------------------------------------------
+// Unsupported-op errors surface through the facade
+// ---------------------------------------------------------------------------
+
+test("pullReopen on a bitbucket repo surfaces the 'cannot be reopened' error", async () => {
+  const dir = await makeRepo("https://bitbucket.org/acme/app.git");
+  fetchMock = mockGitHubFetch([]); // reopenBitbucketPull never fetches — asserting none happens
+
+  const res = await pullReopen({ dir, number: 1 });
+  expect(res.ok).toBe(false);
+  if (res.ok) return;
+  expect(res.error).toContain("cannot be reopened");
+  expect(fetchMock.calls).toHaveLength(0);
+});

--- a/src/bun/git-host.ts
+++ b/src/bun/git-host.ts
@@ -1,0 +1,641 @@
+import type {
+  GitHubChecksResult,
+  GitHubComment,
+  GitHubCommentsResult,
+  GitHubItemKind,
+  GitHubItemState,
+  GitHubLabelsResult,
+  GitHubListItem,
+  GitHubListResult,
+  GitHubPullDefaultsResult,
+  GitHubPullLineComment,
+  GitHubPullMergeMethod,
+  GitHubPullMergeResult,
+  GitHubPullReviewCommentsResult,
+  GitHubPullReviewEvent,
+  GitHubRateLimit,
+  GitProvider,
+  TaskDiff,
+} from "../shared/types.ts";
+import {
+  closeGitHubPull,
+  createGitHubComment,
+  createGitHubIssue,
+  createGitHubPull,
+  createGitHubPullLineComment,
+  getGitHubPullChecks,
+  getGitHubPullDefaults,
+  getGitHubPullDiff,
+  getGitHubViewer,
+  listGitHubComments,
+  listGitHubItems,
+  listGitHubItemsAcrossRepos,
+  listGitHubLabels,
+  listGitHubPullReviewComments,
+  mergeGitHubPull,
+  reopenGitHubPull,
+  replyGitHubPullLineComment,
+  reviewGitHubPull,
+  run,
+  updateGitHubIssue,
+} from "./github.ts";
+import { providerRepoForDir } from "./git-provider.ts";
+import {
+  closeGitLabPull,
+  createGitLabComment,
+  createGitLabIssue,
+  createGitLabPull,
+  createGitLabPullLineComment,
+  getGitLabPullChecks,
+  getGitLabPullDefaults,
+  getGitLabPullDiff,
+  getGitLabViewer,
+  listGitLabComments,
+  listGitLabItems,
+  listGitLabLabels,
+  listGitLabPullReviewComments,
+  mergeGitLabPull,
+  reopenGitLabPull,
+  replyGitLabLineComment,
+  reviewGitLabPull,
+  updateGitLabIssue,
+} from "./gitlab.ts";
+import {
+  closeBitbucketPull,
+  createBitbucketComment,
+  createBitbucketIssue,
+  createBitbucketPull,
+  createBitbucketPullLineComment,
+  getBitbucketPullChecks,
+  getBitbucketPullDefaults,
+  getBitbucketPullDiff,
+  getBitbucketViewer,
+  listBitbucketComments,
+  listBitbucketItems,
+  listBitbucketPullReviewComments,
+  mergeBitbucketPull,
+  reopenBitbucketPull,
+  replyBitbucketLineComment,
+  reviewBitbucketPull,
+  updateBitbucketIssue,
+} from "./bitbucket.ts";
+
+/**
+ * Provider dispatch facade (T4, docs/plans/multi-provider-git-modal.md §4).
+ * server.ts's core `/github/*` routes call into this module instead of
+ * `github.ts` directly; this is the single choke point that decides — per
+ * project directory — whether a request is served by GitHub (`github.ts`,
+ * unchanged pass-through), GitLab (`gitlab.ts`), or Bitbucket (`bitbucket.ts`).
+ *
+ * Every exported function here takes the same `{dir, ...}`-shaped input the
+ * route used to pass straight to a `github.ts` function. On the GitHub path
+ * that object is passed straight through — zero behavior change, since
+ * `github.ts`'s own functions are untouched. On the GitLab/Bitbucket path,
+ * `providerRepoForDir` resolves the already-detected `ProviderRepoInfo` once,
+ * and the adapter (which never shells out to git or resolves a remote itself)
+ * is called with it.
+ *
+ * Two things the adapters can't do themselves, because they only ever see a
+ * resolved `ProviderRepoInfo` with no working directory (see their own doc
+ * comments):
+ *  - `sourcePath` on every normalized `GitHubListItem` is null coming out of
+ *    an adapter — `withSourcePath` stitches `dir` on, mirroring what
+ *    `github.ts`'s own `normalizeItem(kind, raw, dir)` does inline.
+ *  - `pullDefaults().head` (the current local branch) can't be read without a
+ *    working directory — `currentBranchFor` fills it in for GitLab/Bitbucket
+ *    the same way `getGitHubPullDefaults` reads it via `git branch
+ *    --show-current` for GitHub.
+ *
+ * Never throws across the route boundary: every function resolves to
+ * `{ok:true, ...} | {ok:false, error}`, same convention as `github.ts`.
+ */
+
+const NO_REMOTE_ERROR = "project does not have a supported git remote (GitHub, GitLab, or Bitbucket)";
+
+export interface FacadeError {
+  ok: false;
+  error: string;
+}
+
+type ListResponse = ({ ok: true } & GitHubListResult) | FacadeError;
+type PullDefaultsResponse = ({ ok: true } & GitHubPullDefaultsResult) | FacadeError;
+type IssueResponse = ({ ok: true; item: GitHubListItem; message?: string }) | FacadeError;
+type DiffResponse = ({ ok: true } & TaskDiff) | FacadeError;
+type CommentsResponse = ({ ok: true } & GitHubCommentsResult) | FacadeError;
+type CommentResponse = ({ ok: true; comment: GitHubComment }) | FacadeError;
+type LineCommentResponse = ({ ok: true; comment: GitHubPullLineComment }) | FacadeError;
+type ReviewCommentsResponse = ({ ok: true } & GitHubPullReviewCommentsResult) | FacadeError;
+type ChecksResponse = ({ ok: true } & GitHubChecksResult) | FacadeError;
+type MergeResponse = GitHubPullMergeResult | FacadeError;
+type ActionResponse = ({ ok: true; message?: string; item?: GitHubListItem; commentPosted?: boolean }) | FacadeError;
+type ViewerResponse = ({ ok: true; login: string }) | FacadeError;
+type LabelsResponse = ({ ok: true } & GitHubLabelsResult) | FacadeError;
+
+function withSourcePath(item: GitHubListItem, dir: string): GitHubListItem {
+  return { ...item, sourcePath: dir };
+}
+
+/** Mirrors `github.ts`'s own (unexported) `currentBranch` — used to fill in
+ *  `pullDefaults().head` for GitLab/Bitbucket, which have no local working
+ *  directory to read a branch from (see the module doc comment). */
+async function currentBranchFor(dir: string): Promise<string> {
+  const result = await run(["git", "branch", "--show-current"], dir, 5_000);
+  return result.ok ? result.stdout.trim() : "";
+}
+
+/**
+ * Resolves which provider (and repo identity) a project directory's git
+ * remote points at — powers the new `/github/provider-info` route the UI
+ * (T5) uses to pick terminology/gating before making any other call.
+ */
+export async function providerInfoForDir(
+  dir: string,
+): Promise<
+  | { ok: true; provider: GitProvider; owner: string; name: string; host: string; remoteHost: string }
+  | FacadeError
+> {
+  const info = await providerRepoForDir(dir);
+  if (!info) return { ok: false, error: NO_REMOTE_ERROR };
+  return { ok: true, provider: info.provider, owner: info.owner, name: info.name, host: info.host, remoteHost: info.remoteHost };
+}
+
+export interface ListItemsInput {
+  dir: string;
+  kind: GitHubItemKind;
+  state: GitHubItemState;
+  query?: string;
+  labels?: string[];
+  assignee?: string;
+  createdByMe?: boolean;
+  assignedToMe?: boolean;
+  reviewRequested?: boolean;
+  /** GitHub-only raw search qualifiers — ignored on GitLab/Bitbucket, whose
+   *  adapters use structured filters instead. */
+  searchQuery?: string;
+  page?: number;
+  sort?: "created" | "updated" | "comments";
+  direction?: "asc" | "desc";
+}
+
+/** Single-repo item listing, dispatched by provider. GitHub delegates
+ *  straight to `listGitHubItems` (unchanged). GitLab/Bitbucket dispatch to
+ *  their adapter and stitch `sourcePath = dir` onto every returned item
+ *  (adapters always normalize it to null — see the module doc comment). */
+export async function listItems(input: ListItemsInput): Promise<ListResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return listGitHubItems(input);
+
+  const opts = {
+    kind: input.kind,
+    state: input.state,
+    query: input.query,
+    labels: input.labels,
+    assignee: input.assignee,
+    createdByMe: input.createdByMe,
+    assignedToMe: input.assignedToMe,
+    reviewRequested: input.reviewRequested,
+    page: input.page,
+    sort: input.sort,
+    direction: input.direction,
+  };
+  const res = repoInfo.provider === "gitlab" ? await listGitLabItems(repoInfo, opts) : await listBitbucketItems(repoInfo, opts);
+  if (!res.ok) return res;
+  return { ...res, items: res.items.map((item) => withSourcePath(item, input.dir)) };
+}
+
+export interface ListItemsAcrossReposInput {
+  dirs: string[];
+  kind: GitHubItemKind;
+  state: GitHubItemState;
+  query?: string;
+  labels?: string[];
+  assignee?: string;
+  createdByMe?: boolean;
+  assignedToMe?: boolean;
+  reviewRequested?: boolean;
+  searchQuery?: string;
+  sort?: "created" | "updated" | "comments";
+  direction?: "asc" | "desc";
+}
+
+const AGGREGATE_CONCURRENCY = 5;
+
+/**
+ * Multi-repo aggregate listing ("All repositories" in the dialog).
+ *
+ * Zero-regression fast path: when every selected dir resolves to GitHub, this
+ * delegates wholesale to `listGitHubItemsAcrossRepos` — the exact same code
+ * path as before this facade existed.
+ *
+ * Otherwise (mixed providers, or all non-GitHub): each dir is detected once,
+ * then dispatched through this module's own single-repo `listItems` (so each
+ * repo gets its own provider's auth + normalization), and the per-repo
+ * results are merged/sorted/truncated with the same policy
+ * `listGitHubItemsAcrossRepos` uses — a bounded-concurrency worker pool, a
+ * failing repo is skipped rather than failing the whole aggregate, default
+ * sort is "updated desc" (no cross-repo relevance signal to rank by), and
+ * `hasMore` on the merged result means "at least one contributing repo had
+ * more than one page" (truncated), not "there's a page 2 to fetch" — the UI
+ * has no per-repo cursor to advance in aggregate mode, matching the existing
+ * GitHub-only aggregate's documented behavior.
+ */
+export async function listItemsAcrossRepos(input: ListItemsAcrossReposInput): Promise<ListResponse> {
+  const dirs = Array.from(new Set(input.dirs.filter((d) => d.trim())));
+  if (dirs.length === 0) return { ok: false, error: "no projects to aggregate" };
+
+  const providers = new Map<string, GitProvider | null>();
+  for (const dir of dirs) {
+    const info = await providerRepoForDir(dir);
+    providers.set(dir, info?.provider ?? null);
+  }
+
+  if (dirs.every((d) => providers.get(d) === "github")) {
+    return listGitHubItemsAcrossRepos({
+      dirs,
+      kind: input.kind,
+      state: input.state,
+      query: input.query,
+      labels: input.labels,
+      assignee: input.assignee,
+      createdByMe: input.createdByMe,
+      assignedToMe: input.assignedToMe,
+      reviewRequested: input.reviewRequested,
+      searchQuery: input.searchQuery,
+      sort: input.sort,
+      direction: input.direction,
+    });
+  }
+
+  const perRepo: { dir: string; res: ListResponse }[] = new Array(dirs.length);
+  let next = 0;
+  const worker = async () => {
+    while (true) {
+      const i = next++;
+      if (i >= dirs.length) return;
+      const dir = dirs[i]!;
+      perRepo[i] = {
+        dir,
+        res: await listItems({
+          dir,
+          kind: input.kind,
+          state: input.state,
+          query: input.query,
+          labels: input.labels,
+          assignee: input.assignee,
+          createdByMe: input.createdByMe,
+          assignedToMe: input.assignedToMe,
+          reviewRequested: input.reviewRequested,
+          searchQuery: input.searchQuery,
+          sort: input.sort,
+          direction: input.direction,
+          page: 1,
+        }),
+      };
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(AGGREGATE_CONCURRENCY, dirs.length) }, worker));
+
+  const repos: string[] = [];
+  const items: GitHubListItem[] = [];
+  let truncated = false;
+  let auth: "token" | "none" = "none";
+  let rateLimit: GitHubRateLimit | null = null;
+  for (const { dir, res } of perRepo) {
+    if (!res.ok) continue;
+    repos.push(res.repo);
+    for (const item of res.items) items.push(withSourcePath(item, dir));
+    if (res.hasMore) truncated = true;
+    if (res.auth === "token") auth = "token";
+    if (res.rateLimit && (!rateLimit || res.rateLimit.remaining < rateLimit.remaining)) rateLimit = res.rateLimit;
+  }
+  if (repos.length === 0) {
+    return { ok: false, error: "none of the selected projects have a usable git remote" };
+  }
+
+  const sortField = input.sort ?? "updated";
+  const direction = input.direction ?? "desc";
+  const sortValue = (item: GitHubListItem): number => {
+    if (sortField === "comments") return item.comments;
+    const raw = sortField === "created" ? item.createdAt : item.updatedAt;
+    const t = Date.parse(raw);
+    return Number.isNaN(t) ? 0 : t;
+  };
+  items.sort((a, b) => {
+    const diff = sortValue(a) - sortValue(b);
+    return direction === "asc" ? diff : -diff;
+  });
+
+  return {
+    ok: true,
+    repo: `${repos.length} ${repos.length === 1 ? "repository" : "repositories"}`,
+    repos,
+    webUrl: null,
+    auth,
+    items,
+    page: 1,
+    hasMore: truncated,
+    rateLimit,
+  };
+}
+
+export async function pullDefaults(input: { dir: string }): Promise<PullDefaultsResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return getGitHubPullDefaults(input);
+  const res = repoInfo.provider === "gitlab" ? await getGitLabPullDefaults(repoInfo) : await getBitbucketPullDefaults(repoInfo);
+  if (!res.ok) return res;
+  return { ...res, head: await currentBranchFor(input.dir) };
+}
+
+export interface PullCreateInput {
+  dir: string;
+  title: string;
+  head: string;
+  base: string;
+  body?: string;
+  draft?: boolean;
+  reviewers?: string[];
+}
+
+/** Reviewer assignment on create isn't part of the GitLab/Bitbucket adapters'
+ *  core subset (see their own doc comments) — `reviewers` is silently
+ *  ignored for those two providers. */
+export async function pullCreate(input: PullCreateInput): Promise<IssueResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return createGitHubPull(input);
+  const pullInput = { title: input.title, head: input.head, base: input.base, body: input.body, draft: input.draft };
+  const res = repoInfo.provider === "gitlab" ? await createGitLabPull(repoInfo, pullInput) : await createBitbucketPull(repoInfo, pullInput);
+  if (!res.ok) return res;
+  return { ...res, item: withSourcePath(res.item, input.dir) };
+}
+
+export async function pullDiff(input: { dir: string; number: number }): Promise<DiffResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return getGitHubPullDiff(input);
+  return repoInfo.provider === "gitlab" ? getGitLabPullDiff(repoInfo, input.number) : getBitbucketPullDiff(repoInfo, input.number);
+}
+
+export interface ListCommentsInput {
+  dir: string;
+  number: number;
+  /** Which endpoint to query on GitLab/Bitbucket — their comment APIs split
+   *  merge-requests/pull-requests from issues, unlike GitHub's single
+   *  `/issues/:number/comments` endpoint that serves both (so GitHub ignores
+   *  this field entirely). The UI passes the open item's kind through the
+   *  `/github/comments` route (GitHubDialog.tsx → api.ts → server.ts); the
+   *  `"pulls"` default below is only a defensive fallback for callers that
+   *  omit it. */
+  kind?: GitHubItemKind;
+}
+
+export async function listComments(input: ListCommentsInput): Promise<CommentsResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return listGitHubComments(input);
+  const kind = input.kind ?? "pulls";
+  return repoInfo.provider === "gitlab"
+    ? listGitLabComments(repoInfo, input.number, kind)
+    : listBitbucketComments(repoInfo, input.number, kind);
+}
+
+export interface CreateCommentInput extends ListCommentsInput {
+  body: string;
+}
+
+export async function createComment(input: CreateCommentInput): Promise<CommentResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return createGitHubComment(input);
+  const kind = input.kind ?? "pulls";
+  return repoInfo.provider === "gitlab"
+    ? createGitLabComment(repoInfo, input.number, kind, input.body)
+    : createBitbucketComment(repoInfo, input.number, kind, input.body);
+}
+
+export interface PullLineCommentInput {
+  dir: string;
+  number: number;
+  body: string;
+  path: string;
+  line: number;
+  side: "LEFT" | "RIGHT";
+}
+
+export async function pullLineComment(input: PullLineCommentInput): Promise<LineCommentResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return createGitHubPullLineComment(input);
+  const lineInput = { path: input.path, line: input.line, side: input.side, body: input.body };
+  return repoInfo.provider === "gitlab"
+    ? createGitLabPullLineComment(repoInfo, input.number, lineInput)
+    : createBitbucketPullLineComment(repoInfo, input.number, lineInput);
+}
+
+export async function pullReviewComments(input: { dir: string; number: number }): Promise<ReviewCommentsResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return listGitHubPullReviewComments(input);
+  return repoInfo.provider === "gitlab"
+    ? listGitLabPullReviewComments(repoInfo, input.number)
+    : listBitbucketPullReviewComments(repoInfo, input.number);
+}
+
+export async function pullLineCommentReply(
+  input: { dir: string; number: number; commentId: number; body: string },
+): Promise<LineCommentResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return replyGitHubPullLineComment(input);
+  return repoInfo.provider === "gitlab"
+    ? replyGitLabLineComment(repoInfo, input.number, input.commentId, input.body)
+    : replyBitbucketLineComment(repoInfo, input.number, input.commentId, input.body);
+}
+
+export async function pullChecks(input: { dir: string; number: number }): Promise<ChecksResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return getGitHubPullChecks(input);
+  return repoInfo.provider === "gitlab" ? getGitLabPullChecks(repoInfo, input.number) : getBitbucketPullChecks(repoInfo, input.number);
+}
+
+export interface PullMergeInput {
+  dir: string;
+  number: number;
+  method: GitHubPullMergeMethod;
+  title?: string;
+  message?: string;
+}
+
+export async function pullMerge(input: PullMergeInput): Promise<MergeResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return mergeGitHubPull(input);
+  return repoInfo.provider === "gitlab"
+    ? mergeGitLabPull(repoInfo, input.number, input.method)
+    : mergeBitbucketPull(repoInfo, input.number, input.method);
+}
+
+export interface PullCloseInput {
+  dir: string;
+  number: number;
+  comment?: string;
+}
+
+/** GitHub's `closeGitHubPull` posts an optional trailing comment as part of
+ *  the same request; the GitLab/Bitbucket adapters' close functions don't
+ *  accept one (see their doc comments — "close" and "comment" are separate
+ *  concerns on those APIs), so the facade composes it here from the
+ *  adapters' own comment functions — same "close, then best-effort comment"
+ *  shape `closeGitHubPull` itself uses. */
+export async function pullClose(input: PullCloseInput): Promise<ActionResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return closeGitHubPull(input);
+
+  const res = repoInfo.provider === "gitlab" ? await closeGitLabPull(repoInfo, input.number) : await closeBitbucketPull(repoInfo, input.number);
+  if (!res.ok) return res;
+  const item = res.item ? withSourcePath(res.item, input.dir) : undefined;
+
+  const comment = input.comment?.trim();
+  if (!comment) return { ...res, ...(item ? { item } : {}) };
+
+  const commentRes = repoInfo.provider === "gitlab"
+    ? await createGitLabComment(repoInfo, input.number, "pulls", comment)
+    : await createBitbucketComment(repoInfo, input.number, "pulls", comment);
+  if (!commentRes.ok) {
+    return {
+      ok: true,
+      message: `${res.message ?? "Closed."} but the comment was not posted: ${commentRes.error}`,
+      commentPosted: false,
+      ...(item ? { item } : {}),
+    };
+  }
+  return {
+    ok: true,
+    message: `${res.message ?? "Closed."} Comment posted.`,
+    commentPosted: true,
+    ...(item ? { item } : {}),
+  };
+}
+
+/** Bitbucket has no API to move a declined pull request back to open — the
+ *  adapter (`reopenBitbucketPull`) always returns a friendly error, which is
+ *  passed through as-is. */
+export async function pullReopen(input: { dir: string; number: number }): Promise<IssueResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return reopenGitHubPull(input);
+  if (repoInfo.provider === "bitbucket") {
+    const res = await reopenBitbucketPull(repoInfo, input.number);
+    if (res.ok) return { ok: false, error: "Bitbucket returned an unexpected reopen response" };
+    return res;
+  }
+  const res = await reopenGitLabPull(repoInfo, input.number);
+  if (!res.ok) return res;
+  return { ...res, item: withSourcePath(res.item, input.dir) };
+}
+
+export interface PullReviewInput {
+  dir: string;
+  number: number;
+  event: GitHubPullReviewEvent;
+  body?: string;
+  comments?: { path: string; line: number; side: "LEFT" | "RIGHT"; body: string }[];
+}
+
+/** GitLab/Bitbucket reviews don't support a batch of inline comments attached
+ *  to one review call the way GitHub's "pending review" flow does —
+ *  `comments` is accepted here for interface parity with the shared route,
+ *  but silently ignored for those two providers; a caller wanting inline
+ *  comments on GitLab/Bitbucket posts them individually via `pullLineComment`
+ *  instead. */
+export async function pullReview(input: PullReviewInput): Promise<ActionResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return reviewGitHubPull(input);
+  return repoInfo.provider === "gitlab"
+    ? reviewGitLabPull(repoInfo, input.number, input.event, input.body)
+    : reviewBitbucketPull(repoInfo, input.number, input.event, input.body);
+}
+
+export interface IssueCreateInput {
+  dir: string;
+  title: string;
+  body?: string;
+  labels?: string[];
+  assignees?: string[];
+  milestone?: number | null;
+}
+
+/** `milestone` isn't part of the GitLab/Bitbucket adapters' create-issue
+ *  input (see their own interfaces) — silently dropped for those providers. */
+export async function issueCreate(input: IssueCreateInput): Promise<IssueResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return createGitHubIssue(input);
+  if (repoInfo.provider === "gitlab") {
+    const res = await createGitLabIssue(repoInfo, { title: input.title, body: input.body, labels: input.labels, assignees: input.assignees });
+    if (!res.ok) return res;
+    return { ...res, item: withSourcePath(res.item, input.dir) };
+  }
+  const res = await createBitbucketIssue(repoInfo, { title: input.title, body: input.body });
+  if (!res.ok) return res;
+  return { ...res, item: withSourcePath(res.item, input.dir) };
+}
+
+export interface IssueUpdateInput {
+  dir: string;
+  number: number;
+  kind?: GitHubItemKind;
+  title?: string;
+  body?: string;
+  state?: "open" | "closed";
+  labels?: string[];
+  assignees?: string[];
+  milestone?: number | null;
+}
+
+/** `milestone` isn't part of the GitLab/Bitbucket adapters' update-issue
+ *  input — silently dropped for those providers, same as `issueCreate`. */
+export async function issueUpdate(input: IssueUpdateInput): Promise<IssueResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return updateGitHubIssue(input);
+  if (repoInfo.provider === "gitlab") {
+    const res = await updateGitLabIssue(repoInfo, input.number, {
+      kind: input.kind,
+      title: input.title,
+      body: input.body,
+      state: input.state,
+      labels: input.labels,
+      assignees: input.assignees,
+    });
+    if (!res.ok) return res;
+    return { ...res, item: withSourcePath(res.item, input.dir) };
+  }
+  const res = await updateBitbucketIssue(repoInfo, input.number, { title: input.title, body: input.body, state: input.state });
+  if (!res.ok) return res;
+  return { ...res, item: withSourcePath(res.item, input.dir) };
+}
+
+export async function viewer(input: { dir: string }): Promise<ViewerResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return getGitHubViewer(input);
+  return repoInfo.provider === "gitlab" ? getGitLabViewer(repoInfo) : getBitbucketViewer(repoInfo);
+}
+
+/** Bitbucket has no labels concept at all (see `bitbucket.ts`'s module doc
+ *  comment) — rather than erroring, this returns a well-formed empty result
+ *  so the UI's labels filter/picker renders "no labels" instead of a broken
+ *  request. */
+export async function labels(input: { dir: string }): Promise<LabelsResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return listGitHubLabels(input);
+  if (repoInfo.provider === "gitlab") return listGitLabLabels(repoInfo);
+  return { ok: true, repo: `${repoInfo.owner}/${repoInfo.name}`, labels: [] };
+}

--- a/src/bun/git-provider.test.ts
+++ b/src/bun/git-provider.test.ts
@@ -1,0 +1,293 @@
+import { test, expect, beforeEach, afterEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  providerForHost,
+  providerRepoForDir,
+  gitlabToken,
+  bitbucketCreds,
+} from "./git-provider.ts";
+import { setGitHubToken, tokenForHost } from "./github-tokens.ts";
+import { makeAliasGitHubRepo } from "./github-test-util.ts";
+
+// git-provider.ts resolves AGETOR_DATA_DIR lazily at call time (via
+// github-tokens.ts's resolveDataDir), so — like github-tokens.test.ts — it's
+// safe to swap the env var per-test. Each test gets its own mkdtemp token
+// store dir; GITLAB_TOKEN/BITBUCKET_TOKEN/BITBUCKET_EMAIL are saved/cleared
+// before every test and restored after so no test can leak env into another,
+// and so gitlabToken/bitbucketCreds's env-fallback tier only ever sees what a
+// given test explicitly sets.
+const ORIGINAL_DATA_DIR = process.env.AGETOR_DATA_DIR;
+const ENV_KEYS = ["GITLAB_TOKEN", "BITBUCKET_TOKEN", "BITBUCKET_EMAIL"] as const;
+let dataDir: string;
+let savedEnv: Record<string, string | undefined> = {};
+let createdDirs: string[] = [];
+
+beforeEach(() => {
+  dataDir = mkdtempSync(path.join(tmpdir(), "agetor-git-provider-tokens-"));
+  process.env.AGETOR_DATA_DIR = dataDir;
+  savedEnv = {};
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  for (const dir of createdDirs) rmSync(dir, { recursive: true, force: true });
+  createdDirs = [];
+});
+
+afterAll(() => {
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.AGETOR_DATA_DIR;
+  else process.env.AGETOR_DATA_DIR = ORIGINAL_DATA_DIR;
+});
+
+// ---------------------------------------------------------------------------
+// providerForHost
+// ---------------------------------------------------------------------------
+
+test("providerForHost maps canonical provider hosts, null for anything else", () => {
+  expect(providerForHost("github.com")).toBe("github");
+  expect(providerForHost("gitlab.com")).toBe("gitlab");
+  expect(providerForHost("bitbucket.org")).toBe("bitbucket");
+  expect(providerForHost("git.internal.corp")).toBeNull();
+  expect(providerForHost("")).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// providerRepoForDir
+// ---------------------------------------------------------------------------
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+}
+
+/** A throwaway git repo with the given named remotes (added in the given
+ *  order — `providerRepoForDir` is expected to always try `origin` first
+ *  regardless of add/listing order, which some of the tests below rely on). */
+async function makeRepoWithRemotes(remotes: { name: string; url: string }[]): Promise<string> {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-git-provider-repo-"));
+  createdDirs.push(dir);
+  await git(["init", "-b", "main"], dir);
+  for (const r of remotes) {
+    await git(["remote", "add", r.name, r.url], dir);
+  }
+  return dir;
+}
+
+test("providerRepoForDir resolves a GitLab ssh-alias remote, keeping the raw alias as remoteHost", async () => {
+  const dir = await makeRepoWithRemotes([{ name: "origin", url: "git@gitlab-work.io:acme/app.git" }]);
+  expect(await providerRepoForDir(dir)).toEqual({
+    provider: "gitlab",
+    host: "gitlab.com",
+    remoteHost: "gitlab-work.io",
+    owner: "acme",
+    name: "app",
+  });
+});
+
+test("providerRepoForDir resolves a plain Bitbucket https remote", async () => {
+  const dir = await makeRepoWithRemotes([{ name: "origin", url: "https://bitbucket.org/acme/app.git" }]);
+  expect(await providerRepoForDir(dir)).toEqual({
+    provider: "bitbucket",
+    host: "bitbucket.org",
+    remoteHost: "bitbucket.org",
+    owner: "acme",
+    name: "app",
+  });
+});
+
+test("providerRepoForDir resolves a GitHub ssh-alias remote", async () => {
+  const dir = await makeAliasGitHubRepo("acme", "widgets", "github-alias.com");
+  createdDirs.push(dir);
+  expect(await providerRepoForDir(dir)).toEqual({
+    provider: "github",
+    host: "github.com",
+    remoteHost: "github-alias.com",
+    owner: "acme",
+    name: "widgets",
+  });
+});
+
+test("providerRepoForDir returns null for an unsupported git host", async () => {
+  const dir = await makeRepoWithRemotes([{ name: "origin", url: "git@example.com:x/y.git" }]);
+  expect(await providerRepoForDir(dir)).toBeNull();
+});
+
+test("providerRepoForDir returns null for a directory that isn't a git repo", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-git-provider-nonrepo-"));
+  createdDirs.push(dir);
+  expect(await providerRepoForDir(dir)).toBeNull();
+});
+
+test("providerRepoForDir returns null for a nonexistent directory", async () => {
+  expect(await providerRepoForDir(path.join(tmpdir(), "agetor-does-not-exist-xyz"))).toBeNull();
+});
+
+test("providerRepoForDir prefers origin over other remotes regardless of add order", async () => {
+  // "aaa-upstream" sorts before "origin" alphabetically, so without the
+  // explicit origin-first reordering this would resolve to the gitlab
+  // upstream remote instead of the github origin.
+  const dir = await makeRepoWithRemotes([
+    { name: "aaa-upstream", url: "git@gitlab-work.io:acme/other.git" },
+    { name: "origin", url: "https://github.com/acme/main.git" },
+  ]);
+  expect(await providerRepoForDir(dir)).toEqual({
+    provider: "github",
+    host: "github.com",
+    remoteHost: "github.com",
+    owner: "acme",
+    name: "main",
+  });
+});
+
+test("providerRepoForDir falls through to another remote when origin is unsupported", async () => {
+  const dir = await makeRepoWithRemotes([
+    { name: "origin", url: "git@example.com:x/y.git" },
+    { name: "upstream", url: "https://gitlab.com/acme/app.git" },
+  ]);
+  expect(await providerRepoForDir(dir)).toEqual({
+    provider: "gitlab",
+    host: "gitlab.com",
+    remoteHost: "gitlab.com",
+    owner: "acme",
+    name: "app",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gitlabToken
+// ---------------------------------------------------------------------------
+
+test("gitlabToken: a stored exact alias-host token wins", async () => {
+  setGitHubToken("gitlab-work.io", "alias-tok");
+  setGitHubToken("gitlab.com", "default-tok");
+  expect(await gitlabToken("gitlab-work.io")).toBe("alias-tok");
+});
+
+test("gitlabToken: falls back to a stored gitlab.com entry when there's no exact match", async () => {
+  setGitHubToken("gitlab.com", "default-tok");
+  expect(await gitlabToken("gitlab-other-alias.io")).toBe("default-tok");
+});
+
+test("gitlabToken: a stored github.com entry is not leaked to a gitlab host (cross-provider leak guard)", async () => {
+  setGitHubToken("github.com", "gh-tok");
+  const originalPath = process.env.PATH;
+  process.env.PATH = "/nonexistent-agetor-test-path";
+  try {
+    expect(await gitlabToken("gitlab-work.io")).toBeNull();
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});
+
+test("gitlabToken: GITLAB_TOKEN env is used when the store is empty", async () => {
+  process.env.GITLAB_TOKEN = "env-tok";
+  expect(await gitlabToken("gitlab-work.io")).toBe("env-tok");
+});
+
+test("gitlabToken: a stored token beats GITLAB_TOKEN env", async () => {
+  setGitHubToken("gitlab-work.io", "stored-tok");
+  process.env.GITLAB_TOKEN = "env-tok";
+  expect(await gitlabToken("gitlab-work.io")).toBe("stored-tok");
+});
+
+test("gitlabToken: null when nothing is stored, no env, and the glab CLI is unavailable", async () => {
+  // Force the `glab` shellout to fail deterministically (ENOENT) rather than
+  // depending on whether the real `glab` CLI happens to be installed and
+  // authenticated on the machine running this test.
+  const originalPath = process.env.PATH;
+  process.env.PATH = "/nonexistent-agetor-test-path";
+  try {
+    expect(await gitlabToken("gitlab-work.io")).toBeNull();
+    expect(await gitlabToken(null)).toBeNull();
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// bitbucketCreds
+// ---------------------------------------------------------------------------
+
+test("bitbucketCreds: stored 'email:token' resolves to basic auth", async () => {
+  setGitHubToken("bitbucket-work.org", "user@example.com:abc123");
+  expect(await bitbucketCreds("bitbucket-work.org")).toEqual({
+    kind: "basic",
+    username: "user@example.com",
+    password: "abc123",
+  });
+});
+
+test("bitbucketCreds: a stored bare token (no colon) resolves to bearer auth", async () => {
+  setGitHubToken("bitbucket-work.org", "plain-bearer-token");
+  expect(await bitbucketCreds("bitbucket-work.org")).toEqual({ kind: "bearer", token: "plain-bearer-token" });
+});
+
+test("bitbucketCreds: a colon inside the secret splits on the FIRST colon only", async () => {
+  setGitHubToken("bitbucket-work.org", "user@example.com:abc:123:xyz");
+  expect(await bitbucketCreds("bitbucket-work.org")).toEqual({
+    kind: "basic",
+    username: "user@example.com",
+    password: "abc:123:xyz",
+  });
+});
+
+test("bitbucketCreds: BITBUCKET_TOKEN + BITBUCKET_EMAIL env combo yields basic auth", async () => {
+  process.env.BITBUCKET_TOKEN = "tok-no-colon";
+  process.env.BITBUCKET_EMAIL = "me@example.com";
+  expect(await bitbucketCreds("bitbucket-work.org")).toEqual({
+    kind: "basic",
+    username: "me@example.com",
+    password: "tok-no-colon",
+  });
+});
+
+test("bitbucketCreds: BITBUCKET_TOKEN containing a colon is parsed as basic auth even without BITBUCKET_EMAIL", async () => {
+  process.env.BITBUCKET_TOKEN = "env@example.com:env-tok";
+  expect(await bitbucketCreds(null)).toEqual({
+    kind: "basic",
+    username: "env@example.com",
+    password: "env-tok",
+  });
+});
+
+test("bitbucketCreds: BITBUCKET_TOKEN alone (no email, no colon) yields bearer auth", async () => {
+  process.env.BITBUCKET_TOKEN = "bare-env-token";
+  expect(await bitbucketCreds(null)).toEqual({ kind: "bearer", token: "bare-env-token" });
+});
+
+test("bitbucketCreds: falls back to a stored bitbucket.org entry when there's no exact remoteHost match", async () => {
+  setGitHubToken("bitbucket.org", "fallback-tok");
+  expect(await bitbucketCreds("some-other-alias.org")).toEqual({ kind: "bearer", token: "fallback-tok" });
+});
+
+test("bitbucketCreds: a stored github.com entry is not leaked to a bitbucket host (cross-provider leak guard)", async () => {
+  setGitHubToken("github.com", "gh-tok");
+  expect(await bitbucketCreds("bitbucket-work.org")).toBeNull();
+});
+
+test("bitbucketCreds: null when nothing is stored and no env is set", async () => {
+  expect(await bitbucketCreds("bitbucket-work.org")).toBeNull();
+  expect(await bitbucketCreds(null)).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// tokenForHost (github-tokens.ts) — regression guard for existing github
+// callers, since git-provider.ts's gitlabToken/bitbucketCreds share this same
+// resolution primitive with a non-default fallbackHost.
+// ---------------------------------------------------------------------------
+
+test("tokenForHost: default fallbackHost is still github.com", () => {
+  setGitHubToken("github.com", "gh-default-tok");
+  expect(tokenForHost("some-unrelated-host.example.com")).toBe("gh-default-tok");
+  expect(tokenForHost(null)).toBe("gh-default-tok");
+});

--- a/src/bun/git-provider.ts
+++ b/src/bun/git-provider.ts
@@ -1,0 +1,149 @@
+import { existsSync } from "node:fs";
+import type { GitProvider, ProviderRepoInfo } from "../shared/types.ts";
+import { canonicalGitHost, parseGitRemote, run } from "./github.ts";
+import { tokenForHost } from "./github-tokens.ts";
+
+/**
+ * Multi-provider git-forge detection + auth resolution
+ * (docs/plans/multi-provider-git-modal.md, docs/plans/github-multi-identity-tokens.md).
+ *
+ * This module is the provider-agnostic counterpart to `repoForDir`/`githubToken`
+ * in `github.ts`: it resolves *which* provider (GitHub/GitLab/Bitbucket) a
+ * project directory's git remote points at, and how to authenticate against
+ * it, without hard-gating to `github.com` the way `parseGitHubRemote` does.
+ *
+ * Raw-host-is-identity convention: a user pins per-identity SSH keys via
+ * `~/.ssh/config` host aliases (`git@gitlab-work.io:group/app.git`), so the
+ * host in a remote URL is often not the provider's real hostname.
+ * `canonicalGitHost` (github.ts) maps any such alias to the provider's cloud
+ * hostname (`gitlab.com`, `bitbucket.org`, …) for API-base-URL purposes, but
+ * the RAW pre-canonicalization host is what identifies this specific
+ * account/workspace — that's the key the token store (`github-tokens.ts`) is
+ * keyed by, and it's already host-keyed with zero schema change needed to
+ * hold gitlab/bitbucket alias hosts alongside github ones.
+ *
+ * Leaf module: does not import `db.ts` or `server.ts`. May import from
+ * `github-tokens.ts`, `../shared/types.ts`, and `github.ts` (only the
+ * provider-agnostic exports: `parseGitRemote`, `canonicalGitHost`, `run`).
+ */
+
+const GITLAB_FETCH_TIMEOUT_MS = 5_000;
+
+/** Map a canonical provider host (as produced by `canonicalGitHost`) to the
+ *  `GitProvider` it identifies, or null when it's none of the three supported
+ *  cloud forges (self-hosted GitLab/Bitbucket Server, or an unrelated host —
+ *  both out of scope per the plan). */
+export function providerForHost(canonicalHost: string): GitProvider | null {
+  switch (canonicalHost) {
+    case "github.com":
+      return "github";
+    case "gitlab.com":
+      return "gitlab";
+    case "bitbucket.org":
+      return "bitbucket";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolve the provider + repo identity for a project directory by walking its
+ * git remotes, mirroring `repoForDir`'s iteration order (`origin` first, then
+ * the rest in whatever order `git remote` lists them; first parseable +
+ * supported-provider remote wins). Returns null when the dir isn't a git repo,
+ * has no remotes, or its remotes all resolve to an unsupported host.
+ */
+export async function providerRepoForDir(dir: string): Promise<ProviderRepoInfo | null> {
+  if (!existsSync(dir)) return null;
+  const remotes = await run(["git", "remote"], dir);
+  if (!remotes.ok) return null;
+  const names = remotes.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+  const ordered = ["origin", ...names.filter((n) => n !== "origin")];
+  for (const name of ordered) {
+    const url = await run(["git", "remote", "get-url", name], dir);
+    if (!url.ok) continue;
+    const parsed = parseGitRemote(url.stdout);
+    if (!parsed) continue;
+    const provider = providerForHost(parsed.host);
+    if (!provider) continue;
+    return {
+      provider,
+      host: parsed.host,
+      remoteHost: parsed.rawHost,
+      owner: parsed.owner,
+      name: parsed.name,
+    };
+  }
+  return null;
+}
+
+/**
+ * Resolve the token to authenticate a GitLab request with, for a repo whose
+ * raw remote host is `remoteHost` (null when there's no repo in scope).
+ * Resolution order mirrors `githubToken` in github.ts:
+ *   1. A stored token for `remoteHost` (the raw-host-keyed store in
+ *      `github-tokens.ts` — works for a gitlab alias host as-is, no schema
+ *      change; falls back to a `gitlab.com`-labeled entry the same way
+ *      `tokenForHost` falls back to `github.com` for GitHub).
+ *   2. `GITLAB_TOKEN` env.
+ *   3. Best-effort `glab config get token --host gitlab.com` shellout
+ *      (5s timeout; any failure — missing binary, non-zero exit, timeout —
+ *      swallowed to null, same as `githubToken`'s `gh auth token` fallback).
+ */
+export async function gitlabToken(remoteHost: string | null): Promise<string | null> {
+  const stored = tokenForHost(remoteHost, "gitlab.com");
+  if (stored) return stored;
+  const envToken = process.env.GITLAB_TOKEN;
+  if (envToken) return envToken;
+  const glab = await run(["glab", "config", "get", "token", "--host", "gitlab.com"], undefined, GITLAB_FETCH_TIMEOUT_MS);
+  return glab.ok && glab.stdout ? glab.stdout : null;
+}
+
+/**
+ * Bitbucket Cloud credential shapes. Bitbucket's REST API accepts either:
+ *  - Basic auth: account email + API token (the current recommended method —
+ *    app passwords were retired 2026-06-09).
+ *  - Bearer auth: a workspace or repository access token.
+ * The caller (the Bitbucket adapter, T3) picks the `Authorization` header
+ * shape from which variant `bitbucketCreds` resolves.
+ */
+export type BitbucketCreds =
+  | { kind: "basic"; username: string; password: string }
+  | { kind: "bearer"; token: string };
+
+/**
+ * Resolve Bitbucket Cloud credentials for a repo whose raw remote host is
+ * `remoteHost` (null when there's no repo in scope). Resolution order:
+ *   1. A stored credential string for `remoteHost` (the raw-host-keyed store
+ *      in `github-tokens.ts`, falling back to a `bitbucket.org`-labeled
+ *      entry the same way `tokenForHost` falls back to `github.com`).
+ *   2. `BITBUCKET_TOKEN` env (+ optional `BITBUCKET_EMAIL`).
+ *
+ * Convention for turning a single credential string into a typed credential:
+ * a value containing `:` splits on the FIRST `:` into `email:api_token` and
+ * is treated as Basic auth (the colon can't appear in an email's local part
+ * before the `@`, so splitting on the first `:` is unambiguous even if the
+ * API token itself happens to contain `:`). A value with no `:` is treated as
+ * a Bearer token (a workspace/repo access token). When `BITBUCKET_EMAIL` is
+ * set and `BITBUCKET_TOKEN` has no `:`, the two are combined into Basic auth
+ * (`email:token`) rather than requiring the caller to pre-join them.
+ */
+export async function bitbucketCreds(remoteHost: string | null): Promise<BitbucketCreds | null> {
+  const stored = tokenForHost(remoteHost, "bitbucket.org");
+  if (stored) return parseBitbucketCredential(stored);
+  const envToken = process.env.BITBUCKET_TOKEN;
+  if (envToken) {
+    const email = process.env.BITBUCKET_EMAIL;
+    if (email && !envToken.includes(":")) {
+      return { kind: "basic", username: email, password: envToken };
+    }
+    return parseBitbucketCredential(envToken);
+  }
+  return null;
+}
+
+function parseBitbucketCredential(raw: string): BitbucketCreds {
+  const idx = raw.indexOf(":");
+  if (idx === -1) return { kind: "bearer", token: raw };
+  return { kind: "basic", username: raw.slice(0, idx), password: raw.slice(idx + 1) };
+}

--- a/src/bun/github-tokens.ts
+++ b/src/bun/github-tokens.ts
@@ -143,18 +143,26 @@ export function deleteGitHubToken(host: string): boolean {
 
 /**
  * Resolve a stored token for `host`, implementing only steps 1–2 of the
- * full resolution order (exact host match, then the `github.com` entry as
- * default) — env var and `gh auth token` fallback live in github.ts, which
- * calls this as its first step. `host` is expected pre-lowercased by the
- * caller's parsing, but is normalized again here defensively.
+ * full resolution order (exact host match, then the provider's canonical-host
+ * entry as default) — env var and CLI fallback live in the callers. `host` is
+ * expected pre-lowercased by the caller's parsing, but is normalized again
+ * here defensively.
+ *
+ * Cross-provider callers (`gitlabToken`/`bitbucketCreds` in
+ * `src/bun/git-provider.ts`) also call this as their first resolution step,
+ * since the store is host-keyed and needs no schema change to hold gitlab/
+ * bitbucket alias hosts alongside github ones. They pass their own provider's
+ * canonical host (`gitlab.com` / `bitbucket.org`) as `fallbackHost` so a
+ * no-exact-match lookup never leaks a GitHub token to another provider's API
+ * — it falls through to null and lets the caller's env/CLI steps run instead.
  */
-export function tokenForHost(host: string | null): string | null {
+export function tokenForHost(host: string | null, fallbackHost: string = "github.com"): string | null {
   const tokens = readTokensFile();
   if (host !== null) {
     const normalized = normalizeHost(host);
     const exact = tokens.find((t) => t.host === normalized);
     if (exact) return exact.token;
   }
-  const fallback = tokens.find((t) => t.host === "github.com");
+  const fallback = tokens.find((t) => t.host === fallbackHost);
   return fallback ? fallback.token : null;
 }

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -65,7 +65,7 @@ import type {
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
 import { tokenForHost } from "./github-tokens.ts";
 
-interface CommandResult {
+export interface CommandResult {
   ok: boolean;
   stdout: string;
   stderr: string;
@@ -79,7 +79,7 @@ interface PipedProcess {
   kill: () => void;
 }
 
-interface GitHubRepo {
+export interface GitHubRepo {
   owner: string;
   name: string;
   /** Raw (pre-canonicalization) remote host — e.g. `github-work.com` for an
@@ -526,7 +526,7 @@ const GITHUB_DIFF_BODY_CAP_BYTES = 8_000_000;
  *  unrecognized/absent value locks without a reason instead of erroring. */
 const ISSUE_LOCK_REASONS = new Set(["off-topic", "too heated", "resolved", "spam"]);
 
-async function run(cmd: string[], cwd?: string, timeoutMs = 10_000): Promise<CommandResult> {
+export async function run(cmd: string[], cwd?: string, timeoutMs = 10_000): Promise<CommandResult> {
   let proc: PipedProcess;
   try {
     proc = Bun.spawn(cmd, {
@@ -565,7 +565,7 @@ async function run(cmd: string[], cwd?: string, timeoutMs = 10_000): Promise<Com
  *  SSH keys via `~/.ssh/config` host aliases (`github-work.com`, `bitbucket-x.org`,
  *  …), so the host in a remote URL is often not the provider's real hostname.
  *  Any host containing the provider's name resolves to that provider. */
-function canonicalGitHost(host: string): string {
+export function canonicalGitHost(host: string): string {
   const lower = host.toLowerCase();
   if (lower.includes("github")) return "github.com";
   if (lower.includes("gitlab")) return "gitlab.com";
@@ -579,7 +579,7 @@ function canonicalGitHost(host: string): string {
  *  (the ssh alias itself, when one is in play) — callers that need to route a
  *  per-identity token use `rawHost`, not `host`. Returns null for local paths
  *  and anything unrecognized. */
-function parseGitRemote(raw: string): { host: string; rawHost: string; owner: string; name: string } | null {
+export function parseGitRemote(raw: string): { host: string; rawHost: string; owner: string; name: string } | null {
   const remote = raw.trim();
   if (!remote) return null;
 
@@ -817,7 +817,7 @@ export const __githubInternals = {
   privateRepoHint,
 };
 
-async function repoForDir(dir: string): Promise<GitHubRepo | null> {
+export async function repoForDir(dir: string): Promise<GitHubRepo | null> {
   if (!existsSync(dir)) return null;
   const remotes = await run(["git", "remote"], dir);
   if (!remotes.ok) return null;
@@ -853,7 +853,7 @@ export async function remoteHostsForDirs(dirs: string[]): Promise<string[]> {
  *  env, (3) `gh auth token`. `host` is a required parameter (not optional) so
  *  every call site has to thread it through explicitly rather than silently
  *  falling back to the single-identity env/gh behavior this replaces. */
-async function githubToken(host: string | null): Promise<string | null> {
+export async function githubToken(host: string | null): Promise<string | null> {
   const stored = tokenForHost(host);
   if (stored) return stored;
   const envToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;

--- a/src/bun/gitlab-network.test.ts
+++ b/src/bun/gitlab-network.test.ts
@@ -1,0 +1,706 @@
+// Network-level tests for gitlab.ts (TT2, docs/plans/multi-provider-git-modal.md),
+// exercising the real request/response path (URL, headers, body, pagination,
+// error mapping) via the fetch-mock harness reused from github-test-util.ts.
+// Complements gitlab.test.ts, which unit-tests the pure helpers in isolation.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { mockGitLabFetch, sampleRepo } from "./gitlab-test-util.ts";
+import {
+  closeGitLabPull,
+  createGitLabComment,
+  createGitLabIssue,
+  createGitLabPull,
+  createGitLabPullLineComment,
+  getGitLabPullChecks,
+  getGitLabPullDefaults,
+  getGitLabPullDiff,
+  getGitLabViewer,
+  listGitLabComments,
+  listGitLabItems,
+  listGitLabLabels,
+  mergeGitLabPull,
+  replyGitLabLineComment,
+  reopenGitLabPull,
+  reviewGitLabPull,
+  updateGitLabIssue,
+} from "./gitlab.ts";
+
+const REPO = sampleRepo();
+
+// gitlab.ts resolves its token via github-tokens.ts's raw-host-keyed store
+// first, falling back to GITLAB_TOKEN env (see git-provider.ts's
+// `gitlabToken`) — an AGETOR_DATA_DIR pointed at an empty mkdtemp dir keeps
+// the store empty so every test below deterministically falls through to the
+// env var instead of shelling out to `glab` or picking up a real credential.
+const ORIGINAL_DATA_DIR = process.env.AGETOR_DATA_DIR;
+const ORIGINAL_GITLAB_TOKEN = process.env.GITLAB_TOKEN;
+let dataDir: string;
+
+beforeAll(() => {
+  dataDir = mkdtempSync(path.join(tmpdir(), "agetor-gitlab-net-"));
+  process.env.AGETOR_DATA_DIR = dataDir;
+  process.env.GITLAB_TOKEN = "test-token";
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.AGETOR_DATA_DIR;
+  else process.env.AGETOR_DATA_DIR = ORIGINAL_DATA_DIR;
+  if (ORIGINAL_GITLAB_TOKEN === undefined) delete process.env.GITLAB_TOKEN;
+  else process.env.GITLAB_TOKEN = ORIGINAL_GITLAB_TOKEN;
+});
+
+// ---------------------------------------------------------------------------
+// listGitLabItems
+// ---------------------------------------------------------------------------
+
+test("listGitLabItems hits /api/v4/projects/acme%2Fapp/merge_requests with per_page/page/order_by/sort and the PRIVATE-TOKEN header", async () => {
+  const mock = mockGitLabFetch([
+    { match: "/api/v4/projects/acme%2Fapp/merge_requests", json: [] },
+  ]);
+  try {
+    const res = await listGitLabItems(REPO, { kind: "pulls", state: "open", page: 2, sort: "created", direction: "asc" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(mock.calls).toHaveLength(1);
+    const call = mock.calls[0]!;
+    expect(call.url).toContain("/api/v4/projects/acme%2Fapp/merge_requests");
+    const q = new URL(call.url).searchParams;
+    expect(q.get("per_page")).toBe("30");
+    expect(q.get("page")).toBe("2");
+    expect(q.get("order_by")).toBe("created_at");
+    expect(q.get("sort")).toBe("asc");
+    expect(call.headers["private-token"]).toBe("test-token");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listGitLabItems sets `state` for open and closed(issues), but omits it entirely for state:\"all\"", async () => {
+  const openMock = mockGitLabFetch([{ match: "merge_requests", json: [] }]);
+  try {
+    await listGitLabItems(REPO, { kind: "pulls", state: "open" });
+    expect(new URL(openMock.calls[0]!.url).searchParams.get("state")).toBe("opened");
+  } finally {
+    openMock.restore();
+  }
+
+  const closedIssuesMock = mockGitLabFetch([{ match: "issues", json: [] }]);
+  try {
+    await listGitLabItems(REPO, { kind: "issues", state: "closed" });
+    expect(new URL(closedIssuesMock.calls[0]!.url).searchParams.get("state")).toBe("closed");
+  } finally {
+    closedIssuesMock.restore();
+  }
+
+  // "all" is a regression-guard: GitLab's issues list endpoint doesn't
+  // document `state=all` the way the MR list does, so "all" is expressed by
+  // omitting the `state` param entirely on both endpoints.
+  const allMock = mockGitLabFetch([{ match: "merge_requests", json: [] }]);
+  try {
+    await listGitLabItems(REPO, { kind: "pulls", state: "all" });
+    expect(new URL(allMock.calls[0]!.url).searchParams.has("state")).toBe(false);
+  } finally {
+    allMock.restore();
+  }
+});
+
+test("listGitLabItems joins labels with a comma and sets assignee_username", async () => {
+  const mock = mockGitLabFetch([{ match: "merge_requests", json: [] }]);
+  try {
+    await listGitLabItems(REPO, { kind: "pulls", state: "open", labels: ["bug", "p1"], assignee: "bob" });
+    const q = new URL(mock.calls[0]!.url).searchParams;
+    expect(q.get("labels")).toBe("bug,p1");
+    expect(q.get("assignee_username")).toBe("bob");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listGitLabItems scope precedence: createdByMe beats assignedToMe beats reviewRequested", async () => {
+  const mock = mockGitLabFetch([{ match: "merge_requests", json: [] }]);
+  try {
+    await listGitLabItems(REPO, { kind: "pulls", state: "open", createdByMe: true, assignedToMe: true, reviewRequested: true });
+    expect(new URL(mock.calls[0]!.url).searchParams.get("scope")).toBe("created_by_me");
+  } finally {
+    mock.restore();
+  }
+
+  const mock2 = mockGitLabFetch([{ match: "merge_requests", json: [] }]);
+  try {
+    await listGitLabItems(REPO, { kind: "pulls", state: "open", assignedToMe: true, reviewRequested: true });
+    expect(new URL(mock2.calls[0]!.url).searchParams.get("scope")).toBe("assigned_to_me");
+  } finally {
+    mock2.restore();
+  }
+
+  const mock3 = mockGitLabFetch([{ match: "merge_requests", json: [] }]);
+  try {
+    await listGitLabItems(REPO, { kind: "pulls", state: "open", reviewRequested: true });
+    expect(new URL(mock3.calls[0]!.url).searchParams.get("scope")).toBe("reviews_for_me");
+  } finally {
+    mock3.restore();
+  }
+});
+
+test("listGitLabItems ignores reviewRequested for issues (no reviewer concept there)", async () => {
+  const mock = mockGitLabFetch([{ match: "issues", json: [] }]);
+  try {
+    await listGitLabItems(REPO, { kind: "issues", state: "open", reviewRequested: true });
+    expect(new URL(mock.calls[0]!.url).searchParams.has("scope")).toBe(false);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listGitLabItems closed pulls fan out to two requests (closed, then merged), merged + sorted, hasMore false", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: /state=closed/,
+      json: [{ iid: 1, title: "closed one", state: "closed", web_url: "https://x/1", updated_at: "2026-01-01T00:00:00Z" }],
+    },
+    {
+      match: /state=merged/,
+      json: [{ iid: 2, title: "merged one", state: "merged", web_url: "https://x/2", updated_at: "2026-01-05T00:00:00Z" }],
+    },
+  ]);
+  try {
+    const res = await listGitLabItems(REPO, { kind: "pulls", state: "closed" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(mock.calls).toHaveLength(2);
+    expect(res.items.map((i) => i.number)).toEqual([2, 1]); // newest updatedAt first
+    expect(res.hasMore).toBe(false);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listGitLabItems closed issues is a single direct state=closed request (no fan-out)", async () => {
+  const mock = mockGitLabFetch([
+    { match: /state=closed/, json: [{ iid: 1, title: "t", state: "closed", web_url: "https://x/1" }] },
+  ]);
+  try {
+    const res = await listGitLabItems(REPO, { kind: "issues", state: "closed" });
+    expect(res.ok).toBe(true);
+    expect(mock.calls).toHaveLength(1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listGitLabItems (single-state) hasMore is true when x-next-page/Link indicate another page", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: "merge_requests",
+      json: [{ iid: 1, title: "t", state: "opened", web_url: "https://x/1" }],
+      headers: { "x-next-page": "2" },
+    },
+  ]);
+  try {
+    const res = await listGitLabItems(REPO, { kind: "pulls", state: "open" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.hasMore).toBe(true);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listGitLabItems (single-state) hasMore is false with no next-page signal", async () => {
+  const mock = mockGitLabFetch([
+    { match: "merge_requests", json: [{ iid: 1, title: "t", state: "opened", web_url: "https://x/1" }] },
+  ]);
+  try {
+    const res = await listGitLabItems(REPO, { kind: "pulls", state: "open" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.hasMore).toBe(false);
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// getGitLabPullDefaults / createGitLabPull
+// ---------------------------------------------------------------------------
+
+test("getGitLabPullDefaults reads default_branch from the project GET, head is empty (facade fills it in)", async () => {
+  const mock = mockGitLabFetch([
+    { match: "/api/v4/projects/acme%2Fapp", json: { default_branch: "main" } },
+  ]);
+  try {
+    const res = await getGitLabPullDefaults(REPO);
+    expect(res).toEqual({ ok: true, repo: "acme/app", head: "", base: "main" });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("createGitLabPull POSTs source_branch/target_branch and prefixes the title on draft", async () => {
+  const mock = mockGitLabFetch([
+    {
+      method: "POST",
+      match: "/merge_requests",
+      json: { iid: 3, title: "Draft: Add x", state: "opened", web_url: "https://x/3" },
+    },
+  ]);
+  try {
+    const res = await createGitLabPull(REPO, { title: "Add x", body: "desc", base: "main", head: "feature", draft: true });
+    expect(res.ok).toBe(true);
+    const call = mock.calls[0]!;
+    const body = JSON.parse(call.body!);
+    expect(body).toMatchObject({ title: "Draft: Add x", description: "desc", source_branch: "feature", target_branch: "main" });
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// getGitLabPullDiff
+// ---------------------------------------------------------------------------
+
+test("getGitLabPullDiff hits raw_diffs and parses the plain-text unified diff into files", async () => {
+  const diff = [
+    "diff --git a/foo.ts b/foo.ts",
+    "index 111..222 100644",
+    "--- a/foo.ts",
+    "+++ b/foo.ts",
+    "@@ -1,1 +1,1 @@",
+    "-old",
+    "+new",
+    "",
+  ].join("\n");
+  const mock = mockGitLabFetch([{ match: "/merge_requests/5/raw_diffs", text: diff }]);
+  try {
+    const res = await getGitLabPullDiff(REPO, 5);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.files.map((f) => f.path)).toEqual(["foo.ts"]);
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// listGitLabComments — system note exclusion
+// ---------------------------------------------------------------------------
+
+test("listGitLabComments excludes system notes (label/assignee automation) from the result", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: "/merge_requests/1/notes",
+      json: [
+        { id: 1, body: "added label ~bug", system: true, author: { username: "bot" } },
+        { id: 2, body: "a real comment", system: false, author: { username: "alice" } },
+      ],
+    },
+  ]);
+  try {
+    const res = await listGitLabComments(REPO, 1, "pulls");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.comments.map((c) => c.id)).toEqual([2]);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("createGitLabComment POSTs {body} to the notes endpoint", async () => {
+  const mock = mockGitLabFetch([
+    { method: "POST", match: "/issues/7/notes", json: { id: 9, body: "hi", author: null } },
+  ]);
+  try {
+    const res = await createGitLabComment(REPO, 7, "issues", "hi");
+    expect(res.ok).toBe(true);
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ body: "hi" });
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// createGitLabPullLineComment
+// ---------------------------------------------------------------------------
+
+test("createGitLabPullLineComment fetches versions first, then POSTs discussions with a full position for RIGHT (new_line)", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: "/merge_requests/5/versions",
+      json: [{ base_commit_sha: "base1", start_commit_sha: "start1", head_commit_sha: "head1" }],
+    },
+    {
+      method: "POST",
+      match: "/merge_requests/5/discussions",
+      json: { notes: [{ id: 1, body: "nit", position: { new_path: "a.ts", old_path: "a.ts", new_line: 10 } }] },
+    },
+  ]);
+  try {
+    const res = await createGitLabPullLineComment(REPO, 5, { path: "a.ts", line: 10, side: "RIGHT", body: "nit" });
+    expect(res.ok).toBe(true);
+    expect(mock.calls).toHaveLength(2);
+    expect(mock.calls[0]!.url).toContain("/merge_requests/5/versions");
+    const postBody = JSON.parse(mock.calls[1]!.body!);
+    expect(postBody.position).toMatchObject({
+      base_sha: "base1",
+      start_sha: "start1",
+      head_sha: "head1",
+      new_line: 10,
+    });
+    expect(postBody.position.old_line).toBeUndefined();
+  } finally {
+    mock.restore();
+  }
+});
+
+test("createGitLabPullLineComment posts old_line (not new_line) for side:LEFT", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: "/versions",
+      json: [{ base_commit_sha: "b", start_commit_sha: "s", head_commit_sha: "h" }],
+    },
+    {
+      method: "POST",
+      match: "/discussions",
+      json: { notes: [{ id: 1, body: "nit", position: { old_path: "a.ts", old_line: 4 } }] },
+    },
+  ]);
+  try {
+    const res = await createGitLabPullLineComment(REPO, 5, { path: "a.ts", line: 4, side: "LEFT", body: "nit" });
+    expect(res.ok).toBe(true);
+    const postBody = JSON.parse(mock.calls[1]!.body!);
+    expect(postBody.position.old_line).toBe(4);
+    expect(postBody.position.new_line).toBeUndefined();
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// replyGitLabLineComment
+// ---------------------------------------------------------------------------
+
+test("replyGitLabLineComment resolves the discussion id via GET discussions, then POSTs to /discussions/:id/notes", async () => {
+  const mock = mockGitLabFetch([
+    {
+      method: "GET",
+      match: "/merge_requests/5/discussions",
+      json: [{ id: "disc-abc", notes: [{ id: 42 }] }],
+    },
+    {
+      method: "POST",
+      match: "/discussions/disc-abc/notes",
+      json: { id: 43, body: "reply", position: { new_path: "a.ts", new_line: 1 } },
+    },
+  ]);
+  try {
+    const res = await replyGitLabLineComment(REPO, 5, 42, "reply");
+    expect(res.ok).toBe(true);
+    expect(mock.calls).toHaveLength(2);
+    expect(mock.calls[1]!.url).toContain("/discussions/disc-abc/notes");
+    expect(JSON.parse(mock.calls[1]!.body!)).toEqual({ body: "reply" });
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// getGitLabPullChecks
+// ---------------------------------------------------------------------------
+
+test("getGitLabPullChecks GETs the MR for sha/head_pipeline, then commit statuses, mapped to GitHubCheckRun[]", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: "/merge_requests/9",
+      json: { sha: "deadbeef", head_pipeline: { id: 1, status: "running", web_url: "https://ci/1" } },
+    },
+    {
+      match: "/repository/commits/deadbeef/statuses",
+      json: [{ id: 5, name: "build", status: "success", target_url: "https://ci/5" }],
+    },
+  ]);
+  try {
+    const res = await getGitLabPullChecks(REPO, 9);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.sha).toBe("deadbeef");
+    expect(res.checkRuns).toEqual([
+      { id: 5, name: "build", status: "completed", conclusion: "success", htmlUrl: "https://ci/5", startedAt: null, completedAt: null },
+    ]);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullChecks falls back to a synthetic pipeline entry when there are no per-job statuses", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: "/merge_requests/9",
+      json: { sha: "deadbeef", head_pipeline: { id: 77, status: "running", web_url: "https://ci/pipe/77" } },
+    },
+    { match: "/statuses", json: [] },
+  ]);
+  try {
+    const res = await getGitLabPullChecks(REPO, 9);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.checkRuns).toEqual([
+      { id: 77, name: "pipeline #77", status: "in_progress", conclusion: null, htmlUrl: "https://ci/pipe/77", startedAt: null, completedAt: null },
+    ]);
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// mergeGitLabPull
+// ---------------------------------------------------------------------------
+
+test("mergeGitLabPull PUTs /merge with squash:true for method:squash", async () => {
+  const mock = mockGitLabFetch([
+    { method: "PUT", match: "/merge_requests/5/merge", json: { state: "merged", merge_commit_sha: "abc" } },
+  ]);
+  try {
+    const res = await mergeGitLabPull(REPO, 5, "squash");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.merged).toBe(true);
+    expect(res.sha).toBe("abc");
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ squash: true });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("mergeGitLabPull PUTs /merge with squash:false for method:merge", async () => {
+  const mock = mockGitLabFetch([
+    { method: "PUT", match: "/merge_requests/5/merge", json: { state: "merged" } },
+  ]);
+  try {
+    await mergeGitLabPull(REPO, 5, "merge");
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ squash: false });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("mergeGitLabPull returns a friendly error on 405 (not mergeable)", async () => {
+  const mock = mockGitLabFetch([
+    { method: "PUT", match: "/merge", status: 405, json: { message: "405 Method Not Allowed" } },
+  ]);
+  try {
+    const res = await mergeGitLabPull(REPO, 5, "merge");
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toContain("cannot be merged right now");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("mergeGitLabPull rejects the \"rebase\" method defensively (GitLab has no rebase merge strategy)", async () => {
+  const res = await mergeGitLabPull(REPO, 5, "rebase");
+  expect(res.ok).toBe(false);
+});
+
+// ---------------------------------------------------------------------------
+// close / reopen
+// ---------------------------------------------------------------------------
+
+test("closeGitLabPull PUTs state_event:close", async () => {
+  const mock = mockGitLabFetch([
+    { method: "PUT", match: "/merge_requests/5", json: { iid: 5, title: "t", state: "closed", web_url: "https://x/5" } },
+  ]);
+  try {
+    const res = await closeGitLabPull(REPO, 5);
+    expect(res.ok).toBe(true);
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ state_event: "close" });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("reopenGitLabPull PUTs state_event:reopen", async () => {
+  const mock = mockGitLabFetch([
+    { method: "PUT", match: "/merge_requests/5", json: { iid: 5, title: "t", state: "opened", web_url: "https://x/5" } },
+  ]);
+  try {
+    const res = await reopenGitLabPull(REPO, 5);
+    expect(res.ok).toBe(true);
+    expect(JSON.parse(mock.calls[0]!.body!)).toEqual({ state_event: "reopen" });
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// reviewGitLabPull
+// ---------------------------------------------------------------------------
+
+test("reviewGitLabPull APPROVE POSTs /approve, and posts a note when a body is given", async () => {
+  const mock = mockGitLabFetch([
+    { method: "POST", match: "/merge_requests/5/approve", json: {} },
+    { method: "POST", match: "/merge_requests/5/notes", json: { id: 1, body: "lgtm" } },
+  ]);
+  try {
+    const res = await reviewGitLabPull(REPO, 5, "APPROVE", "lgtm");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.commentPosted).toBe(true);
+    expect(mock.calls).toHaveLength(2);
+    expect(mock.calls[0]!.url).toContain("/approve");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("reviewGitLabPull APPROVE with no body only hits /approve", async () => {
+  const mock = mockGitLabFetch([{ method: "POST", match: "/approve", json: {} }]);
+  try {
+    const res = await reviewGitLabPull(REPO, 5, "APPROVE");
+    expect(res.ok).toBe(true);
+    expect(mock.calls).toHaveLength(1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("reviewGitLabPull REQUEST_CHANGES fails fast with no network call — not supported on GitLab", async () => {
+  const mock = mockGitLabFetch([]); // any fetch call would throw (unmatched route)
+  try {
+    const res = await reviewGitLabPull(REPO, 5, "REQUEST_CHANGES", "please fix");
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error.toLowerCase()).toContain("not supported on gitlab");
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// create / update issue
+// ---------------------------------------------------------------------------
+
+test("createGitLabIssue POSTs title/description and joins labels with a comma", async () => {
+  const mock = mockGitLabFetch([
+    { method: "POST", match: "/issues", json: { iid: 1, title: "Bug", state: "opened", web_url: "https://x/1" } },
+  ]);
+  try {
+    const res = await createGitLabIssue(REPO, { title: "Bug", body: "repro steps", labels: ["bug", "p1"] });
+    expect(res.ok).toBe(true);
+    const body = JSON.parse(mock.calls[0]!.body!);
+    expect(body).toMatchObject({ title: "Bug", description: "repro steps", labels: "bug,p1" });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("updateGitLabIssue PUTs state_event:close for state:closed and joins labels", async () => {
+  const mock = mockGitLabFetch([
+    { method: "PUT", match: "/issues/3", json: { iid: 3, title: "Bug", state: "closed", web_url: "https://x/3" } },
+  ]);
+  try {
+    const res = await updateGitLabIssue(REPO, 3, { state: "closed", labels: ["bug", "p1"] });
+    expect(res.ok).toBe(true);
+    const body = JSON.parse(mock.calls[0]!.body!);
+    expect(body).toMatchObject({ state_event: "close", labels: "bug,p1" });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("updateGitLabIssue PUTs state_event:reopen for state:open, targeting merge_requests when kind:pulls", async () => {
+  const mock = mockGitLabFetch([
+    { method: "PUT", match: "/merge_requests/3", json: { iid: 3, title: "t", state: "opened", web_url: "https://x/3" } },
+  ]);
+  try {
+    const res = await updateGitLabIssue(REPO, 3, { kind: "pulls", state: "open" });
+    expect(res.ok).toBe(true);
+    const body = JSON.parse(mock.calls[0]!.body!);
+    expect(body).toMatchObject({ state_event: "reopen" });
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// getGitLabViewer / listGitLabLabels
+// ---------------------------------------------------------------------------
+
+test("getGitLabViewer hits /user and maps username to login", async () => {
+  const mock = mockGitLabFetch([{ match: "/api/v4/user", json: { username: "octocat" } }]);
+  try {
+    const res = await getGitLabViewer(REPO);
+    expect(res).toEqual({ ok: true, login: "octocat" });
+    expect(mock.calls[0]!.headers["private-token"]).toBe("test-token");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("listGitLabLabels follows pagination and sorts alphabetically", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: /labels\?per_page=100$/,
+      json: [{ name: "wip", color: "#00ff00", description: "" }],
+      headers: { "x-next-page": "2" },
+    },
+    {
+      match: /page=2/,
+      json: [{ name: "bug", color: "#ff0000", description: "a defect" }],
+    },
+  ]);
+  try {
+    const res = await listGitLabLabels(REPO);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.labels.map((l) => l.name)).toEqual(["bug", "wip"]);
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 401 auth hint
+// ---------------------------------------------------------------------------
+
+test("a 401 response surfaces the authHint wording pointing at Settings", async () => {
+  const mock = mockGitLabFetch([
+    { match: "/user", status: 401, json: { message: "401 Unauthorized" } },
+  ]);
+  try {
+    const res = await getGitLabViewer(REPO);
+    // getGitLabViewer with a token present still calls the endpoint; on 401
+    // the authHint wraps the message with a pointer to Settings.
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toContain("Settings");
+    expect(res.error).toContain("GitLab tokens");
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Unmatched-route guard
+// ---------------------------------------------------------------------------
+
+test("mockGitLabFetch's unmatched-route guard surfaces as a fetch error — guards every test above against a silently-passing unexpected request", async () => {
+  // fetchGitLab (gitlab.ts) wraps every `fetch` call in a try/catch that turns
+  // a thrown error into `{ok:false,error:...}` rather than letting it reject —
+  // so an unmatched route in any test above would show up as a failed
+  // assertion on the *response shape*, not an uncaught rejection. This test
+  // pins that behavior down directly: a route table with no match for
+  // raw_diffs surfaces mockGitLabFetch's own "no route for" message.
+  const mock = mockGitLabFetch([{ match: "/api/v4/user", json: { username: "x" } }]);
+  try {
+    const res = await getGitLabPullDiff(REPO, 1);
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toContain("no route for");
+  } finally {
+    mock.restore();
+  }
+});

--- a/src/bun/gitlab-test-util.ts
+++ b/src/bun/gitlab-test-util.ts
@@ -1,0 +1,127 @@
+// Test-only helpers for exercising the network functions in `gitlab.ts` (TT2,
+// docs/plans/multi-provider-git-modal.md).
+//
+// Unlike github.ts's exported functions (which resolve `{owner,name}` from a
+// real git remote via `repoForDir`), every gitlab.ts function already takes a
+// resolved `ProviderRepoInfo` — the adapter is a leaf module that never shells
+// out to git itself (see gitlab.ts's module doc comment). So there is no
+// git-repo-on-disk fixture to build here, only a plain object factory.
+//
+// `mockGitHubFetch` (github-test-util.ts) is host-agnostic — it just matches
+// on the request URL/method against a route table over `globalThis.fetch` —
+// so it is reused directly here rather than re-implemented.
+import type { ProviderRepoInfo } from "../shared/types.ts";
+
+export { mockGitHubFetch as mockGitLabFetch } from "./github-test-util.ts";
+export type { MockRoute, FetchCall, FetchMock } from "./github-test-util.ts";
+
+/** A resolved GitLab repo identity, as `providerRepoForDir` (git-provider.ts)
+ *  would produce for a project whose remote points at gitlab.com (or an
+ *  ssh-alias host that canonicalizes to it). */
+export function sampleRepo(overrides: Partial<ProviderRepoInfo> = {}): ProviderRepoInfo {
+  return {
+    provider: "gitlab",
+    host: "gitlab.com",
+    remoteHost: "gitlab.com",
+    owner: "acme",
+    name: "app",
+    ...overrides,
+  };
+}
+
+/** Same as `sampleRepo`, but with `remoteHost` set to a raw ssh-alias host
+ *  (e.g. `git@gitlab-work.io:acme/app.git`) — exercises the multi-identity
+ *  token-routing path the same way `makeAliasGitHubRepo` does for GitHub. */
+export function sampleAliasRepo(aliasHost = "gitlab-work.io", overrides: Partial<ProviderRepoInfo> = {}): ProviderRepoInfo {
+  return sampleRepo({ remoteHost: aliasHost, ...overrides });
+}
+
+/** A minimal-but-valid GitLab merge-request JSON object (REST v4 shape), as
+ *  returned by the merge_requests list/detail/create/update endpoints.
+ *  Overridable per-field for individual tests. */
+export function gitlabMergeRequest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    iid: 1,
+    title: "Add feature",
+    state: "opened",
+    draft: false,
+    web_url: "https://gitlab.com/acme/app/-/merge_requests/1",
+    author: { username: "alice", avatar_url: null, web_url: null },
+    assignees: [],
+    milestone: null,
+    description: "body text",
+    labels: ["bug"],
+    user_notes_count: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: null,
+    merged_at: null,
+    discussion_locked: false,
+    sha: "deadbeef",
+    ...overrides,
+  };
+}
+
+/** A minimal-but-valid GitLab issue JSON object (REST v4 shape). */
+export function gitlabIssue(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    iid: 5,
+    title: "Bug report",
+    state: "opened",
+    web_url: "https://gitlab.com/acme/app/-/issues/5",
+    author: { username: "alice", avatar_url: null, web_url: null },
+    assignees: [],
+    milestone: null,
+    description: "steps to reproduce",
+    labels: [],
+    user_notes_count: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: null,
+    discussion_locked: false,
+    ...overrides,
+  };
+}
+
+/** A minimal-but-valid GitLab note (`/notes`) JSON object. `system: false`
+ *  by default — set `system: true` to exercise the system-note exclusion in
+ *  `listGitLabComments`. */
+export function gitlabNote(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 100,
+    body: "a comment",
+    author: { username: "bob", avatar_url: null, web_url: null },
+    created_at: "2026-01-01T01:00:00Z",
+    updated_at: "2026-01-01T01:00:00Z",
+    system: false,
+    ...overrides,
+  };
+}
+
+/** A minimal-but-valid GitLab discussion (`/discussions`) JSON object,
+ *  wrapping one or more notes. Pass `notes` overrides to shape the inline
+ *  `DiffNote` payload used for line-comment tests. */
+export function gitlabDiscussion(notes: Record<string, unknown>[], overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "disc-1",
+    individual_note: false,
+    notes,
+    ...overrides,
+  };
+}
+
+/** A minimal-but-valid `DiffNote` — a note carrying an inline `position`. */
+export function gitlabDiffNote(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ...gitlabNote(),
+    type: "DiffNote",
+    position: {
+      position_type: "text",
+      new_path: "src/foo.ts",
+      old_path: "src/foo.ts",
+      new_line: 10,
+      old_line: null,
+    },
+    ...overrides,
+  };
+}

--- a/src/bun/gitlab.test.ts
+++ b/src/bun/gitlab.test.ts
@@ -1,0 +1,510 @@
+// Pure-helper tests for gitlab.ts (TT2, docs/plans/multi-provider-git-modal.md),
+// exercised entirely through `__gitlabInternals` — no network, no fetch mock.
+// Complements gitlab-network.test.ts, which exercises the exported async
+// functions end-to-end (URL/header/pagination shapes) via a mocked fetch.
+import { expect, test } from "bun:test";
+import { __gitlabInternals } from "./gitlab.ts";
+import { sampleRepo } from "./gitlab-test-util.ts";
+
+const {
+  encodeProjectId,
+  apiError,
+  authHint,
+  pageLinks,
+  resolveNextPage,
+  normalizeUser,
+  normalizeLabels,
+  normalizeItem,
+  noteHtmlUrl,
+  normalizeComment,
+  normalizeLineComment,
+  mapGitLabStatus,
+  normalizeCommitStatusAsCheckRun,
+  normalizePipelineAsCheckRun,
+  normalizeRepoLabel,
+  sortItems,
+  gitlabStateParams,
+} = __gitlabInternals;
+
+const REPO = sampleRepo();
+
+// ---------------------------------------------------------------------------
+// encodeProjectId
+// ---------------------------------------------------------------------------
+
+test("encodeProjectId percent-encodes the owner/name slash", () => {
+  expect(encodeProjectId("acme", "my-app")).toBe("acme%2Fmy-app");
+  expect(encodeProjectId("o", "r")).toBe("o%2Fr");
+});
+
+// ---------------------------------------------------------------------------
+// normalizeItem — merge request + issue normalization
+// ---------------------------------------------------------------------------
+
+test("normalizeItem maps an opened MR onto GitHubListItem", () => {
+  const item = normalizeItem("pulls", {
+    iid: 42,
+    title: "Add feature",
+    state: "opened",
+    draft: true,
+    web_url: "https://gitlab.com/acme/app/-/merge_requests/42",
+    author: { username: "alice", avatar_url: "https://x/a.png", web_url: "https://gitlab.com/alice" },
+    assignees: [{ username: "bob", avatar_url: null, web_url: null }],
+    milestone: { iid: 3, title: "v1" },
+    description: "the body",
+    labels: ["bug", "p1"],
+    user_notes_count: 4,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: null,
+    merged_at: null,
+    discussion_locked: false,
+  });
+  expect(item).toEqual({
+    kind: "pulls",
+    number: 42,
+    title: "Add feature",
+    state: "open",
+    draft: true,
+    htmlUrl: "https://gitlab.com/acme/app/-/merge_requests/42",
+    author: { login: "alice", avatarUrl: "https://x/a.png", htmlUrl: "https://gitlab.com/alice" },
+    assignees: [{ login: "bob", avatarUrl: null, htmlUrl: null }],
+    milestone: { number: 3, title: "v1" },
+    body: "the body",
+    labels: [{ name: "bug", color: null }, { name: "p1", color: null }],
+    comments: 4,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-02T00:00:00Z",
+    closedAt: null,
+    mergedAt: null,
+    locked: false,
+    sourcePath: null,
+  });
+});
+
+test("normalizeItem folds a merged MR into state:closed with mergedAt set", () => {
+  const item = normalizeItem("pulls", {
+    iid: 1,
+    title: "t",
+    state: "merged",
+    web_url: "https://x",
+    merged_at: "2026-02-01T00:00:00Z",
+  });
+  expect(item).toMatchObject({ state: "closed", mergedAt: "2026-02-01T00:00:00Z" });
+});
+
+test("normalizeItem treats a closed (declined) MR as state:closed with no mergedAt", () => {
+  const item = normalizeItem("pulls", {
+    iid: 1,
+    title: "t",
+    state: "closed",
+    web_url: "https://x",
+    closed_at: "2026-02-01T00:00:00Z",
+  });
+  expect(item).toMatchObject({ state: "closed", mergedAt: null, closedAt: "2026-02-01T00:00:00Z" });
+});
+
+test("normalizeItem treats a transient locked MR as still open", () => {
+  const item = normalizeItem("pulls", { iid: 1, title: "t", state: "locked", web_url: "https://x" });
+  expect(item).toMatchObject({ state: "open" });
+});
+
+test("normalizeItem rejects an unrecognized state", () => {
+  expect(normalizeItem("pulls", { iid: 1, title: "t", state: "weird", web_url: "https://x" })).toBeNull();
+});
+
+test("normalizeItem rejects missing iid/title/web_url", () => {
+  expect(normalizeItem("pulls", { title: "t", state: "opened", web_url: "https://x" })).toBeNull();
+  expect(normalizeItem("pulls", { iid: 1, state: "opened", web_url: "https://x" })).toBeNull();
+  expect(normalizeItem("pulls", { iid: 1, title: "t", state: "opened" })).toBeNull();
+  expect(normalizeItem("pulls", null)).toBeNull();
+});
+
+test("normalizeItem maps an issue the same way as an MR (no merged/draft semantics)", () => {
+  const item = normalizeItem("issues", {
+    iid: 7,
+    title: "Bug report",
+    state: "opened",
+    web_url: "https://gitlab.com/acme/app/-/issues/7",
+    description: "steps",
+    labels: [],
+    user_notes_count: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  });
+  expect(item).toMatchObject({ kind: "issues", number: 7, state: "open", draft: false, body: "steps" });
+});
+
+test("normalizeItem defaults draft to false, body to \"\" and labels to [] when absent", () => {
+  const item = normalizeItem("pulls", { iid: 1, title: "t", state: "opened", web_url: "https://x" });
+  expect(item).toMatchObject({ draft: false, body: "", labels: [], comments: 0, createdAt: "", updatedAt: "" });
+});
+
+test("normalizeItem passes sourcePath through (facade stitches it on)", () => {
+  const item = normalizeItem("pulls", { iid: 1, title: "t", state: "opened", web_url: "https://x" }, "/some/dir");
+  expect(item).toMatchObject({ sourcePath: "/some/dir" });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeUser / normalizeLabels
+// ---------------------------------------------------------------------------
+
+test("normalizeUser maps username→login and web_url→htmlUrl, rejects usernameless shapes", () => {
+  expect(normalizeUser({ username: "alice", avatar_url: "u", web_url: "w" })).toEqual({
+    login: "alice",
+    avatarUrl: "u",
+    htmlUrl: "w",
+  });
+  expect(normalizeUser({ username: "bob" })).toEqual({ login: "bob", avatarUrl: null, htmlUrl: null });
+  expect(normalizeUser({ avatar_url: "u" })).toBeNull();
+  expect(normalizeUser(null)).toBeNull();
+});
+
+test("normalizeLabels accepts a plain string array, synthesizing null color", () => {
+  expect(normalizeLabels(["bug", "p1"])).toEqual([
+    { name: "bug", color: null },
+    { name: "p1", color: null },
+  ]);
+});
+
+test("normalizeLabels also accepts details-shaped {name,color} objects defensively", () => {
+  expect(normalizeLabels([{ name: "bug", color: "#f00" }])).toEqual([{ name: "bug", color: "#f00" }]);
+  expect(normalizeLabels([{ name: "wip" }])).toEqual([{ name: "wip", color: null }]);
+});
+
+test("normalizeLabels drops malformed entries and non-array input", () => {
+  expect(normalizeLabels([1, null, { color: "x" }, "ok"])).toEqual([{ name: "ok", color: null }]);
+  expect(normalizeLabels(null)).toEqual([]);
+  expect(normalizeLabels(undefined)).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// noteHtmlUrl / normalizeComment
+// ---------------------------------------------------------------------------
+
+test("noteHtmlUrl anchors into the merge_requests page for pulls, issues page for issues", () => {
+  expect(noteHtmlUrl(REPO, "pulls", 42, 100)).toBe(
+    "https://gitlab.com/acme/app/-/merge_requests/42#note_100",
+  );
+  expect(noteHtmlUrl(REPO, "issues", 7, 55)).toBe("https://gitlab.com/acme/app/-/issues/7#note_55");
+});
+
+test("normalizeComment maps a note onto GitHubComment, deriving htmlUrl from noteHtmlUrl", () => {
+  const comment = normalizeComment(
+    { id: 100, body: "hi", author: { username: "bob" }, created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:00:00Z" },
+    REPO,
+    "pulls",
+    42,
+  );
+  expect(comment).toEqual({
+    id: 100,
+    body: "hi",
+    htmlUrl: "https://gitlab.com/acme/app/-/merge_requests/42#note_100",
+    author: { login: "bob", avatarUrl: null, htmlUrl: null },
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  });
+});
+
+test("normalizeComment rejects a non-numeric/missing id", () => {
+  expect(normalizeComment({ body: "hi" }, REPO, "pulls", 1)).toBeNull();
+  expect(normalizeComment(null, REPO, "pulls", 1)).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// normalizeLineComment — DiffNote position mapping
+// ---------------------------------------------------------------------------
+
+test("normalizeLineComment maps new_line to side:RIGHT", () => {
+  const c = normalizeLineComment(
+    {
+      id: 1,
+      body: "nit",
+      author: { username: "alice" },
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      position: { new_path: "src/foo.ts", old_path: "src/foo.ts", new_line: 12, old_line: null },
+    },
+    REPO,
+    42,
+  );
+  expect(c).toMatchObject({ side: "RIGHT", line: 12, path: "src/foo.ts" });
+});
+
+test("normalizeLineComment maps old_line to side:LEFT when new_line is absent", () => {
+  const c = normalizeLineComment(
+    {
+      id: 2,
+      body: "nit",
+      position: { new_path: null, old_path: "src/foo.ts", new_line: null, old_line: 9 },
+    },
+    REPO,
+    42,
+  );
+  expect(c).toMatchObject({ side: "LEFT", line: 9, path: "src/foo.ts" });
+});
+
+test("normalizeLineComment prefers new_line over old_line when both are present", () => {
+  const c = normalizeLineComment(
+    { id: 3, body: "x", position: { new_path: "a.ts", old_path: "a.ts", new_line: 5, old_line: 4 } },
+    REPO,
+    1,
+  );
+  expect(c).toMatchObject({ side: "RIGHT", line: 5 });
+});
+
+test("normalizeLineComment falls back to old_path when new_path is absent (delete-side comment)", () => {
+  const c = normalizeLineComment(
+    { id: 4, body: "x", position: { new_path: null, old_path: "deleted.ts", new_line: null, old_line: 3 } },
+    REPO,
+    1,
+  );
+  expect(c).toMatchObject({ path: "deleted.ts", side: "LEFT", line: 3 });
+});
+
+test("normalizeLineComment rejects a note with neither new_line nor old_line", () => {
+  expect(
+    normalizeLineComment({ id: 5, body: "x", position: { new_path: "a.ts", old_path: "a.ts" } }, REPO, 1),
+  ).toBeNull();
+});
+
+test("normalizeLineComment rejects missing position or missing id", () => {
+  expect(normalizeLineComment({ id: 6, body: "x" }, REPO, 1)).toBeNull();
+  expect(normalizeLineComment({ body: "x", position: { new_line: 1 } }, REPO, 1)).toBeNull();
+  expect(normalizeLineComment(null, REPO, 1)).toBeNull();
+});
+
+test("normalizeLineComment rejects a position with no resolvable path", () => {
+  expect(
+    normalizeLineComment({ id: 7, body: "x", position: { new_line: 1 } }, REPO, 1),
+  ).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// mapGitLabStatus — pipeline/commit-status vocabulary → GitHub check-run vocab
+// ---------------------------------------------------------------------------
+
+test("mapGitLabStatus maps non-terminal states with null conclusion", () => {
+  expect(mapGitLabStatus("pending")).toEqual({ status: "queued", conclusion: null });
+  expect(mapGitLabStatus("running")).toEqual({ status: "in_progress", conclusion: null });
+});
+
+test("mapGitLabStatus maps terminal states to completed + a conclusion", () => {
+  expect(mapGitLabStatus("success")).toEqual({ status: "completed", conclusion: "success" });
+  expect(mapGitLabStatus("failed")).toEqual({ status: "completed", conclusion: "failure" });
+  expect(mapGitLabStatus("canceled")).toEqual({ status: "completed", conclusion: "cancelled" });
+  expect(mapGitLabStatus("skipped")).toEqual({ status: "completed", conclusion: "skipped" });
+});
+
+test("mapGitLabStatus rides an unrecognized status through verbatim rather than coercing to unknown", () => {
+  expect(mapGitLabStatus("manual")).toEqual({ status: "manual", conclusion: null });
+});
+
+test("mapGitLabStatus defaults an empty status string to \"unknown\"", () => {
+  expect(mapGitLabStatus("")).toEqual({ status: "unknown", conclusion: null });
+});
+
+test("normalizeCommitStatusAsCheckRun maps a commit-status entry through mapGitLabStatus", () => {
+  const run = normalizeCommitStatusAsCheckRun({
+    id: 9,
+    name: "build",
+    status: "success",
+    target_url: "https://ci/9",
+    started_at: "2026-01-01T00:00:00Z",
+    finished_at: "2026-01-01T00:05:00Z",
+  });
+  expect(run).toEqual({
+    id: 9,
+    name: "build",
+    status: "completed",
+    conclusion: "success",
+    htmlUrl: "https://ci/9",
+    startedAt: "2026-01-01T00:00:00Z",
+    completedAt: "2026-01-01T00:05:00Z",
+  });
+});
+
+test("normalizeCommitStatusAsCheckRun rejects missing id/name", () => {
+  expect(normalizeCommitStatusAsCheckRun({ name: "build" })).toBeNull();
+  expect(normalizeCommitStatusAsCheckRun({ id: 1 })).toBeNull();
+  expect(normalizeCommitStatusAsCheckRun(null)).toBeNull();
+});
+
+test("normalizePipelineAsCheckRun synthesizes a \"pipeline #<id>\" entry", () => {
+  const run = normalizePipelineAsCheckRun({ id: 77, status: "running", web_url: "https://ci/pipe/77" });
+  expect(run).toEqual({
+    id: 77,
+    name: "pipeline #77",
+    status: "in_progress",
+    conclusion: null,
+    htmlUrl: "https://ci/pipe/77",
+    startedAt: null,
+    completedAt: null,
+  });
+});
+
+test("normalizePipelineAsCheckRun rejects a non-numeric id", () => {
+  expect(normalizePipelineAsCheckRun({ status: "running" })).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// normalizeRepoLabel
+// ---------------------------------------------------------------------------
+
+test("normalizeRepoLabel strips the leading # from GitLab's hex color", () => {
+  expect(normalizeRepoLabel({ name: "bug", color: "#d73a4a", description: "a defect" })).toEqual({
+    name: "bug",
+    color: "d73a4a",
+    description: "a defect",
+  });
+});
+
+test("normalizeRepoLabel defaults missing color/description and rejects nameless entries", () => {
+  expect(normalizeRepoLabel({ name: "wip" })).toEqual({ name: "wip", color: "", description: "" });
+  expect(normalizeRepoLabel({ color: "#fff" })).toBeNull();
+  expect(normalizeRepoLabel(null)).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// apiError / authHint
+// ---------------------------------------------------------------------------
+
+test("apiError prefers a string `message`, then joins an array `message`, then falls back to `error`", () => {
+  expect(apiError({ message: "nope" }, 400, "Bad Request")).toBe("nope");
+  expect(apiError({ message: ["title is required", "too short"] }, 400, "Bad Request")).toBe(
+    "title is required, too short",
+  );
+  expect(apiError({ error: "invalid_token" }, 401, "Unauthorized")).toBe("invalid_token");
+});
+
+test("apiError falls back to the HTTP status line for an unrecognized body shape", () => {
+  expect(apiError(null, 500, "Internal Server Error")).toBe("500 Internal Server Error");
+  expect(apiError({}, 404, "Not Found")).toBe("404 Not Found");
+  expect(apiError("plain text", 502, "Bad Gateway")).toBe("502 Bad Gateway");
+});
+
+test("authHint enriches both 401 and 404 with a Settings pointer", () => {
+  const msg401 = authHint(401, "Unauthorized", REPO, false);
+  expect(msg401).toContain("acme/app");
+  expect(msg401).toContain(REPO.remoteHost);
+  expect(msg401).toContain("Settings");
+
+  const msg404 = authHint(404, "Not Found", REPO, false);
+  expect(msg404).toContain("acme/app");
+  expect(msg404).toContain("Settings");
+});
+
+test("authHint mentions the configured token can't access it when hadToken is true", () => {
+  const msg = authHint(404, "Not Found", REPO, true);
+  expect(msg).toContain("cannot access it");
+});
+
+test("authHint passes non-401/404 statuses through unchanged", () => {
+  expect(authHint(500, "boom", REPO, false)).toBe("boom");
+  expect(authHint(403, "forbidden", REPO, true)).toBe("forbidden");
+});
+
+test("authHint falls back to gitlab.com when remoteHost is empty", () => {
+  const msg = authHint(404, "Not Found", { ...REPO, remoteHost: "" }, false);
+  expect(msg).toContain("gitlab.com");
+});
+
+// ---------------------------------------------------------------------------
+// pageLinks / resolveNextPage
+// ---------------------------------------------------------------------------
+
+test("pageLinks extracts the rel=\"next\" URL from a Link header", () => {
+  expect(pageLinks('<https://gitlab.com/api/v4/x?page=2>; rel="next"')).toBe(
+    "https://gitlab.com/api/v4/x?page=2",
+  );
+  expect(
+    pageLinks('<https://x/1>; rel="prev", <https://x/2>; rel="next", <https://x/3>; rel="last"'),
+  ).toBe("https://x/2");
+});
+
+test("pageLinks returns null when there's no next rel or the header is absent", () => {
+  expect(pageLinks(null)).toBeNull();
+  expect(pageLinks('<https://x/1>; rel="prev"')).toBeNull();
+  expect(pageLinks("")).toBeNull();
+});
+
+function fakeResponse(headers: Record<string, string>): Response {
+  return new Response(null, { headers });
+}
+
+test("resolveNextPage prefers the Link header over x-next-page", () => {
+  const res = fakeResponse({ link: '<https://x/next>; rel="next"', "x-next-page": "9" });
+  expect(resolveNextPage(res, "https://x/current?page=1")).toBe("https://x/next");
+});
+
+test("resolveNextPage falls back to x-next-page, setting it on the current URL", () => {
+  const res = fakeResponse({ "x-next-page": "3" });
+  expect(resolveNextPage(res, "https://gitlab.com/api/v4/x?page=2&per_page=30")).toBe(
+    "https://gitlab.com/api/v4/x?page=3&per_page=30",
+  );
+});
+
+test("resolveNextPage returns null when x-next-page is empty or missing (last page)", () => {
+  expect(resolveNextPage(fakeResponse({ "x-next-page": "" }), "https://x?page=1")).toBeNull();
+  expect(resolveNextPage(fakeResponse({}), "https://x?page=1")).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// sortItems
+// ---------------------------------------------------------------------------
+
+function itemWith(overrides: Record<string, unknown>): ReturnType<typeof normalizeItem> {
+  return normalizeItem("pulls", {
+    iid: 1,
+    title: "t",
+    state: "opened",
+    web_url: "https://x",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    user_notes_count: 0,
+    ...overrides,
+  });
+}
+
+test("sortItems sorts by updatedAt desc by default", () => {
+  const older = itemWith({ iid: 1, updated_at: "2026-01-01T00:00:00Z" })!;
+  const newer = itemWith({ iid: 2, updated_at: "2026-01-05T00:00:00Z" })!;
+  const items = [older, newer];
+  sortItems(items, undefined, "desc");
+  expect(items.map((i) => i.number)).toEqual([2, 1]);
+});
+
+test("sortItems sorts by createdAt when sort:\"created\"", () => {
+  const older = itemWith({ iid: 1, created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-09T00:00:00Z" })!;
+  const newer = itemWith({ iid: 2, created_at: "2026-01-05T00:00:00Z", updated_at: "2026-01-01T00:00:00Z" })!;
+  const items = [older, newer];
+  sortItems(items, "created", "asc");
+  expect(items.map((i) => i.number)).toEqual([1, 2]);
+});
+
+test("sortItems sorts by comment count when sort:\"comments\"", () => {
+  const few = itemWith({ iid: 1, user_notes_count: 1 })!;
+  const many = itemWith({ iid: 2, user_notes_count: 9 })!;
+  const items = [few, many];
+  sortItems(items, "comments", "desc");
+  expect(items.map((i) => i.number)).toEqual([2, 1]);
+});
+
+// ---------------------------------------------------------------------------
+// gitlabStateParams
+// ---------------------------------------------------------------------------
+
+test("gitlabStateParams maps open→[opened] for both pulls and issues", () => {
+  expect(gitlabStateParams("pulls", "open")).toEqual(["opened"]);
+  expect(gitlabStateParams("issues", "open")).toEqual(["opened"]);
+});
+
+test("gitlabStateParams maps all→[\"all\"] regardless of kind", () => {
+  expect(gitlabStateParams("pulls", "all")).toEqual(["all"]);
+  expect(gitlabStateParams("issues", "all")).toEqual(["all"]);
+});
+
+test("gitlabStateParams fans closed pulls out to [closed, merged], but issues stay [closed]", () => {
+  expect(gitlabStateParams("pulls", "closed")).toEqual(["closed", "merged"]);
+  expect(gitlabStateParams("issues", "closed")).toEqual(["closed"]);
+});

--- a/src/bun/gitlab.ts
+++ b/src/bun/gitlab.ts
@@ -1,0 +1,1149 @@
+import type {
+  GitHubCheckRun,
+  GitHubChecksResult,
+  GitHubComment,
+  GitHubCommentsResult,
+  GitHubItemKind,
+  GitHubItemState,
+  GitHubLabel,
+  GitHubLabelsResult,
+  GitHubListItem,
+  GitHubListResult,
+  GitHubMilestone,
+  GitHubPullDefaultsResult,
+  GitHubPullLineComment,
+  GitHubPullMergeMethod,
+  GitHubPullMergeResult,
+  GitHubPullReviewCommentsResult,
+  GitHubPullReviewEvent,
+  GitHubRepoLabel,
+  GitHubUser,
+  ProviderRepoInfo,
+  TaskDiff,
+} from "../shared/types.ts";
+import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
+import { gitlabToken } from "./git-provider.ts";
+
+/**
+ * GitLab Cloud (gitlab.com, REST API v4) adapter (T2,
+ * docs/plans/multi-provider-git-modal.md §4). Mirrors `src/bun/github.ts`'s
+ * conventions closely enough that the facade (`git-host.ts`, T4) can dispatch
+ * to either module transparently: same `{ok:true}&Result | {ok:false,error}`
+ * result-union style, a 30s AbortController fetch timeout, `user-agent:
+ * agetor`, and normalizers that produce the *exact same* shared `GitHub*`
+ * wire types the UI already renders — GitLab's MR/issue/note/discussion/
+ * pipeline JSON is mapped onto them rather than inventing GitLab-shaped types.
+ *
+ * Leaf module: does not import `db.ts`, `server.ts`, or `github.ts`. Every
+ * exported function takes an already-resolved `ProviderRepoInfo` (see
+ * `git-provider.ts`) — this adapter never shells out to `git` itself and
+ * never resolves a remote from a directory; that's the facade's job. One
+ * consequence: `ProviderRepoInfo` carries no working directory, so
+ * `GitHubListItem.sourcePath` is always normalized to `null` here — the
+ * facade is responsible for stitching `sourcePath = dir` onto every item it
+ * gets back, the same way `listGitHubItemsAcrossRepos` does for the GitHub
+ * path. Similarly `getGitLabPullDefaults`'s `head` can't be resolved without
+ * a working directory (see its doc comment).
+ */
+
+const GITLAB_API_BASE = "https://gitlab.com/api/v4";
+const GITLAB_FETCH_TIMEOUT_MS = 30_000;
+const GITLAB_DIFF_BODY_CAP_BYTES = 8_000_000;
+
+export interface GitLabError {
+  ok: false;
+  error: string;
+}
+
+type GitLabListResponse = ({ ok: true } & GitHubListResult) | GitLabError;
+type GitLabDiffResponse = ({ ok: true } & TaskDiff) | GitLabError;
+type GitLabPullDefaultsResponse = ({ ok: true } & GitHubPullDefaultsResult) | GitLabError;
+type GitLabIssueResponse = ({ ok: true; item: GitHubListItem; message?: string }) | GitLabError;
+type GitLabCommentsResponse = ({ ok: true } & GitHubCommentsResult) | GitLabError;
+type GitLabCommentResponse = ({ ok: true; comment: GitHubComment }) | GitLabError;
+type GitLabPullLineCommentResponse = ({ ok: true; comment: GitHubPullLineComment }) | GitLabError;
+type GitLabPullReviewCommentsResponse = ({ ok: true } & GitHubPullReviewCommentsResult) | GitLabError;
+type GitLabChecksResponse = ({ ok: true } & GitHubChecksResult) | GitLabError;
+type GitLabPullMergeResponse = GitHubPullMergeResult | GitLabError;
+type GitLabActionResponse = ({ ok: true; message?: string; item?: GitHubListItem; commentPosted?: boolean }) | GitLabError;
+type GitLabViewerResponse = ({ ok: true; login: string }) | GitLabError;
+type GitLabLabelsResponse = ({ ok: true } & GitHubLabelsResult) | GitLabError;
+
+function fetchErrorMessage(e: unknown): string {
+  if (e instanceof DOMException && e.name === "AbortError") return "GitLab request timed out";
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** `PRIVATE-TOKEN` (GitLab's own auth header, not `Authorization: Bearer`) when
+ *  a token is present; 30s abort; `user-agent: agetor` — same shape as
+ *  `fetchGitHub` in github.ts. `url` must be an absolute `https://gitlab.com/api/v4/...`
+ *  URL (every call site below builds one) so pagination helpers can re-derive
+ *  a next-page URL without having to know a base path convention. */
+async function fetchGitLab(
+  url: string,
+  token: string | null,
+  init?: { method?: string; body?: string; accept?: string },
+): Promise<Response | GitLabError> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GITLAB_FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      method: init?.method,
+      signal: controller.signal,
+      headers: {
+        accept: init?.accept ?? "application/json",
+        ...(init?.body ? { "content-type": "application/json" } : {}),
+        "user-agent": "agetor",
+        ...(token ? { "PRIVATE-TOKEN": token } : {}),
+      },
+      body: init?.body,
+    });
+  } catch (e) {
+    return { ok: false, error: fetchErrorMessage(e) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function encodeProjectId(owner: string, name: string): string {
+  return encodeURIComponent(`${owner}/${name}`);
+}
+
+/** GitLab's error bodies are inconsistent — sometimes `{message: string}`,
+ *  sometimes `{message: string[]}` (validation errors), sometimes
+ *  `{error: string}` (OAuth-flavored endpoints). Best-effort flatten; falls
+ *  back to the HTTP status line. Pure — unit-tested via `__gitlabInternals`. */
+function apiError(body: unknown, status: number, statusText: string): string {
+  if (body && typeof body === "object") {
+    const obj = body as Record<string, unknown>;
+    if (typeof obj.message === "string") return obj.message;
+    if (Array.isArray(obj.message)) return obj.message.map(String).join(", ");
+    if (typeof obj.error === "string") return obj.error;
+  }
+  return `${status} ${statusText}`;
+}
+
+/** Enriches a 401/404 with an actionable pointer to Settings, mirroring
+ *  github.ts's `privateRepoHint` wording — GitLab, like GitHub, answers 404
+ *  (not 403) for a private project the caller can't see, and plain 401 for no
+ *  credentials at all. Any other status is returned unchanged. Pure —
+ *  unit-tested via `__gitlabInternals`. */
+function authHint(status: number, message: string, repo: ProviderRepoInfo, hadToken: boolean): string {
+  if (status !== 401 && status !== 404) return message;
+  const host = repo.remoteHost || "gitlab.com";
+  const base = `${repo.owner}/${repo.name} was not found on GitLab — if the project is private, add a token for ${host} in Settings → GitLab tokens`;
+  return hadToken
+    ? `${base} (the configured token cannot access it — check it belongs to the right account)`
+    : base;
+}
+
+function errorFrom(res: Response, body: unknown, repo: ProviderRepoInfo, hadToken: boolean): string {
+  return authHint(res.status, apiError(body, res.status, res.statusText), repo, hadToken);
+}
+
+/** `link: rel="next"` header parser — identical to github.ts's `pageLinks`. */
+function pageLinks(link: string | null): string | null {
+  if (!link) return null;
+  for (const part of link.split(",")) {
+    const [urlPart, relPart] = part.split(";").map((s) => s.trim());
+    if (relPart === 'rel="next"') {
+      const m = /^<(.+)>$/.exec(urlPart ?? "");
+      return m?.[1] ?? null;
+    }
+  }
+  return null;
+}
+
+/** Resolves the next page's absolute URL from a GitLab list response: prefers
+ *  the `Link: rel="next"` header (present on every paginated v4 endpoint),
+ *  falling back to GitLab's own `x-next-page` header (present, but empty,
+ *  once the last page has been reached — an empty/missing value means no next
+ *  page). Pure given `res.headers`/`currentUrl` — unit-tested via
+ *  `__gitlabInternals`. */
+function resolveNextPage(res: Response, currentUrl: string): string | null {
+  const link = pageLinks(res.headers.get("link"));
+  if (link) return link;
+  const nextPage = res.headers.get("x-next-page");
+  if (nextPage === null || !nextPage.trim()) return null;
+  const url = new URL(currentUrl);
+  url.searchParams.set("page", nextPage.trim());
+  return url.toString();
+}
+
+function normalizeUser(raw: unknown): GitHubUser | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.username !== "string") return null;
+  return {
+    login: obj.username,
+    avatarUrl: typeof obj.avatar_url === "string" ? obj.avatar_url : null,
+    htmlUrl: typeof obj.web_url === "string" ? obj.web_url : null,
+  };
+}
+
+/** GitLab's MR/issue *list* endpoints return `labels` as a plain array of
+ *  strings (not objects) unless `with_labels_details=true` is passed, which
+ *  this adapter doesn't use. Synthesizes `{name, color: null}` to match
+ *  `GitHubListItem.labels`'s shape; a details-shaped `{name,color}` object is
+ *  also accepted defensively in case a future call site opts into details.
+ *  Pure — unit-tested via `__gitlabInternals`. */
+function normalizeLabels(raw: unknown): GitHubLabel[] {
+  if (!Array.isArray(raw)) return [];
+  const out: GitHubLabel[] = [];
+  for (const l of raw) {
+    if (typeof l === "string") {
+      out.push({ name: l, color: null });
+    } else if (l && typeof l === "object" && typeof (l as Record<string, unknown>).name === "string") {
+      const obj = l as Record<string, unknown>;
+      out.push({ name: obj.name as string, color: typeof obj.color === "string" ? obj.color : null });
+    }
+  }
+  return out;
+}
+
+/** Maps a GitLab merge request or issue JSON object onto `GitHubListItem`.
+ *  `iid` (project-scoped) is GitLab's counterpart to GitHub's `number`;
+ *  `merged`/`locked` MR states both fold into `state: "closed"` (mirroring
+ *  how GitHub only has open/closed, with `mergedAt` as the side channel the
+ *  UI uses to tell a merge apart from a plain close) — a transient `locked`
+ *  MR (mid-merge) is instead treated as still-open, since it isn't actually
+ *  closed. `sourcePath` is always `null` here (see the module doc comment);
+ *  the facade stitches it on. Pure — unit-tested via `__gitlabInternals`. */
+function normalizeItem(kind: GitHubItemKind, raw: unknown, sourcePath: string | null = null): GitHubListItem | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.iid !== "number" || typeof obj.title !== "string") return null;
+  const rawState = obj.state;
+  if (rawState !== "opened" && rawState !== "closed" && rawState !== "merged" && rawState !== "locked") return null;
+  if (typeof obj.web_url !== "string") return null;
+  const state: "open" | "closed" = rawState === "opened" || rawState === "locked" ? "open" : "closed";
+
+  const assignees = Array.isArray(obj.assignees)
+    ? obj.assignees.map(normalizeUser).filter((x): x is GitHubUser => !!x)
+    : [];
+  const milestoneRaw = obj.milestone && typeof obj.milestone === "object" ? obj.milestone as Record<string, unknown> : null;
+  const milestoneNumber = milestoneRaw
+    ? (typeof milestoneRaw.iid === "number" ? milestoneRaw.iid : (typeof milestoneRaw.id === "number" ? milestoneRaw.id : null))
+    : null;
+  const milestone: GitHubMilestone | null = milestoneRaw && milestoneNumber !== null && typeof milestoneRaw.title === "string"
+    ? { number: milestoneNumber, title: milestoneRaw.title }
+    : null;
+
+  return {
+    kind,
+    number: obj.iid,
+    title: obj.title,
+    state,
+    draft: typeof obj.draft === "boolean" ? obj.draft : false,
+    htmlUrl: obj.web_url,
+    author: normalizeUser(obj.author),
+    assignees,
+    milestone,
+    body: typeof obj.description === "string" ? obj.description : "",
+    labels: normalizeLabels(obj.labels),
+    comments: typeof obj.user_notes_count === "number" ? obj.user_notes_count : 0,
+    createdAt: typeof obj.created_at === "string" ? obj.created_at : "",
+    updatedAt: typeof obj.updated_at === "string" ? obj.updated_at : "",
+    closedAt: typeof obj.closed_at === "string" ? obj.closed_at : null,
+    mergedAt: typeof obj.merged_at === "string" ? obj.merged_at : null,
+    locked: typeof obj.discussion_locked === "boolean" ? obj.discussion_locked : false,
+    sourcePath,
+  };
+}
+
+/** A GitLab note (`/notes`) has no `web_url` of its own — this builds the same
+ *  "anchor into the MR/issue page" URL GitLab's own UI uses
+ *  (`#note_<id>`). Requires the caller's `number` since a note payload alone
+ *  doesn't carry its parent MR/issue iid. */
+function noteHtmlUrl(repo: ProviderRepoInfo, kind: GitHubItemKind, number: number, noteId: number): string {
+  const seg = kind === "pulls" ? "merge_requests" : "issues";
+  return `https://gitlab.com/${repo.owner}/${repo.name}/-/${seg}/${number}#note_${noteId}`;
+}
+
+function normalizeComment(raw: unknown, repo: ProviderRepoInfo, kind: GitHubItemKind, number: number): GitHubComment | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== "number") return null;
+  return {
+    id: obj.id,
+    body: typeof obj.body === "string" ? obj.body : "",
+    htmlUrl: noteHtmlUrl(repo, kind, number, obj.id),
+    author: normalizeUser(obj.author),
+    createdAt: typeof obj.created_at === "string" ? obj.created_at : "",
+    updatedAt: typeof obj.updated_at === "string" ? obj.updated_at : "",
+  };
+}
+
+/** Maps a GitLab discussion note (`type: "DiffNote"`) onto `GitHubPullLineComment`.
+ *  `position.new_line` set → `side: "RIGHT"`; `position.old_line` set →
+ *  `side: "LEFT"` (mirrors GitHub's own LEFT=old/RIGHT=new convention). `path`
+ *  prefers `new_path`, falling back to `old_path` (a delete-side-only comment
+ *  has no `new_path`). Note: `GitHubPullLineComment` has no field for GitLab's
+ *  discussion id — same as github.ts's own `normalizeLineComment`, which drops
+ *  REST's `in_reply_to_id` too — so reply-threading isn't carried in this
+ *  shape; `replyGitLabLineComment` below resolves the discussion id
+ *  out-of-band instead. Pure — unit-tested via `__gitlabInternals`. */
+function normalizeLineComment(raw: unknown, repo: ProviderRepoInfo, number: number): GitHubPullLineComment | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== "number") return null;
+  const position = obj.position && typeof obj.position === "object" ? obj.position as Record<string, unknown> : null;
+  if (!position) return null;
+  const newLine = typeof position.new_line === "number" ? position.new_line : null;
+  const oldLine = typeof position.old_line === "number" ? position.old_line : null;
+  const path = typeof position.new_path === "string"
+    ? position.new_path
+    : (typeof position.old_path === "string" ? position.old_path : null);
+  if (!path) return null;
+  let side: "LEFT" | "RIGHT";
+  let line: number;
+  if (newLine !== null) { side = "RIGHT"; line = newLine; }
+  else if (oldLine !== null) { side = "LEFT"; line = oldLine; }
+  else return null;
+
+  return {
+    id: obj.id,
+    body: typeof obj.body === "string" ? obj.body : "",
+    htmlUrl: noteHtmlUrl(repo, "pulls", number, obj.id),
+    author: normalizeUser(obj.author),
+    createdAt: typeof obj.created_at === "string" ? obj.created_at : "",
+    updatedAt: typeof obj.updated_at === "string" ? obj.updated_at : "",
+    path,
+    line,
+    side,
+  };
+}
+
+/** GitLab commit-status / pipeline status vocabulary → GitHub check-run
+ *  vocabulary. `pending`/`running` are non-terminal (`conclusion: null`);
+ *  everything else is `completed` with a mapped conclusion. An unrecognized
+ *  status string rides through as-is rather than being coerced to
+ *  "unknown", so a future GitLab status value degrades to "shown verbatim"
+ *  instead of "shown as unknown". Pure — unit-tested via `__gitlabInternals`. */
+function mapGitLabStatus(status: string): { status: string; conclusion: string | null } {
+  switch (status) {
+    case "pending": return { status: "queued", conclusion: null };
+    case "running": return { status: "in_progress", conclusion: null };
+    case "success": return { status: "completed", conclusion: "success" };
+    case "failed": return { status: "completed", conclusion: "failure" };
+    case "canceled": return { status: "completed", conclusion: "cancelled" };
+    case "skipped": return { status: "completed", conclusion: "skipped" };
+    default: return { status: status || "unknown", conclusion: null };
+  }
+}
+
+function normalizeCommitStatusAsCheckRun(raw: unknown): GitHubCheckRun | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== "number" || typeof obj.name !== "string") return null;
+  const { status, conclusion } = mapGitLabStatus(typeof obj.status === "string" ? obj.status : "");
+  return {
+    id: obj.id,
+    name: obj.name,
+    status,
+    conclusion,
+    htmlUrl: typeof obj.target_url === "string" ? obj.target_url : null,
+    startedAt: typeof obj.started_at === "string" ? obj.started_at : null,
+    completedAt: typeof obj.finished_at === "string" ? obj.finished_at : null,
+  };
+}
+
+/** Fallback check-run entry representing the MR's own pipeline, used only
+ *  when the commit has no individual per-job statuses to show (some projects
+ *  only report a pipeline, not per-job statuses, through this API). */
+function normalizePipelineAsCheckRun(raw: Record<string, unknown>): GitHubCheckRun | null {
+  if (typeof raw.id !== "number") return null;
+  const { status, conclusion } = mapGitLabStatus(typeof raw.status === "string" ? raw.status : "");
+  return {
+    id: raw.id,
+    name: `pipeline #${raw.id}`,
+    status,
+    conclusion,
+    htmlUrl: typeof raw.web_url === "string" ? raw.web_url : null,
+    startedAt: null,
+    completedAt: null,
+  };
+}
+
+function normalizeRepoLabel(raw: unknown): GitHubRepoLabel | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.name !== "string") return null;
+  // github.ts's GitHubRepoLabel stores color as bare 6-hex (no leading '#');
+  // GitLab returns "#RRGGBB" — strip the '#' so the UI's single color parse
+  // works for either provider without a provider-specific branch.
+  const color = typeof obj.color === "string" ? obj.color.replace(/^#/, "") : "";
+  return {
+    name: obj.name,
+    color,
+    description: typeof obj.description === "string" ? obj.description : "",
+  };
+}
+
+function sortValue(item: GitHubListItem, sort: "created" | "updated" | "comments" | undefined): number {
+  if (sort === "comments") return item.comments;
+  const raw = sort === "created" ? item.createdAt : item.updatedAt;
+  const t = Date.parse(raw);
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function sortItems(items: GitHubListItem[], sort: "created" | "updated" | "comments" | undefined, direction: "asc" | "desc"): void {
+  items.sort((a, b) => {
+    const diff = sortValue(a, sort) - sortValue(b, sort);
+    return direction === "asc" ? diff : -diff;
+  });
+}
+
+/**
+ * Maps the UI's neutral `GitHubItemState` to the GitLab `state` query param(s)
+ * to fetch. The one asymmetry: GitHub's "closed" for pull requests already
+ * includes merged PRs (GitHub only has open/closed, with a `merged` flag
+ * riding along), but GitLab models `closed` and `merged` as two distinct MR
+ * states — there's no single `state=` value that means "closed or merged".
+ * Decision (documented per the plan, since GitLab's API forces a pick):
+ * `kind: "pulls"` + `state: "closed"` fans out to **two** sequential requests
+ * (`state=closed` then `state=merged`), merged and re-sorted client-side by
+ * `listGitLabItems` — see its own comment for the pagination trade-off that
+ * entails. Issues have no "merged" state, so `state: "closed"` there is a
+ * single direct passthrough to `state=closed`.
+ */
+function gitlabStateParams(kind: GitHubItemKind, state: GitHubItemState): string[] {
+  if (state === "all") return ["all"];
+  if (state === "open") return ["opened"];
+  if (kind === "pulls") return ["closed", "merged"];
+  return ["closed"];
+}
+
+export interface ListGitLabItemsOptions {
+  kind: GitHubItemKind;
+  state: GitHubItemState;
+  query?: string;
+  labels?: string[];
+  assignee?: string;
+  createdByMe?: boolean;
+  assignedToMe?: boolean;
+  /** MRs only — GitLab's `scope=reviews_for_me`. Silently ignored for issues,
+   *  mirroring the plan's decision (GitLab issues have no reviewer concept). */
+  reviewRequested?: boolean;
+  page?: number;
+  sort?: "created" | "updated" | "comments";
+  direction?: "asc" | "desc";
+}
+
+const GITLAB_PER_PAGE = 30;
+
+/** Mirrors `listGitHubItems`'s shape (minus `dir` — the facade resolves that
+ *  into `repo`). See `gitlabStateParams` for the closed/merged fan-out this
+ *  applies when `kind: "pulls"` and `state: "closed"`: in that case `page`
+ *  and "Load more" are NOT supported — both requests always fetch their own
+ *  page 1, the two results are merged and re-sorted, and `hasMore` is always
+ *  `false`. That's a deliberate v1 simplification (documented in the plan):
+ *  GitLab's page-based pagination doesn't compose across two independent
+ *  listings without tracking two separate cursors, which the single `page`
+ *  input here has no room to express. Every other state (`open`, `all`, and
+ *  `closed` for issues) is a single direct request with normal pagination. */
+export async function listGitLabItems(repo: ProviderRepoInfo, opts: ListGitLabItemsOptions): Promise<GitLabListResponse> {
+  const token = await gitlabToken(repo.remoteHost);
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const endpoint = opts.kind === "pulls" ? "merge_requests" : "issues";
+  const page = Number.isInteger(opts.page) && (opts.page as number) > 0 ? (opts.page as number) : 1;
+  const orderBy = opts.sort === "created" ? "created_at" : "updated_at";
+  const direction = opts.direction ?? "desc";
+  const states = gitlabStateParams(opts.kind, opts.state);
+  const combinedClosed = states.length > 1;
+
+  const buildUrl = (stateParam: string, sourcePage: number): string => {
+    const url = new URL(`${GITLAB_API_BASE}/projects/${projectId}/${endpoint}`);
+    // "all" is expressed by omitting `state` — the MR list documents
+    // `state=all` but the issues list doesn't, and omission means "all"
+    // uniformly on both endpoints.
+    if (stateParam !== "all") url.searchParams.set("state", stateParam);
+    url.searchParams.set("per_page", String(GITLAB_PER_PAGE));
+    url.searchParams.set("page", String(sourcePage));
+    url.searchParams.set("order_by", orderBy);
+    url.searchParams.set("sort", direction);
+    const query = opts.query?.trim();
+    if (query) url.searchParams.set("search", query);
+    if (opts.labels && opts.labels.length > 0) url.searchParams.set("labels", opts.labels.join(","));
+    const assignee = opts.assignee?.trim();
+    if (assignee) url.searchParams.set("assignee_username", assignee);
+    // `scope` is a single value on the wire — priority when more than one
+    // involvement filter is set: createdByMe, then assignedToMe, then
+    // reviewRequested (MRs only).
+    if (opts.createdByMe) url.searchParams.set("scope", "created_by_me");
+    else if (opts.assignedToMe) url.searchParams.set("scope", "assigned_to_me");
+    else if (opts.reviewRequested && opts.kind === "pulls") url.searchParams.set("scope", "reviews_for_me");
+    return url.toString();
+  };
+
+  const items: GitHubListItem[] = [];
+  let hasMore = false;
+  for (const stateParam of states) {
+    const sourcePage = combinedClosed ? 1 : page;
+    const url = buildUrl(stateParam, sourcePage);
+    const res = await fetchGitLab(url, token);
+    if (!("status" in res)) return res;
+    const body = await res.json().catch(() => null);
+    if (!res.ok) return { ok: false, error: errorFrom(res, body, repo, !!token) };
+    if (!Array.isArray(body)) return { ok: false, error: "GitLab returned an unexpected response" };
+    for (const raw of body) items.push(...([normalizeItem(opts.kind, raw)].filter((x): x is GitHubListItem => !!x)));
+    if (!combinedClosed) hasMore = resolveNextPage(res, url) != null;
+  }
+
+  if (combinedClosed) sortItems(items, opts.sort, direction);
+  const sliced = combinedClosed ? items.slice(0, GITLAB_PER_PAGE) : items;
+
+  return {
+    ok: true,
+    repo: `${repo.owner}/${repo.name}`,
+    webUrl: `https://gitlab.com/${repo.owner}/${repo.name}`,
+    auth: token ? "token" : "none",
+    items: sliced,
+    page,
+    hasMore: combinedClosed ? false : hasMore,
+    // GitLab's rate-limit headers (`RateLimit-*`) don't carry GitHub's
+    // remaining/limit/resource triple in a directly comparable shape — no
+    // rate-limit UI is shown for non-GitHub providers (see PROVIDER_CAPS).
+    rateLimit: null,
+  };
+}
+
+/** Matches `getGitHubPullDefaults`'s `{repo, head, base}` shape. `base` comes
+ *  from `GET /projects/:id`'s `default_branch`. `head` (the branch that would
+ *  be pushed) can't be resolved here: `getGitHubPullDefaults`'s `head` comes
+ *  from shelling out to `git branch --show-current` in the project's working
+ *  directory, but this adapter only ever receives a resolved `ProviderRepoInfo`
+ *  (no `dir`) — per the plan, adapters never call git themselves. `head` is
+ *  returned as `""` (rather than omitted, since the shared result type
+ *  requires it) and the facade (`git-host.ts`, T4) is expected to fill it in
+ *  from the local git branch itself, the same way it must for `dir`-derived
+ *  fields on every other GitLab call. */
+export async function getGitLabPullDefaults(repo: ProviderRepoInfo): Promise<GitLabPullDefaultsResponse> {
+  const token = await gitlabToken(repo.remoteHost);
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}`, token);
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!token) };
+  const obj = json && typeof json === "object" ? json as Record<string, unknown> : {};
+  const base = typeof obj.default_branch === "string" ? obj.default_branch : "main";
+  return { ok: true, repo: `${repo.owner}/${repo.name}`, head: "", base };
+}
+
+export interface CreateGitLabPullInput {
+  title: string;
+  body?: string;
+  base: string;
+  head: string;
+  draft?: boolean;
+}
+
+/** Matches `createGitHubPull`'s `GitHubIssueResponse` shape. GitLab has no
+ *  reviewer field on this endpoint — reviewer assignment isn't part of the
+ *  plan's core subset for GitLab (`reviewRequestedFilter` reads MR reviewers
+ *  set some other way, e.g. the GitLab UI or a separate call not wired up
+ *  here). `draft: true` prefixes the title with `"Draft: "`, GitLab's own
+ *  draft convention (the same one its web UI uses; there's no separate
+ *  boolean field on create). */
+export async function createGitLabPull(repo: ProviderRepoInfo, input: CreateGitLabPullInput): Promise<GitLabIssueResponse> {
+  const title = input.title.trim();
+  const head = input.head.trim();
+  const base = input.base.trim();
+  if (!title) return { ok: false, error: "merge request title required" };
+  if (!head) return { ok: false, error: "head branch required" };
+  if (!base) return { ok: false, error: "base branch required" };
+
+  const token = await gitlabToken(repo.remoteHost);
+  if (!token) return { ok: false, error: "GitLab authentication required to create a merge request" };
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const finalTitle = input.draft ? `Draft: ${title}` : title;
+  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests`, token, {
+    method: "POST",
+    body: JSON.stringify({
+      title: finalTitle,
+      ...(input.body?.trim() ? { description: input.body.trim() } : {}),
+      source_branch: head,
+      target_branch: base,
+    }),
+  });
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!token) };
+  const item = normalizeItem("pulls", json);
+  if (!item) return { ok: false, error: "GitLab returned an unexpected merge request response" };
+  return { ok: true, item, message: "Merge request created." };
+}
+
+/** Matches `getGitHubPullDiff`'s `GitHubDiffResponse` shape, including the 8MB
+ *  size cap (checked via `content-length` first, then a byte-accurate
+ *  fallback) and `parseGitDiff` (git-diff.ts) for the raw unified diff.
+ *  `raw_diffs` is GitLab's stable, generally-available raw-diff endpoint
+ *  (the structured `/diffs` endpoint is intentionally NOT used — the plan
+ *  calls for keeping this adapter on the same raw-unified-diff parse path
+ *  Bitbucket's `/diff` and GitHub's `.diff` media type both go through). */
+export async function getGitLabPullDiff(repo: ProviderRepoInfo, number: number): Promise<GitLabDiffResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
+  const token = await gitlabToken(repo.remoteHost);
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const res = await fetchGitLab(
+    `${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/raw_diffs`,
+    token,
+    { accept: "text/plain" },
+  );
+  if (!("status" in res)) return res;
+  const contentLength = Number(res.headers.get("content-length") ?? 0);
+  if (contentLength > GITLAB_DIFF_BODY_CAP_BYTES) {
+    return { ok: false, error: `Merge request diff is too large to display in Agetor (${Math.ceil(contentLength / 1_000_000)} MB).` };
+  }
+  const body = await res.text().catch(() => "");
+  if (!res.ok) {
+    let msg = body;
+    try {
+      const parsed = JSON.parse(body) as { message?: unknown };
+      if (typeof parsed.message === "string") msg = parsed.message;
+    } catch { /* raw_diffs returns plain text on success, JSON on error */ }
+    return { ok: false, error: msg || `${res.status} ${res.statusText}` };
+  }
+  const bodyBytes = Buffer.byteLength(body, "utf8");
+  if (bodyBytes > GITLAB_DIFF_BODY_CAP_BYTES) {
+    return { ok: false, error: `Merge request diff is too large to display in Agetor (${Math.ceil(bodyBytes / 1_000_000)} MB).` };
+  }
+  const files = parseGitDiff(body);
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  if (files.length > MAX_DIFF_FILES) {
+    const total = files.length;
+    return {
+      ok: true,
+      base: null,
+      files: files.slice(0, MAX_DIFF_FILES),
+      note: `Showing the first ${MAX_DIFF_FILES} of ${total} changed files — the rest are omitted to keep the viewer responsive.`,
+    };
+  }
+  return {
+    ok: true,
+    base: null,
+    files,
+    note: files.length === 0 ? "No diff returned for this merge request." : undefined,
+  };
+}
+
+/** Matches `listGitHubComments`'s `GitHubCommentsResponse` shape. Uses the
+ *  notes API (`sort=asc&order_by=created_at`, chronological — matching
+ *  GitHub's own comment ordering) and **skips system notes** (`system: true`
+ *  — GitLab posts automated notes for label/assignee/milestone changes etc.
+ *  into the same notes stream; GitHub has no equivalent noise in its
+ *  `/issues/:n/comments` endpoint, so filtering keeps the two providers'
+ *  comment lists comparable). */
+export async function listGitLabComments(repo: ProviderRepoInfo, number: number, kind: GitHubItemKind): Promise<GitLabCommentsResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "item number must be positive" };
+  const token = await gitlabToken(repo.remoteHost);
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const endpoint = kind === "pulls" ? "merge_requests" : "issues";
+  const comments: GitHubComment[] = [];
+  let url: string | null = `${GITLAB_API_BASE}/projects/${projectId}/${endpoint}/${number}/notes?sort=asc&order_by=created_at&per_page=100`;
+  for (let page = 0; url && page < 5; page++) {
+    const res = await fetchGitLab(url, token);
+    if (!("status" in res)) return res;
+    const body = await res.json().catch(() => null);
+    if (!res.ok) return { ok: false, error: errorFrom(res, body, repo, !!token) };
+    if (!Array.isArray(body)) return { ok: false, error: "GitLab returned an unexpected notes response" };
+    for (const raw of body) {
+      if (raw && typeof raw === "object" && (raw as Record<string, unknown>).system === true) continue;
+      const comment = normalizeComment(raw, repo, kind, number);
+      if (comment) comments.push(comment);
+    }
+    url = resolveNextPage(res, url);
+  }
+  return { ok: true, repo: `${repo.owner}/${repo.name}`, itemNumber: number, comments };
+}
+
+export async function createGitLabComment(repo: ProviderRepoInfo, number: number, kind: GitHubItemKind, body: string): Promise<GitLabCommentResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "item number must be positive" };
+  const text = body.trim();
+  if (!text) return { ok: false, error: "comment body required" };
+  const token = await gitlabToken(repo.remoteHost);
+  if (!token) return { ok: false, error: "GitLab authentication required to comment" };
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const endpoint = kind === "pulls" ? "merge_requests" : "issues";
+  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/${endpoint}/${number}/notes`, token, {
+    method: "POST",
+    body: JSON.stringify({ body: text }),
+  });
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiError(json, res.status, res.statusText) };
+  const comment = normalizeComment(json, repo, kind, number);
+  if (!comment) return { ok: false, error: "GitLab returned an unexpected comment response" };
+  return { ok: true, comment };
+}
+
+/** Matches `listGitHubPullReviewComments`'s shape. GitLab's inline comments
+ *  live inside "discussions" (each a thread of one or more notes); only notes
+ *  with `type === "DiffNote"` are inline/positioned (a discussion can also
+ *  hold plain top-level notes) so everything else is skipped. Each matching
+ *  note is flattened into its own `GitHubPullLineComment` — see
+ *  `normalizeLineComment`'s doc comment for why no discussion-id/thread field
+ *  is carried (the shared type has no slot for it, matching github.ts's own
+ *  comment shape). */
+export async function listGitLabPullReviewComments(repo: ProviderRepoInfo, number: number): Promise<GitLabPullReviewCommentsResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
+  const token = await gitlabToken(repo.remoteHost);
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const comments: GitHubPullLineComment[] = [];
+  let url: string | null = `${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/discussions?per_page=100`;
+  for (let page = 0; url && page < 5; page++) {
+    const res = await fetchGitLab(url, token);
+    if (!("status" in res)) return res;
+    const body = await res.json().catch(() => null);
+    if (!res.ok) return { ok: false, error: errorFrom(res, body, repo, !!token) };
+    if (!Array.isArray(body)) return { ok: false, error: "GitLab returned an unexpected discussions response" };
+    for (const discussion of body) {
+      if (!discussion || typeof discussion !== "object") continue;
+      const notes = (discussion as Record<string, unknown>).notes;
+      if (!Array.isArray(notes)) continue;
+      for (const raw of notes) {
+        if (!raw || typeof raw !== "object" || (raw as Record<string, unknown>).type !== "DiffNote") continue;
+        const comment = normalizeLineComment(raw, repo, number);
+        if (comment) comments.push(comment);
+      }
+    }
+    url = resolveNextPage(res, url);
+  }
+  return { ok: true, repo: `${repo.owner}/${repo.name}`, pullNumber: number, comments };
+}
+
+export interface CreateGitLabPullLineCommentInput {
+  path: string;
+  line: number;
+  side: "LEFT" | "RIGHT";
+  body: string;
+}
+
+/** Matches `createGitHubPullLineComment`'s shape. GitLab positions an inline
+ *  discussion against three SHAs (`base_sha`/`start_sha`/`head_sha`) rather
+ *  than a single commit id — those come from the merge request's latest diff
+ *  "version" (`GET .../versions`, newest first), fetched here first. */
+export async function createGitLabPullLineComment(
+  repo: ProviderRepoInfo,
+  number: number,
+  input: CreateGitLabPullLineCommentInput,
+): Promise<GitLabPullLineCommentResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
+  const body = input.body.trim();
+  const path = input.path.trim();
+  if (!body) return { ok: false, error: "comment body required" };
+  if (!path) return { ok: false, error: "comment path required" };
+  if (!Number.isInteger(input.line) || input.line <= 0) return { ok: false, error: "comment line must be positive" };
+  if (input.side !== "LEFT" && input.side !== "RIGHT") return { ok: false, error: "comment side must be LEFT or RIGHT" };
+
+  const token = await gitlabToken(repo.remoteHost);
+  if (!token) return { ok: false, error: "GitLab authentication required to comment on a line" };
+  const projectId = encodeProjectId(repo.owner, repo.name);
+
+  const versionsRes = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/versions`, token);
+  if (!("status" in versionsRes)) return versionsRes;
+  const versions = await versionsRes.json().catch(() => null);
+  if (!versionsRes.ok) return { ok: false, error: errorFrom(versionsRes, versions, repo, !!token) };
+  const latest = Array.isArray(versions) && versions.length > 0 ? versions[0] as Record<string, unknown> : null;
+  if (
+    !latest
+    || typeof latest.base_commit_sha !== "string"
+    || typeof latest.start_commit_sha !== "string"
+    || typeof latest.head_commit_sha !== "string"
+  ) {
+    return { ok: false, error: "GitLab returned no diff versions for this merge request" };
+  }
+
+  const position: Record<string, unknown> = {
+    position_type: "text",
+    base_sha: latest.base_commit_sha,
+    start_sha: latest.start_commit_sha,
+    head_sha: latest.head_commit_sha,
+    new_path: path,
+    old_path: path,
+  };
+  if (input.side === "RIGHT") position.new_line = input.line;
+  else position.old_line = input.line;
+
+  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/discussions`, token, {
+    method: "POST",
+    body: JSON.stringify({ body, position }),
+  });
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiError(json, res.status, res.statusText) };
+  const notes = json && typeof json === "object" && Array.isArray((json as Record<string, unknown>).notes)
+    ? (json as Record<string, unknown>).notes as unknown[]
+    : [];
+  const comment = normalizeLineComment(notes[0], repo, number);
+  if (!comment) return { ok: false, error: "GitLab returned an unexpected line comment response" };
+  return { ok: true, comment };
+}
+
+/** Finds the discussion id containing note `noteId` — needed because GitLab's
+ *  reply endpoint is `POST .../discussions/:discussion_id/notes`, addressed
+ *  by discussion, not by the note being replied to. The shared reply
+ *  signature (mirroring `replyGitHubPullLineComment`) only carries a comment
+ *  id, so this does the extra discussions round-trip documented in the plan. */
+async function findDiscussionIdForNote(
+  repo: ProviderRepoInfo,
+  number: number,
+  noteId: number,
+  token: string | null,
+): Promise<{ ok: true; id: string | null } | GitLabError> {
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  let url: string | null = `${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/discussions?per_page=100`;
+  for (let page = 0; url && page < 5; page++) {
+    const res = await fetchGitLab(url, token);
+    if (!("status" in res)) return res;
+    const body = await res.json().catch(() => null);
+    if (!res.ok) return { ok: false, error: errorFrom(res, body, repo, !!token) };
+    if (!Array.isArray(body)) return { ok: false, error: "GitLab returned an unexpected discussions response" };
+    for (const discussion of body) {
+      if (!discussion || typeof discussion !== "object") continue;
+      const obj = discussion as Record<string, unknown>;
+      const notes = Array.isArray(obj.notes) ? obj.notes : [];
+      const found = notes.some((n) => n && typeof n === "object" && (n as Record<string, unknown>).id === noteId);
+      if (found) return { ok: true, id: typeof obj.id === "string" ? obj.id : null };
+    }
+    url = resolveNextPage(res, url);
+  }
+  return { ok: true, id: null };
+}
+
+export async function replyGitLabLineComment(repo: ProviderRepoInfo, number: number, commentId: number, body: string): Promise<GitLabPullLineCommentResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
+  if (!Number.isInteger(commentId) || commentId <= 0) return { ok: false, error: "review comment id must be positive" };
+  const text = body.trim();
+  if (!text) return { ok: false, error: "reply body required" };
+  const token = await gitlabToken(repo.remoteHost);
+  if (!token) return { ok: false, error: "GitLab authentication required to reply" };
+  const projectId = encodeProjectId(repo.owner, repo.name);
+
+  const discussion = await findDiscussionIdForNote(repo, number, commentId, token);
+  if (!discussion.ok) return discussion;
+  if (!discussion.id) return { ok: false, error: "Could not find the discussion for that comment." };
+
+  const res = await fetchGitLab(
+    `${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/discussions/${discussion.id}/notes`,
+    token,
+    { method: "POST", body: JSON.stringify({ body: text }) },
+  );
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiError(json, res.status, res.statusText) };
+  const comment = normalizeLineComment(json, repo, number);
+  if (!comment) return { ok: false, error: "GitLab returned an unexpected reply response" };
+  return { ok: true, comment };
+}
+
+/** Matches `getGitHubPullChecks`'s shape. GitLab has no single "check-runs"
+ *  API — the closest equivalents are (1) per-job commit statuses (`GET
+ *  /projects/:id/repository/commits/:sha/statuses`, populated when CI posts
+ *  granular per-job statuses) and (2) the MR's own pipeline object. When the
+ *  commit has zero individual statuses (some projects only surface the
+ *  pipeline as a whole), the pipeline itself is added as a single synthetic
+ *  check-run entry named `"pipeline #<id>"` so the UI still shows *something*
+ *  rather than an empty checks panel. */
+export async function getGitLabPullChecks(repo: ProviderRepoInfo, number: number): Promise<GitLabChecksResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
+  const token = await gitlabToken(repo.remoteHost);
+  const projectId = encodeProjectId(repo.owner, repo.name);
+
+  const mrRes = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`, token);
+  if (!("status" in mrRes)) return mrRes;
+  const mr = await mrRes.json().catch(() => null);
+  if (!mrRes.ok) return { ok: false, error: errorFrom(mrRes, mr, repo, !!token) };
+  const obj = mr && typeof mr === "object" ? mr as Record<string, unknown> : {};
+  const sha = typeof obj.sha === "string" ? obj.sha : "";
+  if (!sha) return { ok: false, error: "GitLab returned a merge request without a head sha" };
+  const pipeline = obj.head_pipeline && typeof obj.head_pipeline === "object" ? obj.head_pipeline as Record<string, unknown> : null;
+
+  const statusesRes = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/repository/commits/${sha}/statuses?per_page=100`, token);
+  if (!("status" in statusesRes)) return statusesRes;
+  const statuses = await statusesRes.json().catch(() => null);
+  if (!statusesRes.ok) return { ok: false, error: errorFrom(statusesRes, statuses, repo, !!token) };
+  const rawStatuses = Array.isArray(statuses) ? statuses : [];
+  const checkRuns = rawStatuses.map(normalizeCommitStatusAsCheckRun).filter((x): x is GitHubCheckRun => !!x);
+
+  if (checkRuns.length === 0 && pipeline) {
+    const pipelineRun = normalizePipelineAsCheckRun(pipeline);
+    if (pipelineRun) checkRuns.push(pipelineRun);
+  }
+
+  return { ok: true, repo: `${repo.owner}/${repo.name}`, pullNumber: number, sha, checkRuns };
+}
+
+/** Matches `mergeGitHubPull`'s shape. GitLab's `merge_strategy`/merge-method
+ *  vocabulary is squash-or-not (`squash: boolean`) rather than GitHub's
+ *  named strategies — `PROVIDER_CAPS.gitlab.mergeMethods` only ever offers
+ *  `"merge"`/`"squash"` to the UI for this provider, so `"rebase"` should
+ *  never reach here; it's still rejected defensively. */
+export async function mergeGitLabPull(repo: ProviderRepoInfo, number: number, method: GitHubPullMergeMethod): Promise<GitLabPullMergeResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
+  if (method !== "merge" && method !== "squash") {
+    return { ok: false, error: "GitLab only supports merge or squash merge methods" };
+  }
+  const token = await gitlabToken(repo.remoteHost);
+  if (!token) return { ok: false, error: "GitLab authentication required to merge" };
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/merge`, token, {
+    method: "PUT",
+    body: JSON.stringify({ squash: method === "squash" }),
+  });
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) {
+    // 405 = "not mergeable right now" (pipeline/approval/conflict gate);
+    // 409 = a concurrent update changed the MR underneath this request.
+    // GitLab's own messages for both are terse REST-speak — friendlier copy.
+    const msg = res.status === 405
+      ? "This merge request cannot be merged right now (check pipeline status and approvals)."
+      : res.status === 409
+        ? "This merge request was updated concurrently — refresh and try again."
+        : apiError(json, res.status, res.statusText);
+    return { ok: false, error: msg };
+  }
+  const obj = json && typeof json === "object" ? json as Record<string, unknown> : {};
+  const state = typeof obj.state === "string" ? obj.state : "";
+  return {
+    ok: true,
+    merged: state === "merged",
+    sha: typeof obj.merge_commit_sha === "string" ? obj.merge_commit_sha : (typeof obj.sha === "string" ? obj.sha : null),
+    message: "Merge request merged.",
+  };
+}
+
+/** Matches `closeGitHubPull`'s `GitHubActionResponse` shape (no comment
+ *  parameter — the plan's core subset doesn't wire a close-with-comment
+ *  convenience for GitLab; callers wanting a comment can `createGitLabComment`
+ *  separately, same as any other note). */
+export async function closeGitLabPull(repo: ProviderRepoInfo, number: number): Promise<GitLabActionResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
+  const token = await gitlabToken(repo.remoteHost);
+  if (!token) return { ok: false, error: "GitLab authentication required to close a merge request" };
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`, token, {
+    method: "PUT",
+    body: JSON.stringify({ state_event: "close" }),
+  });
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiError(json, res.status, res.statusText) };
+  const item = normalizeItem("pulls", json);
+  return { ok: true, message: "Merge request closed.", ...(item ? { item } : {}) };
+}
+
+/** Matches `reopenGitHubPull`'s `GitHubIssueResponse` shape. */
+export async function reopenGitLabPull(repo: ProviderRepoInfo, number: number): Promise<GitLabIssueResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
+  const token = await gitlabToken(repo.remoteHost);
+  if (!token) return { ok: false, error: "GitLab authentication required to reopen a merge request" };
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`, token, {
+    method: "PUT",
+    body: JSON.stringify({ state_event: "reopen" }),
+  });
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiError(json, res.status, res.statusText) };
+  const item = normalizeItem("pulls", json);
+  if (!item) return { ok: false, error: "GitLab returned an unexpected merge request response" };
+  return { ok: true, item, message: "Merge request reopened." };
+}
+
+/** Matches `reviewGitHubPull`'s `GitHubActionResponse` shape, restricted to
+ *  what GitLab supports: `APPROVE` (`POST .../approve`, optionally followed
+ *  by a plain note when `body` is set) and `COMMENT` (a plain note, no
+ *  approval state change). `REQUEST_CHANGES` has no GitLab equivalent — MRs
+ *  have no "changes requested" review state — so it's rejected up front;
+ *  `PROVIDER_CAPS.gitlab.requestChanges: false` is what keeps the UI from
+ *  ever sending it, this is defense-in-depth. */
+export async function reviewGitLabPull(repo: ProviderRepoInfo, number: number, verdict: GitHubPullReviewEvent, body?: string): Promise<GitLabActionResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
+  if (verdict === "REQUEST_CHANGES") {
+    return { ok: false, error: "Requesting changes is not supported on GitLab merge requests." };
+  }
+  const token = await gitlabToken(repo.remoteHost);
+  if (!token) return { ok: false, error: "GitLab authentication required to review" };
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const text = body?.trim() ?? "";
+
+  if (verdict === "APPROVE") {
+    const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/approve`, token, {
+      method: "POST",
+      body: "{}",
+    });
+    if (!("status" in res)) return res;
+    const json = await res.json().catch(() => null);
+    if (!res.ok) return { ok: false, error: apiError(json, res.status, res.statusText) };
+    if (!text) return { ok: true, message: "Merge request approved." };
+    const noteResult = await createGitLabComment(repo, number, "pulls", text);
+    if (!noteResult.ok) {
+      return { ok: true, message: `Merge request approved, but the comment was not posted: ${noteResult.error}`, commentPosted: false };
+    }
+    return { ok: true, message: "Merge request approved and comment posted.", commentPosted: true };
+  }
+
+  // COMMENT — a plain note, no approval state change.
+  if (!text) return { ok: false, error: "review comment body required" };
+  const noteResult = await createGitLabComment(repo, number, "pulls", text);
+  if (!noteResult.ok) return noteResult;
+  return { ok: true, message: "Review comment submitted." };
+}
+
+/** Resolves each username to a GitLab user id via `GET /projects/:id/users?search=`
+ *  — GitLab's issue create/update endpoints only accept `assignee_ids`, never
+ *  usernames. Best-effort: a username with no exact match (typo, not a member
+ *  of the project) is silently dropped rather than failing the whole request,
+ *  per the plan's decision — the alternative (rejecting the entire
+ *  create/update over one bad assignee) is worse UX for a field the user
+ *  likely won't double-check immediately. */
+async function resolveAssigneeIds(projectId: string, usernames: string[], token: string | null): Promise<number[]> {
+  const trimmed = usernames.map((s) => s.trim()).filter(Boolean);
+  if (trimmed.length === 0) return [];
+  const ids: number[] = [];
+  for (const username of trimmed) {
+    const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/users?search=${encodeURIComponent(username)}`, token);
+    if (!("status" in res) || !res.ok) continue;
+    const body = await res.json().catch(() => null);
+    if (!Array.isArray(body)) continue;
+    const match = body.find((u) => u && typeof u === "object" && (u as Record<string, unknown>).username === username);
+    if (match && typeof (match as Record<string, unknown>).id === "number") ids.push((match as Record<string, unknown>).id as number);
+  }
+  return ids;
+}
+
+export interface CreateGitLabIssueInput {
+  title: string;
+  body?: string;
+  labels?: string[];
+  assignees?: string[];
+}
+
+export async function createGitLabIssue(repo: ProviderRepoInfo, input: CreateGitLabIssueInput): Promise<GitLabIssueResponse> {
+  const title = input.title.trim();
+  if (!title) return { ok: false, error: "issue title required" };
+  const token = await gitlabToken(repo.remoteHost);
+  if (!token) return { ok: false, error: "GitLab authentication required to create an issue" };
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const labels = input.labels?.map((s) => s.trim()).filter(Boolean) ?? [];
+  const assigneeIds = await resolveAssigneeIds(projectId, input.assignees ?? [], token);
+
+  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/issues`, token, {
+    method: "POST",
+    body: JSON.stringify({
+      title,
+      ...(input.body?.trim() ? { description: input.body.trim() } : {}),
+      ...(labels.length > 0 ? { labels: labels.join(",") } : {}),
+      ...(assigneeIds.length > 0 ? { assignee_ids: assigneeIds } : {}),
+    }),
+  });
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiError(json, res.status, res.statusText) };
+  const item = normalizeItem("issues", json);
+  if (!item) return { ok: false, error: "GitLab returned an unexpected issue response" };
+  return { ok: true, item, message: "Issue created." };
+}
+
+export interface UpdateGitLabIssueInput {
+  /** The `/issues` and `/merge_requests` PUT endpoints are separate on
+   *  GitLab (unlike GitHub's single `/issues/:number` patching both) — `kind`
+   *  picks which one, mirroring `UpdateGitHubIssueInput`'s `kind` field. */
+  kind?: GitHubItemKind;
+  title?: string;
+  body?: string;
+  state?: "open" | "closed";
+  labels?: string[];
+  assignees?: string[];
+}
+
+export async function updateGitLabIssue(repo: ProviderRepoInfo, number: number, input: UpdateGitLabIssueInput): Promise<GitLabIssueResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "issue number must be positive" };
+  const token = await gitlabToken(repo.remoteHost);
+  if (!token) return { ok: false, error: "GitLab authentication required to update an issue" };
+  const kind: GitHubItemKind = input.kind === "pulls" ? "pulls" : "issues";
+  const endpoint = kind === "pulls" ? "merge_requests" : "issues";
+  const noun = kind === "pulls" ? "merge request" : "issue";
+  const projectId = encodeProjectId(repo.owner, repo.name);
+
+  const patch: Record<string, unknown> = {};
+  if (input.title?.trim()) patch.title = input.title.trim();
+  if (input.body !== undefined) patch.description = input.body.trim();
+  if (input.state === "closed") patch.state_event = "close";
+  else if (input.state === "open") patch.state_event = "reopen";
+  if (input.labels) patch.labels = input.labels.map((s) => s.trim()).filter(Boolean).join(",");
+  if (input.assignees) patch.assignee_ids = await resolveAssigneeIds(projectId, input.assignees, token);
+
+  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/${endpoint}/${number}`, token, {
+    method: "PUT",
+    body: JSON.stringify(patch),
+  });
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiError(json, res.status, res.statusText) };
+  const item = normalizeItem(kind, json);
+  if (!item) return { ok: false, error: `GitLab returned an unexpected ${noun} response` };
+  return { ok: true, item, message: `${kind === "pulls" ? "Merge request" : "Issue"} updated.` };
+}
+
+/** Matches `getGitHubViewer`'s `{ok:true,login:string}` shape — no-token
+ *  resolves to an empty login rather than erroring, same as the GitHub side. */
+export async function getGitLabViewer(repo: ProviderRepoInfo): Promise<GitLabViewerResponse> {
+  const token = await gitlabToken(repo.remoteHost);
+  if (!token) return { ok: true, login: "" };
+  const res = await fetchGitLab(`${GITLAB_API_BASE}/user`, token);
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!token) };
+  const login = json && typeof json === "object" && typeof (json as Record<string, unknown>).username === "string"
+    ? (json as Record<string, unknown>).username as string
+    : "";
+  return { ok: true, login };
+}
+
+/** Matches `listGitHubLabels`'s shape (3-page cap, following the next-page
+ *  link, alphabetically sorted). */
+export async function listGitLabLabels(repo: ProviderRepoInfo): Promise<GitLabLabelsResponse> {
+  const token = await gitlabToken(repo.remoteHost);
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const labels: GitHubRepoLabel[] = [];
+  let url: string | null = `${GITLAB_API_BASE}/projects/${projectId}/labels?per_page=100`;
+  for (let page = 0; url && page < 3; page++) {
+    const res = await fetchGitLab(url, token);
+    if (!("status" in res)) return res;
+    const body = await res.json().catch(() => null);
+    if (!res.ok) return { ok: false, error: errorFrom(res, body, repo, !!token) };
+    if (!Array.isArray(body)) return { ok: false, error: "GitLab returned an unexpected labels response" };
+    for (const raw of body) {
+      const label = normalizeRepoLabel(raw);
+      if (label) labels.push(label);
+    }
+    url = resolveNextPage(res, url);
+  }
+  labels.sort((a, b) => a.name.localeCompare(b.name));
+  return { ok: true, repo: `${repo.owner}/${repo.name}`, labels };
+}
+
+/** Pure normalizers/param-builders exposed for tests (TT2,
+ *  `gitlab.test.ts`) — mirrors github.ts's `__githubInternals`. */
+export const __gitlabInternals = {
+  encodeProjectId,
+  apiError,
+  authHint,
+  pageLinks,
+  resolveNextPage,
+  normalizeUser,
+  normalizeLabels,
+  normalizeItem,
+  noteHtmlUrl,
+  normalizeComment,
+  normalizeLineComment,
+  mapGitLabStatus,
+  normalizeCommitStatusAsCheckRun,
+  normalizePipelineAsCheckRun,
+  normalizeRepoLabel,
+  sortItems,
+  gitlabStateParams,
+};

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -76,14 +76,9 @@ import {
   addGitHubSubIssue,
   applyGitHubSuggestion,
   cancelGitHubWorkflowRun,
-  closeGitHubPull,
-  createGitHubComment,
   createGitHubDiscussion,
-  createGitHubIssue,
-  createGitHubPull,
   createGitHubLabel,
   createGitHubMilestone,
-  createGitHubPullLineComment,
   createGitHubRelease,
   deleteGitHubComment,
   deleteGitHubDiscussion,
@@ -96,26 +91,17 @@ import {
   getGitHubDiscussion,
   getGitHubIssuePinned,
   getGitHubProjectItems,
-  getGitHubPullChecks,
   getGitHubPullLinkedIssues,
   getGitHubRepoPermissions,
   getGitHubThreadSubscription,
-  getGitHubViewer,
-  getGitHubPullDefaults,
-  getGitHubPullDiff,
   getGitHubPullMergeability,
   getGitHubPullReviewThreads,
   listGitHubAssignees,
-  listGitHubComments,
   listGitHubDiscussions,
-  listGitHubItems,
-  listGitHubItemsAcrossRepos,
-  listGitHubLabels,
   listGitHubMilestones,
   listGitHubNotifications,
   listGitHubProjectsV2,
   listGitHubPullCommits,
-  listGitHubPullReviewComments,
   listGitHubReactions,
   listGitHubReleases,
   listGitHubSubIssues,
@@ -124,15 +110,11 @@ import {
   listGitHubWorkflows,
   markAllGitHubNotificationsRead,
   markGitHubNotificationRead,
-  mergeGitHubPull,
   removeGitHubProjectItem,
   removeGitHubReaction,
   removeGitHubSubIssue,
-  reopenGitHubPull,
-  replyGitHubPullLineComment,
   requestGitHubPullReviewers,
   rerunGitHubWorkflowRun,
-  reviewGitHubPull,
   setGitHubDiscussionAnswer,
   setGitHubIssueLock,
   setGitHubIssuePinned,
@@ -144,13 +126,13 @@ import {
   transferGitHubIssue,
   unsubscribeGitHubThread,
   updateGitHubComment,
-  updateGitHubIssue,
   updateGitHubLabel,
   updateGitHubMilestone,
   updateGitHubPullBranch,
   updateGitHubRelease,
   remoteHostsForDirs,
 } from "./github.ts";
+import * as gitHost from "./git-host.ts";
 import { getDiscoveredModels, refreshDiscoveredModels } from "./agent-discovery.ts";
 import { getMainWindow } from "./window.ts";
 import {
@@ -665,7 +647,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (direction !== null && direction !== "asc" && direction !== "desc") {
             return json({ error: "direction must be asc or desc" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await listGitHubItems({
+          const result = await gitHost.listItems({
             dir,
             kind: kind as GitHubItemKind,
             state: state as GitHubItemState,
@@ -729,7 +711,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           const labels = Array.isArray(body.labels)
             ? body.labels.filter((s): s is string => typeof s === "string" && s.trim().length > 0)
             : [];
-          const result = await listGitHubItemsAcrossRepos({
+          const result = await gitHost.listItemsAcrossRepos({
             dirs: paths,
             kind: kind as GitHubItemKind,
             state: state as GitHubItemState,
@@ -772,7 +754,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (typeof number !== "number" || !Number.isInteger(number) || number <= 0) {
             return json({ error: "valid pull request number required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await getGitHubPullDiff({ dir, number });
+          const result = await gitHost.pullDiff({ dir, number });
           if (!result.ok) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }
@@ -785,7 +767,23 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           const url = new URL(req.url);
           const dir = url.searchParams.get("path");
           if (!dir) return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
-          const result = await getGitHubViewer({ dir });
+          const result = await gitHost.viewer({ dir });
+          if (!result.ok) {
+            return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
+          }
+          return json(result, { headers: corsHeaders(req) });
+        }),
+      },
+
+      // Provider detection (T4, docs/plans/multi-provider-git-modal.md) — the
+      // dialog calls this before anything else to pick terminology/gating for
+      // the project's resolved provider (GitHub/GitLab/Bitbucket).
+      "/github/provider-info": {
+        GET: authed(async (req) => {
+          const url = new URL(req.url);
+          const dir = url.searchParams.get("path");
+          if (!dir) return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
+          const result = await gitHost.providerInfoForDir(dir);
           if (!result.ok) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }
@@ -798,7 +796,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           const url = new URL(req.url);
           const dir = url.searchParams.get("path");
           if (!dir) return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
-          const result = await listGitHubLabels({ dir });
+          const result = await gitHost.labels({ dir });
           if (!result.ok) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }
@@ -1220,21 +1218,29 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           const url = new URL(req.url);
           const dir = url.searchParams.get("path");
           const number = Number(url.searchParams.get("number"));
+          const rawKind = url.searchParams.get("kind");
+          const kind = rawKind === "pulls" || rawKind === "issues" ? rawKind : undefined;
           if (!dir) return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
           if (!Number.isInteger(number) || number <= 0) {
             return json({ error: "valid item number required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await listGitHubComments({ dir, number });
+          const result = await gitHost.listComments({ dir, number, kind });
           if (!result.ok) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }
           return json(result, { headers: corsHeaders(req) });
         }),
         POST: authed(async (req) => {
-          const body = (await req.json().catch(() => ({}))) as { path?: string; number?: number; body?: string };
+          const body = (await req.json().catch(() => ({}))) as {
+            path?: string;
+            number?: number;
+            body?: string;
+            kind?: string;
+          };
           const dir = body.path;
           const rawNumber = body.number;
           const commentBody = body.body;
+          const kind = body.kind === "pulls" || body.kind === "issues" ? body.kind : undefined;
           if (!dir) return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
           if (typeof rawNumber !== "number" || !Number.isInteger(rawNumber) || rawNumber <= 0) {
             return json({ error: "valid item number required" }, { status: 400, headers: corsHeaders(req) });
@@ -1243,10 +1249,11 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (typeof commentBody !== "string" || !commentBody.trim()) {
             return json({ error: "comment body required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await createGitHubComment({
+          const result = await gitHost.createComment({
             dir,
             number,
             body: commentBody,
+            kind,
           });
           if (!result.ok) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
@@ -1283,7 +1290,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (body.side !== "LEFT" && body.side !== "RIGHT") {
             return json({ error: "valid comment side required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await createGitHubPullLineComment({
+          const result = await gitHost.pullLineComment({
             dir,
             number: rawNumber,
             body: body.body,
@@ -1307,7 +1314,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (!Number.isInteger(number) || number <= 0) {
             return json({ error: "valid pull request number required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await listGitHubPullReviewComments({ dir, number });
+          const result = await gitHost.pullReviewComments({ dir, number });
           if (!result.ok) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }
@@ -1372,7 +1379,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (typeof body.body !== "string" || !body.body.trim()) {
             return json({ error: "reply body required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await replyGitHubPullLineComment({
+          const result = await gitHost.pullLineCommentReply({
             dir,
             number: rawNumber,
             commentId: rawCommentId,
@@ -1394,7 +1401,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (!Number.isInteger(number) || number <= 0) {
             return json({ error: "valid pull request number required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await getGitHubPullChecks({ dir, number });
+          const result = await gitHost.pullChecks({ dir, number });
           if (!result.ok) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }
@@ -1462,7 +1469,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (typeof rawNumber !== "number" || !Number.isInteger(rawNumber) || rawNumber <= 0) {
             return json({ error: "valid pull request number required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await reopenGitHubPull({ dir, number: rawNumber });
+          const result = await gitHost.pullReopen({ dir, number: rawNumber });
           if (!result.ok) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }
@@ -1559,7 +1566,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           const url = new URL(req.url);
           const dir = url.searchParams.get("path");
           if (!dir) return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
-          const result = await getGitHubPullDefaults({ dir });
+          const result = await gitHost.pullDefaults({ dir });
           if (!result.ok) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }
@@ -1589,7 +1596,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (typeof body.base !== "string" || !body.base.trim()) {
             return json({ error: "base branch required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await createGitHubPull({
+          const result = await gitHost.pullCreate({
             dir,
             title: body.title,
             head: body.head,
@@ -1624,7 +1631,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             return json({ error: "valid review event required" }, { status: 400, headers: corsHeaders(req) });
           }
           const event = body.event as GitHubPullReviewEvent;
-          // Inline comments are re-validated/sanitized in reviewGitHubPull; here
+          // Inline comments are re-validated/sanitized in gitHost.pullReview; here
           // we just narrow the wire shape.
           const comments = Array.isArray(body.comments)
             ? body.comments.flatMap((c) => {
@@ -1637,7 +1644,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
                 return [{ path: o.path, line: o.line, side, body: o.body }];
               })
             : undefined;
-          const result = await reviewGitHubPull({
+          const result = await gitHost.pullReview({
             dir,
             number: rawNumber,
             event,
@@ -1670,7 +1677,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             return json({ error: "valid merge method required" }, { status: 400, headers: corsHeaders(req) });
           }
           const method = body.method as GitHubPullMergeMethod;
-          const result = await mergeGitHubPull({
+          const result = await gitHost.pullMerge({
             dir,
             number: rawNumber,
             method,
@@ -1697,7 +1704,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (typeof rawNumber !== "number" || !Number.isInteger(rawNumber) || rawNumber <= 0) {
             return json({ error: "valid pull request number required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await closeGitHubPull({
+          const result = await gitHost.pullClose({
             dir,
             number: rawNumber,
             comment: typeof body.comment === "string" ? body.comment : undefined,
@@ -1724,7 +1731,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (typeof body.title !== "string" || !body.title.trim()) {
             return json({ error: "issue title required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await createGitHubIssue({
+          const result = await gitHost.issueCreate({
             dir,
             title: body.title,
             body: typeof body.body === "string" ? body.body : undefined,
@@ -1761,7 +1768,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (body.state && body.state !== "open" && body.state !== "closed") {
             return json({ error: "valid issue state required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await updateGitHubIssue({
+          const result = await gitHost.issueUpdate({
             dir,
             number: rawNumber,
             kind: body.kind === "pulls" ? "pulls" : "issues",

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -606,8 +606,8 @@ export default function App() {
             variant="ghost"
             size="icon"
             onClick={() => setGithubOpen(true)}
-            aria-label="GitHub"
-            title="GitHub pull requests and issues"
+            aria-label="Git"
+            title="Git pull requests and issues (GitHub, GitLab, Bitbucket)"
           >
             <GitPullRequest className="size-4" />
           </Button>

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -102,9 +102,12 @@ import type {
   GitHubUser,
   GitHubWorkflow,
   GitHubWorkflowRun,
+  GitProvider,
   Project,
+  ProviderCaps,
   TaskDiff,
 } from "../../../shared/types.ts";
+import { PROVIDER_CAPS } from "../../../shared/types.ts";
 
 interface Props {
   open: boolean;
@@ -190,6 +193,12 @@ function LabelAssigneeMilestoneFields({
   assigneeDraft,
   milestoneDraft,
   disabled,
+  // Provider gating (T5): labels are Bitbucket-unsupported (caps.labels) and
+  // milestones are GitLab/Bitbucket-unsupported (caps.milestones). Both
+  // default to `true` so every existing GitHub call site (which never passes
+  // these) renders exactly as before.
+  showLabels = true,
+  showMilestones = true,
   onLabelDraftChange,
   onAssigneeDraftChange,
   onMilestoneDraftChange,
@@ -201,6 +210,8 @@ function LabelAssigneeMilestoneFields({
   assigneeDraft: string;
   milestoneDraft: string;
   disabled?: boolean;
+  showLabels?: boolean;
+  showMilestones?: boolean;
   onLabelDraftChange: (body: string) => void;
   onAssigneeDraftChange: (body: string) => void;
   onMilestoneDraftChange: (body: string) => void;
@@ -249,7 +260,7 @@ function LabelAssigneeMilestoneFields({
 
   return (
     <>
-      {repoLabels.length > 0 ? (
+      {showLabels && (repoLabels.length > 0 ? (
         <div
           className="flex h-8 flex-wrap items-center gap-1 overflow-y-auto rounded-md border border-input bg-transparent px-1.5 py-1"
           title="Labels"
@@ -274,7 +285,7 @@ function LabelAssigneeMilestoneFields({
           className="h-8 text-xs"
           disabled={disabled}
         />
-      )}
+      ))}
       {repoAssignees.length > 0 ? (
         <div
           className="flex h-8 flex-wrap items-center gap-1 overflow-y-auto rounded-md border border-input bg-transparent px-1.5 py-1"
@@ -301,7 +312,7 @@ function LabelAssigneeMilestoneFields({
           disabled={disabled}
         />
       )}
-      {repoMilestones.length > 0 ? (
+      {showMilestones && (repoMilestones.length > 0 ? (
         <Select
           value={milestoneDraft}
           onChange={(e) => onMilestoneDraftChange(e.target.value)}
@@ -324,7 +335,7 @@ function LabelAssigneeMilestoneFields({
           className="h-8 text-xs"
           disabled={disabled}
         />
-      )}
+      ))}
     </>
   );
 }
@@ -402,6 +413,15 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
   const [projectPath, setProjectPath] = useState("");
   // "All repositories" (G8/F15) — see AGGREGATE_PROJECT_PATH.
   const isAggregate = projectPath === AGGREGATE_PROJECT_PATH;
+  // Provider awareness (T5, docs/plans/multi-provider-git-modal.md): which git
+  // forge the current project (or, in aggregate mode, the whole registered set)
+  // resolves to. `null` while unresolved (or on lookup failure) — treated the
+  // same as "mixed" by `caps` below so the dialog never renders a half-known
+  // provider's gaps; it only ever narrows once resolution lands. Cached per
+  // project path so switching between two already-seen projects is instant and
+  // aggregate mode doesn't refetch on every render.
+  const [provider, setProvider] = useState<GitProvider | "mixed" | null>(null);
+  const providerCache = useRef<Map<string, GitProvider | null>>(new Map());
   const [kind, setKind] = useState<GitHubItemKind>("pulls");
   const [state, setState] = useState<GitHubItemState>("open");
   const [query, setQuery] = useState("");
@@ -639,6 +659,78 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
     () => (isAggregate ? projects.map((p) => p.path).join("\n") : ""),
     [isAggregate, projects],
   );
+
+  // Resolve provider-info (T5) whenever the selected project (or, in aggregate
+  // mode, the candidate set) changes. Single-repo: one lookup, cached by path.
+  // Aggregate: resolve every registered project (cached individually so
+  // re-entering aggregate mode doesn't refetch already-known repos), then
+  // collapse to "github" only if every one of them is GitHub — otherwise
+  // "mixed". `provider` starts `null` each time the target changes, so a
+  // stale provider from the previously-selected project can never leak onto
+  // the next one while the new lookup is in flight.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const resolveOne = async (path: string): Promise<GitProvider | null> => {
+      const cached = providerCache.current.get(path);
+      if (cached !== undefined) return cached;
+      try {
+        const res = await api.getProviderInfo(path);
+        const resolved = res.ok ? res.provider : null;
+        providerCache.current.set(path, resolved);
+        return resolved;
+      } catch {
+        providerCache.current.set(path, null);
+        return null;
+      }
+    };
+    if (isAggregate) {
+      setProvider(null);
+      void (async () => {
+        const resolved = await Promise.all(projects.map((p) => resolveOne(p.path)));
+        if (cancelled) return;
+        setProvider(resolved.length > 0 && resolved.every((r) => r === "github") ? "github" : "mixed");
+      })();
+    } else if (projectPath) {
+      setProvider(null);
+      void resolveOne(projectPath).then((resolved) => {
+        if (!cancelled) setProvider(resolved);
+      });
+    } else {
+      setProvider(null);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [open, isAggregate, projectPath, aggregatePathsKey]);
+
+  // While unresolved (null) or in aggregate mode with mixed providers, default
+  // to GitHub's capability set so terminology/gating never flicker for the
+  // (overwhelmingly common) GitHub case during the brief lookup window.
+  const caps: ProviderCaps = provider === "mixed" || provider === null ? PROVIDER_CAPS.github : PROVIDER_CAPS[provider];
+  // GitHub-exclusive panels (Labels/Milestones/Releases/Notifications/Actions/
+  // Projects/Discussions manager buttons, per plan §8.6) require a *confirmed*
+  // GitHub repo, unlike `caps` above which defaults to GitHub's flags while
+  // unresolved — a manager panel that briefly appears then vanishes once a
+  // non-GitHub project resolves is worse than a beat of extra latency before
+  // it appears. Mixed aggregate mode has no single repo these panels could
+  // act on either way.
+  const panelsEnabled = provider === "github";
+
+  // GitLab/Bitbucket have no raw search-qualifier syntax (caps.searchSyntax) —
+  // if a provider switch lands on one of them while "GH mode" was left on from
+  // a previously-selected GitHub project, fall back to the plain substring
+  // filter rather than silently keeping the query box in a mode it can't use.
+  useEffect(() => {
+    if (!caps.searchSyntax && searchSyntax) setSearchSyntax(false);
+  }, [caps.searchSyntax, searchSyntax]);
+
+  // Same guard for the "Comments" sort option (GitHub-only, caps.commentSort)
+  // — a provider switch away from GitHub can't leave the sort stuck on an
+  // option that no longer appears in the dropdown.
+  useEffect(() => {
+    if (!caps.commentSort && sortField === "comments") setSortField("best-match");
+  }, [caps.commentSort, sortField]);
 
   // `page`/`append` power the "Load more" flow (F16): a plain refresh or a
   // filter/sort change always fetches page 1 and replaces `result`; "Load
@@ -1937,7 +2029,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
     const requestId = ++commentSeq.current;
     setCommentsLoading((cur) => ({ ...cur, [key]: true }));
     setCommentErrors((cur) => ({ ...cur, [key]: undefined }));
-    api.listGitHubComments({ path: expandedItemPath, number })
+    api.listGitHubComments({ path: expandedItemPath, number, kind: expandedItem.kind })
       .then((payload) => {
         if (requestId !== commentSeq.current) return;
         setComments((cur) => ({ ...cur, [key]: payload.comments }));
@@ -1990,7 +2082,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
     setCommentSubmitting((cur) => ({ ...cur, [itemKey(item)]: true }));
     setCommentErrors((cur) => ({ ...cur, [itemKey(item)]: undefined }));
     try {
-      const { comment } = await api.createGitHubComment({ path: itemPath, number: item.number, body });
+      const { comment } = await api.createGitHubComment({ path: itemPath, number: item.number, body, kind: item.kind });
       setComments((cur) => ({ ...cur, [itemKey(item)]: [...(cur[itemKey(item)] ?? []), comment] }));
       setCommentDrafts((cur) => ({ ...cur, [itemKey(item)]: "" }));
     } catch (e) {
@@ -2611,7 +2703,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
       setEditorOpen((cur) => ({ ...cur, [itemKey(item)]: false }));
       setTitleDrafts((cur) => ({ ...cur, [itemKey(item)]: undefined }));
       setBodyDrafts((cur) => ({ ...cur, [itemKey(item)]: undefined }));
-      setActionMessages((cur) => ({ ...cur, [itemKey(item)]: `${item.kind === "pulls" ? "Pull request" : "Issue"} updated.` }));
+      setActionMessages((cur) => ({ ...cur, [itemKey(item)]: `${item.kind === "pulls" ? caps.pullNoun : "Issue"} updated.` }));
     } catch (e) {
       setActionErrors((cur) => ({ ...cur, [itemKey(item)]: e instanceof Error ? e.message : String(e) }));
     } finally {
@@ -2682,7 +2774,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
             </Button>
             <div className="min-w-0">
               <div id="github-dialog-title" className="flex items-center gap-2 text-sm font-semibold">
-                {expandedItem.kind === "pulls" ? "Pull request" : "Issue"} #{expandedItem.number}
+                {expandedItem.kind === "pulls" ? caps.pullNoun : "Issue"} #{expandedItem.number}
                 {isAggregate && repoLabelFor(expandedItem) && (
                   <span
                     className="rounded border border-border/60 bg-muted/40 px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground"
@@ -2711,7 +2803,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
                 {PANEL_TITLES[view.panel]}
               </div>
               <div className="mt-0.5 truncate text-xs text-muted-foreground">
-                {result ? result.repo : "GitHub"}
+                {result ? result.repo : caps.providerName}
               </div>
             </div>
           </div>
@@ -2719,7 +2811,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
           <div className="min-w-0">
             <div id="github-dialog-title" className="flex items-center gap-2 text-sm font-semibold">
               <GitPullRequest className="size-4 shrink-0 text-muted-foreground" />
-              GitHub
+              {provider === "mixed" ? "Git" : caps.providerName}
             </div>
             <div className="mt-0.5 flex flex-wrap items-center gap-x-2 truncate text-xs text-muted-foreground">
               {result ? (
@@ -2728,10 +2820,12 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
                     {result.repo}
                     {result.auth === "none" && " · unauthenticated"}
                   </span>
-                  {result.rateLimit && <RateLimitBadge rateLimit={result.rateLimit} />}
+                  {/* Rate-limit badge is GitHub API-specific (F17) — gate it so a
+                      GitLab/Bitbucket repo never renders a "GitHub API" tooltip. */}
+                  {result.rateLimit && provider === "github" && <RateLimitBadge rateLimit={result.rateLimit} />}
                 </>
               ) : (
-                "Pull requests and issues"
+                `${caps.pullNounPlural} and issues`
               )}
             </div>
           </div>
@@ -2741,8 +2835,8 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
             <Button
               size="icon"
               variant="ghost"
-              title="Open on GitHub"
-              aria-label="Open on GitHub"
+              title={`Open on ${caps.providerName}`}
+              aria-label={`Open on ${caps.providerName}`}
               onClick={() => { void api.openExternal(expandedItem.htmlUrl); }}
             >
               <ExternalLink className="size-4" />
@@ -2750,82 +2844,96 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
           )}
           {!showDetail && (
           <>
-          <Button
-            size="icon"
-            variant={labelManagerOpen ? "secondary" : "ghost"}
-            title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Manage labels"}
-            aria-label="Manage labels"
-            disabled={!projectPath || isAggregate}
-            onClick={() => setView((cur) => togglePanel(cur, "labels"))}
-          >
-            <Tag className="size-4" />
-          </Button>
-          <Button
-            size="icon"
-            variant={milestoneManagerOpen ? "secondary" : "ghost"}
-            title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Manage milestones"}
-            aria-label="Manage milestones"
-            disabled={!projectPath || isAggregate}
-            onClick={() => setView((cur) => togglePanel(cur, "milestones"))}
-          >
-            <Milestone className="size-4" />
-          </Button>
-          <Button
-            size="icon"
-            variant={releaseManagerOpen ? "secondary" : "ghost"}
-            title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Manage releases"}
-            aria-label="Manage releases"
-            disabled={!projectPath || isAggregate}
-            onClick={() => setView((cur) => togglePanel(cur, "releases"))}
-          >
-            <Rocket className="size-4" />
-          </Button>
-          <Button
-            size="icon"
-            variant={notificationsOpen ? "secondary" : "ghost"}
-            title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Notifications"}
-            aria-label="Notifications"
-            disabled={!projectPath || isAggregate}
-            onClick={() => setView((cur) => togglePanel(cur, "notifications"))}
-          >
-            <Bell className="size-4" />
-          </Button>
-          <Button
-            size="icon"
-            variant={actionsManagerOpen ? "secondary" : "ghost"}
-            title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Actions"}
-            aria-label="Actions"
-            disabled={!projectPath || isAggregate}
-            onClick={() => setView((cur) => togglePanel(cur, "actions"))}
-          >
-            <Workflow className="size-4" />
-          </Button>
-          <Button
-            size="icon"
-            variant={projectsManagerOpen ? "secondary" : "ghost"}
-            title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Projects"}
-            aria-label="Projects"
-            disabled={!projectPath || isAggregate}
-            onClick={() => setView((cur) => togglePanel(cur, "projects"))}
-          >
-            <Kanban className="size-4" />
-          </Button>
-          <Button
-            size="icon"
-            variant={discussionsManagerOpen ? "secondary" : "ghost"}
-            title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Discussions"}
-            aria-label="Discussions"
-            disabled={!projectPath || isAggregate}
-            onClick={() => setView((cur) => togglePanel(cur, "discussions"))}
-          >
-            <MessagesSquare className="size-4" />
-          </Button>
+          {panelsEnabled && caps.labels && (
+            <Button
+              size="icon"
+              variant={labelManagerOpen ? "secondary" : "ghost"}
+              title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Manage labels"}
+              aria-label="Manage labels"
+              disabled={!projectPath || isAggregate}
+              onClick={() => setView((cur) => togglePanel(cur, "labels"))}
+            >
+              <Tag className="size-4" />
+            </Button>
+          )}
+          {panelsEnabled && caps.milestones && (
+            <Button
+              size="icon"
+              variant={milestoneManagerOpen ? "secondary" : "ghost"}
+              title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Manage milestones"}
+              aria-label="Manage milestones"
+              disabled={!projectPath || isAggregate}
+              onClick={() => setView((cur) => togglePanel(cur, "milestones"))}
+            >
+              <Milestone className="size-4" />
+            </Button>
+          )}
+          {panelsEnabled && caps.releases && (
+            <Button
+              size="icon"
+              variant={releaseManagerOpen ? "secondary" : "ghost"}
+              title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Manage releases"}
+              aria-label="Manage releases"
+              disabled={!projectPath || isAggregate}
+              onClick={() => setView((cur) => togglePanel(cur, "releases"))}
+            >
+              <Rocket className="size-4" />
+            </Button>
+          )}
+          {panelsEnabled && caps.notifications && (
+            <Button
+              size="icon"
+              variant={notificationsOpen ? "secondary" : "ghost"}
+              title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Notifications"}
+              aria-label="Notifications"
+              disabled={!projectPath || isAggregate}
+              onClick={() => setView((cur) => togglePanel(cur, "notifications"))}
+            >
+              <Bell className="size-4" />
+            </Button>
+          )}
+          {panelsEnabled && caps.actions && (
+            <Button
+              size="icon"
+              variant={actionsManagerOpen ? "secondary" : "ghost"}
+              title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Actions"}
+              aria-label="Actions"
+              disabled={!projectPath || isAggregate}
+              onClick={() => setView((cur) => togglePanel(cur, "actions"))}
+            >
+              <Workflow className="size-4" />
+            </Button>
+          )}
+          {panelsEnabled && caps.projects && (
+            <Button
+              size="icon"
+              variant={projectsManagerOpen ? "secondary" : "ghost"}
+              title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Projects"}
+              aria-label="Projects"
+              disabled={!projectPath || isAggregate}
+              onClick={() => setView((cur) => togglePanel(cur, "projects"))}
+            >
+              <Kanban className="size-4" />
+            </Button>
+          )}
+          {panelsEnabled && caps.discussions && (
+            <Button
+              size="icon"
+              variant={discussionsManagerOpen ? "secondary" : "ghost"}
+              title={isAggregate ? AGGREGATE_DISABLED_TITLE : "Discussions"}
+              aria-label="Discussions"
+              disabled={!projectPath || isAggregate}
+              onClick={() => setView((cur) => togglePanel(cur, "discussions"))}
+            >
+              <MessagesSquare className="size-4" />
+            </Button>
+          )}
           {result && result.webUrl && (
             <Button
               size="icon"
               variant="ghost"
-              title="Open repository on GitHub"
-              aria-label="Open repository on GitHub"
+              title={`Open repository on ${caps.providerName}`}
+              aria-label={`Open repository on ${caps.providerName}`}
               onClick={() => { void api.openExternal(result.webUrl!); }}
             >
               <ExternalLink className="size-4" />
@@ -2868,7 +2976,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
             className="h-7"
             onClick={() => setKind("pulls")}
           >
-            PRs
+            {caps.pullAbbrevPlural}
           </Button>
           <Button
             size="sm"
@@ -2904,32 +3012,36 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
             placeholder={searchSyntax ? "GitHub search — press Enter (is:open label:bug sort:updated…)" : "Search title, body, number, author…"}
             className="h-8 pl-8 pr-14 text-xs"
           />
-          <Button
-            size="sm"
-            variant={searchSyntax ? "secondary" : "ghost"}
-            className="absolute right-1 top-1/2 h-6 -translate-y-1/2 px-2 text-[10px] font-medium uppercase"
-            disabled={result?.auth === "none"}
-            title={
-              result?.auth === "none"
-                ? "Sign in to GitHub to use search syntax"
-                : "Toggle GitHub search syntax (is:open author:me label:bug sort:updated…) — runs server-side via the Search API on Enter"
-            }
-            onClick={() => {
-              const next = !searchSyntax;
-              setSearchSyntax(next);
-              if (next) setSearchSubmitted(query);
-            }}
-          >
-            GH
-          </Button>
+          {caps.searchSyntax && (
+            <Button
+              size="sm"
+              variant={searchSyntax ? "secondary" : "ghost"}
+              className="absolute right-1 top-1/2 h-6 -translate-y-1/2 px-2 text-[10px] font-medium uppercase"
+              disabled={result?.auth === "none"}
+              title={
+                result?.auth === "none"
+                  ? "Sign in to GitHub to use search syntax"
+                  : "Toggle GitHub search syntax (is:open author:me label:bug sort:updated…) — runs server-side via the Search API on Enter"
+              }
+              onClick={() => {
+                const next = !searchSyntax;
+                setSearchSyntax(next);
+                if (next) setSearchSubmitted(query);
+              }}
+            >
+              GH
+            </Button>
+          )}
         </div>
-        <Input
-          value={labels}
-          onChange={(e) => setLabels(e.target.value)}
-          placeholder="Labels, comma separated"
-          className="h-8 text-xs"
-          list="github-dialog-labels"
-        />
+        {caps.labels && (
+          <Input
+            value={labels}
+            onChange={(e) => setLabels(e.target.value)}
+            placeholder="Labels, comma separated"
+            className="h-8 text-xs"
+            list="github-dialog-labels"
+          />
+        )}
         <Input
           value={assignee}
           onChange={(e) => setAssignee(e.target.value)}
@@ -2948,7 +3060,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
             <option value="best-match">Best match</option>
             <option value="created">Created</option>
             <option value="updated">Updated</option>
-            <option value="comments">Comments</option>
+            {caps.commentSort && <option value="comments">Comments</option>}
           </Select>
           <Button
             size="icon"
@@ -3014,6 +3126,8 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
         {showDetail && expandedItem ? (
           <GitHubItemDetail
             item={expandedItem}
+            caps={caps}
+            provider={provider}
             itemPath={expandedItemPath}
             canPush={canPush}
             viewerLogin={viewerLogin}
@@ -3326,6 +3440,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
         )}
         {kind === "pulls" && !isAggregate && (
           <PullComposer
+            caps={caps}
             open={pullComposerOpen}
             title={newPullTitle}
             body={newPullBody}
@@ -3352,6 +3467,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
 
         {kind === "issues" && !isAggregate && (
           <IssueComposer
+            caps={caps}
             open={issueComposerOpen}
             title={newIssueTitle}
             body={newIssueBody}
@@ -3402,19 +3518,20 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
         {!loading && !error && result && result.items.length === 0 && (
           <div className="flex flex-col items-center justify-center gap-2 py-12 text-center text-sm text-muted-foreground">
             <GitPullRequest className="size-6 opacity-40" />
-            No {kind === "pulls" ? "pull requests" : "issues"} match these filters.
+            No {kind === "pulls" ? caps.pullNounPlural.toLowerCase() : "issues"} match these filters.
           </div>
         )}
 
         {result && result.items.length > 0 && (
           <div className="flex flex-col gap-2">
             <div className="px-1 text-xs text-muted-foreground">
-              {result.items.length} {kind === "pulls" ? "pull requests" : "issues"}
+              {result.items.length} {kind === "pulls" ? caps.pullNounPlural.toLowerCase() : "issues"}
             </div>
             {result.items.map((item) => (
               <GitHubItemRow
                 key={itemKey(item)}
                 item={item}
+                caps={caps}
                 repoBadge={isAggregate ? repoLabelFor(item) : undefined}
                 onToggle={() => openItemDetail(item)}
               />
@@ -3446,6 +3563,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, onClose }: Pr
 }
 
 function PullComposer({
+  caps,
   open,
   title,
   body,
@@ -3468,6 +3586,7 @@ function PullComposer({
   onPushHead,
   onSubmit,
 }: {
+  caps: ProviderCaps;
   open: boolean;
   title: string;
   body: string;
@@ -3495,7 +3614,7 @@ function PullComposer({
       <div className="mb-3 flex justify-end">
         <Button size="sm" onClick={() => onOpenChange(true)}>
           <Plus className="mr-2 size-3.5" />
-          New PR
+          New {caps.pullAbbrev}
         </Button>
       </div>
     );
@@ -3506,7 +3625,7 @@ function PullComposer({
       <div className="mb-2 flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
           <GitPullRequest className="size-3.5" />
-          New pull request
+          New {caps.pullNoun.toLowerCase()}
         </div>
         {error && (
           <span className="inline-flex items-center gap-1 text-[11px] text-rose-400">
@@ -3559,7 +3678,7 @@ function PullComposer({
             variant="outline"
             disabled={submitting || pushing || !head.trim()}
             onClick={onPushHead}
-            title="Push the head branch to its remote so GitHub can open the pull request"
+            title={`Push the head branch to its remote so ${caps.providerName} can open the ${caps.pullNoun.toLowerCase()}`}
           >
             {pushing ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <ArrowUpFromLine className="mr-2 size-3.5" />}
             Push head
@@ -3578,7 +3697,7 @@ function PullComposer({
           )}
         </div>
         <p className="text-[11px] text-muted-foreground">
-          The head branch must exist on the remote before GitHub can open the pull request — push it first if it's a new local branch.
+          The head branch must exist on the remote before {caps.providerName} can open the {caps.pullNoun.toLowerCase()} — push it first if it's a new local branch.
         </p>
       </div>
       <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
@@ -3597,7 +3716,7 @@ function PullComposer({
           </Button>
           <Button size="sm" disabled={submitting || !title.trim() || !head.trim() || !base.trim()} onClick={onSubmit}>
             {submitting ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <Plus className="mr-2 size-3.5" />}
-            Create PR
+            Create {caps.pullAbbrev}
           </Button>
         </div>
       </div>
@@ -3606,6 +3725,7 @@ function PullComposer({
 }
 
 function IssueComposer({
+  caps,
   open,
   title,
   body,
@@ -3622,6 +3742,7 @@ function IssueComposer({
   onMilestoneChange,
   onSubmit,
 }: {
+  caps: ProviderCaps;
   open: boolean;
   title: string;
   body: string;
@@ -3678,13 +3799,15 @@ function IssueComposer({
           className="min-h-24 resize-y text-sm"
           disabled={submitting}
         />
-        <Input
-          value={labels}
-          onChange={(e) => onLabelsChange(e.target.value)}
-          placeholder="Labels, comma separated"
-          className="h-8 text-xs"
-          disabled={submitting}
-        />
+        {caps.labels && (
+          <Input
+            value={labels}
+            onChange={(e) => onLabelsChange(e.target.value)}
+            placeholder="Labels, comma separated"
+            className="h-8 text-xs"
+            disabled={submitting}
+          />
+        )}
         <div className="grid gap-2 md:grid-cols-2">
           <Input
             value={assignees}
@@ -3693,13 +3816,15 @@ function IssueComposer({
             className="h-8 text-xs"
             disabled={submitting}
           />
-          <Input
-            value={milestone}
-            onChange={(e) => onMilestoneChange(e.target.value)}
-            placeholder="Milestone number"
-            className="h-8 text-xs"
-            disabled={submitting}
-          />
+          {caps.milestones && (
+            <Input
+              value={milestone}
+              onChange={(e) => onMilestoneChange(e.target.value)}
+              placeholder="Milestone number"
+              className="h-8 text-xs"
+              disabled={submitting}
+            />
+          )}
         </div>
       </div>
       <div className="mt-3 flex justify-end gap-2">
@@ -5726,10 +5851,14 @@ function DiscussionCommentRow({
 
 function GitHubItemRow({
   item,
+  caps,
   repoBadge,
   onToggle,
 }: {
   item: GitHubListItem;
+  // Terminology/link labels follow the project's provider (multi-provider
+  // support, docs/plans/multi-provider-git-modal.md).
+  caps: ProviderCaps;
   // Aggregate mode (G8/F15): shows a small repo badge next to the title
   // (redundant, and hidden, in single-repo mode) so items from different
   // repos are distinguishable in the merged list.
@@ -5820,8 +5949,8 @@ function GitHubItemRow({
         <Button
           size="icon"
           variant="ghost"
-          title="Open on GitHub"
-          aria-label={`Open #${item.number} on GitHub`}
+          title={`Open on ${caps.providerName}`}
+          aria-label={`Open #${item.number} on ${caps.providerName}`}
           onClick={() => { void api.openExternal(item.htmlUrl); }}
         >
           <ExternalLink className="size-4" />
@@ -5843,6 +5972,8 @@ function GitHubItemRow({
  */
 function GitHubItemDetail({
   item,
+  caps,
+  provider,
   itemPath,
   canPush,
   viewerLogin,
@@ -5950,6 +6081,13 @@ function GitHubItemDetail({
   onRetryCommits,
 }: {
   item: GitHubListItem;
+  caps: ProviderCaps;
+  // "github" gates the GitHub-exclusive per-item affordances (reactions,
+  // sub-issues, pin, lock, transfer, suggestion-apply, pending-review batch,
+  // thread-resolve, reviewer-request UI) that even `caps` can't express
+  // because their write path is GitHub GraphQL/REST-specific, not merely
+  // "unsupported on this provider's core API".
+  provider: GitProvider | "mixed" | null;
   itemPath: string;
   canPush: boolean;
   viewerLogin: string;
@@ -6065,7 +6203,7 @@ function GitHubItemDetail({
     <div>
       <div className="mb-2 flex items-center justify-between gap-2">
         <div className="text-[11px] font-medium uppercase text-muted-foreground">
-          {item.kind === "pulls" ? "Pull request" : "Issue"} #{item.number}
+          {item.kind === "pulls" ? caps.pullNoun : "Issue"} #{item.number}
         </div>
         {!editorOpen && (
           <Button
@@ -6081,7 +6219,7 @@ function GitHubItemDetail({
           </Button>
         )}
       </div>
-      {item.kind === "pulls" && linkedIssues && linkedIssues.length > 0 && (
+      {item.kind === "pulls" && caps.linkedIssues && linkedIssues && linkedIssues.length > 0 && (
         <LinkedIssuesLine issues={linkedIssues} />
       )}
       {editorOpen ? (
@@ -6107,11 +6245,15 @@ function GitHubItemDetail({
           )}
         </div>
       )}
-      <Reactions path={itemPath} subject={{ type: "issue", id: item.number }} viewer={viewerLogin} />
+      {caps.reactions && (
+        <Reactions path={itemPath} subject={{ type: "issue", id: item.number }} viewer={viewerLogin} />
+      )}
       {item.kind === "pulls" && (
         <>
           <PullActions
             item={item}
+            caps={caps}
+            provider={provider}
             reviewDraft={reviewDraft}
             closeDraft={closeDraft}
             mergeMethod={mergeMethod}
@@ -6137,6 +6279,8 @@ function GitHubItemDetail({
             canModifyOwn={canModifyOwn}
           />
           <PullTriage
+            caps={caps}
+            provider={provider}
             repoLabels={repoLabels}
             repoAssignees={repoAssignees}
             repoMilestones={repoMilestones}
@@ -6159,12 +6303,18 @@ function GitHubItemDetail({
             canPush={canPush}
           />
           <CheckRuns checks={checks} loading={checksLoading} error={checksError} onRetry={onRetryChecks} onRefresh={onRefreshChecks} />
-          <CommitStatus status={commitStatus} loading={commitStatusLoading} error={commitStatusError} onRetry={onRetryCommitStatus} onRefresh={onRefreshCommitStatus} />
+          {caps.commitStatusPanel && (
+            <CommitStatus status={commitStatus} loading={commitStatusLoading} error={commitStatusError} onRetry={onRetryCommitStatus} onRefresh={onRefreshCommitStatus} />
+          )}
           <PullCommits commits={commits} loading={commitsLoading} error={commitsError} onRetry={onRetryCommits} />
-          <PullDiff diff={diff} loading={diffLoading} error={diffError} onRetry={onRetryDiff} onRefresh={onRefreshDiff} onLineComment={onLineComment} onAddToReview={onAddToReview} pending={pendingReview} />
-          <PendingReview comments={pendingReview} stale={pendingStale} onRemove={onRemovePendingReview} />
+          <PullDiff diff={diff} loading={diffLoading} error={diffError} onRetry={onRetryDiff} onRefresh={onRefreshDiff} onLineComment={onLineComment} onAddToReview={onAddToReview} pending={pendingReview} allowBatchReview={provider === "github"} />
+          {provider === "github" && (
+            <PendingReview comments={pendingReview} stale={pendingStale} onRemove={onRemovePendingReview} />
+          )}
           <ReviewComments
             path={itemPath}
+            caps={caps}
+            resolveSupported={provider === "github"}
             comments={reviewComments}
             loading={reviewCommentsLoading}
             error={reviewCommentError}
@@ -6190,6 +6340,7 @@ function GitHubItemDetail({
       {item.kind === "issues" && (
         <IssueActions
           item={item}
+          caps={caps}
           path={itemPath}
           repoLabels={repoLabels}
           repoAssignees={repoAssignees}
@@ -6219,6 +6370,7 @@ function GitHubItemDetail({
       )}
       <Conversation
         path={itemPath}
+        caps={caps}
         comments={comments}
         loading={commentsLoading}
         error={commentError}
@@ -6260,8 +6412,22 @@ const MERGE_TONE_CLASS: Record<MergeTone, string> = {
   muted: "text-muted-foreground",
 };
 
+/** Merge-method dropdown label for the neutral `GitHubPullMergeMethod`
+ *  vocabulary (see the `PROVIDER_CAPS.mergeMethods` doc comment in
+ *  shared/types.ts): Bitbucket has no "rebase and merge" strategy — its
+ *  linear-history option is `fast_forward`, mapped onto the shared "rebase"
+ *  value, so it reads as "Fast-forward" rather than GitHub/GitLab's "Rebase
+ *  and merge" wording. */
+function mergeMethodLabel(method: GitHubPullMergeMethod, provider: GitProvider | "mixed" | null): string {
+  if (method === "rebase" && provider === "bitbucket") return "Fast-forward";
+  if (method === "merge") return "Create merge commit";
+  if (method === "squash") return "Squash and merge";
+  return "Rebase and merge";
+}
+
 function IssueActions({
   item,
+  caps,
   path,
   repoLabels,
   repoAssignees,
@@ -6289,6 +6455,7 @@ function IssueActions({
   canModifyOwn,
 }: {
   item: GitHubListItem;
+  caps: ProviderCaps;
   path: string;
   repoLabels: GitHubRepoLabel[];
   repoAssignees: GitHubUser[];
@@ -6352,6 +6519,8 @@ function IssueActions({
           assigneeDraft={assigneeDraft}
           milestoneDraft={milestoneDraft}
           disabled={isBusy}
+          showLabels={caps.labels}
+          showMilestones={caps.milestones}
           onLabelDraftChange={onLabelDraftChange}
           onAssigneeDraftChange={onAssigneeDraftChange}
           onMilestoneDraftChange={onMilestoneDraftChange}
@@ -6372,66 +6541,70 @@ function IssueActions({
           {busy === nextState ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <XCircle className="mr-2 size-3.5" />}
           {item.state === "open" ? "Close issue" : "Reopen issue"}
         </Button>
-        <IssuePinToggle path={path} number={item.number} canPush={canPush} />
+        {caps.pinIssue && <IssuePinToggle path={path} number={item.number} canPush={canPush} />}
       </div>
 
-      <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
-        <Select
-          value={lockReasonDraft}
-          onChange={(e) => onLockReasonDraftChange(e.target.value)}
-          className="h-8 w-40 text-xs"
-          disabled={isBusy || item.locked || !canPush}
-          title="Lock reason (optional)"
-          aria-label="Lock reason"
-        >
-          <option value="">No reason</option>
-          <option value="off-topic">Off-topic</option>
-          <option value="too heated">Too heated</option>
-          <option value="resolved">Resolved</option>
-          <option value="spam">Spam</option>
-        </Select>
-        <Button size="sm" variant="outline" disabled={pushDisabled} title={pushTitle} onClick={onToggleLock}>
-          {busy === "lock" ? (
-            <Loader2 className="mr-2 size-3.5 animate-spin" />
-          ) : item.locked ? (
-            <Unlock className="mr-2 size-3.5" />
-          ) : (
-            <Lock className="mr-2 size-3.5" />
-          )}
-          {item.locked ? "Unlock conversation" : "Lock conversation"}
-        </Button>
-      </div>
-
-      <SubIssues path={path} issueNumber={item.number} canPush={canPush} />
-
-      <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
-        <Input
-          value={transferDraft}
-          onChange={(e) => onTransferDraftChange(e.target.value)}
-          placeholder="Transfer to owner/repo"
-          className="h-8 w-48 text-xs"
-          disabled={isBusy || !canPush}
-        />
-        {transferConfirming ? (
-          <>
-            <span className="text-[11px] text-amber-400">
-              Transfer #{item.number} to {transferDraft.trim() || "…"}? This can't be undone.
-            </span>
-            <Button size="sm" variant="destructive" disabled={pushDisabled || !transferDraft.trim()} title={pushTitle} onClick={onTransferIssue}>
-              {busy === "transfer" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <ArrowRightLeft className="mr-2 size-3.5" />}
-              Confirm transfer
-            </Button>
-            <Button size="sm" variant="ghost" disabled={isBusy} onClick={onCancelTransfer}>
-              Cancel
-            </Button>
-          </>
-        ) : (
-          <Button size="sm" variant="outline" disabled={pushDisabled || !transferDraft.trim()} title={pushTitle} onClick={onTransferIssue}>
-            <ArrowRightLeft className="mr-2 size-3.5" />
-            Transfer issue
+      {caps.lockConversation && (
+        <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
+          <Select
+            value={lockReasonDraft}
+            onChange={(e) => onLockReasonDraftChange(e.target.value)}
+            className="h-8 w-40 text-xs"
+            disabled={isBusy || item.locked || !canPush}
+            title="Lock reason (optional)"
+            aria-label="Lock reason"
+          >
+            <option value="">No reason</option>
+            <option value="off-topic">Off-topic</option>
+            <option value="too heated">Too heated</option>
+            <option value="resolved">Resolved</option>
+            <option value="spam">Spam</option>
+          </Select>
+          <Button size="sm" variant="outline" disabled={pushDisabled} title={pushTitle} onClick={onToggleLock}>
+            {busy === "lock" ? (
+              <Loader2 className="mr-2 size-3.5 animate-spin" />
+            ) : item.locked ? (
+              <Unlock className="mr-2 size-3.5" />
+            ) : (
+              <Lock className="mr-2 size-3.5" />
+            )}
+            {item.locked ? "Unlock conversation" : "Lock conversation"}
           </Button>
-        )}
-      </div>
+        </div>
+      )}
+
+      {caps.subIssues && <SubIssues path={path} issueNumber={item.number} canPush={canPush} />}
+
+      {caps.issueTransfer && (
+        <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
+          <Input
+            value={transferDraft}
+            onChange={(e) => onTransferDraftChange(e.target.value)}
+            placeholder="Transfer to owner/repo"
+            className="h-8 w-48 text-xs"
+            disabled={isBusy || !canPush}
+          />
+          {transferConfirming ? (
+            <>
+              <span className="text-[11px] text-amber-400">
+                Transfer #{item.number} to {transferDraft.trim() || "…"}? This can't be undone.
+              </span>
+              <Button size="sm" variant="destructive" disabled={pushDisabled || !transferDraft.trim()} title={pushTitle} onClick={onTransferIssue}>
+                {busy === "transfer" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <ArrowRightLeft className="mr-2 size-3.5" />}
+                Confirm transfer
+              </Button>
+              <Button size="sm" variant="ghost" disabled={isBusy} onClick={onCancelTransfer}>
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <Button size="sm" variant="outline" disabled={pushDisabled || !transferDraft.trim()} title={pushTitle} onClick={onTransferIssue}>
+              <ArrowRightLeft className="mr-2 size-3.5" />
+              Transfer issue
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -6704,6 +6877,8 @@ function ItemEditor({
 }
 
 function PullTriage({
+  caps,
+  provider,
   repoLabels,
   repoAssignees,
   repoMilestones,
@@ -6725,6 +6900,11 @@ function PullTriage({
   onRequestReviewers,
   canPush,
 }: {
+  caps: ProviderCaps;
+  // Reviewer-request UI is GitHub-only (GitLab/Bitbucket reviewer assignment
+  // isn't part of the adapters' core subset — see git-host.ts's `pullCreate`
+  // doc comment); gate on a confirmed GitHub repo, not merely `caps`.
+  provider: GitProvider | "mixed" | null;
   repoLabels: GitHubRepoLabel[];
   repoAssignees: GitHubUser[];
   repoMilestones: GitHubRepoMilestone[];
@@ -6781,6 +6961,8 @@ function PullTriage({
           assigneeDraft={assigneeDraft}
           milestoneDraft={milestoneDraft}
           disabled={isBusy}
+          showLabels={caps.labels}
+          showMilestones={caps.milestones}
           onLabelDraftChange={onLabelDraftChange}
           onAssigneeDraftChange={onAssigneeDraftChange}
           onMilestoneDraftChange={onMilestoneDraftChange}
@@ -6790,38 +6972,42 @@ function PullTriage({
           Save triage
         </Button>
       </div>
-      <div className="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
-        <Input
-          value={reviewerDraft}
-          onChange={(e) => onReviewerDraftChange(e.target.value)}
-          placeholder={prOpen ? "Reviewers, comma separated" : "Reviewers can only be requested on open PRs"}
-          className="h-8 text-xs"
-          disabled={isBusy || !prOpen || !canPush}
-        />
-        <Input
-          value={teamReviewerDraft}
-          onChange={(e) => onTeamReviewerDraftChange(e.target.value)}
-          placeholder={prOpen ? "Teams, comma separated (org slugs)" : "Teams can only be requested on open PRs"}
-          className="h-8 text-xs"
-          disabled={isBusy || !prOpen || !canPush}
-        />
-        <Button
-          size="sm"
-          variant="outline"
-          disabled={pushDisabled || !prOpen || (!reviewerDraft.trim() && !teamReviewerDraft.trim())}
-          title={reviewersTitle}
-          onClick={onRequestReviewers}
-        >
-          {busy === "reviewers" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <GitPullRequest className="mr-2 size-3.5" />}
-          Request review
-        </Button>
-      </div>
+      {provider === "github" && (
+        <div className="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+          <Input
+            value={reviewerDraft}
+            onChange={(e) => onReviewerDraftChange(e.target.value)}
+            placeholder={prOpen ? "Reviewers, comma separated" : "Reviewers can only be requested on open PRs"}
+            className="h-8 text-xs"
+            disabled={isBusy || !prOpen || !canPush}
+          />
+          <Input
+            value={teamReviewerDraft}
+            onChange={(e) => onTeamReviewerDraftChange(e.target.value)}
+            placeholder={prOpen ? "Teams, comma separated (org slugs)" : "Teams can only be requested on open PRs"}
+            className="h-8 text-xs"
+            disabled={isBusy || !prOpen || !canPush}
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={pushDisabled || !prOpen || (!reviewerDraft.trim() && !teamReviewerDraft.trim())}
+            title={reviewersTitle}
+            onClick={onRequestReviewers}
+          >
+            {busy === "reviewers" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <GitPullRequest className="mr-2 size-3.5" />}
+            Request review
+          </Button>
+        </div>
+      )}
     </div>
   );
 }
 
 function PullActions({
   item,
+  caps,
+  provider,
   reviewDraft,
   closeDraft,
   mergeMethod,
@@ -6847,6 +7033,12 @@ function PullActions({
   canModifyOwn,
 }: {
   item: GitHubListItem;
+  caps: ProviderCaps;
+  // The draft-toggle *write* is GitHub GraphQL-only even though GitLab and
+  // Bitbucket both support draft PRs at creation time (caps.draft stays true
+  // for them) — see the ProviderCaps doc comment. Gate the toggle control
+  // itself on a confirmed GitHub repo; the draft badge elsewhere is ungated.
+  provider: GitProvider | "mixed" | null;
   reviewDraft: string;
   closeDraft: string;
   mergeMethod: GitHubPullMergeMethod;
@@ -6892,7 +7084,7 @@ function PullActions({
           <GitPullRequest className="size-3.5" />
           Actions
         </div>
-        {item.state === "open" && (
+        {item.state === "open" && provider === "github" && (
           <Button size="sm" variant="ghost" className="h-7" disabled={!!busy || !canPush} title={pushTitle} onClick={onToggleDraft}>
             {busy === "draft" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <FilePen className="mr-2 size-3.5" />}
             {item.draft ? "Mark ready for review" : "Convert to draft"}
@@ -6943,7 +7135,7 @@ function PullActions({
             <span className="text-[11px] text-muted-foreground">Mergeability unavailable.</span>
           )}
           <div className="ml-auto flex items-center gap-2">
-            {view?.showUpdateBranch && (
+            {caps.updateBranch && view?.showUpdateBranch && (
               <Button size="sm" variant="outline" disabled={pushDisabled} title={pushTitle} onClick={onUpdateBranch}>
                 {busy === "update-branch" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <ArrowUpFromLine className="mr-2 size-3.5" />}
                 Update branch
@@ -7001,15 +7193,17 @@ function PullActions({
               {busy === "COMMENT" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <MessageSquare className="mr-2 size-3.5" />}
               Comment
             </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={disabled || (!reviewDraft.trim() && pendingCount === 0)}
-              onClick={() => onReview("REQUEST_CHANGES")}
-            >
-              {busy === "REQUEST_CHANGES" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <XCircle className="mr-2 size-3.5" />}
-              Request
-            </Button>
+            {caps.requestChanges && (
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={disabled || (!reviewDraft.trim() && pendingCount === 0)}
+                onClick={() => onReview("REQUEST_CHANGES")}
+              >
+                {busy === "REQUEST_CHANGES" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <XCircle className="mr-2 size-3.5" />}
+                Request
+              </Button>
+            )}
           </div>
         </div>
 
@@ -7023,9 +7217,11 @@ function PullActions({
             title="Merge method"
             aria-label="Merge method"
           >
-            <option value="merge">Create merge commit</option>
-            <option value="squash">Squash and merge</option>
-            <option value="rebase">Rebase and merge</option>
+            {caps.mergeMethods.map((method) => (
+              <option key={method} value={method}>
+                {mergeMethodLabel(method, provider)}
+              </option>
+            ))}
           </Select>
           <Button
             size="sm"
@@ -7037,7 +7233,7 @@ function PullActions({
             {busy === "merge" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <GitMerge className="mr-2 size-3.5" />}
             Merge
           </Button>
-          {item.state === "open" && (
+          {item.state === "open" && caps.autoMerge && (
             <div className="mt-2 flex items-center gap-2">
               {mergeability?.autoMerge ? (
                 <>
@@ -7180,8 +7376,8 @@ function PullCommits({
                   <button
                     type="button"
                     className="shrink-0 font-mono text-[11px] text-muted-foreground hover:underline"
-                    title="Open commit on GitHub"
-                    aria-label={`Open commit ${commit.sha.slice(0, 7)} on GitHub`}
+                    title="Open commit"
+                    aria-label={`Open commit ${commit.sha.slice(0, 7)}`}
                     onClick={() => { void api.openExternal(commit.htmlUrl); }}
                   >
                     {commit.sha.slice(0, 7)}
@@ -7274,8 +7470,8 @@ function CheckRuns({
                 <Button
                   size="icon"
                   variant="ghost"
-                  title="Open check on GitHub"
-                  aria-label={`Open ${run.name} check on GitHub`}
+                  title="Open check"
+                  aria-label={`Open ${run.name} check`}
                   onClick={() => { void api.openExternal(run.htmlUrl!); }}
                 >
                   <ExternalLink className="size-3.5" />
@@ -7394,6 +7590,7 @@ function PullDiff({
   onLineComment,
   onAddToReview,
   pending,
+  allowBatchReview,
 }: {
   diff?: TaskDiff;
   loading: boolean;
@@ -7403,6 +7600,13 @@ function PullDiff({
   onLineComment: (target: LineCommentTarget) => Promise<void>;
   onAddToReview: (target: LineCommentTarget) => void;
   pending: LineCommentTarget[];
+  // GitLab/Bitbucket reviews don't support GitHub's "pending review" batch of
+  // inline comments (see git-host.ts's `PullReviewInput` doc comment — the
+  // facade silently drops a non-GitHub review's `comments` array), so
+  // "Add to review" would queue comments that are never actually submitted.
+  // Hide the batch affordance entirely on those providers; a single inline
+  // comment still posts immediately via `onLineComment`.
+  allowBatchReview: boolean;
 }) {
   const totals = useMemo(() => {
     const files = diff?.files ?? [];
@@ -7476,6 +7680,7 @@ function PullDiff({
               onLineComment={onLineComment}
               onAddToReview={onAddToReview}
               queuedKeys={queuedKeys}
+              allowBatchReview={allowBatchReview}
             />
           ))}
         </div>
@@ -7536,6 +7741,7 @@ function PendingReview({
 
 function ReviewComments({
   path,
+  caps,
   comments,
   loading,
   error,
@@ -7555,8 +7761,10 @@ function ReviewComments({
   onRetry,
   canPush,
   canResolveThreads,
+  resolveSupported,
 }: {
   path: string;
+  caps: ProviderCaps;
   comments?: GitHubPullLineComment[];
   loading: boolean;
   error?: string;
@@ -7582,6 +7790,11 @@ function ReviewComments({
   // this is the wider `canPush || prAuthorIsViewer` flag — distinct from
   // `canPush`, which the apply-suggestion write still needs on its own.
   canResolveThreads: boolean;
+  // Thread resolve/reopen is a GitHub GraphQL-only concept — GitLab/Bitbucket
+  // review threads have no equivalent — so this is gated separately from
+  // `canResolveThreads` (which only expresses *who* may resolve, not whether
+  // the provider supports resolving at all).
+  resolveSupported: boolean;
 }) {
   const [busyThread, setBusyThread] = useState<string | null>(null);
   const [threadError, setThreadError] = useState<{ id: string; msg: string } | null>(null);
@@ -7663,7 +7876,7 @@ function ReviewComments({
                       outdated
                     </span>
                   )}
-                  {thread && (
+                  {thread && resolveSupported && (
                     <Button
                       size="sm"
                       variant="ghost"
@@ -7690,16 +7903,18 @@ function ReviewComments({
                   canModify={!!viewerLogin && comment.author?.login === viewerLogin}
                   onEdit={(body) => onEdit(comment.id, body)}
                   onDelete={() => onDelete(comment.id)}
-                  suggestion={hasSuggestion(comment.body) ? {
+                  suggestion={caps.suggestions && hasSuggestion(comment.body) ? {
                     canApply: !!viewerLogin && prOpen,
                     canPush,
                     applying: !!applyBusy[comment.id],
                     onApply: () => onApply(comment.id),
                   } : undefined}
                 />
-                <div className="px-3 pb-2">
-                  <Reactions path={path} subject={{ type: "reviewComment", id: comment.id }} viewer={viewerLogin} />
-                </div>
+                {caps.reactions && (
+                  <div className="px-3 pb-2">
+                    <Reactions path={path} subject={{ type: "reviewComment", id: comment.id }} viewer={viewerLogin} />
+                  </div>
+                )}
                 <div className="border-t border-border/50 p-2">
                   <Textarea
                     value={draft}
@@ -7726,6 +7941,7 @@ function ReviewComments({
 
 function Conversation({
   path,
+  caps,
   comments,
   loading,
   error,
@@ -7739,6 +7955,7 @@ function Conversation({
   onRetry,
 }: {
   path: string;
+  caps: ProviderCaps;
   comments?: GitHubComment[];
   loading: boolean;
   error?: string;
@@ -7793,6 +8010,7 @@ function Conversation({
               <CommentBlock
                 key={comment.id}
                 path={path}
+                caps={caps}
                 comment={comment}
                 viewerLogin={viewerLogin}
                 canModify={!!viewerLogin && comment.author?.login === viewerLogin}
@@ -7829,6 +8047,7 @@ function Conversation({
 
 function CommentBlock({
   path,
+  caps,
   comment,
   viewerLogin,
   canModify,
@@ -7836,6 +8055,7 @@ function CommentBlock({
   onDelete,
 }: {
   path: string;
+  caps: ProviderCaps;
   comment: GitHubComment;
   viewerLogin: string;
   canModify: boolean;
@@ -7850,9 +8070,11 @@ function CommentBlock({
         {comment.updatedAt && comment.updatedAt !== comment.createdAt && <span>edited {fmtDate(comment.updatedAt)}</span>}
       </div>
       <EditableCommentBody body={comment.body} canModify={canModify} onEdit={onEdit} onDelete={onDelete} />
-      <div className="px-3 pb-2">
-        <Reactions path={path} subject={{ type: "issueComment", id: comment.id }} viewer={viewerLogin} />
-      </div>
+      {caps.reactions && (
+        <div className="px-3 pb-2">
+          <Reactions path={path} subject={{ type: "issueComment", id: comment.id }} viewer={viewerLogin} />
+        </div>
+      )}
     </div>
   );
 }
@@ -8261,11 +8483,13 @@ function DiffFileBlock({
   onLineComment,
   onAddToReview,
   queuedKeys,
+  allowBatchReview,
 }: {
   file: DiffFile;
   onLineComment: (target: LineCommentTarget) => Promise<void>;
   onAddToReview: (target: LineCommentTarget) => void;
   queuedKeys: Set<string>;
+  allowBatchReview: boolean;
 }) {
   const meta = STATUS_META[file.status];
   const Icon = meta.icon;
@@ -8285,7 +8509,7 @@ function DiffFileBlock({
         <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file, no textual diff.</div>
       ) : (
         <>
-          <DiffBody file={file} hunks={file.hunks} onLineComment={onLineComment} onAddToReview={onAddToReview} queuedKeys={queuedKeys} />
+          <DiffBody file={file} hunks={file.hunks} onLineComment={onLineComment} onAddToReview={onAddToReview} queuedKeys={queuedKeys} allowBatchReview={allowBatchReview} />
           {file.truncated && (
             <div className="border-t border-border/60 px-3 py-1.5 text-[11px] italic text-muted-foreground">
               Diff truncated because this file's changes are too large to display in full.
@@ -8303,12 +8527,14 @@ function DiffBody({
   onLineComment,
   onAddToReview,
   queuedKeys,
+  allowBatchReview,
 }: {
   file: DiffFile;
   hunks: string;
   onLineComment: (target: LineCommentTarget) => Promise<void>;
   onAddToReview: (target: LineCommentTarget) => void;
   queuedKeys: Set<string>;
+  allowBatchReview: boolean;
 }) {
   const rows = useMemo(() => toRows(hunks), [hunks]);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
@@ -8417,7 +8643,7 @@ function DiffBody({
               {postedKey === rowKey && (
                 <span className="sticky right-0 shrink-0 bg-card/90 px-1 text-[11px] text-emerald-400">commented</span>
               )}
-              {queued && postedKey !== rowKey && (
+              {allowBatchReview && queued && postedKey !== rowKey && (
                 <span className="sticky right-0 shrink-0 bg-card/90 px-1 text-[11px] text-sky-400">queued</span>
               )}
             </div>
@@ -8470,16 +8696,18 @@ function DiffBody({
                   >
                     Cancel
                   </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={submitting || !draft.trim()}
-                    title="Queue this comment for a single review submission"
-                    onClick={() => queue(target)}
-                  >
-                    <Plus className="mr-2 size-3.5" />
-                    Add to review
-                  </Button>
+                  {allowBatchReview && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={submitting || !draft.trim()}
+                      title="Queue this comment for a single review submission"
+                      onClick={() => queue(target)}
+                    >
+                      <Plus className="mr-2 size-3.5" />
+                      Add to review
+                    </Button>
+                  )}
                   <Button size="sm" disabled={submitting || !draft.trim()} onClick={() => { void submit(target); }}>
                     {submitting ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <MessageSquare className="mr-2 size-3.5" />}
                     Comment

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   GitHubCommitStatus,
   GitHubCommitStatusResult,
   GitHubAssigneesResult,
+  GitProvider,
   GitHubDiscussion,
   GitHubDiscussionCategory,
   GitHubDiscussionComment,
@@ -95,6 +96,7 @@ export type {
   GitHubCommitStatusResult,
   GitHubItemKind,
   GitHubItemState,
+  GitProvider,
   GitHubAssigneesResult,
   GitHubDiscussion,
   GitHubDiscussionCategory,
@@ -539,14 +541,20 @@ export const api = {
     const q = new URLSearchParams({ path: input.path });
     return j<GitHubPullDefaultsResult>(`/github/pull-defaults?${q.toString()}`);
   },
-  listGitHubComments: (input: { path: string; number: number }) => {
+  // `kind` ("pulls"|"issues") lets GitLab/Bitbucket route to the right
+  // notes/comments endpoint (their APIs split MR/PR comments from issue
+  // comments, unlike GitHub's single endpoint) — see git-host.ts's
+  // `ListCommentsInput` doc comment. Optional/additive: omitted, the server
+  // defaults to "pulls" (GitHub ignores it entirely).
+  listGitHubComments: (input: { path: string; number: number; kind?: GitHubItemKind }) => {
     const q = new URLSearchParams({
       path: input.path,
       number: String(input.number),
     });
+    if (input.kind) q.set("kind", input.kind);
     return j<GitHubCommentsResult>(`/github/comments?${q.toString()}`);
   },
-  createGitHubComment: (input: { path: string; number: number; body: string }) =>
+  createGitHubComment: (input: { path: string; number: number; body: string; kind?: GitHubItemKind }) =>
     j<{ comment: GitHubComment }>("/github/comments", {
       method: "POST",
       body: JSON.stringify(input),
@@ -554,6 +562,15 @@ export const api = {
   getGitHubViewer: (input: { path: string }) => {
     const q = new URLSearchParams({ path: input.path });
     return j<{ ok: true; login: string }>(`/github/viewer?${q.toString()}`);
+  },
+  // Provider detection (T4, docs/plans/multi-provider-git-modal.md) — call
+  // before the other GitHub* helpers to learn which provider (GitHub/GitLab/
+  // Bitbucket) a project's git remote resolves to.
+  getProviderInfo: (path: string) => {
+    const q = new URLSearchParams({ path });
+    return j<{ ok: true; provider: GitProvider; owner: string; name: string; host: string; remoteHost: string }>(
+      `/github/provider-info?${q.toString()}`,
+    );
   },
   listGitHubLabels: (input: { path: string }) => {
     const q = new URLSearchParams({ path: input.path });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1831,3 +1831,197 @@ export interface BranchInfo {
  * the shape is now per-harness (multiple rows can share a `kind`).
  */
 export type AgentStatus = HarnessStatus;
+
+/**
+ * Multi-provider git-forge support (docs/plans/multi-provider-git-modal.md).
+ * `canonicalGitHost` in `src/bun/github.ts` already maps any host containing
+ * "github"/"gitlab"/"bitbucket" to the provider's cloud hostname — this is
+ * the provider identifier that maps to that canonical host 1:1.
+ */
+export type GitProvider = "github" | "gitlab" | "bitbucket";
+
+/**
+ * A resolved provider + repo identity for a project directory, as returned by
+ * `providerRepoForDir` (`src/bun/git-provider.ts`) and the `provider-info`
+ * route consumed by the GitHub/GitLab/Bitbucket dialog.
+ */
+export interface ProviderRepoInfo {
+  provider: GitProvider;
+  /** Canonical provider host, e.g. "gitlab.com" — NOT the token-store key. */
+  host: string;
+  /** Raw (pre-canonicalization) remote host — e.g. the ssh-alias host a user
+   *  pins per-identity in `~/.ssh/config`. This is the token-store key (see
+   *  `github-tokens.ts`'s host-keyed store and `docs/plans/github-multi-identity-tokens.md`) —
+   *  callers resolving a token for this repo must use `remoteHost`, not `host`. */
+  remoteHost: string;
+  owner: string;
+  name: string;
+}
+
+/**
+ * Per-provider feature flags + terminology driving the GitHub/GitLab/Bitbucket
+ * dialog's gating (Wave 4, `GitHubDialog.tsx`): affordances the selected
+ * provider doesn't support are hidden rather than shown broken. GitHub is the
+ * baseline the dialog was originally built against, so every flag is `true`
+ * there; GitLab/Bitbucket flip off whatever their APIs can't back (see the
+ * provider API facts in the plan's §2 for the source of each flag).
+ */
+export interface ProviderCaps {
+  labels: boolean;
+  milestones: boolean;
+  /** GitHub's raw search-qualifier syntax (`label:bug sort:updated`) — GitHub
+   *  only; GitLab/Bitbucket use structured filters instead. */
+  searchSyntax: boolean;
+  reviewRequestedFilter: boolean;
+  checks: boolean;
+  /** The separate GitHub commit-status panel (distinct from the CheckRuns UI,
+   *  which GitLab/Bitbucket statuses are normalized into instead). */
+  commitStatusPanel: boolean;
+  reactions: boolean;
+  draft: boolean;
+  autoMerge: boolean;
+  suggestions: boolean;
+  subIssues: boolean;
+  projects: boolean;
+  discussions: boolean;
+  actions: boolean;
+  notifications: boolean;
+  releases: boolean;
+  issueTracker: boolean;
+  requestChanges: boolean;
+  updateBranch: boolean;
+  linkedIssues: boolean;
+  commentSort: boolean;
+  lockConversation: boolean;
+  pinIssue: boolean;
+  issueTransfer: boolean;
+  mergeMethods: GitHubPullMergeMethod[];
+  providerName: string;
+  /** Singular term for a "pull request" in this provider's own terminology. */
+  pullNoun: string;
+  pullNounPlural: string;
+  pullAbbrev: string;
+  pullAbbrevPlural: string;
+}
+
+/**
+ * Per-provider capability + terminology table. GitHub is full-featured (the
+ * dialog's original baseline); GitLab and Bitbucket flip off flags for panels
+ * and actions their APIs don't support (Projects/Discussions/Actions/
+ * Notifications/Releases/Reactions/SubIssues/Suggestions/AutoMerge/
+ * UpdateBranch/LinkedIssues/CommentSort/Lock/Pin/Transfer are GitHub-only).
+ *
+ * `mergeMethods` reuses {@link GitHubPullMergeMethod} ("merge"|"squash"|"rebase")
+ * as the neutral merge-strategy vocabulary:
+ * - GitHub: merge, squash, rebase (all three, unchanged).
+ * - GitLab: merge, squash (GitLab has no rebase-as-a-merge-strategy option —
+ *   its "rebase" action rewrites the branch before merging, it isn't a merge
+ *   strategy choice like GitHub's).
+ * - Bitbucket: merge, squash, rebase — Bitbucket's three `merge_strategy`
+ *   values are `merge_commit` / `squash` / `fast_forward`. There is no
+ *   fast-forward entry in {@link GitHubPullMergeMethod}, so `fast_forward`
+ *   (a linear, no-merge-commit history — the same end result GitHub's
+ *   "rebase and merge" produces) is mapped to `"rebase"` here; the adapter
+ *   (Wave 2/T3, `src/bun/bitbucket.ts`) is responsible for translating
+ *   `"rebase"` back to `merge_strategy: "fast_forward"` on the wire.
+ */
+export const PROVIDER_CAPS: Record<GitProvider, ProviderCaps> = {
+  github: {
+    labels: true,
+    milestones: true,
+    searchSyntax: true,
+    reviewRequestedFilter: true,
+    checks: true,
+    commitStatusPanel: true,
+    reactions: true,
+    draft: true,
+    autoMerge: true,
+    suggestions: true,
+    subIssues: true,
+    projects: true,
+    discussions: true,
+    actions: true,
+    notifications: true,
+    releases: true,
+    issueTracker: true,
+    requestChanges: true,
+    updateBranch: true,
+    linkedIssues: true,
+    commentSort: true,
+    lockConversation: true,
+    pinIssue: true,
+    issueTransfer: true,
+    mergeMethods: ["merge", "squash", "rebase"],
+    providerName: "GitHub",
+    pullNoun: "Pull request",
+    pullNounPlural: "Pull requests",
+    pullAbbrev: "PR",
+    pullAbbrevPlural: "PRs",
+  },
+  gitlab: {
+    labels: true,
+    milestones: false,
+    searchSyntax: false,
+    reviewRequestedFilter: true,
+    checks: true,
+    commitStatusPanel: false,
+    reactions: false,
+    draft: true,
+    autoMerge: false,
+    suggestions: false,
+    subIssues: false,
+    projects: false,
+    discussions: false,
+    actions: false,
+    notifications: false,
+    releases: false,
+    issueTracker: true,
+    requestChanges: false,
+    updateBranch: false,
+    linkedIssues: false,
+    commentSort: false,
+    lockConversation: false,
+    pinIssue: false,
+    issueTransfer: false,
+    mergeMethods: ["merge", "squash"],
+    providerName: "GitLab",
+    pullNoun: "Merge request",
+    pullNounPlural: "Merge requests",
+    pullAbbrev: "MR",
+    pullAbbrevPlural: "MRs",
+  },
+  bitbucket: {
+    labels: false,
+    milestones: false,
+    searchSyntax: false,
+    reviewRequestedFilter: true,
+    checks: true,
+    commitStatusPanel: false,
+    reactions: false,
+    draft: true,
+    autoMerge: false,
+    suggestions: false,
+    subIssues: false,
+    projects: false,
+    discussions: false,
+    actions: false,
+    notifications: false,
+    releases: false,
+    issueTracker: true,
+    requestChanges: true,
+    updateBranch: false,
+    linkedIssues: false,
+    commentSort: false,
+    lockConversation: false,
+    pinIssue: false,
+    issueTransfer: false,
+    // merge_commit/squash/fast_forward → merge/squash/rebase; see the
+    // ProviderCaps doc comment above for the fast_forward↔"rebase" mapping.
+    mergeMethods: ["merge", "squash", "rebase"],
+    providerName: "Bitbucket",
+    pullNoun: "Pull request",
+    pullNounPlural: "Pull requests",
+    pullAbbrev: "PR",
+    pullAbbrevPlural: "PRs",
+  },
+};


### PR DESCRIPTION
…itHub

The modal (previously GitHub-only, erroring with "project does not have a GitHub remote") now detects the project's provider from its git remote — including ~/.ssh/config host aliases — and works against GitLab Cloud and Bitbucket Cloud for the core flow: list/filter PRs-MRs and issues, detail, diff, comments and inline line comments with replies, CI status, create, merge, close/decline, approve, and issue create/update.

- src/bun/git-provider.ts: provider detection (providerRepoForDir) and per-provider credential resolution (gitlabToken, bitbucketCreds); tokenForHost gains a fallbackHost param so a GitLab/Bitbucket lookup can never leak a stored GitHub PAT to another provider's API.
- src/bun/gitlab.ts + bitbucket.ts: adapters normalizing GitLab v4 and Bitbucket 2.0 responses into the existing GitHub* shared types.
- src/bun/git-host.ts: facade dispatching ~20 core ops at the route layer; the GitHub branch passes through the untouched github.ts functions (zero behavior change for GitHub repos); GET /github/provider-info added.
- UI: dialog title/terminology follow the provider (GitLab: Merge requests / MRs), capabilities gated via PROVIDER_CAPS so GitHub-exclusive panels (Projects, Discussions, Actions, Notifications, Releases, Reactions, sub-issues) hide on non-GitHub projects.
- Tests: 203 new tests (git-provider/git-host 36, gitlab 86, bitbucket 81); full suite 1469 pass, typecheck + vite build green.

Plan: docs/plans/multi-provider-git-modal.md