### PR TITLE
fix: verify the AskUserQuestion answer drive so "Submit answers" can't strand in tmux

### DIFF
--- a/docs/plans/fix-ask-submit-answers-stranded.md
+++ b/docs/plans/fix-ask-submit-answers-stranded.md
@@ -1,0 +1,180 @@
+# Plan — Fix stranded "Submit answers" on AskUserQuestion drive
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-15 |
+| Source | Agetor task: "task details get stuck on `submit answers` from claude code questions; TUI stays in tmux; user must attach and confirm manually" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/claude-code-not-submiting-answers |
+| Base SHA | b49e3f878fe10f8d5fa3735034a5e49466b88d80 (tree clean) |
+| Mode | Autonomous — grill + plan-approval gates self-served; assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+When a user answers a multi-question / multiSelect AskUserQuestion card from Agetor's task
+details, the drive must reliably confirm the native TUI's "Ready to submit your answers?"
+review screen — and when any keystroke is nonetheless swallowed, Agetor must self-heal
+(retry, or surface a clickable card) instead of stranding the modal until the user attaches
+to tmux manually.
+
+Success =
+- The confirm `Enter` is sent only after the review screen is actually rendered, and the
+  drive result is verified against pane content (modal gone), not `send-keys` exit codes.
+- A swallowed confirm is retried automatically (bounded).
+- A review screen that persists anyway (or that the user reaches manually) produces a
+  generic numbered-prompt card ("1. Submit answers / 2. Cancel") in the UI instead of
+  being structurally invisible.
+- `bun run typecheck` green, full `bun test` green, new unit tests cover the changed logic.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- Drive plan: `planAskAnswers` (`src/bun/claude-questions.ts:434-501`). Every non-singleFlat
+  plan ends with a bare trailing `Enter` (line ~498) that assumes the review screen is
+  already rendered with cursor on "1. Submit answers".
+- Driver: `sendModalKeys` (`src/bun/claude-tmux.ts:1243-1259`) — one `tmux send-keys` per
+  key, flat 35ms gap, `stillCurrent()` re-gate. Success = every send-keys exited 0.
+  **No pane-content verification anywhere on the drive path.** The transition onto the
+  `✔ Submit` tab triggers Ink's heaviest repaint (full review summary); the confirm Enter
+  arrives 35ms later and is intermittently swallowed → false `ok:true`.
+- Route: `POST /ask-questions/:id/answer` (`src/bun/server.ts:3454-3499`) calls
+  `resolveAskCard` unconditionally (intended: scraper re-collects on failure).
+- The self-heal is structurally broken for the review screen: `scrapeOnce`
+  (`src/bun/claude-tmux.ts:3011-3027`) computes `askOnPane = detectAskModal(tail) !== null`,
+  which is true for BOTH `"question"` and `"review"`; it suppresses
+  `matchNumberedModal`/`matchYesNoModal` whenever true, but `collectAndRegisterAskCard` →
+  `parseModalPane` requires question/footer signatures the review screen lacks, and the
+  JSONL has no tool_use until the modal is answered. Net: a stranded review screen matches
+  nothing, forever, on every tick.
+- `matchNumberedModal` (`claude-tmux.ts:~2620-2732`) WOULD match the review screen
+  (`❯ 1. Submit answers` / `2. Cancel`: ≥2 numbered choices, cursor marker, "1." anchor).
+  No footer → not high-confidence → two-tick stability gate (~2 ticks) before registering.
+- Prior art to mirror: `cycleToMode` verify-and-retry (only content-verified drive in the
+  codebase); repo comment doctrine "prefer raising gaps over lowering"
+  (`claude-tmux.ts:4610-4625`); `collectAskQuestionsFromPane`'s injectable `io`
+  (capture/send/sleep) pattern for unit-testability; fixture
+  `src/bun/fixtures/askuserquestion/review_submit.txt` (review screen, already used by
+  `claude-questions.test.ts`).
+- `captureTail(state)` (`claude-tmux.ts:1710`) captures the pane tail; usable inside
+  `queueTmuxOp` callbacks.
+
+## 3. Approach & key decisions
+
+Three coordinated changes (defense in depth):
+
+1. **Deterministic confirm**: teach the plan which drives end on the review screen
+   (`confirmsReview: !singleFlat` on the drive-mode `SubmitPlan`), and replace the blind
+   trailing 35ms-gap Enter with: send all body keys → poll `capture-pane` until
+   `detectAskModal(tail) === "review"` (bounded, ~80ms steps up to ~800ms) → send Enter.
+2. **Verify-and-retry**: after the full plan (and for singleFlat too), poll until
+   `detectAskModal(tail) === null` (bounded). If `"review"` is still present after the
+   confirm, resend `Enter` (max 2 resends — a stray Enter at the empty REPL is benign;
+   a "question" sighting during verification is treated as "keep waiting" since it can be
+   a teardown transient; genuine mis-drives time out to `ok:false`). New function
+   `driveAskAnswers(taskId, plan)` in `claude-tmux.ts` wraps body-keys + confirm + verify
+   inside one `queueTmuxOp`; `sendModalKeys` stays as-is for the Escape paths.
+3. **Un-strand the review screen**: in `scrapeOnce`, narrow the ask-modal suppression to
+   `detectAskModal(tail) === "question"`. A persistent review screen then flows to
+   `matchNumberedModal` → a normal tmux_prompt card the user can click ("Submit answers"),
+   and the existing auto-cancel sweep cleans it up if the modal leaves the pane.
+
+Alternatives considered:
+- Only raising the flat inter-key gap (e.g. 35→150ms): shrinks but does not close the race,
+  and slows every drive. Rejected as sole fix; wait-for-render replaces it exactly where
+  needed.
+- Having the scraper auto-press Enter on a lingering review screen: decides on the user's
+  behalf (they may have navigated there manually intending to cancel). Rejected — surface
+  a card instead.
+- Gating `resolveAskCard` on `ok`: unnecessary once the scraper backstop works (documented
+  rationale for the unconditional resolve remains valid: clearing `askCardId` is what lets
+  re-collection happen), and keeping the card while keys were partially driven would show a
+  stale cursor-state card. Keep unconditional.
+- Frontend `{ ok }` handling (RunPanel ignores it): with the backstop, a failed drive
+  produces a fresh card within ~1-3s via the normal interaction channels. Out of scope.
+
+Known acceptable edge: during a *retrying* drive the review screen can persist ≥2 scrape
+ticks and register a ghost "Submit answers" card just as the retry lands; the next tick's
+auto-cancel sweep (`answerTmuxPrompt(..., "__external__")`) resolves it. Rare, self-healing.
+
+## 4. Work breakdown — implementation tasks
+
+**T1 (single agent — the three files are one coherent change and the edits are small):**
+- `src/bun/claude-questions.ts`: add `confirmsReview: boolean` to the drive variant of
+  `SubmitPlan`; set it to `!singleFlat` in `planAskAnswers`; update the module docstring's
+  drive-sequence description.
+- `src/bun/claude-tmux.ts`:
+  - Add `driveAskAnswers(taskId, plan)` (exported): inside one `queueTmuxOp` — send body
+    keys (plan.keys minus the trailing confirm when `confirmsReview`) with the existing
+    35ms gap + `stillCurrent()` re-gate; if `confirmsReview`, poll pane until review screen
+    renders (WAIT_FOR_REVIEW: ~80ms steps, ≤10 attempts), then send Enter; verify with
+    polls until `detectAskModal` returns null (VERIFY: ~120ms steps, ≤8 attempts), resending
+    Enter on a `"review"` sighting at most 2 times; every sleep followed by a
+    `stillCurrent()` re-gate. Return verified boolean. Structure the poll/decide logic as a
+    pure, exported-for-test helper (mirror `__forTest` / injectable-io conventions) so unit
+    tests need no tmux.
+  - `scrapeOnce`: `const askKind = detectAskModal(tail); const askOnPane = askKind === "question";`
+    (suppression + collect + card lifecycle all key off question-kind only). Update the
+    block comment to explain why `"review"` deliberately falls through to the numbered
+    matcher.
+- `src/bun/server.ts`: import `driveAskAnswers`; in the `/ask-questions/:id/answer` drive
+  branch call `ok = await driveAskAnswers(pending.taskId, plan)` instead of
+  `sendModalKeys(pending.taskId, plan.keys)`. Escape paths unchanged.
+- Acceptance: typecheck green; existing test suite green; no behavior change for
+  singleFlat drives beyond added verification.
+
+## 5. Work breakdown — test tasks
+
+**TT1 (single agent):**
+- `src/bun/claude-questions.test.ts`: assert `confirmsReview` on existing plan shapes
+  (multi-question → true; single multiSelect → true; singleFlat → false; message-mode
+  unaffected).
+- `src/bun/claude-tmux-scraper.test.ts`: `matchNumberedModal` on the review-screen tail
+  (from `fixtures/askuserquestion/review_submit.txt`) → 2 choices ("Submit answers",
+  "Cancel"), cursor 0, not high-confidence.
+- New tests for the drive verify logic (same file as sibling driver tests or a new
+  `claude-tmux-askdrive.test.ts`): via the pure helper / injectable io — confirm Enter is
+  sent only after review renders; swallowed-confirm (review persists) → Enter resent then
+  ok; review persists past retries → false; question-screen sighting mid-verify then gone →
+  true; question persists → false; singleFlat (no confirm wait) verifies modal-gone.
+- Covers: T1.
+
+## 6. Execution waves
+
+- Wave 1: T1 (one sonnet agent — owns `src/bun/claude-questions.ts`,
+  `src/bun/claude-tmux.ts`, `src/bun/server.ts`).
+- Review (opus) on the wave-1 diff.
+- Wave 2: TT1 (one sonnet agent — owns the test files only).
+- Test run (haiku): `bun run typecheck` + `bun test`.
+- Fixes as needed (sonnet), re-run to green.
+
+## 7. Blast radius & risks
+
+- `sendModalKeys` keeps its exact semantics (still used for `Escape` at
+  `server.ts:3481`/`:3530`); only the answer-drive call site changes.
+- Narrowing the scrapeOnce suppression: the `"review"` kind now takes the numbered-modal
+  path. Two-tick stability prevents transient mid-drive review screens (<1s) from
+  registering; the recently-answered TTL + auto-cancel sweep handle churn. The
+  `askCardLive` full-rate polling and the modal-gone card resolution keep working —
+  when review is on the pane and an ask card is still registered (user navigated manually
+  via tmux attach), the card now resolves as externally-answered, which matches the
+  existing external-dismissal backstop semantics.
+- `collectAndRegisterAskCard`'s mid-collect abort checks `detectAskModal(...) === null` —
+  unchanged and still correct (a review sighting mid-collect means the user advanced; the
+  collect result is discarded on the next gate).
+- Drive duration grows by the verification window (~120ms-1s typical, bounded ~2.5s worst
+  case) — well under the route's ordinary latency expectations; the run panel already
+  treats answering as async.
+- Claude Code version drift: fixtures were captured on 2.1.161-2.1.183; if a future TUI
+  changes the review wording, `detectAskModal` misses it and we fall back to today's
+  behavior minus stranding (numbered matcher may still catch it). No regression vector.
+
+## 8. Open questions / assumptions (autonomous mode — logged, not asked)
+
+1. Assumed the intermittency is the Ink repaint race, not a Claude Code layout change —
+   supported by "sometimes" in the report and by fixtures matching current signatures.
+2. Assumed a stray `Enter` at the empty claude REPL prompt is a no-op (basis for benign
+   bounded resends). Verified behavior on claude-code ≤2.1.183.
+3. Assumed surfacing a clickable "Submit answers / Cancel" card is the right UX for a
+   review screen Agetor cannot safely auto-drive (vs. auto-submitting on the user's
+   behalf).
+4. Frontend continues to ignore `{ ok }`; deemed out of scope since the backstop card
+   makes failures visible and actionable.

--- a/src/bun/claude-questions.test.ts
+++ b/src/bun/claude-questions.test.ts
@@ -293,7 +293,7 @@ describe("planAskAnswers — drive sequences", () => {
     const plan = planAskAnswers(specs, answers);
     expect(plan.mode).toBe("drive");
     // Green = index 1 → Down once, Enter. Flat single-select ⇒ NO trailing submit Enter.
-    expect(plan).toEqual({ mode: "drive", keys: ["Down", "Enter"] });
+    expect(plan).toEqual({ mode: "drive", keys: ["Down", "Enter"], confirmsReview: false });
   });
 
   test("first option of a flat single-select needs no arrow", () => {
@@ -301,7 +301,7 @@ describe("planAskAnswers — drive sequences", () => {
       [{ question: "q", multiSelect: false, options: ["Red", "Green"] }],
       [{ selected: ["Red"] }],
     );
-    expect(plan).toEqual({ mode: "drive", keys: ["Enter"] });
+    expect(plan).toEqual({ mode: "drive", keys: ["Enter"], confirmsReview: false });
   });
 
   test("captured multi example: Toppings[Ham,Mushroom] + Size[Large]", () => {
@@ -320,6 +320,7 @@ describe("planAskAnswers — drive sequences", () => {
     expect(plan).toEqual({
       mode: "drive",
       keys: ["Down", "Enter", "Down", "Enter", "Right", "Down", "Enter", "Enter"],
+      confirmsReview: true,
     });
   });
 
@@ -332,6 +333,7 @@ describe("planAskAnswers — drive sequences", () => {
     expect(plan).toEqual({
       mode: "drive",
       keys: ["Enter", "Down", "Down", "Enter", "Right", "Enter"],
+      confirmsReview: true,
     });
   });
 
@@ -346,6 +348,7 @@ describe("planAskAnswers — drive sequences", () => {
     expect(planAsc).toEqual({
       mode: "drive",
       keys: ["Down", "Enter", "Down", "Down", "Enter", "Right", "Enter"],
+      confirmsReview: true,
     });
   });
 
@@ -359,6 +362,7 @@ describe("planAskAnswers — drive sequences", () => {
     expect(plan).toEqual({
       mode: "drive",
       keys: ["Down", "Enter", "Down", "Down", "Enter", "Enter"],
+      confirmsReview: true,
     });
   });
 });

--- a/src/bun/claude-questions.ts
+++ b/src/bun/claude-questions.ts
@@ -45,6 +45,12 @@
  *          ❯ 1. Submit answers
  *            2. Cancel
  *      Enter (cursor defaults to "1. Submit answers") submits everything.
+ *      `planAskAnswers` marks this shape with `confirmsReview: true`, so the
+ *      driver (`driveAskAnswers` in claude-tmux.ts) withholds that final
+ *      Enter until the review screen is actually rendered — and, once sent,
+ *      re-verifies the modal actually closed rather than trusting the
+ *      keystroke's exit code, since the review screen's full-summary repaint
+ *      is Ink's heaviest and can swallow a keystroke arriving mid-repaint.
  *
  * "Type something." (the Other/custom entry) does NOT open an inline field in
  * 2.1.161 — selecting it cancels the structured question ("User declined to
@@ -82,14 +88,24 @@ export interface AskAnswer {
  * How to deliver the answer back to claude:
  *  - `drive`: emulate keystrokes into the native modal and let claude record
  *     a real structured tool_result. Only possible when every answer is a
- *     non-empty subset of preset options.
+ *     non-empty subset of preset options. `keys` is the full send-keys
+ *     sequence, including the trailing confirm `Enter` when the drive ends
+ *     on the "Ready to submit your answers?" review screen. `confirmsReview`
+ *     tells the driver whether that trailing key is a blind Enter (false —
+ *     the singleFlat case submits directly on the selection Enter, no review
+ *     screen ever renders) or a confirm that must be sent only once the
+ *     review screen is actually on the pane (true — every other shape). The
+ *     driver (`driveAskAnswers` in claude-tmux.ts) uses this flag to gate
+ *     and verify the confirm instead of firing it blind; the key sequence
+ *     itself is unchanged so existing consumers of `keys` (and tests
+ *     asserting it) keep working.
  *  - `message`: dismiss the modal (Esc) and post the answer as a normal turn.
  *     Used whenever a custom/free-text answer is involved, or the picks can't
  *     be driven safely (empty answer, unknown label, arity mismatch). `text`
  *     is the message body to paste; `reason` explains the choice (for logs).
  */
 export type SubmitPlan =
-  | { mode: "drive"; keys: NavKey[] }
+  | { mode: "drive"; keys: NavKey[]; confirmsReview: boolean }
   | { mode: "message"; text: string; reason: string };
 
 /* ────────────────────────────────────────────────────────────────────────── *
@@ -429,7 +445,10 @@ export type MessageFallbackReason =
  *   - single-select: arrow to the one pick and Enter (which auto-advances);
  *   - a single single-select question submits on that Enter (no review screen);
  *     every other shape ends on the review screen, so a trailing Enter confirms
- *     "1. Submit answers".
+ *     "1. Submit answers". `confirmsReview` mirrors that split (`false` for
+ *     the singleFlat case, `true` otherwise) so the driver knows whether the
+ *     last key in `keys` needs to wait for the review screen to render before
+ *     it's safe to send.
  */
 export function planAskAnswers(specs: AskQuestionSpec[], answers: AskAnswer[]): SubmitPlan {
   const fallback = (reason: MessageFallbackReason): SubmitPlan => ({
@@ -497,7 +516,7 @@ export function planAskAnswers(specs: AskQuestionSpec[], answers: AskAnswer[]): 
   // review screen with the cursor on "1. Submit answers".
   if (!singleFlat) keys.push("Enter");
 
-  return { mode: "drive", keys };
+  return { mode: "drive", keys, confirmsReview: !singleFlat };
 }
 
 /* ────────────────────────────────────────────────────────────────────────── *

--- a/src/bun/claude-tmux-askdrive.test.ts
+++ b/src/bun/claude-tmux-askdrive.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// claude-tmux.ts transitively opens the SQLite DB (db.ts) on module load —
+// point AGETOR_DATA_DIR at a scratch dir before the import, mirroring
+// claude-tmux-scraper.test.ts.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-askdrive-"));
+
+import { __forTest } from "./claude-tmux.ts";
+import type { AskModalKind } from "./claude-questions.ts";
+
+const { decideAskDriveStep, ASK_VERIFY_MAX_RESENDS } = __forTest;
+
+// ────────────────────────────────────────────────────────────────────────────
+// decideAskDriveStep — pure per-poll decision table driving both phases of
+// driveAskAnswers: the confirm-wait phase (confirmSent=false, waiting for the
+// review screen to render before sending the confirm Enter) and the verify
+// phase (confirmSent=true — or a singleFlat plan with no confirm phase at
+// all — waiting for the modal to actually close). See claude-tmux.ts's
+// doc comment on decideAskDriveStep for the full semantics this pins.
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("decideAskDriveStep — kind=null (modal left the pane)", () => {
+  test("→ 'done' regardless of confirmSent/resends — the only success case", () => {
+    for (const confirmSent of [false, true]) {
+      for (const resends of [0, 1, ASK_VERIFY_MAX_RESENDS, ASK_VERIFY_MAX_RESENDS + 1]) {
+        expect(decideAskDriveStep(null, confirmSent, resends)).toBe("done");
+      }
+    }
+  });
+});
+
+describe("decideAskDriveStep — kind='review'", () => {
+  test("confirmSent=false → 'send-enter' (first confirm, not bounded by resends)", () => {
+    // This is the initial confirm sent as soon as the review screen renders
+    // during the confirm-wait phase — not a resend, so the resend cap does
+    // not apply even if `resends` happens to already be at/above the cap.
+    expect(decideAskDriveStep("review", false, 0)).toBe("send-enter");
+    expect(decideAskDriveStep("review", false, ASK_VERIFY_MAX_RESENDS)).toBe("send-enter");
+  });
+
+  test("confirmSent=true, resends below the cap → 'send-enter' (resend the swallowed confirm)", () => {
+    for (let resends = 0; resends < ASK_VERIFY_MAX_RESENDS; resends++) {
+      expect(decideAskDriveStep("review", true, resends)).toBe("send-enter");
+    }
+  });
+
+  test("confirmSent=true, resends === ASK_VERIFY_MAX_RESENDS → 'fail' (cap reached)", () => {
+    expect(decideAskDriveStep("review", true, ASK_VERIFY_MAX_RESENDS)).toBe("fail");
+  });
+
+  test("confirmSent=true, resends beyond the cap → 'fail' (stays failed, not re-armed)", () => {
+    expect(decideAskDriveStep("review", true, ASK_VERIFY_MAX_RESENDS + 1)).toBe("fail");
+  });
+});
+
+describe("decideAskDriveStep — kind='question'", () => {
+  test("confirmSent=false (mid-drive, still navigating the tab bar) → 'wait'", () => {
+    expect(decideAskDriveStep("question", false, 0)).toBe("wait");
+  });
+
+  test("confirmSent=true (verify phase — treated as a teardown transient) → 'wait', even past the resend cap", () => {
+    // A "question" sighting never fails on its own, unlike "review" — the
+    // caller's own attempt budget is what eventually times a genuine
+    // mis-drive out, not this function.
+    expect(decideAskDriveStep("question", true, 0)).toBe("wait");
+    expect(decideAskDriveStep("question", true, ASK_VERIFY_MAX_RESENDS)).toBe("wait");
+    expect(decideAskDriveStep("question", true, ASK_VERIFY_MAX_RESENDS + 1)).toBe("wait");
+  });
+});
+
+test("decideAskDriveStep — exhaustive table over kind × confirmSent × resends", () => {
+  // Belt-and-suspenders: walk the full grid so a regression in any single
+  // combination names itself instead of hiding behind the grouped cases
+  // above. Mirrors the table in the plan doc (docs/plans/fix-ask-submit-
+  // answers-stranded.md §5) rather than any hardcoded resend count.
+  const kinds: Array<AskModalKind | null> = [null, "review", "question"];
+  const resendsToTry = [0, 1, ASK_VERIFY_MAX_RESENDS, ASK_VERIFY_MAX_RESENDS + 1];
+
+  for (const kind of kinds) {
+    for (const confirmSent of [false, true]) {
+      for (const resends of resendsToTry) {
+        const step = decideAskDriveStep(kind, confirmSent, resends);
+        if (kind === null) {
+          expect(step).toBe("done");
+        } else if (kind === "question") {
+          expect(step).toBe("wait");
+        } else {
+          // kind === "review"
+          expect(step).toBe(
+            !confirmSent ? "send-enter" : resends < ASK_VERIFY_MAX_RESENDS ? "send-enter" : "fail",
+          );
+        }
+      }
+    }
+  }
+});

--- a/src/bun/claude-tmux-scraper.test.ts
+++ b/src/bun/claude-tmux-scraper.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -10,6 +10,11 @@ process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-scraper-")
 import { __forTest } from "./claude-tmux.ts";
 
 const { matchNumberedModal, matchYesNoModal, matchStartupConsentDialog, clearedStabilityGate } = __forTest;
+
+/** Real tmux pane captures of claude-code 2.1.161's AskUserQuestion modal —
+ *  same fixture directory claude-questions.test.ts reads from. */
+const fx = (name: string): string =>
+  readFileSync(path.join(import.meta.dir, "fixtures", "askuserquestion", `${name}.txt`), "utf8");
 
 test("matchNumberedModal — claude plan-mode dialog (cursor on choice 1)", () => {
   const pane = `
@@ -174,6 +179,32 @@ Esc to cancel · Tab to amend
 
 `);
   expect(m!.highConfidence).toBe(true);
+});
+
+test("matchNumberedModal — AskUserQuestion review/submit screen ('Ready to submit your answers?') matches as a numbered modal", () => {
+  // scrapeOnce now narrows the ask-modal suppression to detectAskModal ===
+  // "question" only (claude-tmux.ts), so a lingering "review" screen falls
+  // through to this matcher instead of being structurally invisible. Slice
+  // the fixture down to the review block itself — tab bar through the
+  // "2. Cancel" line — the way a real 40-line pane tail would present it.
+  const lines = fx("review_submit").split("\n");
+  const tabBarIdx = lines.findIndex((l) => l.includes("✔ Submit"));
+  const cancelIdx = lines.findIndex((l) => /2\.\s+Cancel/.test(l));
+  expect(tabBarIdx).toBeGreaterThan(-1);
+  expect(cancelIdx).toBeGreaterThan(tabBarIdx);
+  const tail = lines.slice(tabBarIdx, cancelIdx + 1).join("\n");
+
+  const m = matchNumberedModal(tail);
+  expect(m).not.toBeNull();
+  expect(m!.choices).toEqual([
+    { key: "1", label: "Submit answers" },
+    { key: "2", label: "Cancel" },
+  ]);
+  expect(m!.cursorIndex).toBe(0);
+  // No "Esc to cancel" footer on the review screen → not high-confidence,
+  // so the two-tick stability gate applies before scrapeOnce registers it
+  // (guards against a mid-drive transient sighting registering a ghost card).
+  expect(m!.highConfidence).toBeFalsy();
 });
 
 test("clearedStabilityGate — high-confidence registers on first sighting; others need two ticks", () => {

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -1317,6 +1317,9 @@ type AskDriveStep = "done" | "send-enter" | "wait" | "fail";
  *    `"review"` sighting here means the just-sent confirm was swallowed by
  *    Ink's repaint and must be resent, bounded by `ASK_VERIFY_MAX_RESENDS`
  *    so a genuinely stuck review screen fails instead of looping forever.
+ *    (A singleFlat plan never renders a review screen, so `confirmSent`
+ *    stays false there; if one ever appeared anyway, the step would send —
+ *    not resend — the confirm, which is the robust choice.)
  *
  * `kind === null` (the modal has left the pane) is `"done"` regardless of
  * phase or resend count — the only success case. `"question"` is always

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -25,7 +25,7 @@ import {
   type TmuxPromptChoice,
 } from "./interactions.ts";
 import { resolveTmuxBin, tmuxSocketArgs } from "./tmux-resolution.ts";
-import { detectAskModal, parseModalPane, type NavKey, type ParsedQuestionPane } from "./claude-questions.ts";
+import { detectAskModal, parseModalPane, type AskModalKind, type NavKey, type ParsedQuestionPane } from "./claude-questions.ts";
 
 /**
  * Driver that hosts Claude Code's interactive REPL inside a per-task tmux
@@ -1254,6 +1254,179 @@ export async function sendModalKeys(taskId: string, keys: NavKey[]): Promise<boo
       if (!stillCurrent()) return;
     }
     ok = true;
+  }, state);
+  return ok;
+}
+
+/**
+ * Gap between the review-screen tab transition and the first poll for the
+ * "Ready to submit your answers?" screen to render. This is Ink's heaviest
+ * repaint on the whole AskUserQuestion modal — the full review summary,
+ * every question + answer — and the flat 35ms `sendModalKeys` gap that
+ * suffices for every other keystroke was intermittently too short for it:
+ * the confirm Enter would arrive mid-repaint and get swallowed, producing a
+ * false `ok:true` with the modal still stranded on the pane. 80ms per poll,
+ * up to `ASK_REVIEW_POLL_ATTEMPTS` (~800ms total), gives the repaint room
+ * without blocking the common case, where the screen is usually already up
+ * by the first or second poll. Prefer raising over lowering if the race
+ * resurfaces — the cost of raising is a few hundred ms of added drive
+ * latency; the cost of lowering is a return of the swallowed-Enter bug this
+ * whole driver exists to fix.
+ */
+const ASK_REVIEW_POLL_MS = 80;
+/** Poll budget for `ASK_REVIEW_POLL_MS` — bounds how long `driveAskAnswers`
+ *  waits for the review screen before giving up on the confirm-gate and
+ *  falling through to verification without ever sending a blind Enter. */
+const ASK_REVIEW_POLL_ATTEMPTS = 10;
+
+/**
+ * Poll gap for the post-confirm verification phase (`detectAskModal` →
+ * `null` = the modal actually closed). Looser than the review-wait gap
+ * because there's no repaint to catch mid-frame here — this loop is purely
+ * confirming the confirm landed, and a lone "review" sighting is the signal
+ * to resend, not a race to win. `ASK_VERIFY_POLL_ATTEMPTS` (~1s total at
+ * this gap) comfortably covers ordinary repaint + teardown latency; a
+ * mis-drive that never resolves times out to `false` rather than hanging
+ * the answer route.
+ */
+const ASK_VERIFY_POLL_MS = 120;
+const ASK_VERIFY_POLL_ATTEMPTS = 8;
+/** Cap on resending the confirm Enter when verification still sees
+ *  "review" — i.e. the earlier send (from the review-wait phase or a prior
+ *  resend) was swallowed. A stray extra Enter lands on the empty REPL
+ *  prompt once the modal genuinely closes, which is a no-op, so this is
+ *  purely a loop-termination bound, not a correctness one. */
+const ASK_VERIFY_MAX_RESENDS = 2;
+
+/** Outcome of one poll in `driveAskAnswers`'s confirm/verify phases. */
+type AskDriveStep = "done" | "send-enter" | "wait" | "fail";
+
+/**
+ * Pure per-poll decision for `driveAskAnswers`, factored out of the
+ * tmux-driving loop so the swallowed-confirm retry logic is unit-testable
+ * without a live tmux pane (mirrors `decideScrapeTick`'s split). The same
+ * decision table drives both of `driveAskAnswers`'s phases:
+ *
+ *  - waiting for the review screen to render before sending the confirm
+ *    (`confirmSent: false`) — a `"review"` sighting fires the confirm
+ *    immediately (not bounded by `resends`, since this is the first send,
+ *    not a resend); a lingering `"question"` (still navigating the tab bar)
+ *    or an already-vanished modal both fall through without a blind Enter;
+ *  - verifying the modal actually closed after the confirm (`confirmSent:
+ *    true`, or no confirm phase at all for a singleFlat plan) — a
+ *    `"review"` sighting here means the just-sent confirm was swallowed by
+ *    Ink's repaint and must be resent, bounded by `ASK_VERIFY_MAX_RESENDS`
+ *    so a genuinely stuck review screen fails instead of looping forever.
+ *
+ * `kind === null` (the modal has left the pane) is `"done"` regardless of
+ * phase or resend count — the only success case. `"question"` is always
+ * `"wait"`: mid-drive it's normal progress toward the review screen, and
+ * during verification it's treated as a teardown transient rather than a
+ * fresh mis-drive (a genuine mis-drive times out via the caller's attempt
+ * budget, which this function doesn't own).
+ */
+function decideAskDriveStep(
+  kind: AskModalKind | null,
+  confirmSent: boolean,
+  resends: number,
+): AskDriveStep {
+  if (kind === null) return "done";
+  if (kind === "review") {
+    if (!confirmSent) return "send-enter";
+    return resends < ASK_VERIFY_MAX_RESENDS ? "send-enter" : "fail";
+  }
+  return "wait";
+}
+
+/**
+ * Drive a `planAskAnswers` `mode: "drive"` plan into the task's tmux
+ * session, verified-and-retried rather than trusting `send-keys` exit codes.
+ *
+ * This supersedes the blind trailing Enter `sendModalKeys` used to send for
+ * plans that end on the "Ready to submit your answers?" review screen: that
+ * Enter arrived a flat 35ms after the tab-transition key while Ink was still
+ * repainting the heaviest screen in the whole modal, and was intermittently
+ * swallowed. `driveAskAnswers` instead:
+ *
+ *  1. Sends every key up to (but not including) a review-confirming trailing
+ *     Enter exactly like `sendModalKeys` — same 35ms gap, same per-key
+ *     `stillCurrent()` re-gate. (`plan.confirmsReview` is false for the
+ *     singleFlat shape, which has no review screen and no confirm to gate —
+ *     the full key list is sent here and phase 2 below just verifies.)
+ *  2. When `confirmsReview`, polls the pane (`ASK_REVIEW_POLL_MS` /
+ *     `ASK_REVIEW_POLL_ATTEMPTS`) until the review screen is actually
+ *     rendered, then sends the confirm Enter. A mis-drive that never reaches
+ *     the review screen within the window is not force-confirmed with a
+ *     blind Enter — it falls through to verification, which will time out.
+ *  3. Always verifies (including singleFlat): polls
+ *     (`ASK_VERIFY_POLL_MS` / `ASK_VERIFY_POLL_ATTEMPTS`) until the modal is
+ *     gone, resending the confirm on a `"review"` sighting (bounded by
+ *     `ASK_VERIFY_MAX_RESENDS`) and waiting out a `"question"` sighting.
+ *
+ * The whole sequence runs inside one `queueTmuxOp` callback (same
+ * serialization-behind-any-in-flight-paste rationale as `sendModalKeys`), so
+ * the confirm-wait and verify polls can't interleave with a racing user
+ * paste either. `sendModalKeys` is unchanged and still used for the
+ * `Escape` dismissal paths, which have no review screen to wait for.
+ */
+export async function driveAskAnswers(
+  taskId: string,
+  plan: { keys: NavKey[]; confirmsReview: boolean },
+): Promise<boolean> {
+  const state = sessions.get(taskId);
+  if (!state) return false;
+  const { keys, confirmsReview } = plan;
+  if (keys.length === 0) return true;
+  // The trailing key IS the confirm Enter when confirmsReview — split it off
+  // so it can be gated on the review screen actually rendering (step 2)
+  // instead of fired blind after the flat inter-key gap (step 1).
+  const body = confirmsReview ? keys.slice(0, -1) : keys;
+
+  let ok = false;
+  await queueTmuxOp(taskId, async (stillCurrent) => {
+    for (const key of body) {
+      if (!tmux(["send-keys", "-t", state.sessionName, key]).ok) return;
+      // Inter-key gap mirrors sendModalKeys: a bursted pair can read as a
+      // single Ink event, and the gap lets the dispose re-gate fire.
+      await Bun.sleep(35);
+      if (!stillCurrent()) return;
+    }
+
+    let confirmSent = false;
+    if (confirmsReview) {
+      for (let attempt = 0; attempt < ASK_REVIEW_POLL_ATTEMPTS && !confirmSent; attempt++) {
+        await Bun.sleep(ASK_REVIEW_POLL_MS);
+        if (!stillCurrent()) return;
+        const step = decideAskDriveStep(detectAskModal(captureTail(state)), confirmSent, 0);
+        if (step === "done") { ok = true; return; }
+        if (step === "send-enter") {
+          if (!tmux(["send-keys", "-t", state.sessionName, "Enter"]).ok) return;
+          confirmSent = true;
+        }
+        // "wait" — review screen not up yet; keep polling. ("fail" cannot
+        // occur here — decideAskDriveStep only returns it once confirmSent.)
+      }
+      // Attempts exhausted without a "review" sighting: don't send a blind
+      // Enter (see doc comment). Fall through to verification below, which
+      // times out to false if the modal genuinely never resolves.
+    }
+
+    let resends = 0;
+    for (let attempt = 0; attempt < ASK_VERIFY_POLL_ATTEMPTS; attempt++) {
+      await Bun.sleep(ASK_VERIFY_POLL_MS);
+      if (!stillCurrent()) return;
+      const step = decideAskDriveStep(detectAskModal(captureTail(state)), confirmSent, resends);
+      if (step === "done") { ok = true; return; }
+      if (step === "fail") return;
+      if (step === "send-enter") {
+        if (!tmux(["send-keys", "-t", state.sessionName, "Enter"]).ok) return;
+        confirmSent = true;
+        resends++;
+      }
+      // "wait" — keep polling; a persistent "question" sighting times out
+      // here rather than being force-resolved.
+    }
+    // Verify budget exhausted without ever seeing the modal close.
   }, state);
   return ok;
 }
@@ -3003,12 +3176,33 @@ function scrapeOnce(state: SessionState): void {
   // Native AskUserQuestion modal handling. Its options render as a numbered
   // checkbox list (`❯ 1. [✔] Cheese …`) that matchNumberedModal would otherwise
   // grab, producing a competing single-keystroke tmux_prompt card. So whenever
-  // the modal is on the pane we (a) suppress the numbered matcher and (b) drive
-  // the structured-card flow off the pane (collectAndRegisterAskCard). When the
-  // modal leaves the pane (answered/cancelled) we drop the card. ExitPlanMode's
-  // approval modal carries no AskUserQuestion signature, so it still flows
-  // through the numbered matcher as intended.
-  const askOnPane = detectAskModal(tail) !== null;
+  // the *question* screen is on the pane we (a) suppress the numbered matcher
+  // and (b) drive the structured-card flow off the pane
+  // (collectAndRegisterAskCard). When it leaves the pane (answered/cancelled)
+  // we drop the card. ExitPlanMode's approval modal carries no AskUserQuestion
+  // signature, so it still flows through the numbered matcher as intended.
+  //
+  // The *review* screen ("Ready to submit your answers?") is deliberately
+  // NOT included in this suppression, even though `detectAskModal` reports it
+  // too. `driveAskAnswers` (claude-tmux.ts) verifies its own confirm Enter
+  // and self-heals a swallowed one, but two cases still land a review screen
+  // that nothing is driving: the drive's bounded resends genuinely exhausted
+  // (a real failure, not just a slow repaint), or the user attached to tmux
+  // directly and navigated to review by hand. `parseModalPane` can't parse
+  // the review screen (no question/footer signature) and the JSONL has no
+  // tool_use until the modal is answered, so with the old blanket suppression
+  // a stranded review screen matched nothing on every tick, forever — the
+  // bug this whole change fixes. Letting `askOnPane` go false for "review"
+  // lets it fall through to `matchNumberedModal`, which DOES match it
+  // (`❯ 1. Submit answers` / `2. Cancel` — ≥2 numbered choices, cursor
+  // marker, "1." anchor) and, after the usual two-tick stability gate,
+  // registers an ordinary clickable tmux_prompt card. If an ask card is
+  // still registered when that happens (the driver hadn't dropped it yet,
+  // or the user reached review by hand), the `else` branch below resolves it
+  // as externally-answered — the same semantics external dismissal already
+  // has for the question screen.
+  const askKind = detectAskModal(tail);
+  const askOnPane = askKind === "question";
   if (askOnPane) {
     if (state.askFirstSeenAt === null) state.askFirstSeenAt = now;
     if (!claudeIsWriting && !state.askCardId && !state.askCollecting) {
@@ -4358,6 +4552,16 @@ export const __forTest = {
   SCRAPE_IDLE_POLL_MS,
   SCRAPE_DEEP_IDLE_AFTER_MS,
   SCRAPE_DEEP_IDLE_POLL_MS,
+  /** Pure per-poll decision used by `driveAskAnswers`'s confirm/verify
+   *  phases — exposed so the swallowed-confirm retry logic (resend on a
+   *  "review" sighting, wait out a "question" sighting, bounded resends)
+   *  can be asserted without a live tmux pane. */
+  decideAskDriveStep,
+  ASK_REVIEW_POLL_MS,
+  ASK_REVIEW_POLL_ATTEMPTS,
+  ASK_VERIFY_POLL_MS,
+  ASK_VERIFY_POLL_ATTEMPTS,
+  ASK_VERIFY_MAX_RESENDS,
   readPendingAskQuestionsFromJsonl,
   shouldWaitForAskJsonl,
   resumeJsonlOffset,

--- a/src/bun/interactions.ts
+++ b/src/bun/interactions.ts
@@ -25,7 +25,8 @@ export type InteractionKind =
  * invisible to the user. The scraper in `claude-tmux.ts` detects it on the
  * pane, pairs it with the structured `questions` it saw in the JSONL tool_use,
  * and surfaces it as a structured card. The answer is driven back as keystrokes
- * (`planAskAnswers` + `sendModalKeys`); there is no blocking hook curl.
+ * (`planAskAnswers` + `driveAskAnswers`, or `sendModalKeys(["Escape"])` for the
+ * message-mode fallback); there is no blocking hook curl.
  * ────────────────────────────────────────────────────────────────────────── */
 
 /** One question inside an AskUserQuestion tool call (claude code shape). */
@@ -51,7 +52,7 @@ export interface AskQuestionsRequest {
   /**
    * How the answer is delivered back to claude. Only `"scraper"` exists now:
    * the native modal is detected on the tmux pane and the answer is driven
-   * back as keystrokes (`planAskAnswers` + `sendModalKeys`), then the card is
+   * back as keystrokes (`planAskAnswers` + `driveAskAnswers`), then the card is
    * removed via `resolveScrapedAskQuestions`. Registered by
    * `registerScrapedAskQuestions`.
    */

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -39,6 +39,7 @@ import {
 } from "./tmux-resolution.ts";
 import {
   dismissTmuxPrompt,
+  driveAskAnswers,
   jsonlPathFor,
   rebuildEventsFromJsonl,
   markTmuxPromptAnswered,
@@ -3448,9 +3449,10 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       // ─── Interactions: claude built-in AskUserQuestion (scraper-sourced) ──
       // The native modal is live on the tmux pane; there's no promise. Plan
       // the keystrokes from the user's picks and drive them into the modal
-      // (planAskAnswers + sendModalKeys), or, for a custom/free-text answer,
-      // Esc the modal and post the answer as a normal follow-up turn. Then
-      // drop the card.
+      // (planAskAnswers + driveAskAnswers, which verifies-and-retries the
+      // review-screen confirm rather than trusting send-keys exit codes), or,
+      // for a custom/free-text answer, Esc the modal (sendModalKeys) and post
+      // the answer as a normal follow-up turn. Then drop the card.
       "/ask-questions/:id/answer": {
         POST: authed(async (req) => {
           const body = (await req.json().catch(() => ({}))) as Partial<AskQuestionsAnswer>;
@@ -3473,7 +3475,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             const plan = planAskAnswers(specs, sanitised);
             let ok = false;
             if (plan.mode === "drive") {
-              ok = await sendModalKeys(pending.taskId, plan.keys);
+              ok = await driveAskAnswers(pending.taskId, plan);
             } else {
               // Custom/free-text (or anything we can't drive): dismiss the
               // native modal, then deliver the answer as a follow-up turn —


### PR DESCRIPTION
## Problem

Sometimes, after answering a Claude Code AskUserQuestion card from the task details, the tmux TUI stayed stuck on the **"Ready to submit your answers?"** review screen — the task appeared hung until the user ran `tmux attach` and pressed Enter manually, while Agetor's UI already showed the answers as submitted.

Two coupled defects:

1. **Keystroke race (the trigger).** The drive plan's final confirm `Enter` was sent a flat 35ms after the key that transitions the TUI onto the review screen — Ink's heaviest repaint in the whole modal. When the repaint was slow, the Enter was silently swallowed. `sendModalKeys` judged success purely by `tmux send-keys` exit codes (tmux writing bytes to the pty says nothing about Ink consuming them), so the drive reported a false success and `resolveAskCard` dropped the UI card anyway.
2. **Structural strand (why it never self-healed).** The intended fallback ("clear `askCardId` → scraper re-collects a fresh card") is blind to the review screen: `scrapeOnce` suppressed `matchNumberedModal` whenever *any* ask modal was on the pane, but nothing can build a card for the review screen — `parseModalPane` needs the question/footer signatures it lacks, and Claude doesn't write the `AskUserQuestion` tool_use to the JSONL until the modal is *answered*. So a stranded review screen matched nothing, on every scrape tick, forever.

## What changed

- **`driveAskAnswers`** (new in `claude-tmux.ts`, used by the `/ask-questions/:id/answer` drive path): sends the selection keys as before, then **polls `capture-pane` until the review screen has actually rendered before sending the confirm Enter**, then verifies the modal really left the pane — resending the confirm (bounded by `ASK_VERIFY_MAX_RESENDS`; a stray Enter at the empty REPL is benign) if it was swallowed. Returns a content-verified result instead of trusting exit codes. The per-poll decision is a pure helper (`decideAskDriveStep`, exported via `__forTest`) so the retry logic is unit-testable without tmux. `sendModalKeys` is unchanged and still serves the Escape/dismiss paths.
- **`planAskAnswers`** drive plans now carry `confirmsReview` (true for every shape except the flat single-select single question, which has no review screen) so the driver knows which plans need the render-gated confirm.
- **Scraper backstop:** `scrapeOnce` now suppresses the numbered-modal matcher only for the *question* screen. A review screen that persists anyway (exhausted retries, or a user who navigated there via `tmux attach`) falls through to `matchNumberedModal` and surfaces as a normal clickable **"Submit answers / Cancel"** card — never invisible again.

## Tests

- Exhaustive decision-table tests for `decideAskDriveStep` (`claude-tmux-askdrive.test.ts`) against the exported resend budget.
- `matchNumberedModal` proven to match the real `review_submit.txt` fixture tail (choices `Submit answers`/`Cancel`, cursor 0, not high-confidence → two-tick stability gate applies), pinning the fallthrough backstop.
- `confirmsReview` pinned across all plan shapes in the existing `planAskAnswers` assertions.
- Full suite: **1563 pass / 1 skip / 0 fail**; `bun run typecheck` green.

## Notes

- Plan + investigation record: `docs/plans/fix-ask-submit-answers-stranded.md`.
- Known cosmetic edge (documented in the plan): if a drive is mid-retry across two scrape ticks, a ghost "Submit answers" card can appear briefly and self-cancels on the next tick via the existing auto-cancel sweep.
- Unit-verified; a live smoke test (answer a multi-question AskUserQuestion from the task details against a dev build) is the remaining manual check.