### PR TITLE
fix: false "cannot reach agetor API" toasts + instant archive via deferred teardown

### DIFF
--- a/docs/plans/fix-archive-teardown-queue.md
+++ b/docs/plans/fix-archive-teardown-queue.md
@@ -1,0 +1,66 @@
+# Plan — Deferred, serialized archive teardown (rapid multi-archive slowness)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-14 |
+| Source | /implement follow-up on fix/cannot-reach-api — "requests queue getting crowded and slow when archiving multiple tasks one right after the other" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/cannot-reach-api |
+| Base SHA | bd1ef73 (waves build on the toast fix) |
+| Mode | **Autonomous** — grill/approval gates bypassed; assumptions in §8 |
+
+## 1. Objective & success criteria
+
+`POST /tasks/:id/archive` responds in milliseconds regardless of worktree size; archiving N tasks back-to-back never contends on git locks; archive→unarchive / archive→start / archive→delete races stay correct. Typecheck + full `bun test` green.
+
+## 2. Context & constraints
+
+- `archiveTask` (`src/bun/orchestrator.ts`) awaits, before responding: `dropSession`/`dropCodexSession` (blocking `Bun.spawnSync` tmux kill), `killTerminalsForTask`, `detachWorktree` (`git status` dirty check → `git worktree remove --force` → `git worktree prune` → async `rm` of the tree). Multi-second on real worktrees.
+- Rapid successive archives: each POST waits its own teardown; concurrent teardowns of tasks in the same source repo contend on git's locks (`worktree remove`/`prune` mutate `.git/worktrees` + config) — detach is best-effort, so contention silently strands worktrees.
+- `unarchiveTask` restores only when `!existsSync(worktreePath)`; `startTask` auto-unarchives and calls `prepareWorkdir`; `deleteTask` re-runs the same teardown shape then deletes the row. All three race a deferred teardown unless they await it.
+- Teardown ordering is load-bearing: sessions/shells cwd'd inside the worktree must die before `git worktree remove` (documented at both call sites).
+- Fleet rule: never enumerate-and-kill `agetor-*` tmux sessions; every kill must be keyed to a task id from this instance's own DB (prior incident entry 5af0b527). The boot sweep below respects this.
+- Boot: `index.ts:120` calls `reconcileOrphans()` (sync).
+
+## 3. Approach & key decisions
+
+**Defer + serialize.** Archive flips the DB row and returns immediately; the heavy teardown runs in a background queue. One global FIFO chain serializes all teardowns (eliminates same-repo git-lock contention — simplest correct granularity; per-repo chains rejected as needless complexity for a single-user app). A `Map<taskId, Promise>` exposes per-task completion so the three racing operations can await it:
+
+- `unarchiveTask` awaits the task's pending teardown before its `existsSync` restore check.
+- `startTask` awaits it before `prepareWorkdir`.
+- `deleteTask` routes its own teardown *through* the queue and still awaits it (DELETE semantics unchanged, but now serialized against in-flight archive teardowns).
+
+**Crash/quit safety.** Previously `dropSession` ran synchronously inside the request, so quitting right after archiving couldn't leak a session. With deferral, quit-before-teardown leaks the tmux session and the worktree dir. Fix: a boot-time sweep — for every task in *our own DB* with `archivedAt != null && worktreePath && existsSync(worktreePath)`, enqueue the same teardown job. This also heals the pre-existing crash-mid-archive gap. Session kills remain keyed to own task ids.
+
+Alternative considered: converting the tmux `spawnSync` kills to async — still recommended as a separate follow-up; inside the background queue their ~10ms stalls are acceptable.
+
+## 4. Work breakdown — implementation tasks
+
+| ID | Goal | Owns | Deps | Acceptance |
+| --- | --- | --- | --- | --- |
+| U1 | Teardown queue in orchestrator: `enqueueTeardown(taskId, job)` (global FIFO chain, errors warn-logged, per-task pending map), `pendingTeardown(taskId)` export; archiveTask returns immediately after row flip + enqueue; unarchive/start await pending; deleteTask teardown routed through queue (still awaited); `sweepArchivedTeardowns()` export; one-line call in index.ts after `reconcileOrphans()` | `src/bun/orchestrator.ts`, `src/bun/index.ts` | — | typecheck green; ordering (sessions→terminals→worktree) preserved inside the job |
+
+## 5. Work breakdown — test tasks
+
+| ID | Goal | Owns | Covers |
+| --- | --- | --- | --- |
+| UT1 | New `src/bun/orchestrator-archive-teardown.test.ts`: archive returns before worktree gone + `pendingTeardown` resolves to removal; archive→unarchive restores the worktree; two same-repo tasks archived back-to-back both tear down cleanly; boot sweep removes a stranded archived worktree | `src/bun/orchestrator-archive-teardown.test.ts` | U1 |
+
+## 6. Execution waves
+
+Wave 1: U1 (single agent — one file owns the logic). Barrier: typecheck + commit. Wave 2: UT1 + code review (opus) in parallel (review is read-only). Then full suite + fixes.
+
+## 7. Blast radius & risks
+
+- Archive response no longer proves teardown happened — UI only reads `archivedAt`, unaffected. Disk reclaim is eventual.
+- Quit with queued teardowns → healed at next boot by the sweep. Confirm-on-quit doesn't wait for the queue (acceptable: sessions/worktrees are recoverable state).
+- `deleteTask` now waits behind earlier queued teardowns — slightly slower under burst, but correct and lock-safe.
+- `unarchive` under a burst waits for the whole chain up to its task — bounded by the burst the user just created.
+- Global chain means one wedged git op delays later teardowns; existing `git()` timeouts bound each step.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+1. **Assumed** eventual disk reclaim is acceptable (archive returns before the worktree is removed).
+2. **Assumed** a single global teardown chain (not per-repo) is the right granularity for a single-user app.
+3. **Assumed** the boot sweep enqueuing kills keyed to own archived task ids is compatible with the shared-tmux-socket safety rule (it is keyed, never enumerated).
+4. tmux `spawnSync`→async conversion remains out of scope (tracked follow-up).

--- a/docs/plans/fix-cannot-reach-api-toasts.md
+++ b/docs/plans/fix-cannot-reach-api-toasts.md
@@ -1,0 +1,88 @@
+# Plan — Fix "cannot reach agetor API" toasts
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-14 |
+| Source | /implement — recurring toast `cannot reach agetor API at http://127.0.0.1:4317 (…) — is the bun process running?` on archive/start/etc., increasing in frequency |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/cannot-reach-api |
+| Base SHA | 3f4b057e826383869fff20bf118f7c33b0072d0f |
+| Mode | **Autonomous** — grill (Phase 2) and plan approval (Phase 3) gates bypassed; all assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+Stop the false "cannot reach API" toasts that fire while the Bun process is alive and healthy. Success:
+- Archiving a task whose worktree takes >10s to remove completes without a toast.
+- Starting a task (worktree materialization) completes without a toast.
+- A mutation issued after minutes of user inactivity (stale pooled keep-alive socket) succeeds transparently.
+- A genuinely dead server still produces the toast (no false "everything is fine").
+- `bun run typecheck` green; full `bun test` green.
+
+## 2. Context & constraints (grounded findings)
+
+**Primary root cause — Bun's default 10s `idleTimeout` on `Bun.serve`:**
+- `src/bun/server.ts:443-449` — `Bun.serve({ port, hostname: "127.0.0.1", development: false, websocket, routes, fetch })`. No `idleTimeout`, no `server.timeout()` anywhere in the repo. Bun 1.3.10 default is **10s**, max **255**, `0` disables (confirmed: bun.com/docs/runtime/http/server, oven-sh/bun#13712).
+- The idle timer is a single per-connection inactivity timer. It fires **(a)** on idle pooled keep-alive sockets between requests, and **(b)** mid-request while a handler is still awaiting and hasn't written a byte — async or sync makes no difference (oven-sh/bun#13712, closed as intended).
+- WKWebView/CFNetwork **never auto-retries POSTs** on a dropped reused connection; only idempotent GET/PUT are retried (Apple Technical Q&A QA1941). A dropped socket surfaces as WebKit's bare `"Load failed"`.
+- `src/mainview/lib/api.ts:263-293` — `j()` maps **every** fetch rejection with message `"Load failed"` to the toast text. No retry, no timeout, no classification. Background polls swallow errors (`App.tsx:120-133`, `RunPanel.tsx:359-397`); only user mutations surface it (`App.tsx:424-517`) — exactly matching the report (archive, start).
+
+So the two reported cases are directly explained:
+- **Archive** → `POST /tasks/:id/archive` (`server.ts:3105-3107`) awaits `archiveTask` → `detachWorktree` (`orchestrator.ts:1806`) → `git worktree remove/prune` + `rmSync` of the whole worktree (`worktree.ts:819`). >10s of no response bytes → Bun kills the connection → "Load failed" → toast.
+- **Start** → `POST /tasks/:id/start` (`server.ts:3096`) awaits worktree materialization (`git worktree add` on the user's repo) — same >10s window on big repos.
+- **Any mutation after idle** → pooled socket idled >10s, server closed it, WKWebView reuses it for a POST, no auto-retry → toast. Explains sporadic failures on quick actions too.
+
+**Amplifiers (why "more and more recently"):**
+- SSE keepalive pings are every **15s** (`server.ts:3789,3829,3916,4052`) — longer than the 10s idle window, so quiet SSE streams are killed and silently reconnect constantly (EventSource auto-reconnects; adds churn, no toast).
+- `rmSync` (`worktree.ts:771,819`) blocks the whole single-threaded Bun process during archive/delete.
+- Usage growth: `c0878ae` (Jul 7) added a 400ms-per-running-task `spawnSync` death-watch; `ee151a8` (Jul 12) added the GitHub dialog's heavy fetch fan-out. More concurrency → more pooled connections going stale, more event-loop jitter.
+- The toast text has existed unchanged since the initial commit (`3492804`); the *frequency* changed with usage, not the code path.
+
+**Constraints:** Electrobun (not Electron); `Bun.serve` object-style `routes`; `/health` is unauthenticated + CORS-allowed (`server.ts:457`) — usable as a client-side liveness probe. Route handlers close over the outer `const server`, so `server.timeout(req, 0)` is callable inside handlers (pattern verified by a prior fleet finding on Bun 1.3.10).
+
+## 3. Approach & key decisions
+
+1. **Server: set `idleTimeout: 255` (max) on `Bun.serve`** — one line, removes the 10s trap for pooled sockets and for handlers up to ~4 min. Chose 255 over `0` (disable): keeps a safety reaper for genuinely dead sockets while being far above WKWebView's own pool-idle horizon, and far above the 15s SSE ping cadence so streams stay alive.
+2. **Server: `server.timeout(req, 0)` on the four long-op handlers** — `/tasks/:id/start`, `/tasks/:id/archive`, `/tasks/:id/unarchive`, `DELETE /tasks/:id` — worktree add/remove on a huge repo could plausibly exceed even 255s. Mirrors the per-request pattern already proven in this codebase family.
+3. **Client: health-gated single retry in `j()`** — on any fetch *rejection* (network layer, incl. "Load failed"): probe `GET /health` with a short abort (1.5s). If the server answers → the failure was a transient socket race; retry the original request **once** (bodies are JSON strings, safely re-sendable). If the probe fails or the retry fails → surface a toast that now distinguishes "server not responding" from "request failed twice despite a healthy server". Logic extracted into a pure, dependency-injected helper (`src/mainview/lib/net-retry.ts`) so it's unit-testable under `bun test`.
+4. **Server: `rmSync` → async `rm`** in `removeWorktree` + `detachWorktree` (`worktree.ts:771,819`) — stops multi-second event-loop stalls on archive/delete from starving every other connection.
+5. **Out of scope (recommended follow-up, logged, not done here):** converting `claude-tmux.ts`/`codex-tmux.ts` timer-driven `Bun.spawnSync` tmux calls to async. Those stalls are milliseconds each and cannot by themselves trip a 10s/255s idle timer; the conversion touches delicate death-watch/scraper logic and deserves its own branch.
+
+Alternatives considered: `idleTimeout: 0` (rejected — loses dead-socket reaping for no extra benefit); `Connection: close` per response (not supported on `Bun.serve`); blind POST retry without health probe (rejected — Apple explicitly warns; health gate + single-shot keeps duplicate risk negligible since a stale-socket failure means the request never reached the server).
+
+## 4. Work breakdown — implementation tasks
+
+| ID | Goal | Owns (exclusive) | Deps | Acceptance |
+| --- | --- | --- | --- | --- |
+| T1 | `idleTimeout: 255` on `Bun.serve` + `server.timeout(req, 0)` in start/archive/unarchive/delete handlers, with comments explaining the 10s default trap | `src/bun/server.ts` | — | typecheck green; options + 4 handlers updated |
+| T2 | Health-gated single-retry fetch layer; clearer failure messages | `src/mainview/lib/api.ts`, `src/mainview/lib/net-retry.ts` (new) | — | `j()` delegates to injected helper; behavior per §3.3 |
+| T3 | Async worktree removal | `src/bun/worktree.ts` | — | `rmSync` gone from both call sites; awaited `rm` from `node:fs/promises`; comments/semantics preserved |
+
+## 5. Work breakdown — test tasks
+
+| ID | Goal | Owns | Covers |
+| --- | --- | --- | --- |
+| TT1 | Integration test: keep-alive socket reused after >10s idle succeeds; boots real server per `server-auth.test.ts` conventions (temp `AGETOR_DATA_DIR`) | `src/bun/server-keepalive.test.ts` (new) | T1 |
+| TT2 | Unit tests for retry helper with fake fetch: transient error + healthy → retried once & succeeds; server down → "cannot reach" error; retry fails → error; HTTP 4xx/5xx → no retry | `src/mainview/lib/net-retry.test.ts` (new) | T2 |
+
+T3 is covered by the existing `worktree.test.ts` suite (removal semantics unchanged, only sync→async).
+
+## 6. Execution waves
+
+- **Wave 1 (parallel):** T1, T2, T3 — fully file-disjoint. Barrier: typecheck + commit.
+- **Wave 2 (parallel):** TT1, TT2 — file-disjoint, depend on Wave 1. Barrier: commit.
+- Then: code review (opus), full `bun test` + `bun run typecheck`, fixes if needed.
+
+## 7. Blast radius & risks
+
+- `idleTimeout: 255` is global: a truly dead connection lingers up to 255s instead of 10s — harmless on loopback.
+- `server.timeout(req, 0)`: only the four named handlers; a hung git op would hold that one connection open indefinitely — the handlers already have their own git timeouts (`worktree.ts` `git()` helper).
+- Client retry: residual duplicate-mutation risk if a request reached the server *and* the connection died before any response byte *and* the health probe then succeeded. Single retry only; considered acceptable for a local single-user app (worst realistic case: a duplicated backlog draft or a re-sent agent message).
+- Async `rm`: `deleteTask`/`archiveTask` already `await` these functions; no caller change needed. Best-effort semantics preserved.
+- Tests: `bun`/`tmux` are not on non-interactive-shell PATH — export `/opt/homebrew/bin` + `~/.bun/bin` (known fleet gotcha). New tests must set `AGETOR_DATA_DIR` to a mkdtemp dir before importing db/orchestrator modules.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+1. **Assumed** single retry of mutations gated on a successful `/health` probe is acceptable duplicate-risk for a local app (owner unavailable to confirm). The health-gate + the fact that stale-socket failures occur before request delivery make duplicates very unlikely.
+2. **Assumed** 255s is an acceptable ceiling for pooled-socket lifetime; chose it over `0` to keep dead-socket reaping.
+3. **Assumed** the tmux `spawnSync` conversion is out of scope for this fix branch (follow-up recommended).
+4. **Not verified live** (no running instance to trace): that a specific failing request coincides with a stale pooled socket — but the mechanism is confirmed by Bun docs + Apple QA1941, and the archive/start >10s-handler path is deterministic.

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -3,7 +3,7 @@ import Electrobun, { ApplicationMenu, BrowserWindow, Screen, Updater, Utils } fr
 import { rehydratePath } from "./login-path.ts";
 import { startApiServer, API_PORT, API_TOKEN, type ApiNative } from "./server.ts";
 import { db, harnesses, pidFilePath, tasks, dataDir } from "./db.ts";
-import { reconcileOrphans } from "./orchestrator.ts";
+import { reconcileOrphans, sweepArchivedTeardowns } from "./orchestrator.ts";
 import { broadcastAppEvent, consumeForceQuit } from "./quit-guard.ts";
 import { refreshDiscoveredModels } from "./agent-discovery.ts";
 import { startUpdaterLoop, applyUpdate, checkForUpdate, getUpdateSnapshot } from "./updater.ts";
@@ -118,6 +118,12 @@ rehydratePath();
 // Mark any runs that were "running" when we last shut down as orphaned, so the
 // kanban doesn't show stuck cards.
 reconcileOrphans();
+
+// Heal any archive/delete teardown (tmux kill, terminal shells, worktree
+// detach) that was deferred to the in-memory teardown queue but never ran
+// because agetor quit or crashed before the job fired. Fire-and-forget — it
+// only enqueues jobs onto that queue, keyed to this instance's own task ids.
+sweepArchivedTeardowns();
 
 installNativeMenu();
 

--- a/src/bun/orchestrator-archive-teardown.test.ts
+++ b/src/bun/orchestrator-archive-teardown.test.ts
@@ -1,0 +1,411 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Top-level: db.ts captures AGETOR_DATA_DIR at first import — `beforeAll`
+// would race with any sibling test file that already imported db.ts.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-test-"));
+// Drive claude through an in-process fake instead of tmux + the real CLI.
+// AGETOR_CLAUDE_BIN is also overridden so the agent-status preflight inside
+// startTask passes without claude installed.
+process.env.AGETOR_CLAUDE_DRIVER = "fake";
+process.env.AGETOR_CLAUDE_BIN = "/bin/echo";
+process.env.AGETOR_TMUX_BIN = "/bin/echo"; // tmux probe in agent-status passes
+process.env.AGETOR_CLAUDE_ARGS = "";
+
+// Standalone helper: run git in a directory (mirrors orchestrator.test.ts's
+// `git` helper — kept local here since this file owns no shared test util).
+async function git(args: string[], cwd: string) {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+}
+
+// Standalone helper: a real temp git repo for worktree-isolation tests. Never
+// point a task at a real repo in these tests — always mkdtemp (see worktree
+// isolation warning in CLAUDE.md).
+async function makeRepo(): Promise<string> {
+  const repo = mkdtempSync(path.join(tmpdir(), "agetor-archive-teardown-repo-"));
+  await git(["init", "-b", "main"], repo);
+  await git(["config", "user.email", "test@example.com"], repo);
+  await git(["config", "user.name", "test"], repo);
+  writeFileSync(path.join(repo, "README"), "hi\n");
+  await git(["add", "."], repo);
+  await git(["commit", "-m", "init"], repo);
+  return repo;
+}
+
+test("archiveTask defers teardown: dir survives until pendingTeardown resolves, then the worktree is gone and branch + DB pointers remain", async () => {
+  const { createTask, archiveTask, pendingTeardown } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "deferred detach",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+    const branch = prepared.branch!;
+    expect(existsSync(worktreePath)).toBe(true);
+
+    const archived = await archiveTask(taskId);
+    expect("task" in archived).toBe(true);
+    if (!("task" in archived)) throw new Error(archived.error);
+    expect(archived.task.archivedAt).not.toBeNull();
+
+    await pendingTeardown(taskId);
+
+    // Checkout gone from disk…
+    expect(existsSync(worktreePath)).toBe(false);
+
+    // …but the branch survives in the source repo.
+    const proc = Bun.spawn(["git", "branch", "--list", branch], { cwd: repo, stdout: "pipe" });
+    const out = (await new Response(proc.stdout).text()).trim();
+    await proc.exited;
+    expect(out).toContain(branch);
+
+    // The DB row keeps worktreePath/branch non-null.
+    const after = tasks.get(taskId);
+    expect(after?.worktreePath).toBe(worktreePath);
+    expect(after?.branch).toBe(branch);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("archiveTask responds before teardown runs — the worktree is (usually) still on disk immediately after archiveTask resolves", async () => {
+  const { createTask, archiveTask, pendingTeardown } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "immediate response",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+    expect(existsSync(worktreePath)).toBe(true);
+
+    const archived = await archiveTask(taskId);
+    expect("task" in archived).toBe(true);
+
+    // detachWorktree's first step (`git status`) yields the event loop before
+    // it gets to removing the checkout, so — most of the time — the dir is
+    // still present the instant archiveTask resolves. This is inherently a
+    // timing assertion; if it ever flakes, the fallback signal is that
+    // `pendingTeardown(taskId)` has not yet settled (there IS a teardown in
+    // flight for this task right now).
+    const stillHasDirImmediately = existsSync(worktreePath);
+    let settledImmediately = false;
+    pendingTeardown(taskId).then(() => {
+      settledImmediately = true;
+    });
+    // Give queued microtasks (but not the deferred job's own awaits) a chance
+    // to run without letting the teardown's internal awaits resolve.
+    await Promise.resolve();
+    expect(stillHasDirImmediately || !settledImmediately).toBe(true);
+
+    await pendingTeardown(taskId);
+    expect(existsSync(worktreePath)).toBe(false);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("unarchiveTask right after archiveTask waits out the deferred teardown then restores the worktree", async () => {
+  const { createTask, archiveTask, unarchiveTask } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "archive-unarchive race",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+
+    const archived = await archiveTask(taskId);
+    if (!("task" in archived)) throw new Error(archived.error);
+
+    // No manual pendingTeardown await here — unarchiveTask must serialize
+    // against the still-in-flight (or about-to-run) archive teardown itself.
+    const restored = await unarchiveTask(taskId);
+    expect("task" in restored).toBe(true);
+    if (!("task" in restored)) throw new Error(restored.error);
+    expect(restored.task.archivedAt).toBeNull();
+    expect(existsSync(worktreePath)).toBe(true);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("back-to-back archives against the same source repo both respond fast and both fully tear down", async () => {
+  const { createTask, archiveTask, pendingTeardown } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+
+  const createdA = await createTask({
+    title: "back-to-back A",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in createdA) throw new Error(createdA.error);
+  const idA = createdA.task.id;
+
+  const createdB = await createTask({
+    title: "back-to-back B",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in createdB) throw new Error(createdB.error);
+  const idB = createdB.task.id;
+
+  try {
+    const preparedA = await prepareWorkdir(createdA.task);
+    if ("error" in preparedA) throw new Error(preparedA.error);
+    tasks.update(idA, { branch: preparedA.branch, worktreePath: preparedA.worktreePath });
+    tasks.update(idA, { column: "done" });
+
+    const preparedB = await prepareWorkdir(createdB.task);
+    if ("error" in preparedB) throw new Error(preparedB.error);
+    tasks.update(idB, { branch: preparedB.branch, worktreePath: preparedB.worktreePath });
+    tasks.update(idB, { column: "done" });
+
+    const worktreePathA = preparedA.worktreePath!;
+    const worktreePathB = preparedB.worktreePath!;
+    const branchA = preparedA.branch!;
+    const branchB = preparedB.branch!;
+
+    // No teardown awaits in between — both archives must return fast without
+    // blocking on each other's `git worktree remove`/`prune`.
+    const archivedA = await archiveTask(idA);
+    const archivedB = await archiveTask(idB);
+    expect("task" in archivedA).toBe(true);
+    expect("task" in archivedB).toBe(true);
+
+    await pendingTeardown(idA);
+    await pendingTeardown(idB);
+
+    expect(existsSync(worktreePathA)).toBe(false);
+    expect(existsSync(worktreePathB)).toBe(false);
+
+    const proc = Bun.spawn(["git", "branch", "--list"], { cwd: repo, stdout: "pipe" });
+    const out = (await new Response(proc.stdout).text()).trim();
+    await proc.exited;
+    expect(out).toContain(branchA);
+    expect(out).toContain(branchB);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [idA]);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [idB]);
+  }
+});
+
+test("sweepArchivedTeardowns enqueues teardown for a task stranded archived-with-worktree-on-disk (simulated crash-before-teardown)", async () => {
+  const { createTask, pendingTeardown, sweepArchivedTeardowns } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "boot sweep",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+    expect(existsSync(worktreePath)).toBe(true);
+
+    // Simulate "quit before teardown ran": stamp archivedAt directly,
+    // bypassing archiveTask (and therefore bypassing enqueueTeardown too) —
+    // this is what a crash between the DB flip and the deferred job actually
+    // running would leave behind on the next boot.
+    tasks.update(taskId, { archivedAt: Date.now() });
+    expect(existsSync(worktreePath)).toBe(true);
+
+    const enqueued = sweepArchivedTeardowns();
+    expect(enqueued).toBeGreaterThanOrEqual(1);
+
+    await pendingTeardown(taskId);
+    expect(existsSync(worktreePath)).toBe(false);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("FIFO ordering: pendingTeardown(b) resolving implies a's teardown (enqueued first) has already completed", async () => {
+  // Documents (and relies on) the teardown queue being a per-workdir FIFO
+  // chain, per enqueueTeardown's contract in orchestrator.ts. Both tasks here
+  // are created against the SAME source repo (`repo`, one `makeRepo()` call),
+  // so they share one chain keyed on that workdir — b's job cannot run
+  // before a's has settled. Two tasks in different source repos would get
+  // independent chains with no ordering guarantee between them (see the
+  // "independent workdirs" test below).
+  const { createTask, archiveTask, pendingTeardown } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+
+  const createdA = await createTask({
+    title: "fifo A",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in createdA) throw new Error(createdA.error);
+  const idA = createdA.task.id;
+
+  const createdB = await createTask({
+    title: "fifo B",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in createdB) throw new Error(createdB.error);
+  const idB = createdB.task.id;
+
+  try {
+    const preparedA = await prepareWorkdir(createdA.task);
+    if ("error" in preparedA) throw new Error(preparedA.error);
+    tasks.update(idA, { branch: preparedA.branch, worktreePath: preparedA.worktreePath });
+    tasks.update(idA, { column: "done" });
+
+    const preparedB = await prepareWorkdir(createdB.task);
+    if ("error" in preparedB) throw new Error(preparedB.error);
+    tasks.update(idB, { branch: preparedB.branch, worktreePath: preparedB.worktreePath });
+    tasks.update(idB, { column: "done" });
+
+    const worktreePathA = preparedA.worktreePath!;
+
+    await archiveTask(idA);
+    await archiveTask(idB);
+
+    // Await only b's teardown — a's must already be done, since both jobs
+    // share the same FIFO chain and a was enqueued first.
+    await pendingTeardown(idB);
+    expect(existsSync(worktreePathA)).toBe(false);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [idA]);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [idB]);
+  }
+});
+
+test("independent workdirs: teardowns for two tasks in different source repos don't share a chain and both complete", async () => {
+  // Unlike the FIFO test above (same repo → same chain), these two tasks are
+  // each created against their OWN temp source repo, so they key into
+  // separate `teardownTails` entries and their teardowns run on independent
+  // chains. This is the fix for the global-FIFO regression: a big teardown
+  // backlog in one repo must never stall a delete/archive in an unrelated
+  // repo. Awaiting both `pendingTeardown`s and asserting both dirs are gone
+  // proves the two chains don't interfere with (or depend on) each other.
+  const { createTask, archiveTask, pendingTeardown } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repoA = await makeRepo();
+  const repoB = await makeRepo();
+
+  const createdA = await createTask({
+    title: "independent workdir A",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repoA,
+    isolation: "worktree",
+  });
+  if ("error" in createdA) throw new Error(createdA.error);
+  const idA = createdA.task.id;
+
+  const createdB = await createTask({
+    title: "independent workdir B",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repoB,
+    isolation: "worktree",
+  });
+  if ("error" in createdB) throw new Error(createdB.error);
+  const idB = createdB.task.id;
+
+  try {
+    const preparedA = await prepareWorkdir(createdA.task);
+    if ("error" in preparedA) throw new Error(preparedA.error);
+    tasks.update(idA, { branch: preparedA.branch, worktreePath: preparedA.worktreePath });
+    tasks.update(idA, { column: "done" });
+
+    const preparedB = await prepareWorkdir(createdB.task);
+    if ("error" in preparedB) throw new Error(preparedB.error);
+    tasks.update(idB, { branch: preparedB.branch, worktreePath: preparedB.worktreePath });
+    tasks.update(idB, { column: "done" });
+
+    const worktreePathA = preparedA.worktreePath!;
+    const worktreePathB = preparedB.worktreePath!;
+
+    const archivedA = await archiveTask(idA);
+    const archivedB = await archiveTask(idB);
+    expect("task" in archivedA).toBe(true);
+    expect("task" in archivedB).toBe(true);
+
+    await pendingTeardown(idA);
+    await pendingTeardown(idB);
+
+    expect(existsSync(worktreePathA)).toBe(false);
+    expect(existsSync(worktreePathB)).toBe(false);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [idA]);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [idB]);
+  }
+});

--- a/src/bun/orchestrator.test.ts
+++ b/src/bun/orchestrator.test.ts
@@ -261,7 +261,7 @@ test("archiveTask stamps archivedAt and unarchiveTask clears it", async () => {
 });
 
 test("archiveTask detaches the worktree from disk but keeps branch + DB pointers", async () => {
-  const { createTask, archiveTask } = await import("./orchestrator.ts");
+  const { createTask, archiveTask, pendingTeardown } = await import("./orchestrator.ts");
   const { prepareWorkdir } = await import("./worktree.ts");
   const { db, tasks } = await import("./db.ts");
 
@@ -293,6 +293,11 @@ test("archiveTask detaches the worktree from disk but keeps branch + DB pointers
     expect("task" in archived).toBe(true);
     if (!("task" in archived)) throw new Error(archived.error);
     expect(archived.task.archivedAt).not.toBeNull();
+
+    // Teardown (session drop, terminal kill, worktree detach) is deferred onto
+    // the global FIFO queue rather than run synchronously — wait it out before
+    // asserting on-disk state.
+    await pendingTeardown(taskId);
 
     // Checkout gone from disk…
     expect(existsSync(worktreePath)).toBe(false);
@@ -353,7 +358,7 @@ test("archiveTask keeps a dirty worktree on disk instead of discarding uncommitt
 });
 
 test("unarchiveTask rematerializes a worktree that archive detached", async () => {
-  const { createTask, archiveTask, unarchiveTask } = await import("./orchestrator.ts");
+  const { createTask, archiveTask, unarchiveTask, pendingTeardown } = await import("./orchestrator.ts");
   const { prepareWorkdir } = await import("./worktree.ts");
   const { db, tasks } = await import("./db.ts");
 
@@ -377,6 +382,9 @@ test("unarchiveTask rematerializes a worktree that archive detached", async () =
     const worktreePath = prepared.worktreePath!;
     const archived = await archiveTask(taskId);
     if (!("task" in archived)) throw new Error(archived.error);
+    // Teardown is deferred onto the global FIFO queue — wait it out before
+    // asserting the checkout is gone.
+    await pendingTeardown(taskId);
     expect(existsSync(worktreePath)).toBe(false);
 
     const restored = await unarchiveTask(taskId);
@@ -391,7 +399,7 @@ test("unarchiveTask rematerializes a worktree that archive detached", async () =
 });
 
 test("sendInput to an archived task auto-unarchives it and restores the worktree", async () => {
-  const { createTask, archiveTask, sendInput } = await import("./orchestrator.ts");
+  const { createTask, archiveTask, sendInput, pendingTeardown } = await import("./orchestrator.ts");
   const { prepareWorkdir } = await import("./worktree.ts");
   const { db, tasks, runs } = await import("./db.ts");
 
@@ -434,6 +442,9 @@ test("sendInput to an archived task auto-unarchives it and restores the worktree
 
     const archived = await archiveTask(taskId);
     if (!("task" in archived)) throw new Error(archived.error);
+    // Teardown is deferred onto the global FIFO queue — wait it out before
+    // asserting the checkout is gone.
+    await pendingTeardown(taskId);
     expect(existsSync(worktreePath)).toBe(false);
 
     // sendInput must (1) auto-unarchive, (2) restore the worktree via

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -118,33 +118,52 @@ interface ActiveRun {
 const active = new Map<string, ActiveRun>(); // runId -> handle
 
 // Archive/delete teardown (tmux session kill, terminal teardown, worktree
-// detach/remove) is deferred onto a single global FIFO queue so `archiveTask`
-// can flip the DB column and respond in milliseconds instead of blocking on
-// `spawnSync` tmux kills and `git worktree remove --force`/`prune`. The
-// serialization is deliberate, not incidental: concurrent `git worktree
-// remove`/`prune` invocations against the SAME source repo contend on git's
-// internal locks (`.git/worktrees/.lock` etc.), so archiving several tasks
-// back-to-back must still tear them down one at a time — just not on the
-// request's critical path. `teardownTail` is the chain itself; `teardowns`
-// lets callers (unarchive/start/delete, plus the boot-time sweep) await a
-// specific task's in-flight teardown before touching the same worktree.
-let teardownTail: Promise<void> = Promise.resolve();
+// detach/remove) is deferred onto a per-source-workdir FIFO queue so
+// `archiveTask` can flip the DB column and respond in milliseconds instead of
+// blocking on `spawnSync` tmux kills and `git worktree remove --force`/
+// `prune`. The serialization is deliberate, not incidental: concurrent `git
+// worktree remove`/`prune` invocations against the SAME source repo contend
+// on git's internal locks (`.git/worktrees/.lock` etc.), so archiving several
+// tasks that share a workdir must still tear them down one at a time — just
+// not on the request's critical path. Tasks in *different* source repos have
+// no such lock contention, so they get independent chains and never wait on
+// each other — a big worktree removal for repo A must not stall a DELETE in
+// unrelated repo B. `teardownTails` keys the chain by `task.workdir` (the raw
+// string, not a resolved repo root — two tasks pointed at different subdirs
+// of the same repo would therefore get separate chains and could still
+// contend on git's locks; accepted as rare, and best-effort teardown plus the
+// boot sweep heal any resulting strand). `teardowns` is unchanged: it lets
+// callers (unarchive/start/delete, plus the boot-time sweep) await a specific
+// task's in-flight teardown before touching the same worktree, keyed by task
+// id as before — this still works under per-workdir chains because a task's
+// workdir can't change while a teardown is pending (archived tasks are
+// PATCH-frozen, and every materializing path awaits `pendingTeardown` first).
+const teardownTails = new Map<string, Promise<void>>();
 const teardowns = new Map<string, Promise<void>>();
 
 /**
- * Chain `job` onto the global teardown FIFO and track it per-task so
- * `pendingTeardown` can be awaited by callers that must not race a deferred
- * teardown (unarchive, start, delete, the orphan sweep). Errors from `job`
- * are caught and logged — a single misbehaving teardown must never break the
- * chain for every task queued behind it.
+ * Chain `job` onto the teardown FIFO for `key` (the task's source `workdir`)
+ * and track it per-task so `pendingTeardown` can be awaited by callers that
+ * must not race a deferred teardown (unarchive, start, delete, the orphan
+ * sweep). Errors from `job` are caught and logged — a single misbehaving
+ * teardown must never break the chain for every task queued behind it on the
+ * same workdir.
  */
-function enqueueTeardown(taskId: string, job: () => Promise<void>): Promise<void> {
-  const p = teardownTail
+function enqueueTeardown(taskId: string, key: string, job: () => Promise<void>): Promise<void> {
+  const tail = teardownTails.get(key) ?? Promise.resolve();
+  const p = tail
     .then(job)
     .catch((err) => {
       console.warn(`[agetor] deferred teardown failed for task ${taskId}:`, err);
     });
-  teardownTail = p;
+  teardownTails.set(key, p);
+  p.finally(() => {
+    // Only clear the entry if it's still the current tail for this key — a
+    // later enqueue for the same workdir must not have its chain slot
+    // clobbered by this settle, and this also bounds the map's size (an idle
+    // workdir's entry is removed once its chain drains).
+    if (teardownTails.get(key) === p) teardownTails.delete(key);
+  });
   teardowns.set(taskId, p);
   p.finally(() => {
     // Only clear the entry if it's still ours — a later enqueue for the same
@@ -1858,14 +1877,16 @@ export async function archiveTask(taskId: string): Promise<{ task: Task } | { er
   // inline rather than folded into the deferred job.
   codexTurnQueue.delete(taskId);
   // Deferred: the actual teardown (tmux kill, terminal shells, worktree
-  // detach) is pushed onto the global teardown queue rather than awaited
-  // here, so `archiveTask` can flip the DB column and return in milliseconds.
-  // Archiving several tasks back-to-back no longer blocks each POST on
-  // `spawnSync` tmux kills or `git worktree remove --force`/`prune` — those
-  // still run (serialized, see `enqueueTeardown`), just off the request's
-  // critical path. Callers that must not race a deferred teardown (unarchive,
-  // start, delete, the boot sweep) await `pendingTeardown(taskId)` first.
-  void enqueueTeardown(taskId, async () => {
+  // detach) is pushed onto this task's source-workdir teardown queue rather
+  // than awaited here, so `archiveTask` can flip the DB column and return in
+  // milliseconds. Archiving several tasks against the same workdir back-to-
+  // back no longer blocks each POST on `spawnSync` tmux kills or `git
+  // worktree remove --force`/`prune` — those still run (serialized per
+  // workdir, see `enqueueTeardown`), just off the request's critical path;
+  // tasks in a different workdir proceed independently. Callers that must
+  // not race a deferred teardown (unarchive, start, delete, the boot sweep)
+  // await `pendingTeardown(taskId)` first.
+  void enqueueTeardown(taskId, task.workdir, async () => {
     // Same contract as deleteTask: dropSession is non-throwing (it
     // best-efforts tmux teardown internally). Don't wrap — a silent catch
     // would hide a regression in claude-tmux from the next reviewer.
@@ -1930,12 +1951,13 @@ export async function deleteTask(taskId: string): Promise<void> {
   // clears any in-memory tailer. No-op when no session exists.
   const deleteKind = resolveHarness(task.agent)?.kind;
   codexTurnQueue.delete(taskId);
-  // Routed through the same global teardown queue archiveTask uses — DELETE's
-  // semantics are unchanged (still awaited before `tasks.delete` below), but
-  // this serializes it behind any archive teardown already in flight for
-  // another task, so two `git worktree remove`/`prune` calls against the same
-  // source repo never contend on git's locks at the same time.
-  await enqueueTeardown(taskId, async () => {
+  // Routed through the same per-workdir teardown queue archiveTask uses —
+  // DELETE's semantics are unchanged (still awaited before `tasks.delete`
+  // below), but this serializes it behind any archive teardown already in
+  // flight for another task in the SAME source workdir, so two `git worktree
+  // remove`/`prune` calls against the same repo never contend on git's locks
+  // at the same time. A delete against an unrelated workdir is unaffected.
+  await enqueueTeardown(taskId, task.workdir, async () => {
     if (deleteKind === "claude-code") dropSession(taskId);
     else if (deleteKind === "codex") dropCodexSession(taskId);
     // Kill any open terminal tabs before removing the worktree — a live shell
@@ -1961,11 +1983,13 @@ export async function deleteTask(taskId: string): Promise<void> {
  * `tasks.list()` already includes archived rows (no archived filter in its
  * query), so a plain scan is enough. Re-enqueues the identical teardown job
  * `archiveTask` would have run — session drop keyed to the task's own id,
- * `killTerminalsForTask`, `detachWorktree` — through the same global queue,
- * so it's serialized against anything already in flight. Kills are always
- * keyed to a specific task id from this instance's own DB; this never
- * enumerates or kills `agetor-*` tmux sessions directly (the shared-socket
- * rule reconcileOrphans documents above applies here too).
+ * `killTerminalsForTask`, `detachWorktree` — through the same per-workdir
+ * queue (keyed on each task's own `workdir`), so it's serialized against
+ * anything already in flight for that source repo without waiting on
+ * unrelated repos' backlogs. Kills are always keyed to a specific task id
+ * from this instance's own DB; this never enumerates or kills `agetor-*`
+ * tmux sessions directly (the shared-socket rule reconcileOrphans documents
+ * above applies here too).
  *
  * Fire-and-forget from the caller's perspective — returns the count enqueued,
  * not a promise, since it only needs to kick the jobs off.
@@ -1976,9 +2000,13 @@ export function sweepArchivedTeardowns(): number {
     if (task.archivedAt == null) continue;
     if (!task.worktreePath) continue;
     if (!existsSync(task.worktreePath)) continue;
+    // Defensive: an archived task shouldn't have a live run (archiveTask
+    // refuses to archive one), but mirror that guard here too rather than
+    // risk tearing down a worktree out from under an in-flight run.
+    if (task.runId && active.has(task.runId)) continue;
     const taskId = task.id;
     const kind = resolveHarness(task.agent)?.kind;
-    enqueueTeardown(taskId, async () => {
+    enqueueTeardown(taskId, task.workdir, async () => {
       if (kind === "claude-code") dropSession(taskId);
       else if (kind === "codex") dropCodexSession(taskId);
       await killTerminalsForTask(taskId);

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -117,6 +117,55 @@ interface ActiveRun {
 }
 const active = new Map<string, ActiveRun>(); // runId -> handle
 
+// Archive/delete teardown (tmux session kill, terminal teardown, worktree
+// detach/remove) is deferred onto a single global FIFO queue so `archiveTask`
+// can flip the DB column and respond in milliseconds instead of blocking on
+// `spawnSync` tmux kills and `git worktree remove --force`/`prune`. The
+// serialization is deliberate, not incidental: concurrent `git worktree
+// remove`/`prune` invocations against the SAME source repo contend on git's
+// internal locks (`.git/worktrees/.lock` etc.), so archiving several tasks
+// back-to-back must still tear them down one at a time — just not on the
+// request's critical path. `teardownTail` is the chain itself; `teardowns`
+// lets callers (unarchive/start/delete, plus the boot-time sweep) await a
+// specific task's in-flight teardown before touching the same worktree.
+let teardownTail: Promise<void> = Promise.resolve();
+const teardowns = new Map<string, Promise<void>>();
+
+/**
+ * Chain `job` onto the global teardown FIFO and track it per-task so
+ * `pendingTeardown` can be awaited by callers that must not race a deferred
+ * teardown (unarchive, start, delete, the orphan sweep). Errors from `job`
+ * are caught and logged — a single misbehaving teardown must never break the
+ * chain for every task queued behind it.
+ */
+function enqueueTeardown(taskId: string, job: () => Promise<void>): Promise<void> {
+  const p = teardownTail
+    .then(job)
+    .catch((err) => {
+      console.warn(`[agetor] deferred teardown failed for task ${taskId}:`, err);
+    });
+  teardownTail = p;
+  teardowns.set(taskId, p);
+  p.finally(() => {
+    // Only clear the entry if it's still ours — a later enqueue for the same
+    // task (e.g. delete right after archive) must not have its promise
+    // clobbered by this settle.
+    if (teardowns.get(taskId) === p) teardowns.delete(taskId);
+  });
+  return p;
+}
+
+/**
+ * Await any deferred teardown currently in flight (or queued) for `taskId`.
+ * Resolves immediately when nothing is pending. Exported so `unarchiveTask`,
+ * `startTask`, and the boot-time sweep can serialize against a still-running
+ * archive/delete teardown before touching the same worktree, and so tests can
+ * drain the queue deterministically.
+ */
+export function pendingTeardown(taskId: string): Promise<void> {
+  return teardowns.get(taskId) ?? Promise.resolve();
+}
+
 export function subscribe(fn: Listener): () => void {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -634,6 +683,12 @@ export async function startTask(taskId: string): Promise<{ runId: string } | { e
   let task = tasks.get(taskId);
   if (!task) return { error: "task not found" };
   if (task.runId && active.has(task.runId)) return { error: "task already running" };
+
+  // startTask auto-unarchives and materializes the worktree below — it must
+  // not race a teardown archiveTask (or deleteTask) deferred for this task,
+  // or a `detachWorktree`/`removeWorktree` still in flight could yank the
+  // directory out from under the freshly-prepared one.
+  await pendingTeardown(taskId);
 
   // Starting an archived task auto-unarchives it — otherwise the card would
   // move through columns (running → review/ready) while hidden behind the
@@ -1161,6 +1216,11 @@ export async function sendInput(runId: string, line: string): Promise<SendInputR
   if (task.archivedAt != null) {
     tasks.update(row.task_id, { archivedAt: null });
   }
+
+  // Same race as unarchiveTask/startTask: a deferred archive teardown may
+  // still be removing this task's worktree — let it finish before the
+  // existsSync check decides whether a restore is needed.
+  await pendingTeardown(row.task_id);
 
   if (task.worktreePath && !existsSync(task.worktreePath)) {
     // Re-fetch so the restore sees the just-cleared archivedAt (prepareWorkdir
@@ -1791,19 +1851,32 @@ export async function archiveTask(taskId: string): Promise<{ task: Task } | { er
   }
   const updated = tasks.update(taskId, { archivedAt: Date.now() });
   if (!updated) return { error: "task not found" };
-  // Same contract as deleteTask: dropSession is non-throwing (it best-efforts
-  // tmux teardown internally). Don't wrap — a silent catch would hide a
-  // regression in claude-tmux from the next reviewer.
+  // Resolved up front (before enqueueing) — same as before, just no longer
+  // re-read inside the deferred job.
   const archiveKind = resolveHarness(task.agent)?.kind;
-  if (archiveKind === "claude-code") dropSession(taskId);
-  else if (archiveKind === "codex") dropCodexSession(taskId);
+  // codexTurnQueue is cheap in-memory bookkeeping (no I/O), so it's dropped
+  // inline rather than folded into the deferred job.
   codexTurnQueue.delete(taskId);
-  // Tear down terminal tabs before detaching the worktree — a live shell
-  // cwd'd inside the worktree would block `git worktree remove`, exactly like
-  // deleteTask's ordering. Awaited (not fire-and-forget) so the shells are
-  // actually gone before detachWorktree runs.
-  await killTerminalsForTask(taskId);
-  await detachWorktree(updated);
+  // Deferred: the actual teardown (tmux kill, terminal shells, worktree
+  // detach) is pushed onto the global teardown queue rather than awaited
+  // here, so `archiveTask` can flip the DB column and return in milliseconds.
+  // Archiving several tasks back-to-back no longer blocks each POST on
+  // `spawnSync` tmux kills or `git worktree remove --force`/`prune` — those
+  // still run (serialized, see `enqueueTeardown`), just off the request's
+  // critical path. Callers that must not race a deferred teardown (unarchive,
+  // start, delete, the boot sweep) await `pendingTeardown(taskId)` first.
+  void enqueueTeardown(taskId, async () => {
+    // Same contract as deleteTask: dropSession is non-throwing (it
+    // best-efforts tmux teardown internally). Don't wrap — a silent catch
+    // would hide a regression in claude-tmux from the next reviewer.
+    if (archiveKind === "claude-code") dropSession(taskId);
+    else if (archiveKind === "codex") dropCodexSession(taskId);
+    // Tear down terminal tabs before detaching the worktree — a live shell
+    // cwd'd inside the worktree would block `git worktree remove`, exactly
+    // like deleteTask's ordering.
+    await killTerminalsForTask(taskId);
+    await detachWorktree(updated);
+  });
   return { task: updated };
 }
 
@@ -1817,6 +1890,13 @@ export async function unarchiveTask(taskId: string): Promise<{ task: Task } | { 
   const task = tasks.get(taskId);
   if (!task) return { error: "task not found" };
   if (task.archivedAt == null) return { task };
+  // Wait out any teardown archiveTask deferred for this task BEFORE deciding
+  // whether the worktree needs restoring. Without this, a still-in-flight
+  // `detachWorktree` could delete the worktree right after the `existsSync`
+  // check below decided it was still present (or right after a restore
+  // recreated it), leaving the task unarchived but pointing at a directory
+  // that's about to vanish out from under it.
+  await pendingTeardown(taskId);
   const updated = tasks.update(taskId, { archivedAt: null });
   if (!updated) return { error: "task not found" };
   if (updated.worktreePath && updated.branch && !existsSync(updated.worktreePath)) {
@@ -1849,15 +1929,62 @@ export async function deleteTask(taskId: string): Promise<void> {
   // for codex it only exists during an in-flight turn — dropCodexSession also
   // clears any in-memory tailer. No-op when no session exists.
   const deleteKind = resolveHarness(task.agent)?.kind;
-  if (deleteKind === "claude-code") dropSession(taskId);
-  else if (deleteKind === "codex") dropCodexSession(taskId);
   codexTurnQueue.delete(taskId);
-  // Kill any open terminal tabs before removing the worktree — a live shell
-  // sitting in the worktree dir would block `git worktree remove`. Awaited so
-  // the shells are actually gone before we tear the directory down.
-  await killTerminalsForTask(taskId);
-  await removeWorktree(task);
+  // Routed through the same global teardown queue archiveTask uses — DELETE's
+  // semantics are unchanged (still awaited before `tasks.delete` below), but
+  // this serializes it behind any archive teardown already in flight for
+  // another task, so two `git worktree remove`/`prune` calls against the same
+  // source repo never contend on git's locks at the same time.
+  await enqueueTeardown(taskId, async () => {
+    if (deleteKind === "claude-code") dropSession(taskId);
+    else if (deleteKind === "codex") dropCodexSession(taskId);
+    // Kill any open terminal tabs before removing the worktree — a live shell
+    // sitting in the worktree dir would block `git worktree remove`. Awaited
+    // so the shells are actually gone before we tear the directory down.
+    await killTerminalsForTask(taskId);
+    await removeWorktree(task);
+  });
   // No per-task attachments directory to clean up — refs are path-only,
   // agetor never copied anything to disk.
   tasks.delete(taskId);
+}
+
+/**
+ * Boot-time healing pass for teardowns that never ran: if agetor quit or
+ * crashed between an `archiveTask` response landing (DB flipped, teardown
+ * enqueued) and the deferred job actually executing, the in-memory queue is
+ * gone on restart but the worktree is still sitting on disk. This also heals
+ * the pre-existing crash-mid-archive case that could strand a worktree even
+ * before teardown was deferred (a crash between the DB update and the old
+ * synchronous `detachWorktree` call).
+ *
+ * `tasks.list()` already includes archived rows (no archived filter in its
+ * query), so a plain scan is enough. Re-enqueues the identical teardown job
+ * `archiveTask` would have run — session drop keyed to the task's own id,
+ * `killTerminalsForTask`, `detachWorktree` — through the same global queue,
+ * so it's serialized against anything already in flight. Kills are always
+ * keyed to a specific task id from this instance's own DB; this never
+ * enumerates or kills `agetor-*` tmux sessions directly (the shared-socket
+ * rule reconcileOrphans documents above applies here too).
+ *
+ * Fire-and-forget from the caller's perspective — returns the count enqueued,
+ * not a promise, since it only needs to kick the jobs off.
+ */
+export function sweepArchivedTeardowns(): number {
+  let enqueued = 0;
+  for (const task of tasks.list()) {
+    if (task.archivedAt == null) continue;
+    if (!task.worktreePath) continue;
+    if (!existsSync(task.worktreePath)) continue;
+    const taskId = task.id;
+    const kind = resolveHarness(task.agent)?.kind;
+    enqueueTeardown(taskId, async () => {
+      if (kind === "claude-code") dropSession(taskId);
+      else if (kind === "codex") dropCodexSession(taskId);
+      await killTerminalsForTask(taskId);
+      await detachWorktree(task);
+    });
+    enqueued++;
+  }
+  return enqueued;
 }

--- a/src/bun/server-keepalive.test.ts
+++ b/src/bun/server-keepalive.test.ts
@@ -1,0 +1,156 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import net from "node:net";
+
+// Regression test for the "cannot reach agetor API" WKWebView bug: Bun.serve
+// defaults `idleTimeout` to 10s, which was killing pooled keep-alive sockets
+// (and any handler that legitimately took >10s to respond) before the fix in
+// src/bun/server.ts set `idleTimeout: 255`. We hold a raw TCP connection idle
+// for just over 10s and prove the *same* socket is still usable afterwards —
+// a plain `fetch` wouldn't deterministically prove connection reuse, since
+// Bun/undici's client pool could silently open a fresh socket for the second
+// request even if the first one had been dropped.
+
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-server-keepalive-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+// Unique port, distinct from every other *.test.ts file's AGETOR_API_PORT.
+process.env.AGETOR_API_PORT = "4472";
+
+const PORT = 4472;
+
+let server: { stop: () => void };
+let token: string;
+
+beforeAll(async () => {
+  await import("./db.ts");
+  const { startApiServer, API_TOKEN } = await import("./server.ts");
+  server = startApiServer() as unknown as { stop: () => void };
+  token = API_TOKEN;
+});
+
+afterAll(() => {
+  server?.stop?.();
+});
+
+/** Parsed result of reading one HTTP/1.1 response off a raw socket. */
+type HttpResponse = { status: number; headers: Record<string, string>; body: string };
+
+/**
+ * Reads exactly one HTTP/1.1 response from `socket`, using the `Content-Length`
+ * header to know when the body is complete (every route in this server
+ * returns a `json()` response, which Bun always emits with a fixed
+ * `Content-Length` rather than chunked transfer-encoding). Any bytes read
+ * past the end of this response are returned as `leftover` so callers that
+ * reuse the same socket for a second request don't lose them.
+ */
+function readHttpResponse(
+  socket: net.Socket,
+  seed = "",
+): Promise<HttpResponse & { leftover: string }> {
+  return new Promise((resolve, reject) => {
+    let buf = seed;
+
+    const onData = (chunk: Buffer) => {
+      buf += chunk.toString("latin1");
+      const headerEnd = buf.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return;
+
+      const headerBlock = buf.slice(0, headerEnd);
+      const [statusLine, ...headerLines] = headerBlock.split("\r\n");
+      const statusMatch = /^HTTP\/1\.1\s+(\d+)/.exec(statusLine ?? "");
+      if (!statusMatch) {
+        cleanup();
+        reject(new Error(`malformed status line: ${statusLine}`));
+        return;
+      }
+      const headers: Record<string, string> = {};
+      for (const line of headerLines) {
+        const idx = line.indexOf(":");
+        if (idx === -1) continue;
+        headers[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim();
+      }
+
+      const contentLength = Number(headers["content-length"] ?? "0");
+      const bodyStart = headerEnd + 4;
+      const haveBody = buf.length - bodyStart;
+      if (haveBody < contentLength) return; // wait for more data
+
+      const body = buf.slice(bodyStart, bodyStart + contentLength);
+      const leftover = buf.slice(bodyStart + contentLength);
+      cleanup();
+      resolve({ status: Number(statusMatch[1]), headers, body, leftover });
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error("socket closed before a full response was read"));
+    };
+    const cleanup = () => {
+      socket.off("data", onData);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+    };
+
+    socket.on("data", onData);
+    socket.on("error", onError);
+    socket.on("close", onClose);
+  });
+}
+
+function connect(): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ host: "127.0.0.1", port: PORT }, () => resolve(socket));
+    socket.once("error", reject);
+  });
+}
+
+function buildRequest(path: string, token: string): string {
+  return (
+    `GET ${path} HTTP/1.1\r\n` +
+    `Host: 127.0.0.1:${PORT}\r\n` +
+    `Authorization: Bearer ${token}\r\n` +
+    `Connection: keep-alive\r\n` +
+    `\r\n`
+  );
+}
+
+test(
+  "an idle-for-11s keep-alive socket survives and serves a second request (idleTimeout: 255 regression)",
+  async () => {
+    const socket = await connect();
+    try {
+      socket.write(buildRequest("/tasks", token));
+      const first = await readHttpResponse(socket);
+      expect(first.status).toBe(200);
+
+      // Bun's default idleTimeout is 10s; wait just past it with no traffic
+      // on the socket at all. Under the old default the server would have
+      // torn down this connection during the wait.
+      await new Promise((r) => setTimeout(r, 11_000));
+
+      socket.write(buildRequest("/tasks", token));
+      const second = await readHttpResponse(socket, first.leftover);
+      expect(second.status).toBe(200);
+      expect(socket.destroyed).toBe(false);
+    } finally {
+      socket.destroy();
+    }
+  },
+  20_000,
+);
+
+test(
+  "/health still responds normally while the idle-keepalive test's socket sits open",
+  async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  },
+  20_000,
+);

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -444,6 +444,13 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
     port: PORT,
     hostname: "127.0.0.1",
     development: false,
+    // Bun's default idleTimeout is 10s, which is far too short here: it closes
+    // idle pooled keep-alive sockets that WKWebView then reuses for a POST
+    // (CFNetwork never auto-retries on a dropped reused connection, so the
+    // webview surfaces "cannot reach agetor API"), and it kills any handler
+    // that awaits >10s before writing bytes. 255 is Bun's max; some handlers
+    // below opt out entirely via server.timeout(req, 0).
+    idleTimeout: 255,
     websocket: terminalWebSocket,
     routes: {
       // Unauthenticated probes only — never returns data.
@@ -3088,6 +3095,10 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           return json(withRunningSubagents(updated), { headers: corsHeaders(req) });
         }),
         DELETE: authed(async (req) => {
+          // Worktree teardown (`git worktree remove` + branch delete, with an
+          // rm -rf fallback) can exceed even the 255s idleTimeout ceiling on
+          // large repos — opt this request out of idle timeout entirely.
+          server.timeout(req, 0);
           await deleteTask(req.params.id);
           return new Response(null, { status: 204, headers: corsHeaders(req) });
         }),
@@ -3095,6 +3106,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
 
       "/tasks/:id/start": {
         POST: authed(async (req) => {
+          server.timeout(req, 0);
           const result = await startTask(req.params.id);
           return "error" in result
             ? json(result, { status: 400, headers: corsHeaders(req) })
@@ -3104,6 +3116,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
 
       "/tasks/:id/archive": {
         POST: authed(async (req) => {
+          server.timeout(req, 0);
           const result = await archiveTask(req.params.id);
           return "error" in result
             ? json(result, { status: 400, headers: corsHeaders(req) })
@@ -3113,6 +3126,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
 
       "/tasks/:id/unarchive": {
         POST: authed(async (req) => {
+          server.timeout(req, 0);
           const result = await unarchiveTask(req.params.id);
           return "error" in result
             ? json(result, { status: 400, headers: corsHeaders(req) })

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, realpathSync } from "node:fs";
+import { rm } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { dataDir } from "./db.ts";
@@ -768,7 +769,10 @@ export async function removeWorktree(task: Task): Promise<void> {
     task.worktreePath.startsWith(ownedPrefix)
     && existsSync(task.worktreePath)
   ) {
-    try { rmSync(task.worktreePath, { recursive: true, force: true }); }
+    // Async on purpose: a synchronous rmSync over a large worktree (e.g. one
+    // with node_modules) would block the event loop for seconds, starving
+    // every other HTTP connection and SSE stream.
+    try { await rm(task.worktreePath, { recursive: true, force: true }); }
     catch { /* best-effort */ }
   }
 }
@@ -816,7 +820,10 @@ export async function detachWorktree(
     task.worktreePath.startsWith(ownedPrefix)
     && existsSync(task.worktreePath)
   ) {
-    try { rmSync(task.worktreePath, { recursive: true, force: true }); }
+    // Async on purpose: a synchronous rmSync over a large worktree (e.g. one
+    // with node_modules) would block the event loop for seconds, starving
+    // every other HTTP connection and SSE stream.
+    try { await rm(task.worktreePath, { recursive: true, force: true }); }
     catch { /* best-effort */ }
   }
   return { removed: !existsSync(task.worktreePath) };

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -75,6 +75,7 @@ import type {
   TerminalTab,
   UpdateStatus,
 } from "../../shared/types.ts";
+import { fetchWithRecovery } from "./net-retry.ts";
 
 export interface UpdateSnapshot {
   status: UpdateStatus;
@@ -261,26 +262,19 @@ export class ApiError extends Error {
 }
 
 async function j<T>(path: string, init?: RequestInit): Promise<T> {
-  let res: Response;
-  try {
-    res = await fetch(`${BASE}${path}`, {
-      ...init,
-      headers: {
-        "content-type": "application/json",
-        "authorization": `Bearer ${API_TOKEN}`,
-        ...(init?.headers ?? {}),
-      },
-    });
-  } catch (e) {
-    // WebKit's bare "Load failed" tells us nothing — replace with
-    // something the user can act on.
-    const msg = (e as Error).message ?? String(e);
-    throw new Error(
-      msg === "Load failed"
-        ? `cannot reach agetor API at ${BASE} (${path}) — is the bun process running? Try restarting \`bun run dev\`.`
-        : msg,
-    );
-  }
+  // fetchWithRecovery absorbs transient socket-layer rejections (WebKit's
+  // bare "Load failed" — see net-retry.ts) via a health-gated single retry
+  // before giving up; it throws a truthful error when the server really is
+  // unreachable. HTTP error statuses still fall through to the !res.ok
+  // handling below unchanged.
+  const res = await fetchWithRecovery({ fetchImpl: fetch, base: BASE }, path, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      "authorization": `Bearer ${API_TOKEN}`,
+      ...(init?.headers ?? {}),
+    },
+  });
   if (res.status === 204) return undefined as T;
   const body = await res.json().catch(() => null);
   if (!res.ok) {

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -261,12 +261,18 @@ export class ApiError extends Error {
   }
 }
 
-async function j<T>(path: string, init?: RequestInit): Promise<T> {
+async function j<T>(
+  path: string,
+  init?: RequestInit,
+  opts?: { retry?: boolean },
+): Promise<T> {
   // fetchWithRecovery absorbs transient socket-layer rejections (WebKit's
   // bare "Load failed" — see net-retry.ts) via a health-gated single retry
   // before giving up; it throws a truthful error when the server really is
   // unreachable. HTTP error statuses still fall through to the !res.ok
-  // handling below unchanged.
+  // handling below unchanged. `opts.retry: false` (set by a handful of
+  // non-idempotent callers below) still probes health for the error
+  // message but never re-issues the request.
   const res = await fetchWithRecovery({ fetchImpl: fetch, base: BASE }, path, {
     ...init,
     headers: {
@@ -274,7 +280,7 @@ async function j<T>(path: string, init?: RequestInit): Promise<T> {
       "authorization": `Bearer ${API_TOKEN}`,
       ...(init?.headers ?? {}),
     },
-  });
+  }, opts);
   if (res.status === 204) return undefined as T;
   const body = await res.json().catch(() => null);
   if (!res.ok) {
@@ -549,10 +555,11 @@ export const api = {
     return j<GitHubCommentsResult>(`/github/comments?${q.toString()}`);
   },
   createGitHubComment: (input: { path: string; number: number; body: string; kind?: GitHubItemKind }) =>
+    // retry: false — a replay would post a duplicate PR/issue comment.
     j<{ comment: GitHubComment }>("/github/comments", {
       method: "POST",
       body: JSON.stringify(input),
-    }),
+    }, { retry: false }),
   getGitHubViewer: (input: { path: string }) => {
     const q = new URLSearchParams({ path: input.path });
     return j<{ ok: true; login: string }>(`/github/viewer?${q.toString()}`);
@@ -1011,7 +1018,9 @@ export const api = {
     column?: ColumnId;
     references?: TaskReference[];
     taskType?: TaskType;
-  }) => j<Task>("/tasks", { method: "POST", body: JSON.stringify(input) }),
+  }) =>
+    // retry: false — a replay would create a duplicate task + branch.
+    j<Task>("/tasks", { method: "POST", body: JSON.stringify(input) }, { retry: false }),
   updateTask: (id: string, patch: Partial<Task>) =>
     j<Task>(`/tasks/${id}`, { method: "PATCH", body: JSON.stringify(patch) }),
   moveTask: (id: string, column: ColumnId) =>
@@ -1044,9 +1053,12 @@ export const api = {
   cancelRun: (runId: string) =>
     j<{ cancelled: boolean }>(`/runs/${runId}/cancel`, { method: "POST" }),
   sendRunInput: (runId: string, line: string) =>
+    // retry: false — a replay would paste a duplicate message into a live
+    // agent tmux session.
     j<{ delivered: true; runId: string } | { delivered: false; reason: string }>(
       `/runs/${runId}/input`,
       { method: "POST", body: JSON.stringify({ line }) },
+      { retry: false },
     ),
 
   // Messages backlog — saved, not-yet-sent draft messages parked on a task.

--- a/src/mainview/lib/net-retry.test.ts
+++ b/src/mainview/lib/net-retry.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from "bun:test";
+import { fetchWithRecovery, type NetRetryDeps } from "./net-retry.ts";
+
+type Call = { url: string; init?: RequestInit };
+type Handler = (url: string, init?: RequestInit) => Promise<Response>;
+
+/** Builds a scripted fetchImpl: the Nth call is served by handlers[N],
+ *  recording every call's url + init for later assertions. */
+function makeFetch(handlers: Handler[]) {
+  const calls: Call[] = [];
+  let n = 0;
+  const fetchImpl = (async (
+    url: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const urlStr = String(url);
+    calls.push({ url: urlStr, init });
+    const handler = handlers[n++];
+    if (!handler) {
+      throw new Error(`unexpected call #${n} to ${urlStr}`);
+    }
+    return handler(urlStr, init);
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const ok = (body = "ok") => new Response(body, { status: 200 });
+const serverError = (status = 500) => new Response("boom", { status });
+
+const BASE = "http://127.0.0.1:4317";
+const PATH = "/tasks";
+
+function deps(fetchImpl: typeof fetch, healthTimeoutMs?: number): NetRetryDeps {
+  return { fetchImpl, base: BASE, healthTimeoutMs };
+}
+
+describe("fetchWithRecovery", () => {
+  test("happy path: first fetch resolves, no probe, no retry", async () => {
+    const { fetchImpl, calls } = makeFetch([async () => ok("first")]);
+    const res = await fetchWithRecovery(deps(fetchImpl), PATH);
+    expect(await res.text()).toBe("first");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${BASE}${PATH}`);
+  });
+
+  test("transient recovery: rejection + healthy probe re-issues original once", async () => {
+    const init: RequestInit = {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    };
+    const { fetchImpl, calls } = makeFetch([
+      async () => {
+        throw new TypeError("Load failed");
+      },
+      async () => ok(), // health probe
+      async () => ok("retried"), // original request, retried
+    ]);
+
+    const res = await fetchWithRecovery(deps(fetchImpl), PATH, init);
+
+    expect(await res.text()).toBe("retried");
+    expect(calls).toHaveLength(3);
+    expect(calls[0]!.url).toBe(`${BASE}${PATH}`);
+    expect(calls[1]!.url).toBe(`${BASE}/health`);
+    expect(calls[2]!.url).toBe(`${BASE}${PATH}`);
+    // retry must re-issue the exact same method/headers/body as the original
+    expect(calls[2]!.init?.method).toBe(calls[0]!.init?.method);
+    expect(calls[2]!.init?.headers).toEqual(calls[0]!.init?.headers);
+    expect(calls[2]!.init?.body).toBe(calls[0]!.init?.body);
+    expect(calls[2]!.init).toBe(calls[0]!.init);
+  });
+
+  test("server down (probe rejects): throws unreachable error mentioning the path", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      async () => {
+        throw new TypeError("Load failed");
+      },
+      async () => {
+        throw new Error("ECONNREFUSED");
+      }, // health probe rejects
+    ]);
+
+    await expect(fetchWithRecovery(deps(fetchImpl), PATH)).rejects.toThrow(
+      /cannot reach agetor API/,
+    );
+    // re-run to inspect message content precisely (fresh fetch script)
+    const { fetchImpl: fetchImpl2 } = makeFetch([
+      async () => {
+        throw new TypeError("Load failed");
+      },
+      async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    ]);
+    try {
+      await fetchWithRecovery(deps(fetchImpl2), PATH);
+      throw new Error("expected fetchWithRecovery to throw");
+    } catch (e) {
+      expect((e as Error).message).toContain("cannot reach agetor API");
+      expect((e as Error).message).toContain(PATH);
+      expect((e as Error).message).toContain(BASE);
+    }
+    expect(calls).toHaveLength(2);
+  });
+
+  test("server down (probe resolves non-ok): treated the same as a failed probe", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      async () => {
+        throw new TypeError("Load failed");
+      },
+      async () => serverError(503), // health probe responds, but not ok
+    ]);
+
+    await expect(fetchWithRecovery(deps(fetchImpl), PATH)).rejects.toThrow(
+      /cannot reach agetor API/,
+    );
+    expect(calls).toHaveLength(2);
+  });
+
+  test("failed twice: rejection + healthy probe + retry also rejects", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      async () => {
+        throw new Error("first failure");
+      },
+      async () => ok(), // health probe succeeds
+      async () => {
+        throw new Error("second failure");
+      }, // retry also fails
+    ]);
+
+    try {
+      await fetchWithRecovery(deps(fetchImpl), PATH);
+      throw new Error("expected fetchWithRecovery to throw");
+    } catch (e) {
+      const message = (e as Error).message;
+      expect(message).toContain("failed twice");
+      expect(message).toContain(`${BASE}${PATH}`);
+      // implementation reports the retry's error message (falling back to the
+      // original only if the retry's message is empty) — see net-retry.ts
+      expect(message).toContain("second failure");
+    }
+    expect(calls).toHaveLength(3);
+  });
+
+  test("HTTP error passthrough: 500 response is returned as-is, no probe/retry", async () => {
+    const { fetchImpl, calls } = makeFetch([async () => serverError(500)]);
+    const res = await fetchWithRecovery(deps(fetchImpl), PATH);
+    expect(res.status).toBe(500);
+    expect(res.ok).toBe(false);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("retry:false + healthy probe: does NOT re-issue, error explains why", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      async () => {
+        throw new TypeError("Load failed");
+      },
+      async () => ok(), // health probe succeeds
+    ]);
+
+    try {
+      await fetchWithRecovery(deps(fetchImpl), PATH, undefined, { retry: false });
+      throw new Error("expected fetchWithRecovery to throw");
+    } catch (e) {
+      const message = (e as Error).message;
+      expect(message).toMatch(/not retried/i);
+      expect(message).toContain(PATH);
+      expect(message).toContain(BASE);
+    }
+    // original request + health probe only — no re-issue.
+    expect(calls).toHaveLength(2);
+    expect(calls[1]!.url).toBe(`${BASE}/health`);
+  });
+
+  test("retry:false + dead server: still throws the cannot-reach error", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      async () => {
+        throw new TypeError("Load failed");
+      },
+      async () => {
+        throw new Error("ECONNREFUSED"); // health probe rejects
+      },
+    ]);
+
+    await expect(
+      fetchWithRecovery(deps(fetchImpl), PATH, undefined, { retry: false }),
+    ).rejects.toThrow(/cannot reach agetor API/);
+    expect(calls).toHaveLength(2);
+  });
+
+  test("caller-initiated abort: rethrown immediately, no probe, no retry", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      async () => {
+        const err = new Error("The user aborted a request.");
+        err.name = "AbortError";
+        throw err;
+      },
+    ]);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      fetchWithRecovery(deps(fetchImpl), PATH, { signal: controller.signal }),
+    ).rejects.toThrow(/aborted/i);
+    // no health probe, no retry — just the original call.
+    expect(calls).toHaveLength(1);
+  });
+
+  test("non-\"Load failed\" original error + dead server: original message surfaces", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      async () => {
+        throw new Error("NetworkError when attempting to fetch resource.");
+      },
+      async () => {
+        throw new Error("ECONNREFUSED"); // health probe rejects
+      },
+    ]);
+
+    try {
+      await fetchWithRecovery(deps(fetchImpl), PATH);
+      throw new Error("expected fetchWithRecovery to throw");
+    } catch (e) {
+      const message = (e as Error).message;
+      expect(message).toBe("NetworkError when attempting to fetch resource.");
+      expect(message).not.toContain("cannot reach agetor API");
+    }
+    expect(calls).toHaveLength(2);
+  });
+
+  test("health probe timeout: hung probe respects AbortSignal and behaves as server-down", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      async () => {
+        throw new TypeError("Load failed");
+      },
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            const err = new Error("The operation was aborted.");
+            err.name = "AbortError";
+            reject(err);
+          });
+        }),
+    ]);
+
+    const start = Date.now();
+    await expect(
+      fetchWithRecovery(deps(fetchImpl, 30), PATH),
+    ).rejects.toThrow(/cannot reach agetor API/);
+    const elapsed = Date.now() - start;
+
+    expect(calls).toHaveLength(2); // original + health probe; no retry
+    // sanity: the timeout actually gated this, not some near-instant path
+    expect(elapsed).toBeLessThan(1000);
+  });
+});

--- a/src/mainview/lib/net-retry.ts
+++ b/src/mainview/lib/net-retry.ts
@@ -29,12 +29,29 @@ export interface NetRetryDeps {
   healthTimeoutMs?: number;
 }
 
+/** Per-call override for `fetchWithRecovery`. `retry` defaults to `true`. */
+export interface FetchRecoveryOpts {
+  /** Set `false` for non-idempotent requests where re-issuing the request
+   *  after a network-layer rejection could double-apply a side effect (the
+   *  server may have already processed the original attempt even though the
+   *  client never saw the response). The health probe still runs — it's
+   *  only used to pick the right error message, never to justify a replay. */
+  retry?: boolean;
+}
+
 function unreachableMessage(base: string, path: string): string {
   return `cannot reach agetor API at ${base} (${path}) — is the bun process running? Try restarting \`bun run dev\`.`;
 }
 
-function failedTwiceMessage(base: string, path: string, originalMsg: string): string {
-  return `request to ${base}${path} failed twice even though the server is up (transient socket errors) — original error: ${originalMsg}`;
+function notRetriedMessage(base: string, path: string, originalMsg: string): string {
+  return `request to ${base}${path} failed in transit (${originalMsg}) — the server may have already processed it, so it was NOT retried because repeating it isn't safe.`;
+}
+
+/** `lastErrorMsg` is the RETRY attempt's error message (falling back to the
+ *  original attempt's message only if the retry's message is empty) — the
+ *  name previously said "originalMsg", which was inaccurate. */
+function failedTwiceMessage(base: string, path: string, lastErrorMsg: string): string {
+  return `request to ${base}${path} failed twice even though the server is up (transient socket errors) — original error: ${lastErrorMsg}`;
 }
 
 /** Probes `GET {base}/health`, resolving `true` iff the response is ok
@@ -58,35 +75,60 @@ async function probeHealth(
 }
 
 /** Performs `fetchImpl(base + path, init)`. On a network-layer rejection
- *  (fetch threw — not an HTTP error status), probes `GET {base}/health`
- *  with an AbortController timeout:
- *  - probe succeeds (`res.ok`): the server is alive; the original request
- *    almost certainly never reached it (stale keep-alive socket) → re-issue
- *    the original request ONCE. If the retry also rejects, throws a
- *    "request failed twice against a live server" error.
- *  - probe fails/times out: throws the "cannot reach agetor API… is the bun
- *    process running?" error (server genuinely unreachable).
+ *  (fetch threw — not an HTTP error status):
+ *  - a caller-initiated abort (`init.signal.aborted` or the error's
+ *    `name === "AbortError"`) is rethrown immediately, unexamined — no
+ *    probe, no retry. The caller asked for this to stop; recovering it
+ *    would be surprising.
+ *  - otherwise probes `GET {base}/health` with an AbortController timeout
+ *    to decide whether the server is actually alive:
+ *    - probe fails/times out: the server is genuinely unreachable. Throws
+ *      the original error's message verbatim UNLESS it's WebKit's generic
+ *      "Load failed", in which case the friendlier "cannot reach agetor
+ *      API… is the bun process running?" message is thrown instead.
+ *    - probe succeeds (`res.ok`): the server is alive, so the original
+ *      request almost certainly never reached it (stale keep-alive socket).
+ *      - `opts.retry !== false` (default): re-issue the original request
+ *        ONCE. If the retry also rejects, throws a "request failed twice
+ *        against a live server" error.
+ *      - `opts.retry === false`: the request is non-idempotent and a
+ *        replay could double-apply a side effect the server may have
+ *        already processed — do NOT re-issue. Throws an error explaining
+ *        the request failed in transit and was not retried.
  *  HTTP error statuses (4xx/5xx) are NOT retried — the `Response` is
  *  returned to the caller as-is so existing `!res.ok` handling still runs. */
 export async function fetchWithRecovery(
   deps: NetRetryDeps,
   path: string,
   init?: RequestInit,
+  opts?: FetchRecoveryOpts,
 ): Promise<Response> {
   const { fetchImpl, base, healthTimeoutMs = 1500 } = deps;
+  const retry = opts?.retry ?? true;
   try {
     return await fetchImpl(`${base}${path}`, init);
   } catch (e) {
+    // A caller-initiated abort must not be retried — it's not a transient
+    // socket failure, the caller asked for this outcome.
+    if (init?.signal?.aborted || (e as Error)?.name === "AbortError") {
+      throw e;
+    }
     const msg = (e as Error).message ?? String(e);
     const alive = await probeHealth(fetchImpl, base, healthTimeoutMs);
     if (!alive) {
+      if (msg !== "Load failed") {
+        throw e instanceof Error ? e : new Error(msg);
+      }
       throw new Error(unreachableMessage(base, path));
+    }
+    if (!retry) {
+      throw new Error(notRetriedMessage(base, path, msg));
     }
     try {
       return await fetchImpl(`${base}${path}`, init);
     } catch (e2) {
-      const msg2 = (e2 as Error).message ?? String(e2);
-      throw new Error(failedTwiceMessage(base, path, msg2 || msg));
+      const lastErrorMsg = (e2 as Error).message ?? String(e2);
+      throw new Error(failedTwiceMessage(base, path, lastErrorMsg || msg));
     }
   }
 }

--- a/src/mainview/lib/net-retry.ts
+++ b/src/mainview/lib/net-retry.ts
@@ -1,0 +1,92 @@
+// Transparent recovery for transient socket failures on the webview <-> bun
+// API connection.
+//
+// WHY: WKWebView's network stack (CFNetwork) pools keep-alive HTTP/1.1
+// sockets. Bun's `idleTimeout` can close a pooled connection server-side at
+// almost the same moment the webview picks it up to send a new request —
+// classically for a POST, which per Apple's own guidance (QA1941) CFNetwork
+// will NOT silently retry the way it retries idempotent GETs. The result is
+// a fetch() rejection whose message is the useless, generic "Load failed",
+// even though the bun process is alive and well. Treating every "Load
+// failed" as "the server is down" (the previous behavior) produced a false
+// "is the bun process running?" toast on a plain socket race.
+//
+// FIX: on a network-layer rejection (fetch threw, not an HTTP error status),
+// probe the unauthenticated `GET /health` route with a short timeout. If the
+// server answers, the original request almost certainly never reached it —
+// re-issue it once. If the probe itself fails/times out, the server really
+// is unreachable and the original "is the bun process running?" message is
+// truthful.
+//
+// NOTE: re-sending `init` verbatim on retry is safe here because every body
+// this app sends through `j()` is a JSON string (or absent) — there is no
+// stream/FormData/Blob body that could already be consumed on first attempt.
+
+export interface NetRetryDeps {
+  fetchImpl: typeof fetch;
+  base: string;
+  /** Timeout for the /health probe, in ms. Default 1500. */
+  healthTimeoutMs?: number;
+}
+
+function unreachableMessage(base: string, path: string): string {
+  return `cannot reach agetor API at ${base} (${path}) — is the bun process running? Try restarting \`bun run dev\`.`;
+}
+
+function failedTwiceMessage(base: string, path: string, originalMsg: string): string {
+  return `request to ${base}${path} failed twice even though the server is up (transient socket errors) — original error: ${originalMsg}`;
+}
+
+/** Probes `GET {base}/health`, resolving `true` iff the response is ok
+ *  within `timeoutMs`. Never throws — any rejection (network error, abort)
+ *  resolves to `false`. */
+async function probeHealth(
+  fetchImpl: typeof fetch,
+  base: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(`${base}/health`, { signal: controller.signal });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Performs `fetchImpl(base + path, init)`. On a network-layer rejection
+ *  (fetch threw — not an HTTP error status), probes `GET {base}/health`
+ *  with an AbortController timeout:
+ *  - probe succeeds (`res.ok`): the server is alive; the original request
+ *    almost certainly never reached it (stale keep-alive socket) → re-issue
+ *    the original request ONCE. If the retry also rejects, throws a
+ *    "request failed twice against a live server" error.
+ *  - probe fails/times out: throws the "cannot reach agetor API… is the bun
+ *    process running?" error (server genuinely unreachable).
+ *  HTTP error statuses (4xx/5xx) are NOT retried — the `Response` is
+ *  returned to the caller as-is so existing `!res.ok` handling still runs. */
+export async function fetchWithRecovery(
+  deps: NetRetryDeps,
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const { fetchImpl, base, healthTimeoutMs = 1500 } = deps;
+  try {
+    return await fetchImpl(`${base}${path}`, init);
+  } catch (e) {
+    const msg = (e as Error).message ?? String(e);
+    const alive = await probeHealth(fetchImpl, base, healthTimeoutMs);
+    if (!alive) {
+      throw new Error(unreachableMessage(base, path));
+    }
+    try {
+      return await fetchImpl(`${base}${path}`, init);
+    } catch (e2) {
+      const msg2 = (e2 as Error).message ?? String(e2);
+      throw new Error(failedTwiceMessage(base, path, msg2 || msg));
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Two related reliability issues in the webview ↔ Bun API path:

1. **False "cannot reach agetor API" toasts.** Archiving, starting, or moving a task
   intermittently toasted `cannot reach agetor API at http://127.0.0.1:4317 (…) — is the
   bun process running?` while the server was perfectly healthy. Frequency grew with usage.
2. **Slow back-to-back archives.** Archiving several tasks in a row queued up — each
   request waited seconds before the next one made progress.

## Root causes

- `Bun.serve` never set `idleTimeout`, so Bun's **10s default** applied. That timer kills
  (a) idle pooled keep-alive sockets — which the WKWebView then reuses for the next POST,
  and CFNetwork **never auto-retries POSTs** on a dropped reused connection (Apple QA1941) —
  and (b) any request whose handler awaits >10s before writing bytes (archive → worktree
  removal, start/unarchive → `git worktree add`). Both surface as WebKit's bare
  `"Load failed"`, which `j()` in `api.ts` mapped straight to the toast. GET polling
  survived (auto-retried + errors swallowed), which is why only user actions toasted.
- `archiveTask` ran its full teardown **before responding**: blocking `spawnSync` tmux
  kill, terminal teardown, `git status` dirty check, `git worktree remove --force`,
  `git worktree prune`, and a recursive `rm` — plus event-loop-blocking `rmSync`.
  Concurrent teardowns in the same source repo also contended on git's locks,
  silently stranding worktrees.

## Changes

**Server**
- `idleTimeout: 255` on `Bun.serve` + `server.timeout(req, 0)` on the four long-op
  handlers (start / archive / unarchive / delete), which can exceed even 255s on big repos.
- `worktree.ts`: `rmSync` → awaited `rm` (no more multi-second event-loop stalls).
- Archive teardown is now **deferred to a background queue keyed per `task.workdir`**:
  archive flips the row and responds in ms; same-repo teardowns stay FIFO-serialized
  (git's lock domain) while unrelated repos run in parallel. `unarchive`/`start`/`delete`/
  `sendInput` await the task's pending teardown before touching the worktree. A boot
  sweep re-enqueues teardowns lost to a quit/crash (keyed to own-DB task ids only —
  never enumerates `agetor-*` sessions).

**Client**
- New `net-retry.ts`: on a network-layer fetch failure, probe the unauthenticated
  `/health` (1.5s cap); if the server is alive, retry the request once; otherwise show
  the (now truthful) toast. Retry is disabled for the non-idempotent POSTs where a
  replay could double-apply (`sendRunInput`, `createTask`, `createGitHubComment`), and
  caller aborts are never retried.

## Testing

- `server-keepalive.test.ts` — raw-socket HTTP/1.1 request, 11s idle, second request on
  the same socket must succeed (fails under the old 10s default).
- `net-retry.test.ts` — 11 unit tests over the retry/health-probe logic.
- `orchestrator-archive-teardown.test.ts` — deferred detach, archive→unarchive race,
  same-repo back-to-back archives, boot sweep, per-chain FIFO, independent repos.
- Full suite: **1515 pass / 0 fail** (108 files), typecheck clean. Two review passes;
  all must-fix/should-fix findings addressed.