### PR TITLE
fix: keep the backlog editor's Save/Cancel row visible in the tray

### DIFF
--- a/docs/plans/fix-backlog-edit-save-button-clipped.md
+++ b/docs/plans/fix-backlog-edit-save-button-clipped.md
@@ -1,0 +1,73 @@
+# Plan — Fix "missing" Save button in backlog draft edit mode
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-16 |
+| Source | agetor task: "it's missing a save button in the edit mode for the backlog message (saved for later)" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/missing-save-button-for-editing-backlog |
+| Base SHA | fee24308ec9e |
+| Mode | Autonomous (agetor-driven run; grill + plan-approval gates self-resolved, assumptions logged below) |
+
+## 1. Objective & success criteria
+
+When the user clicks the pencil icon on a saved backlog draft in the RunPanel tray, the
+inline editor — including its **Save** and **Cancel** buttons — must be fully visible
+without the user having to discover a 160px-tall scroll area.
+
+## 2. Context & findings
+
+- The Save button **exists in code** (`src/mainview/components/kanban/RunPanel.tsx:1663-1669`)
+  and has since the backlog feature landed in one commit (`dae328c`, PR #84). So the report
+  is a visibility bug, not absent code.
+- The tray's item list is capped at `max-h-40` (160px) with `overflow-y-auto`
+  (`RunPanel.tsx:1562`).
+- The inline editor is ~140px tall: `p-2` container + 2-row textarea + inline
+  `ReferencesPicker` (~28px) + `h-8` button row + gaps.
+- Therefore: with two or more drafts, or when editing any row not at the very top, the
+  editor's bottom (the Save/Cancel row) falls below the fold of the 160px window. Nothing
+  scrolls it into view on entering edit mode.
+
+## 3. Approach
+
+Two small changes, both in `RunPanel.tsx`:
+
+1. **Grow the tray while editing** — the list container's class becomes
+   `cn("space-y-1 overflow-y-auto px-2 pb-2", editingId ? "max-h-72" : "max-h-40")`,
+   so the ~140px editor always fits in the 288px window with room for context rows.
+2. **Scroll the Save/Cancel row into view on entering edit mode** — `BacklogItemRow` gets
+   an `actionsRef` on the action-button row; the existing enter-edit effect (already keyed
+   on `[editing]` only, per the poll-clobber gotcha) additionally calls
+   `scrollIntoView({ block: "nearest" })`. Review note: the anchor is the action row (the
+   form's last element), not the editor container — a draft with many reference chips can
+   grow the form past even the enlarged window, and anchoring the container top would
+   re-clip the buttons.
+
+Alternatives considered: sticky action row inside the editor (fights the tiny scrollport),
+removing the cap entirely (lets a long backlog eat the panel). Rejected in favor of the
+minimal pair above.
+
+## 4. Work breakdown
+
+- T1 — `src/mainview/components/kanban/RunPanel.tsx` only: both changes above. Single task,
+  single file; no fan-out (change too small to partition).
+
+## 5. Tests
+
+The webview has no DOM test harness (established convention: extract pure logic to
+`src/mainview/lib/*.ts` for unit tests; visual behavior verified via `bun run dev:hmr`).
+This fix is pure DOM/scroll behavior with no extractable logic, so: run the existing suite
++ typecheck to guard against regressions; manual visual verification is the remaining step.
+
+## 6. Blast radius & risks
+
+- The enter-edit effect keeps its `[editing]`-only deps — the 2s-poll clobber gotcha is not
+  re-introduced.
+- `max-h-72` only applies while an editor is open; the resting tray is unchanged.
+
+## 7. Assumptions (autonomous mode)
+
+- The report refers to the RunPanel BacklogTray inline editor — the only backlog-message
+  edit surface in the app ("Backlog" in NewTaskForm is the kanban column, unrelated).
+- Root cause is the clipping described above; no build the user can run has edit mode
+  without the Save button in code (both shipped in `dae328c`).

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -1559,7 +1559,16 @@ function BacklogTray({
             : "saved messages — send when you're ready"}
         </span>
       </div>
-      <div className="max-h-40 space-y-1 overflow-y-auto px-2 pb-2">
+      {/* Grow the window while a row is being edited: the inline editor is
+          ~140px tall, so under the resting max-h-40 (160px) its Save/Cancel row
+          would be clipped below the fold whenever another draft sits above it —
+          which reads as "there is no save button". */}
+      <div
+        className={cn(
+          "space-y-1 overflow-y-auto px-2 pb-2",
+          editingId !== null ? "max-h-72" : "max-h-40",
+        )}
+      >
         {items.map((item, i) => (
           <BacklogItemRow
             key={item.id}
@@ -1622,6 +1631,7 @@ function BacklogItemRow({
 }) {
   const [draft, setDraft] = useState(item.text);
   const [draftRefs, setDraftRefs] = useState<TaskReference[]>(item.references);
+  const actionsRef = useRef<HTMLDivElement>(null);
   // Re-seed the edit form only when we *enter* edit mode. We deliberately do
   // NOT depend on `item.text` / `item.references`: the 2s task poll rebuilds
   // `task.backlog` into fresh objects (new array references) on every tick, so
@@ -1633,6 +1643,11 @@ function BacklogItemRow({
     if (editing) {
       setDraft(item.text);
       setDraftRefs(item.references);
+      // The editor expands the row well past what was visible before the
+      // click. Anchor the scroll on the Save/Cancel row — the form's last
+      // element — so the buttons are revealed even when the form itself is
+      // taller than the tray's scroll window (many reference chips).
+      actionsRef.current?.scrollIntoView({ block: "nearest" });
     }
   }, [editing]);
 
@@ -1656,7 +1671,7 @@ function BacklogItemRow({
           onChange={setDraftRefs}
           startingFolder={startingFolder}
         />
-        <div className="flex items-center justify-end gap-1.5">
+        <div ref={actionsRef} className="flex items-center justify-end gap-1.5">
           <Button size="sm" variant="ghost" onClick={onCancelEdit}>
             Cancel
           </Button>


### PR DESCRIPTION
## Problem

Clicking the pencil icon on a saved backlog draft ("Save for later") opened the inline editor with **no visible Save button** whenever the task had more than one draft.

The button was never actually missing from the code — it has existed since the backlog feature landed (#84). It was being **clipped**: the tray's item list is capped at `max-h-40` (160px) with `overflow-y-auto`, while the inline edit form (textarea + references picker + Save/Cancel row) is ~140px tall. So unless the edited row was alone at the top, the action row fell below the fold of a barely visible scroll area — reading as "there is no save button".

## Fix

Two small changes in `src/mainview/components/kanban/RunPanel.tsx`:

1. **Grow the tray while editing** — the list container becomes `max-h-72` while a row is in edit mode (`editingId !== null`), returning to `max-h-40` at rest, so the editor fits in the window.
2. **Scroll the Save/Cancel row into view on entering edit mode** — via `scrollIntoView({ block: "nearest" })` in the existing enter-edit effect. The scroll anchor is deliberately the **action row** (the form's last element), not the form container: a draft with many reference chips can grow the form past even the enlarged window, and anchoring the container top would re-clip the buttons.

The enter-edit effect keeps its `[editing]`-only dependency array, so the known 2s-poll input-clobber trap (the task poll rebuilds `task.backlog` references every tick) is not reintroduced.

## Verification

- `bun run typecheck` — green
- `bun test` — 1563 pass / 0 fail
- The fix is pure scroll/layout behavior (the webview has no DOM test harness by convention); remaining manual check: with 2–3 saved drafts, click Edit on the last one and confirm Save/Cancel are visible.

Plan/analysis doc: `docs/plans/fix-backlog-edit-save-button-clipped.md`