### PR TITLE
fix(claude-tmux): deliver oversized prompts via paste-buffer so continuing a task can't fail with "command too long"

### DIFF
--- a/docs/plans/fix-claude-resume-large-prompt-tmux-argv.md
+++ b/docs/plans/fix-claude-resume-large-prompt-tmux-argv.md
@@ -1,0 +1,75 @@
+# Plan — Fix "tmux new-session failed: command too long" on continue-task with a large prompt
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-15 |
+| Source | User report + screenshot (open-tmux 404, SSE flood) + prod DB forensics (task b0f273ba, 3 instant-failed runs) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/api-error-on-continue-task |
+| Base SHA | 3f4b057e826383869fff20bf118f7c33b0072d0f |
+| Mode | **Autonomous** — grill + plan-approval gates bypassed (agetor-orchestrated run, owner unavailable mid-task). All assumptions logged in §8. |
+
+## 1. Objective & success criteria
+
+When a claude-code task's tmux session has ended and the user sends a follow-up (or starts a task) whose prompt is large (multi-KB paste), the run must start successfully instead of failing instantly with `tmux new-session failed: command too long`.
+
+Success criteria:
+- A resume (`spawnResumedSession`) with a prompt of any size spawns the tmux session and delivers the prompt.
+- A fresh task-start with a huge first prompt also works (same root cause).
+- Small prompts keep the exact current argv delivery path (zero behavior change for the common case).
+- `bun run typecheck` green; `bun test` green.
+- The `open-tmux` 404 disappears as a consequence (session actually exists after resume) — no code change needed there.
+
+## 2. Context & constraints (grounded findings)
+
+- Root cause chain: `orchestrator.sendClaudeTurn` (orchestrator.ts:1354) → session gone → `spawnResumedSession` (orchestrator.ts:1531) → `spawnAgent` (agents.ts:523) → `buildCommand` embeds the entire prompt as the final argv element (`args.push("--", prompt)`, agents.ts:325) → `spawnClaudeViaTmux` folds argv into one `tmux new-session … -- <argv>` (claude-tmux.ts:3339-3343) → tmux 3.6a rejects any client command ≥ ~14–16KB total (measured empirically: 14KB ok, 16KB fails with literal stderr `command too long`; tmux's 16KB imsg cap).
+- The safe large-payload mechanism already exists: `pastePromptSync` (claude-tmux.ts:4412) sends the prompt over **stdin** via `tmux load-buffer -b <buf> -` then `paste-buffer -p` + gapped `Enter`, serialized through `queuePaste` (claude-tmux.ts:4602). Used by every live-session follow-up (`sendTurn`).
+- Readiness signal for pasting into a *freshly spawned* session: `readPaneMode(state)` (claude-tmux.ts:3869) returns non-null only when claude's status bar shows an idle mode banner / "? for shortcuts" — i.e. the TUI is drawn and idle at the composer. Startup consent dialogs are auto-confirmed by the existing boot poller (claude-tmux.ts:3439-3528) and `readPaneMode` returns null while they're up, so a wait-for-composer loop naturally waits them out.
+- On resume the JSONL already exists, so the boot JSONL-wait short-circuits and the tailer parks at EOF (claude-tmux.ts:3363) — the pasted prompt's turn is then journaled and resolves the run normally.
+- The failing task's agent kind is `claude-pbsco` (a claude-family custom kind) — the fix must live on the shared claude-code spawn path, not be keyed to the literal `"claude-code"` string without checking how claude-family kinds dispatch in `spawnAgent`/`buildCommand`.
+- `agents.test.ts:110-131, 238-279` currently asserts the prompt is always the final argv element (including with `resumeSessionId`) — those assertions stay valid for small prompts; new cases cover the deferred path.
+- Test conventions: `claude-turn-routing.test.ts` uses a fake `AGETOR_TMUX_BIN` script that logs every argv invocation to a JSONL file — ideal for asserting "new-session argv never contains the big prompt; load-buffer carries it". `claude-followup-restart.test.ts` covers the resume dispatch path with `AGETOR_CLAUDE_BIN=/bin/echo` + real tmux.
+
+## 3. Approach & key decisions
+
+**Threshold-deferred paste.** In the claude spawn path, when the prompt is large, omit it from argv and deliver it after launch via the existing `queuePaste` machinery, gated on composer readiness.
+
+- `CLAUDE_PROMPT_ARGV_MAX_BYTES = 4096` (constant in agents.ts, comment citing the measured ~14–16KB tmux client-command cap and headroom for `-e` env pairs + flags).
+- `buildCommand` claude branch gains an option (or `spawnAgent` decides) to skip `args.push("--", prompt)`; the raw prompt is passed to `spawnClaudeViaTmux` as `deferredPrompt`.
+- `spawnClaudeViaTmux`: after a successful `new-session` + state allocation, when `deferredPrompt` is set, fire an async loop: poll `readPaneMode(state)` every ~400ms up to 30s (abort if session dies); on ready — or best-effort on timeout with a status note — `void queuePaste(taskId, sessionName, deferredPrompt, 0, state, { bracketed: true })`. Emit a `status` chunk so the user sees the prompt is being delivered.
+
+Alternatives considered:
+- *Always paste, never argv*: one code path, but regresses the battle-tested happy path for every task start and races startup consent dialogs on every fresh boot. Rejected — the deferred path should stay the rare exception.
+- *Codex-style stdin/prompt-file*: not applicable — claude's interactive TUI has no prompt-from-file flag and owns its stdin.
+- *Truncate the prompt*: unacceptable data loss.
+
+## 4. Work breakdown — implementation tasks
+
+- **T1 (wave 1)** — Core fix. Owns `src/bun/agents.ts` + `src/bun/claude-tmux.ts` (coupled; single agent). Threshold + defer plumbing + composer-wait paste. Acceptance: typecheck green; a >4KB prompt never appears in the `tmux new-session` argv; small prompts unchanged.
+
+## 5. Work breakdown — test tasks
+
+- **T2 (wave 2)** — Owns `src/bun/agents.test.ts`. Cases: small prompt → argv unchanged (existing assertions still pass); >4KB prompt → argv contains no prompt element (with and without `resumeSessionId`); boundary at exactly 4096 bytes.
+- **T3 (wave 2)** — Owns `src/bun/claude-turn-routing.test.ts` (and `claude-followup-restart.test.ts` if a resume-shaped case fits better there). Using the fake-tmux argv logger: large-prompt resume → `new-session` argv excludes the prompt AND a `load-buffer`/`paste-buffer` sequence delivers it; assert no `command too long`-style failure path.
+
+## 6. Execution waves
+
+- Wave 1: T1 alone (both files coupled).
+- Barrier: typecheck + commit.
+- Wave 2: T2 ∥ T3 (disjoint files).
+- Then: review (opus) → run tests (haiku) → fixes if needed.
+
+## 7. Blast radius & risks
+
+- Every claude-family task start and resume flows through `spawnAgent`/`spawnClaudeViaTmux`. Mitigated by the threshold: <4KB prompts (vast majority) take the byte-identical current path.
+- Paste-at-boot timing: mitigated by the `readPaneMode` readiness gate + existing bracketed-paste gap logic in `queuePaste` (commit 9457e1f). Consent dialogs are handled by the existing boot poller before the composer can appear.
+- On resume, the boot error path (`jsonl-discovery-timeout`) never fires (JSONL exists), so the deferred-paste loop carries its own timeout with best-effort paste + status note rather than hanging silently.
+- `AGETOR_CLAUDE_DRIVER=fake` short-circuits before tmux — orchestrator-level tests unaffected.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+1. **Scope includes the fresh-start path** (same root cause, same fix site) — assumed yes.
+2. **Threshold 4096 bytes on the prompt** — conservative vs the measured ~14–16KB whole-command cap; env-only overflow (pathological giant env) is pre-existing and out of scope.
+3. **The SSE "network connection was lost" flood in the screenshot** is the app/server being down or restarting at capture time, not part of this defect — out of scope.
+4. **`open-tmux` 404** is a downstream symptom (no session exists because spawn failed); no route change.
+5. Medium prompts (4–14KB) that technically worked via argv now go via paste — accepted behavior change, paste is the battle-tested follow-up mechanism.

--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -2,6 +2,7 @@ import { test, expect, beforeEach } from "bun:test";
 import {
   buildCommand,
   buildHarnessTerminalCommand,
+  CLAUDE_PROMPT_ARGV_MAX_BYTES,
   isValidEnvKey,
   toTerminalAppleScript,
 } from "./agents.ts";
@@ -243,6 +244,66 @@ test("claude-code appends the prompt as the final argv element", () => {
 test("claude-code with empty prompt does not append an empty argv element", () => {
   const { cmd } = buildCommand(builtin("claude-code"), "", { ...claudeDefaults });
   expect(cmd).not.toContain("");
+});
+
+// --- deferred prompt (CLAUDE_PROMPT_ARGV_MAX_BYTES) -------------------------
+// Above CLAUDE_PROMPT_ARGV_MAX_BYTES, embedding the prompt in argv blows
+// tmux's ~16KB client-command cap ("command too long"). buildCommand omits
+// the prompt from argv entirely above the threshold and returns it as
+// `deferredPrompt` instead; at-or-below the threshold argv is byte-identical
+// to today's shape.
+
+test("claude-code prompt of exactly CLAUDE_PROMPT_ARGV_MAX_BYTES bytes still rides argv, deferredPrompt undefined", () => {
+  const prompt = "a".repeat(CLAUDE_PROMPT_ARGV_MAX_BYTES);
+  const { cmd, deferredPrompt } = buildCommand(builtin("claude-code"), prompt, { ...claudeDefaults });
+  expect(cmd[cmd.length - 2]).toBe("--");
+  expect(cmd[cmd.length - 1]).toBe(prompt);
+  expect(deferredPrompt).toBeUndefined();
+});
+
+test("claude-code prompt one byte over CLAUDE_PROMPT_ARGV_MAX_BYTES is deferred, not in argv", () => {
+  const prompt = "a".repeat(CLAUDE_PROMPT_ARGV_MAX_BYTES + 1);
+  const { cmd, deferredPrompt } = buildCommand(builtin("claude-code"), prompt, { ...claudeDefaults });
+  expect(cmd).not.toContain(prompt);
+  // No dangling `--` terminator left behind for the (now-absent) prompt.
+  expect(cmd[cmd.length - 1]).not.toBe("--");
+  expect(deferredPrompt).toBe(prompt);
+});
+
+test("claude-code deferred prompt still emits --resume <id>; only the prompt itself is deferred", () => {
+  const prompt = "a".repeat(CLAUDE_PROMPT_ARGV_MAX_BYTES + 1);
+  const { cmd, deferredPrompt } = buildCommand(builtin("claude-code"), prompt, {
+    ...claudeDefaults,
+    resumeSessionId: "abc-123-uuid",
+  });
+  const i = cmd.indexOf("--resume");
+  expect(i).toBeGreaterThan(-1);
+  expect(cmd[i + 1]).toBe("abc-123-uuid");
+  expect(cmd).not.toContain(prompt);
+  expect(cmd[cmd.length - 1]).not.toBe("--");
+  expect(deferredPrompt).toBe(prompt);
+});
+
+test("claude-code defers on UTF-8 byte length, not JS string length (multi-byte prompt)", () => {
+  // "€" is 1 UTF-16 code unit (.length counts it as 1) but 3 UTF-8 bytes.
+  // 2000 of them → .length 2000 (well under the threshold) but byteLength
+  // 6000 (over it) — this only defers if the check is Buffer.byteLength.
+  const prompt = "€".repeat(2000);
+  expect(prompt.length).toBeLessThan(CLAUDE_PROMPT_ARGV_MAX_BYTES);
+  expect(Buffer.byteLength(prompt, "utf8")).toBeGreaterThan(CLAUDE_PROMPT_ARGV_MAX_BYTES);
+  const { cmd, deferredPrompt } = buildCommand(builtin("claude-code"), prompt, { ...claudeDefaults });
+  expect(cmd).not.toContain(prompt);
+  expect(deferredPrompt).toBe(prompt);
+});
+
+test("codex is unaffected by prompt size — always delivered via stdin, never deferred", () => {
+  // Codex's prompt never rides argv (it's piped via stdin, the trailing `-`
+  // sentinel), so it has no size-driven argv problem and no deferredPrompt.
+  const prompt = "a".repeat(CLAUDE_PROMPT_ARGV_MAX_BYTES * 4);
+  const result = buildCommand(builtin("codex"), prompt, { ...codexDefaults });
+  expect(result.cmd).not.toContain(prompt);
+  expect(result.cmd[result.cmd.length - 1]).toBe("-");
+  expect(result.deferredPrompt).toBeUndefined();
 });
 
 test("claude-code resumeSessionId adds --resume <id> to the argv (no --session-id)", () => {

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -15,7 +15,35 @@ export type { SpawnedAgent };
 export interface AgentCommand {
   cmd: string[];
   env?: Record<string, string>;
+  /**
+   * Set only by the claude-code branch of `buildCommand`, when the prompt is
+   * too large to ride in `tmux new-session`'s argv (see
+   * `CLAUDE_PROMPT_ARGV_MAX_BYTES`). `spawnAgent` forwards this to
+   * `spawnClaudeViaTmux` as `ClaudeLaunchOptions.deferredPrompt`, which
+   * delivers it post-launch via the same load-buffer/paste-buffer machinery
+   * live-session follow-ups use, gated on the composer being idle. Always
+   * undefined for codex — its prompt already rides on stdin, never argv, so
+   * it has no size-driven argv problem.
+   */
+  deferredPrompt?: string;
 }
+
+/**
+ * Prompts up to this size stay embedded in the claude-code launch argv
+ * (today's behavior, byte-identical). Above it, `buildCommand` omits the
+ * prompt from argv entirely and returns it as `AgentCommand.deferredPrompt`
+ * instead, so `spawnAgent` can route it through `spawnClaudeViaTmux`'s
+ * post-launch paste path.
+ *
+ * Why: tmux serializes the WHOLE client command — `new-session` flags, every
+ * `-e KEY=VAL` env pair, and the trailing argv — as a single message over its
+ * control socket, and tmux 3.6a rejects anything past its ~16KB imsg cap with
+ * a literal `command too long` (empirically measured: 14KB ok, 16KB fails).
+ * Budgeting 4KB to the prompt alone leaves generous headroom in that same
+ * message for the env block and flags, which ride alongside it regardless of
+ * prompt size.
+ */
+export const CLAUDE_PROMPT_ARGV_MAX_BYTES = 4096;
 
 export interface AgentRunOptions {
   /** Friendly mode id; see AGENT_OPTIONS in shared/types.ts. */
@@ -322,7 +350,22 @@ export function buildCommand(
     // dead session + empty pane + 30s boot timeout (the run just fails with
     // no visible cause). `--` is a no-op for prompts that don't lead with a
     // dash.
-    if (prompt) args.push("--", prompt);
+    //
+    // Above CLAUDE_PROMPT_ARGV_MAX_BYTES, embedding the prompt here blows
+    // tmux's client-command cap and `tmux new-session` fails outright with
+    // `command too long` before claude ever starts — worse than the
+    // unknown-option case above, since there's no session at all to inspect.
+    // Skip the argv entirely and hand the raw prompt back as
+    // `deferredPrompt`; `spawnAgent` forwards it to `spawnClaudeViaTmux`,
+    // which pastes it in once claude's composer is up.
+    let deferredPrompt: string | undefined;
+    if (prompt) {
+      if (Buffer.byteLength(prompt, "utf8") > CLAUDE_PROMPT_ARGV_MAX_BYTES) {
+        deferredPrompt = prompt;
+      } else {
+        args.push("--", prompt);
+      }
+    }
 
     // Effort is required unless the chosen model doesn't accept the flag
     // (Haiku 4.5 today). Unknown effort ids are dropped rather than passed
@@ -336,7 +379,7 @@ export function buildCommand(
       throw new Error(`effort is required for claude-code model ${opts.model}`);
     }
 
-    return { cmd: args, env: Object.keys(env).length ? env : undefined };
+    return { cmd: args, env: Object.keys(env).length ? env : undefined, deferredPrompt };
   }
 
   // codex — hosted in tmux via codex-tmux.ts. The prompt is NOT an argv
@@ -548,6 +591,7 @@ export function spawnAgent(args: SpawnAgentArgs): SpawnedAgent {
       sessionId,
       configDir: harness.home,
       mode: opts.mode ?? null,
+      deferredPrompt: built.deferredPrompt,
     });
   }
 

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -3315,7 +3315,10 @@ const DEFERRED_PROMPT_POLL_MS = 400;
  *  composer before pasting best-effort anyway. Generous — matches
  *  BOOT_TIMEOUT_MS below — because the same startup work (auth probe,
  *  plugin/skill scan, model warmup) that can delay the JSONL also delays the
- *  composer. */
+ *  composer. Deliberately the same literal as `BOOT_TIMEOUT_MS`: both bound
+ *  the same claude startup work, so keeping them numerically co-sized reads
+ *  naturally, but they're independent constants — there's no shared source
+ *  and no requirement to change one when the other changes. */
 const DEFERRED_PROMPT_TIMEOUT_MS = 30_000;
 
 /**
@@ -3426,9 +3429,18 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
   disposeSessionState(sessions.get(opts.taskId), true);
   sessions.set(opts.taskId, state);
 
+  // Keep a handle on the pushed slot (mirrors `sendTurn`'s idiom below) so
+  // the deferred-paste loop can (a) recognise cancellation — `kill()`
+  // splices `turnQueue` without touching `sessions`, so slot-presence is the
+  // only reliable "has this launch been cancelled?" signal — and (b) settle
+  // this exact slot on a paste failure instead of leaving the run `running`
+  // forever.
+  const initialSlot: TurnSlot = { onChunk: opts.onChunk, resolve: null, reject: null };
   const done = new Promise<number>((resolve, reject) => {
-    state.turnQueue.push({ onChunk: opts.onChunk, resolve, reject });
+    initialSlot.resolve = resolve;
+    initialSlot.reject = reject;
   });
+  state.turnQueue.push(initialSlot);
   // Brand-new session has no prior turn to inherit metadata from, but
   // seed `lastChunk` so any metadata claude writes before its first
   // user/assistant entries (e.g. permission-mode banner) still lands on
@@ -3439,12 +3451,20 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
   // CLAUDE_PROMPT_ARGV_MAX_BYTES from argv — embedding it would blow tmux's
   // client-command cap and fail `new-session` outright — and hands it back
   // as `deferredPrompt` instead. Paste it in once claude's composer is
-  // confirmed idle (`readPaneMode` returns non-null), which also naturally
-  // waits out any startup consent dialog: the boot poller below auto-confirms
-  // those, and the composer can't be idle while one is still on screen.
-  // Fire-and-forget, wrapped in try/catch so a throw here can never become an
-  // unhandled rejection (mirrors the boot-dialog poller's posture a few lines
-  // down) — this must never affect the JSONL boot wait itself.
+  // confirmed idle (`readPaneMode` returns non-null). Known startup consent
+  // dialogs (the bypass-permissions warning, trust-folder prompt) are handled
+  // for free: the boot poller below auto-confirms those, and the composer
+  // can't be idle while one is still painted over it. A *generic* startup
+  // question (something only the user can answer — see the boot poller's
+  // "other interactive question" branch) is different: it surfaces as a
+  // `tmux_prompt` card, and pasting over it would corrupt whatever partial
+  // answer is on screen. So each readiness window that times out re-checks
+  // `activeTmuxPromptsForTask` and, if one is still pending, re-arms instead
+  // of pasting — mirroring the boot JSONL-wait's re-arm loop a few dozen
+  // lines down. Fire-and-forget, wrapped in try/catch so a throw here can
+  // never become an unhandled rejection (mirrors the boot-dialog poller's
+  // posture a few lines down) — this must never affect the JSONL boot wait
+  // itself.
   if (opts.deferredPrompt) {
     const deferredPrompt = opts.deferredPrompt;
     opts.onChunk(
@@ -3453,23 +3473,57 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
     );
     void (async () => {
       try {
-        const deadline = Date.now() + DEFERRED_PROMPT_TIMEOUT_MS;
+        // `kill()` (a cancel, or any other path that settles/removes the
+        // initial slot) splices it out of `turnQueue` without touching
+        // `sessions` or the tmux session itself, so neither of the liveness/
+        // identity checks below would ever catch a cancel on their own —
+        // slot-presence is the signal. Checked on every poll tick, on every
+        // re-arm, and immediately before the final paste attempt.
+        const slotLive = () => state.turnQueue.includes(initialSlot);
         let ready = false;
-        while (Date.now() < deadline) {
-          if (!tmux(["has-session", "-t", "=" + sessionName]).ok) return; // session died — nothing to paste into
-          if (sessions.get(opts.taskId) !== state) return; // superseded by a newer spawn/reattach
-          if (readPaneMode(state) !== null) { ready = true; break; }
-          await Bun.sleep(DEFERRED_PROMPT_POLL_MS);
+        windows: for (;;) {
+          const deadline = Date.now() + DEFERRED_PROMPT_TIMEOUT_MS;
+          while (Date.now() < deadline) {
+            if (!tmux(["has-session", "-t", "=" + sessionName]).ok) return; // session died — nothing to paste into
+            if (sessions.get(opts.taskId) !== state) return; // superseded by a newer spawn/reattach
+            if (!slotLive()) return; // cancelled (or otherwise settled) — never paste over it
+            if (readPaneMode(state) !== null) { ready = true; break windows; }
+            await Bun.sleep(DEFERRED_PROMPT_POLL_MS);
+          }
+          // Window timed out. Don't paste over an unanswered startup
+          // question — re-arm a fresh window instead, as long as there's
+          // still something to wait for.
+          if (activeTmuxPromptsForTask(opts.taskId).length === 0) break;
+          if (!tmux(["has-session", "-t", "=" + sessionName]).ok) return;
+          if (sessions.get(opts.taskId) !== state) return;
+          if (!slotLive()) return;
         }
         // Re-check liveness/identity before the final attempt — the loop can
         // exit via the timeout with the session still alive, and a dropped
         // prompt is worse than a best-effort paste into whatever's on screen.
         if (!tmux(["has-session", "-t", "=" + sessionName]).ok) return;
         if (sessions.get(opts.taskId) !== state) return;
+        if (!slotLive()) return; // cancelled during the final liveness check
         if (!ready) {
           opts.onChunk("status", "claude readiness never confirmed — delivering prompt anyway");
         }
-        void queuePaste(opts.taskId, sessionName, deferredPrompt, 0, state, { bracketed: true });
+        void queuePaste(opts.taskId, sessionName, deferredPrompt, 0, state, {
+          bracketed: true,
+          onPasteFailure: () => {
+            // Mirror `sendTurn`'s onPasteFailure idiom exactly: guard against
+            // the (theoretical) race where the slot already popped normally
+            // between the paste call and this failure callback, remove it
+            // from the queue if still present, then reject `done` so the run
+            // settles instead of hanging in `running` forever.
+            if (!initialSlot.reject) return;
+            const idx = state.turnQueue.indexOf(initialSlot);
+            if (idx !== -1) state.turnQueue.splice(idx, 1);
+            const reject = initialSlot.reject;
+            initialSlot.resolve = null;
+            initialSlot.reject = null;
+            reject(new Error("paste failed"));
+          },
+        });
       } catch { /* never let the deferred-paste poller crash the spawn */ }
     })();
   }

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -225,6 +225,15 @@ export interface ClaudeLaunchOptions {
    * installation — see `ensureInstalledForCwd` in hook-installer.ts.)
    */
   mode: string | null;
+  /**
+   * Set by `agents.ts` (`buildCommand` → `spawnAgent`) when the prompt was
+   * too large to embed in `argv` (over `CLAUDE_PROMPT_ARGV_MAX_BYTES` — tmux's
+   * ~16KB client-command cap). When present, `argv` carries no prompt at all
+   * and this raw text is delivered post-launch by pasting it into the tmux
+   * pane once claude's composer is idle, via the same load-buffer/paste-
+   * buffer machinery `sendTurn` uses for live-session follow-ups.
+   */
+  deferredPrompt?: string;
 }
 
 /* ────────────────────────────────────────────────────────────────────────── *
@@ -3296,13 +3305,34 @@ function attachTailer(state: SessionState): void {
  * Public entry points.
  * ────────────────────────────────────────────────────────────────────────── */
 
+/** How often `spawnClaudeViaTmux`'s deferred-paste loop polls `readPaneMode`
+ *  while waiting for a large prompt's target session to reach an idle
+ *  composer. Same cadence as the startup-dialog poller (STARTUP_DIALOG_POLL_MS)
+ *  — frequent enough to paste promptly once claude draws, cheap enough to run
+ *  for the duration of the timeout below. */
+const DEFERRED_PROMPT_POLL_MS = 400;
+/** Bound on how long the deferred-paste loop waits for a confirmed-idle
+ *  composer before pasting best-effort anyway. Generous — matches
+ *  BOOT_TIMEOUT_MS below — because the same startup work (auth probe,
+ *  plugin/skill scan, model warmup) that can delay the JSONL also delays the
+ *  composer. */
+const DEFERRED_PROMPT_TIMEOUT_MS = 30_000;
+
 /**
- * Start a new claude tmux session for the task. The initial prompt rides
- * inside `opts.argv` (claude's documented `claude "query"` form), so we
- * don't paste anything via tmux for the first turn — claude submits it
- * itself on startup. Assumes `sessionExists(taskId)` is false; the caller
- * (orchestrator) is responsible for routing follow-up turns through
- * `sendTurn`.
+ * Start a new claude tmux session for the task. Two delivery modes for the
+ * initial prompt, chosen by `agents.ts` before this is called:
+ *
+ *   - Common case: the prompt rides inside `opts.argv` (claude's documented
+ *     `claude "query"` form), so we don't paste anything via tmux for the
+ *     first turn — claude submits it itself on startup.
+ *   - Large prompt (`opts.deferredPrompt` set, `opts.argv` carries none):
+ *     `argv` boots a bare claude with no initial query, and once the
+ *     composer is confirmed idle (or a bounded timeout elapses) the prompt
+ *     is pasted in via the same load-buffer/paste-buffer machinery
+ *     live-session follow-ups use — see the deferred-paste block below.
+ *
+ * Assumes `sessionExists(taskId)` is false; the caller (orchestrator) is
+ * responsible for routing follow-up turns through `sendTurn`.
  */
 export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
   const sessionName = sessionNameFor(opts.taskId);
@@ -3404,6 +3434,45 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
   // user/assistant entries (e.g. permission-mode banner) still lands on
   // the opening run's stream.
   state.lastChunk = opts.onChunk;
+
+  // Large-prompt delivery: `buildCommand` (agents.ts) omits any prompt over
+  // CLAUDE_PROMPT_ARGV_MAX_BYTES from argv — embedding it would blow tmux's
+  // client-command cap and fail `new-session` outright — and hands it back
+  // as `deferredPrompt` instead. Paste it in once claude's composer is
+  // confirmed idle (`readPaneMode` returns non-null), which also naturally
+  // waits out any startup consent dialog: the boot poller below auto-confirms
+  // those, and the composer can't be idle while one is still on screen.
+  // Fire-and-forget, wrapped in try/catch so a throw here can never become an
+  // unhandled rejection (mirrors the boot-dialog poller's posture a few lines
+  // down) — this must never affect the JSONL boot wait itself.
+  if (opts.deferredPrompt) {
+    const deferredPrompt = opts.deferredPrompt;
+    opts.onChunk(
+      "status",
+      "prompt too large for launch argv — delivering via paste once claude is ready",
+    );
+    void (async () => {
+      try {
+        const deadline = Date.now() + DEFERRED_PROMPT_TIMEOUT_MS;
+        let ready = false;
+        while (Date.now() < deadline) {
+          if (!tmux(["has-session", "-t", "=" + sessionName]).ok) return; // session died — nothing to paste into
+          if (sessions.get(opts.taskId) !== state) return; // superseded by a newer spawn/reattach
+          if (readPaneMode(state) !== null) { ready = true; break; }
+          await Bun.sleep(DEFERRED_PROMPT_POLL_MS);
+        }
+        // Re-check liveness/identity before the final attempt — the loop can
+        // exit via the timeout with the session still alive, and a dropped
+        // prompt is worse than a best-effort paste into whatever's on screen.
+        if (!tmux(["has-session", "-t", "=" + sessionName]).ok) return;
+        if (sessions.get(opts.taskId) !== state) return;
+        if (!ready) {
+          opts.onChunk("status", "claude readiness never confirmed — delivering prompt anyway");
+        }
+        void queuePaste(opts.taskId, sessionName, deferredPrompt, 0, state, { bracketed: true });
+      } catch { /* never let the deferred-paste poller crash the spawn */ }
+    })();
+  }
 
   // Bounded wait for claude to create the JSONL. This is just claude's
   // bootup (auth probe, plugin/skill scan, model warmup, MCP initialize on

--- a/src/bun/claude-turn-routing.test.ts
+++ b/src/bun/claude-turn-routing.test.ts
@@ -477,6 +477,268 @@ test("a large (>4KB) follow-up resume never embeds the prompt in new-session arg
   }
 });
 
+// Regression tests for the opus code-review findings on the deferred-paste
+// fix above (commits de27191 + c6242ae): cancel-during-wait must abort the
+// deferred paste instead of pasting a prompt the user already cancelled, and
+// a failed paste must settle the run instead of leaving it `running` forever.
+
+test("cancelling a run while its large prompt is deferred (composer never confirmed idle) never pastes it — the run settles cancelled", async () => {
+  const { bin, logPath } = fakeDeferredPasteTmuxBin();
+  process.env.AGETOR_TMUX_BIN = bin;
+  delete process.env.AGETOR_CLAUDE_DRIVER; // force the real spawnClaudeViaTmux path
+  process.env.AGETOR_CLAUDE_BIN = "/bin/echo"; // harmless stub launch command
+
+  const { tasks, runs } = await import("./db.ts");
+  const { sendInput, cancelRun } = await import("./orchestrator.ts");
+  const { __forTest, dropSession, jsonlPathFor } = await import("./claude-tmux.ts");
+  const { CLAUDE_PROMPT_ARGV_MAX_BYTES } = await import("./agents.ts");
+
+  const taskId = `task-cancel-deferred-${randomUUID()}`;
+  const priorRunId = `run-cancel-deferred-${randomUUID()}`;
+  const priorClaudeSessionId = "prior-claude-session-id-cancel";
+  const now = Date.now();
+  const workdir = mkdtempSync(path.join(tmpdir(), "agetor-cancel-wd-"));
+
+  const expectedJsonlPath = jsonlPathFor(workdir, priorClaudeSessionId, null);
+  mkdirSync(path.dirname(expectedJsonlPath), { recursive: true });
+  writeFileSync(expectedJsonlPath, "");
+
+  // Keep the composer looking perpetually NOT ready — the deferred-paste
+  // loop's readiness gate (`readPaneMode`) never fires, so it sits in its
+  // poll loop exactly like a launch whose claude session is slow to boot.
+  // This is the window a Stop click needs to land in for the bug to repro.
+  const prevCapture = __forTest.setCaptureModePane(() => "");
+  const prevGap = __forTest.setBracketedEnterGapMs(0);
+  const prevSettle = __forTest.setSlashCommandSettleMs(0);
+
+  const largePrompt = "y".repeat(CLAUDE_PROMPT_ARGV_MAX_BYTES + 500);
+
+  try {
+    tasks.insert({
+      id: taskId,
+      title: "cancel-deferred-resume",
+      prompt: "p",
+      column: "review",
+      agent: "claude-code",
+      workdir,
+      isolation: "none",
+      taskType: "task",
+      branch: null,
+      worktreePath: null,
+      baseRef: null,
+      mode: null,
+      model: "claude-opus-4-7",
+      effort: "medium",
+      references: [], backlog: [],
+      runId: priorRunId,
+      hasOpenableRun: false,
+      pendingInteractionCount: 0,
+      openTerminalCount: 0,
+      archivedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    runs.insert({
+      id: priorRunId,
+      taskId,
+      agent: "claude-code",
+      status: "succeeded",
+      startedAt: now,
+      endedAt: now,
+      exitCode: 0,
+      tmuxSession: "agetor-stale-name",
+      claudeSessionId: priorClaudeSessionId,
+      codexSessionId: null,
+    });
+
+    const result = await sendInput(priorRunId, largePrompt);
+    expect(result.delivered).toBe(true);
+    if (!result.delivered) throw new Error(result.reason);
+    const newRunId = result.runId;
+
+    // Give the spawn a moment to run `new-session` and let the deferred-paste
+    // IIFE reach its poll loop (composer stays "" so it never breaks out).
+    await new Promise((r) => setTimeout(r, 150));
+
+    expect(cancelRun(newRunId)).toBe(true);
+
+    // Let the poll loop wake at least once (DEFERRED_PROMPT_POLL_MS = 400ms)
+    // after the cancel and observe the slot is gone.
+    await new Promise((r) => setTimeout(r, 700));
+
+    // Now flip the composer to "ready" — if the abort check were missing,
+    // the very next poll tick would go ahead and paste. Give it another
+    // full poll interval to prove it doesn't.
+    __forTest.setCaptureModePane(() => "? for shortcuts");
+    await new Promise((r) => setTimeout(r, 700));
+
+    const entries = readLog(logPath);
+    // The whole point of the fix: a cancelled launch must never paste the
+    // deferred prompt, no matter how long the wait or how the composer
+    // eventually looks.
+    expect(entries.some((e) => e.argv.includes("load-buffer"))).toBe(false);
+    expect(entries.some((e) => e.argv.includes("paste-buffer"))).toBe(false);
+
+    const list = runs.listForTask(taskId);
+    const settled = list.find((r) => r.id === newRunId);
+    expect(settled?.status).toBe("cancelled");
+  } finally {
+    __forTest.setCaptureModePane(prevCapture);
+    __forTest.setBracketedEnterGapMs(prevGap);
+    __forTest.setSlashCommandSettleMs(prevSettle);
+    dropSession(taskId);
+    rmSync(path.dirname(expectedJsonlPath), { recursive: true, force: true });
+  }
+});
+
+test("a failed deferred paste (load-buffer errors) settles the run instead of leaving it running forever", async () => {
+  // Same fake tmux as the happy-path deferred test, except `load-buffer`
+  // always fails — simulates a dead socket / vanished pane mid-paste.
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-deferred-fail-tmux-"));
+  const bin = path.join(dir, "tmux");
+  const logPath = path.join(dir, "log.jsonl");
+  const markerDir = path.join(dir, "markers");
+  mkdirSync(markerDir, { recursive: true });
+  writeFileSync(
+    bin,
+    `#!${process.execPath}\n` +
+      `import { appendFileSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";\n` +
+      `import path from "node:path";\n` +
+      `const argv = process.argv.slice(2);\n` +
+      `let stdin = "";\n` +
+      `try { stdin = readFileSync(0, "utf8"); } catch {}\n` +
+      `appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ argv, stdin }) + "\\n");\n` +
+      `function sessionArg() {\n` +
+      `  const sIdx = argv.indexOf("-s");\n` +
+      `  if (sIdx !== -1) return argv[sIdx + 1];\n` +
+      `  const tIdx = argv.indexOf("-t");\n` +
+      `  if (tIdx !== -1) { let v = argv[tIdx + 1]; if (v && v.startsWith("=")) v = v.slice(1); return v; }\n` +
+      `  return null;\n` +
+      `}\n` +
+      `const markerDir = ${JSON.stringify(markerDir)};\n` +
+      `if (argv.includes("new-session")) {\n` +
+      `  const name = sessionArg();\n` +
+      `  if (name) writeFileSync(path.join(markerDir, name), "1");\n` +
+      `  process.exit(0);\n` +
+      `}\n` +
+      `if (argv.includes("kill-session")) {\n` +
+      `  const name = sessionArg();\n` +
+      `  if (name) { try { rmSync(path.join(markerDir, name)); } catch {} }\n` +
+      `  process.exit(0);\n` +
+      `}\n` +
+      `if (argv.includes("has-session")) {\n` +
+      `  const name = sessionArg();\n` +
+      `  if (name && existsSync(path.join(markerDir, name))) process.exit(0);\n` +
+      `  process.stderr.write("can't find session: =" + (name ?? "unknown"));\n` +
+      `  process.exit(1);\n` +
+      `}\n` +
+      // The failure under test: load-buffer (the first step of the deferred
+      // paste) always errors.
+      `if (argv.includes("load-buffer")) {\n` +
+      `  process.stderr.write("no such file or directory");\n` +
+      `  process.exit(1);\n` +
+      `}\n` +
+      `process.exit(0);\n`,
+  );
+  chmodSync(bin, 0o755);
+
+  process.env.AGETOR_TMUX_BIN = bin;
+  delete process.env.AGETOR_CLAUDE_DRIVER; // force the real spawnClaudeViaTmux path
+  process.env.AGETOR_CLAUDE_BIN = "/bin/echo"; // harmless stub launch command
+
+  const { tasks, runs } = await import("./db.ts");
+  const { sendInput } = await import("./orchestrator.ts");
+  const { __forTest, dropSession, jsonlPathFor } = await import("./claude-tmux.ts");
+  const { CLAUDE_PROMPT_ARGV_MAX_BYTES } = await import("./agents.ts");
+
+  const taskId = `task-paste-fail-${randomUUID()}`;
+  const priorRunId = `run-paste-fail-${randomUUID()}`;
+  const priorClaudeSessionId = "prior-claude-session-id-fail";
+  const now = Date.now();
+  const workdir = mkdtempSync(path.join(tmpdir(), "agetor-paste-fail-wd-"));
+
+  const expectedJsonlPath = jsonlPathFor(workdir, priorClaudeSessionId, null);
+  mkdirSync(path.dirname(expectedJsonlPath), { recursive: true });
+  writeFileSync(expectedJsonlPath, "");
+
+  // Make the composer look immediately idle so the deferred-paste loop fires
+  // its (doomed) paste attempt right away instead of spinning toward the
+  // 30s timeout.
+  const prevCapture = __forTest.setCaptureModePane(() => "? for shortcuts");
+  const prevGap = __forTest.setBracketedEnterGapMs(0);
+  const prevSettle = __forTest.setSlashCommandSettleMs(0);
+
+  const largePrompt = "z".repeat(CLAUDE_PROMPT_ARGV_MAX_BYTES + 500);
+
+  try {
+    tasks.insert({
+      id: taskId,
+      title: "paste-fail-resume",
+      prompt: "p",
+      column: "review",
+      agent: "claude-code",
+      workdir,
+      isolation: "none",
+      taskType: "task",
+      branch: null,
+      worktreePath: null,
+      baseRef: null,
+      mode: null,
+      model: "claude-opus-4-7",
+      effort: "medium",
+      references: [], backlog: [],
+      runId: priorRunId,
+      hasOpenableRun: false,
+      pendingInteractionCount: 0,
+      openTerminalCount: 0,
+      archivedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    runs.insert({
+      id: priorRunId,
+      taskId,
+      agent: "claude-code",
+      status: "succeeded",
+      startedAt: now,
+      endedAt: now,
+      exitCode: 0,
+      tmuxSession: "agetor-stale-name",
+      claudeSessionId: priorClaudeSessionId,
+      codexSessionId: null,
+    });
+
+    const result = await sendInput(priorRunId, largePrompt);
+    expect(result.delivered).toBe(true);
+    if (!result.delivered) throw new Error(result.reason);
+    const newRunId = result.runId;
+
+    // Let the spawn + the fire-and-forget deferred-paste chain run their
+    // course, including the doomed load-buffer call and its failure
+    // handling.
+    await new Promise((r) => setTimeout(r, 800));
+
+    const entries = readLog(logPath);
+    expect(entries.some((e) => e.argv.includes("load-buffer"))).toBe(true);
+    // paste-buffer must never have been reached — load-buffer failed first.
+    expect(entries.some((e) => e.argv.includes("paste-buffer"))).toBe(false);
+
+    // The whole point of the fix: a failed deferred paste must settle the
+    // run (not leave it stuck `running` forever waiting on an end_turn that
+    // will never arrive, since claude never received the prompt).
+    const list = runs.listForTask(taskId);
+    const settled = list.find((r) => r.id === newRunId);
+    expect(settled?.status).not.toBe("running");
+    expect(settled?.status).toBe("failed");
+  } finally {
+    __forTest.setCaptureModePane(prevCapture);
+    __forTest.setBracketedEnterGapMs(prevGap);
+    __forTest.setSlashCommandSettleMs(prevSettle);
+    dropSession(taskId);
+    rmSync(path.dirname(expectedJsonlPath), { recursive: true, force: true });
+  }
+});
+
 test("a small (<=4KB) follow-up resume still embeds the prompt in new-session argv — deferral doesn't fire for the common case", async () => {
   // Reuse the fixed-verdict stub (uniform "gone" so the routing gate always
   // takes the respawn path) — this test only cares about the argv shape of

--- a/src/bun/claude-turn-routing.test.ts
+++ b/src/bun/claude-turn-routing.test.ts
@@ -69,7 +69,7 @@ function fakeRoutingTmuxBin(probeCode: number, probeStderr: string): { bin: stri
   return { bin, logPath };
 }
 
-function readLog(logPath: string): Array<{ argv: string[] }> {
+function readLog(logPath: string): Array<{ argv: string[]; stdin?: string }> {
   let raw: string;
   try {
     raw = readFileSync(logPath, "utf8");
@@ -77,6 +77,73 @@ function readLog(logPath: string): Array<{ argv: string[] }> {
     return [];
   }
   return raw.split("\n").filter(Boolean).map((l) => JSON.parse(l));
+}
+
+/**
+ * Write an executable fake tmux for the deferred-large-prompt regression
+ * tests below. Unlike `fakeRoutingTmuxBin` (a single fixed `has-session`
+ * verdict for the whole test), this stub needs to answer `has-session`
+ * differently *before* vs *after* the session is actually created: the
+ * routing gate in `sendClaudeTurn` must see "gone" (so the follow-up takes
+ * the respawn path), while `spawnClaudeViaTmux`'s post-launch deferred-paste
+ * loop — which polls the SAME deterministic session name — must see the
+ * session as alive once `new-session` has run, or it bails out without
+ * pasting.
+ *
+ * Session existence is tracked with marker files (one per session name,
+ * created on `new-session`, removed on `kill-session`) rather than a fixed
+ * verdict, so `has-session` reports real create/kill order like actual tmux
+ * would.
+ *
+ * Every invocation also drains and records stdin (`readFileSync(0)`) — this
+ * is how `load-buffer -b <buf> -` receives the pasted prompt in the real
+ * paste path (`pastePromptSync`), and the stub must consume it rather than
+ * leave it unread so the parent's `Bun.spawnSync` write can't block/fail on
+ * a bigger-than-pipe-buffer payload.
+ */
+function fakeDeferredPasteTmuxBin(): { bin: string; logPath: string } {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-deferred-tmux-"));
+  const bin = path.join(dir, "tmux");
+  const logPath = path.join(dir, "log.jsonl");
+  const markerDir = path.join(dir, "markers");
+  mkdirSync(markerDir, { recursive: true });
+  writeFileSync(
+    bin,
+    `#!${process.execPath}\n` +
+      `import { appendFileSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";\n` +
+      `import path from "node:path";\n` +
+      `const argv = process.argv.slice(2);\n` +
+      `let stdin = "";\n` +
+      `try { stdin = readFileSync(0, "utf8"); } catch {}\n` +
+      `appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ argv, stdin }) + "\\n");\n` +
+      `function sessionArg() {\n` +
+      `  const sIdx = argv.indexOf("-s");\n` +
+      `  if (sIdx !== -1) return argv[sIdx + 1];\n` +
+      `  const tIdx = argv.indexOf("-t");\n` +
+      `  if (tIdx !== -1) { let v = argv[tIdx + 1]; if (v && v.startsWith("=")) v = v.slice(1); return v; }\n` +
+      `  return null;\n` +
+      `}\n` +
+      `const markerDir = ${JSON.stringify(markerDir)};\n` +
+      `if (argv.includes("new-session")) {\n` +
+      `  const name = sessionArg();\n` +
+      `  if (name) writeFileSync(path.join(markerDir, name), "1");\n` +
+      `  process.exit(0);\n` +
+      `}\n` +
+      `if (argv.includes("kill-session")) {\n` +
+      `  const name = sessionArg();\n` +
+      `  if (name) { try { rmSync(path.join(markerDir, name)); } catch {} }\n` +
+      `  process.exit(0);\n` +
+      `}\n` +
+      `if (argv.includes("has-session")) {\n` +
+      `  const name = sessionArg();\n` +
+      `  if (name && existsSync(path.join(markerDir, name))) process.exit(0);\n` +
+      `  process.stderr.write("can't find session: =" + (name ?? "unknown"));\n` +
+      `  process.exit(1);\n` +
+      `}\n` +
+      `process.exit(0);\n`,
+  );
+  chmodSync(bin, 0o755);
+  return { bin, logPath };
 }
 
 test("a transient/unreachable tmux probe routes a follow-up through the existing-session path, never the resume pre-kill", async () => {
@@ -265,6 +332,231 @@ test("an unambiguous 'gone' probe routes a follow-up through the resume path (ki
   } finally {
     // Dispose in-memory state + kill whatever (fake) session is now named
     // for this task, mirroring claude-followup-restart.test.ts's cleanup.
+    dropSession(taskId);
+    rmSync(path.dirname(expectedJsonlPath), { recursive: true, force: true });
+  }
+});
+
+// Regression tests for the fix in commit de27191 (see
+// docs/plans/fix-claude-resume-large-prompt-tmux-argv.md): a follow-up whose
+// prompt is bigger than `CLAUDE_PROMPT_ARGV_MAX_BYTES` used to ride the
+// entire way to `tmux new-session`'s argv, and tmux 3.6a rejects any client
+// command past its ~16KB imsg cap with a literal `command too long` — so a
+// large paste sent to a task whose session had ended failed the spawn
+// outright, before claude ever started. `buildCommand` now omits an
+// oversized prompt from argv and hands it back as `deferredPrompt`;
+// `spawnClaudeViaTmux` boots a bare claude and pastes the prompt in once the
+// composer is confirmed idle via the same load-buffer/paste-buffer machinery
+// live-session follow-ups use.
+
+test("a large (>4KB) follow-up resume never embeds the prompt in new-session argv — it's delivered via load-buffer/paste-buffer instead", async () => {
+  const { bin, logPath } = fakeDeferredPasteTmuxBin();
+  process.env.AGETOR_TMUX_BIN = bin;
+  delete process.env.AGETOR_CLAUDE_DRIVER; // force the real spawnClaudeViaTmux path
+  process.env.AGETOR_CLAUDE_BIN = "/bin/echo"; // harmless stub launch command
+
+  const { db, tasks, runs } = await import("./db.ts");
+  const { sendInput } = await import("./orchestrator.ts");
+  const { __forTest, dropSession, jsonlPathFor } = await import("./claude-tmux.ts");
+  const { CLAUDE_PROMPT_ARGV_MAX_BYTES } = await import("./agents.ts");
+
+  const taskId = `task-large-${randomUUID()}`;
+  const priorRunId = `run-large-${randomUUID()}`;
+  const priorClaudeSessionId = "prior-claude-session-id-large";
+  const now = Date.now();
+  const workdir = mkdtempSync(path.join(tmpdir(), "agetor-large-wd-"));
+
+  // Same rationale as the "gone" test above: pre-create the JSONL the resume
+  // spawn will look for at the deterministic (workdir, sessionId) path so the
+  // boot-wait resolves synchronously instead of spinning.
+  const expectedJsonlPath = jsonlPathFor(workdir, priorClaudeSessionId, null);
+  mkdirSync(path.dirname(expectedJsonlPath), { recursive: true });
+  writeFileSync(expectedJsonlPath, "");
+
+  // Make claude's composer look immediately idle so the deferred-paste
+  // readiness gate (`readPaneMode`, which reads via this seam) fires on its
+  // first poll instead of spinning toward DEFERRED_PROMPT_TIMEOUT_MS (30s).
+  const prevCapture = __forTest.setCaptureModePane(() => "? for shortcuts");
+  const prevGap = __forTest.setBracketedEnterGapMs(0);
+  const prevSettle = __forTest.setSlashCommandSettleMs(0);
+
+  // Comfortably over the threshold regardless of its exact value.
+  const largePrompt = "x".repeat(CLAUDE_PROMPT_ARGV_MAX_BYTES + 500);
+  expect(Buffer.byteLength(largePrompt, "utf8")).toBeGreaterThan(CLAUDE_PROMPT_ARGV_MAX_BYTES);
+
+  try {
+    tasks.insert({
+      id: taskId,
+      title: "large-prompt-resume",
+      prompt: "p",
+      column: "review",
+      agent: "claude-code",
+      workdir,
+      isolation: "none",
+      taskType: "task",
+      branch: null,
+      worktreePath: null,
+      baseRef: null,
+      mode: null,
+      model: "claude-opus-4-7",
+      effort: "medium",
+      references: [], backlog: [],
+      runId: priorRunId,
+      hasOpenableRun: false,
+      pendingInteractionCount: 0,
+      openTerminalCount: 0,
+      archivedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    runs.insert({
+      id: priorRunId,
+      taskId,
+      agent: "claude-code",
+      status: "succeeded",
+      startedAt: now,
+      endedAt: now,
+      exitCode: 0,
+      tmuxSession: "agetor-stale-name",
+      claudeSessionId: priorClaudeSessionId,
+      codexSessionId: null,
+    });
+
+    const result = await sendInput(priorRunId, largePrompt);
+    expect(result.delivered).toBe(true);
+    if (!result.delivered) throw new Error(result.reason);
+    const newRunId = result.runId;
+
+    // Let the spawn + the fire-and-forget deferred-paste chain run their
+    // course (readiness is immediate given the captureModePane stub above,
+    // so this only needs to cover a handful of synchronous tmux round-trips,
+    // not the real 30s timeout).
+    await new Promise((r) => setTimeout(r, 800));
+
+    const entries = readLog(logPath);
+
+    const newSessionEntries = entries.filter((e) => e.argv.includes("new-session"));
+    expect(newSessionEntries.length).toBeGreaterThan(0);
+    // The whole point of the fix: the large prompt must never appear inside
+    // a `new-session` invocation's argv.
+    for (const e of newSessionEntries) {
+      expect(e.argv.some((a) => a.includes(largePrompt))).toBe(false);
+    }
+
+    // It must instead have been delivered over stdin via `load-buffer`.
+    const loadBufferEntries = entries.filter((e) => e.argv.includes("load-buffer"));
+    expect(loadBufferEntries.length).toBeGreaterThan(0);
+    expect(loadBufferEntries.some((e) => e.stdin === largePrompt)).toBe(true);
+
+    // ...followed by a paste-buffer + Enter to actually submit it.
+    const pasteBufferEntries = entries.filter((e) => e.argv.includes("paste-buffer"));
+    expect(pasteBufferEntries.length).toBeGreaterThan(0);
+    const sendKeysEnterEntries = entries.filter(
+      (e) => e.argv.includes("send-keys") && e.argv.includes("Enter"),
+    );
+    expect(sendKeysEnterEntries.length).toBeGreaterThan(0);
+
+    // The run must not have failed with the "command too long" symptom the
+    // fix addresses — since `new-session` never got the oversized argv from
+    // this fake tmux, it always exits 0, but assert the negative directly so
+    // this test would also catch a regression that reintroduced the
+    // embed-in-argv behavior against a real tmux binary's failure text.
+    const runEvents = db
+      .query<{ stream: string; data: string }, [string]>(
+        `SELECT stream, data FROM run_events WHERE run_id = ?`,
+      )
+      .all(newRunId);
+    expect(runEvents.some((e) => e.data.includes("tmux new-session failed"))).toBe(false);
+    expect(runEvents.some((e) => e.data.includes("command too long"))).toBe(false);
+  } finally {
+    __forTest.setCaptureModePane(prevCapture);
+    __forTest.setBracketedEnterGapMs(prevGap);
+    __forTest.setSlashCommandSettleMs(prevSettle);
+    dropSession(taskId);
+    rmSync(path.dirname(expectedJsonlPath), { recursive: true, force: true });
+  }
+});
+
+test("a small (<=4KB) follow-up resume still embeds the prompt in new-session argv — deferral doesn't fire for the common case", async () => {
+  // Reuse the fixed-verdict stub (uniform "gone" so the routing gate always
+  // takes the respawn path) — this test only cares about the argv shape of
+  // the resulting `new-session`, not post-launch readiness polling, so the
+  // simpler stub from the "gone" test above is sufficient.
+  const { bin, logPath } = fakeRoutingTmuxBin(1, "can't find session: =agetor-x");
+  process.env.AGETOR_TMUX_BIN = bin;
+  delete process.env.AGETOR_CLAUDE_DRIVER; // force the real spawnClaudeViaTmux path
+  process.env.AGETOR_CLAUDE_BIN = "/bin/echo"; // harmless stub launch command
+
+  const { tasks, runs } = await import("./db.ts");
+  const { __forTest, dropSession, jsonlPathFor } = await import("./claude-tmux.ts");
+  const { sendInput } = await import("./orchestrator.ts");
+
+  const taskId = `task-small-${randomUUID()}`;
+  const priorRunId = `run-small-${randomUUID()}`;
+  const priorClaudeSessionId = "prior-claude-session-id-small";
+  const now = Date.now();
+  const workdir = mkdtempSync(path.join(tmpdir(), "agetor-small-wd-"));
+
+  const expectedJsonlPath = jsonlPathFor(workdir, priorClaudeSessionId, null);
+  mkdirSync(path.dirname(expectedJsonlPath), { recursive: true });
+  writeFileSync(expectedJsonlPath, "");
+
+  const smallPrompt = "please continue with the small change";
+
+  try {
+    tasks.insert({
+      id: taskId,
+      title: "small-prompt-resume",
+      prompt: "p",
+      column: "review",
+      agent: "claude-code",
+      workdir,
+      isolation: "none",
+      taskType: "task",
+      branch: null,
+      worktreePath: null,
+      baseRef: null,
+      mode: null,
+      model: "claude-opus-4-7",
+      effort: "medium",
+      references: [], backlog: [],
+      runId: priorRunId,
+      hasOpenableRun: false,
+      pendingInteractionCount: 0,
+      openTerminalCount: 0,
+      archivedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    runs.insert({
+      id: priorRunId,
+      taskId,
+      agent: "claude-code",
+      status: "succeeded",
+      startedAt: now,
+      endedAt: now,
+      exitCode: 0,
+      tmuxSession: "agetor-stale-name",
+      claudeSessionId: priorClaudeSessionId,
+      codexSessionId: null,
+    });
+
+    const result = await sendInput(priorRunId, smallPrompt);
+    expect(result.delivered).toBe(true);
+
+    await new Promise((r) => setTimeout(r, 300));
+
+    const entries = readLog(logPath);
+    const newSessionEntries = entries.filter((e) => e.argv.includes("new-session"));
+    expect(newSessionEntries.length).toBeGreaterThan(0);
+    // Guards against accidentally deferring everything: a short prompt must
+    // still ride inside the `new-session` argv, exactly as before the fix.
+    expect(newSessionEntries.some((e) => e.argv.includes(smallPrompt))).toBe(true);
+
+    // And, precisely because it wasn't deferred, no paste machinery should
+    // have fired for it at all.
+    expect(entries.some((e) => e.argv.includes("load-buffer"))).toBe(false);
+  } finally {
     dropSession(taskId);
     rmSync(path.dirname(expectedJsonlPath), { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem

Continuing a claude task whose tmux session had ended, with a large pasted
message (e.g. a multi-KB block of test output), failed instantly:

    status: resuming claude session 3c0c60a1…
    stderr: tmux new-session failed: command too long

The resume path (`spawnResumedSession`) embedded the entire prompt as the
final argv element of `tmux new-session`. tmux serializes the whole client
command (flags + `-e` env pairs + argv) over its client↔server socket with a
~16KB cap — measured on tmux 3.6a: 14KB ok, 16KB fails. Every retry rebuilt
the same oversized command, so the run failed in ~15ms each time, no session
was ever created, and `POST /tasks/:id/open-tmux` 404'd as a downstream
symptom. A fresh task-start with a huge first prompt had the same exposure.

## Fix

- `buildCommand` (agents.ts): prompts over the exported
  `CLAUDE_PROMPT_ARGV_MAX_BYTES` (4096, `Buffer.byteLength` — UTF-8 aware)
  are no longer pushed to argv; they're returned as
  `AgentCommand.deferredPrompt`. Prompts ≤4KB keep the byte-identical
  current path. Covers custom claude-family harnesses too
  (`harness.kind === "claude-code"` is the discriminator).
- `spawnClaudeViaTmux` (claude-tmux.ts): when `deferredPrompt` is set, the
  session launches without the prompt and delivers it post-launch through
  the existing `queuePaste` → `load-buffer`(stdin)/`paste-buffer`/`Enter`
  machinery — the same path live follow-ups already use — gated on
  `readPaneMode(state)` reporting claude idle at the composer (400ms poll,
  30s window, best-effort paste on timeout).

## Hardening (from code review)

- Hitting **Stop** during the readiness wait aborts the pending paste (the
  loop tracks the initial turn slot; a spliced queue means cancelled) —
  before, a cancelled prompt could still be submitted up to 30s later.
- The deferred paste threads `onPasteFailure` mirroring `sendTurn`, so a
  failed `load-buffer`/`paste-buffer` settles the run as `failed` instead of
  stranding it in `running` until the next boot-reconcile.
- The timeout fallback re-arms instead of pasting while an unanswered
  startup question card is pending, so it can't corrupt the user's answer.

## Tests

- `agents.test.ts`: threshold boundary (exactly 4096 rides argv, one byte
  over defers), resume flag preserved, multi-byte UTF-8 counted by bytes,
  codex unaffected.
- `claude-turn-routing.test.ts`: fake-tmux argv-capture regressions — a
  >4KB resume never puts the prompt in `new-session` argv and delivers it
  via load-buffer; a small prompt still rides argv; cancel-during-wait never
  pastes; a failed paste settles the run `failed`.

`bun run typecheck` clean; full `bun test`: 1504 pass / 0 fail.

Plan: docs/plans/fix-claude-resume-large-prompt-tmux-argv.md