### PR TITLE
feature: Worktrees page — stale flags, ticket links, archive-delete, filters/sort, and live git status

### DIFF
--- a/docs/plans/worktrees-git-signals.md
+++ b/docs/plans/worktrees-git-signals.md
@@ -1,0 +1,72 @@
+# Plan — Orphan-prune queue routing + live git staleness signals
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-17 |
+| Source | /implement task: "routing the orphan-delete prune through the teardown queue, and optional live git dirty/ahead/merged staleness signals (kept out of the bulk list to avoid a subprocess fan-out per poll)" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/stale-worktrees |
+| Base SHA | 7982137 |
+| Mode | Interactive — grill answered by owner (merged-target + surface); proceeding to implement |
+
+## 1. Objective & success criteria
+
+Two follow-ups to the Worktrees page:
+
+1. **Orphan-prune through the queue** — `deleteOrphanWorktree`'s `rm` + `git worktree prune` must run on the per-source-repo teardown FIFO (`enqueueTeardown`), like `deleteTask`, so an orphan cleanup can't contend on git's `.git/worktrees/.lock` with a concurrent same-repo archive/delete. Error reporting to the caller is preserved.
+2. **Live git signals** — an on-demand, per-worktree `{ dirty, ahead, merged, ignored }` status (NOT in the bulk `GET /worktrees` poll — that stays fs+DB-only). The Worktrees page auto-fetches these for its rows on open/refresh with a bounded concurrency cap (~5) and shows dirty / ahead / merged badges.
+
+Success: `bun run typecheck` green, `bun test` green including new backend tests for the merged helper, the per-worktree git-status resolution/confinement, and the queued orphan prune.
+
+## 2. Context & constraints (from investigation)
+
+- `enqueueTeardown(taskId, key, job)` (`orchestrator.ts:167-190`) chains `job` onto a per-`key` FIFO; `key` is the source `workdir` (git lock domain). It **swallows job errors** (`.catch` logs, the returned promise still resolves) — so to keep returning `{ error }` on a failed `rm`, the job must record success/failure into a closure the caller reads after awaiting.
+- `deleteOrphanWorktree` (`orchestrator.ts:2128-2171`) currently: validates id + confinement (`basename(dirPath) === id`), refuses live task ids, `await pendingTeardown(id)`, parses `sourceRoot` from the `.git` pointer, `rm`s the dir, then calls `pruneWorktrees(sourceRoot)` **directly** (line 2168) — the bit to move onto the queue.
+- Git helpers in `worktree.ts`: `hasUncommittedChanges(dir)` → `boolean|null` (`:63`), `getAheadCount(dir, baseRef)` → `number|null` (`:91`), the private `git()` wrapper (`:31`, 30s timeout, non-throwing). **No "merged" helper exists** (grep confirmed) — must be built.
+- Existing on-demand pattern: `GET /tasks/:id/git-status` (`server.ts:3280`) returns `{ hasChanges, ahead, ignored }`, composing the two helpers with `Promise.all`; client `api.getTaskGitStatus` (`api.ts:1069`). The new per-worktree endpoint mirrors this shape + adds `merged`.
+- `listWorktrees` id == dir basename == task id; a worktree shares the source repo's refs via its common git dir, so `origin/HEAD`/`main`/`master` and `merge-base --is-ancestor` all resolve correctly with `cwd` = the worktree dir.
+- `WorktreesDialog.tsx` (458 lines) already has `worktrees: WorktreeInfo[]` state, per-row rendering (`sorted.map`, badges at ~:411-431), `busyIds`, refresh, and filters/sort — the git-status cache + badges slot into the existing row.
+- Test conventions: `worktrees-list.test.ts` / `orchestrator-archive-teardown.test.ts` — top-level `AGETOR_DATA_DIR` mkdtemp, fake-driver env, local `makeRepo()`, dynamic imports, `finally` cleanup.
+
+## 3. Approach & key decisions
+
+**Merged semantics** (owner-chosen): `merged` = is the worktree's `HEAD` an ancestor of the **source repo's default branch**. Resolve default via `git rev-parse --abbrev-ref origin/HEAD` → else first of `main`/`master` that exists (`git show-ref --verify --quiet refs/heads/<b>`) → else null (merged reported as `null`/unknown, never a false "merged"). Then `git merge-base --is-ancestor HEAD <default>`: exit 0 → `true`, exit 1 → `false`, other → `null`. Runs with `cwd` = the worktree dir.
+
+**On-demand endpoint**: new `orchestrator.worktreeGitStatus(id)` centralizes dir/baseRef resolution + the same `basename(dirPath) === id` confinement as `deleteOrphanWorktree` (factor the confinement into a small local `resolveWorktreeDir(id)` helper shared by both, so the guard can't drift). For a task-backed id → the task's `worktreePath ?? workdir` + `task.baseRef`; for an orphan id → `join(WORKTREES_DIR, id)` + `baseRef = null`. Composes `hasUncommittedChanges` + `getAheadCount` + the new `isMergedIntoDefaultBranch`. Route: `GET /worktrees/:id/git-status` → `{ dirty, ahead, merged, ignored }` (`ignored: true` when the dir isn't inspectable, mirroring the task endpoint; on ignored we skip ahead/merged).
+
+**Queued prune**: `deleteOrphanWorktree` keeps the id-validation + live-task refusal + `await pendingTeardown(id)` up front, then wraps **both** the `rm` and the `prune` in one `enqueueTeardown(id, sourceRoot ?? dirPath, job)` and awaits it. The job records `{ ok }` / `{ error }` into a closure var; the function returns that after the await, so error reporting is unchanged. Keying by `sourceRoot` puts the prune on the same FIFO as that repo's archive/delete teardowns (the whole point); when the source repo is unknowable (`sourceRoot` null) there's no shared lock domain, so key by `dirPath` (a private chain — behaves like today).
+
+**Frontend auto-fetch**: on open and on Refresh, kick a bounded-concurrency (cap 5) pool that fetches `getWorktreeGitStatus(w.id)` for every worktree in the current list, storing results in a `Map<id, WorktreeGitStatus | { loading: true }>` keyed also by a refresh nonce so Refresh re-runs. Rows render dirty / ahead / merged badges (or a small spinner while loading, nothing on `ignored`). Fetching the full loaded list (not visibility-tracked) is simpler and equivalent here — the list is the whole on-disk worktree set, already small by construction.
+
+**Alternatives considered**: (a) merged vs the pinned `baseRef` — rejected by owner (always "not merged"); (b) putting git signals in the bulk `GET /worktrees` — rejected by the task itself (subprocess fan-out per 5s poll); (c) per-row manual "Check git" button — owner chose auto-fetch instead; (d) reusing `/tasks/:id/git-status` — rejected: it's task-only (no orphans) and lacks `merged`.
+
+## 4. Work breakdown — implementation tasks
+
+| ID | Goal | Files owned | Deps | Acceptance |
+| --- | --- | --- | --- | --- |
+| T1 | Backend: `WorktreeGitStatus` type; `isMergedIntoDefaultBranch` helper; `worktreeGitStatus(id)` + shared `resolveWorktreeDir(id)` confinement; route `GET /worktrees/:id/git-status`; move `deleteOrphanWorktree` rm+prune onto `enqueueTeardown` preserving error return | `src/shared/types.ts`, `src/bun/worktree.ts`, `src/bun/orchestrator.ts`, `src/bun/server.ts` | — | Endpoint returns dirty/ahead/merged/ignored; prune runs on the FIFO; error paths intact |
+| T2 | Frontend: `api.getWorktreeGitStatus`; auto-fetch pool (cap 5) on open/refresh; dirty/ahead/merged badges + per-row loading in `WorktreesDialog` | `src/mainview/lib/api.ts`, `src/mainview/components/worktrees/WorktreesDialog.tsx` | T1 contract (fixed in brief) | Badges appear per row after open; bounded fan-out; no refetch storm on filter/sort |
+
+## 5. Work breakdown — test tasks
+
+| ID | Goal | Files owned | Covers |
+| --- | --- | --- | --- |
+| TT1 | Backend tests: `isMergedIntoDefaultBranch` (fresh worktree at main tip → merged; +1 commit → not merged; default-branch resolution main/master); `worktreeGitStatus` (clean vs dirty; ahead count; orphan dir; `.`-confinement → error, not a crash); `deleteOrphanWorktree` still ok + dir gone with prune now queued (happy path + a concurrent same-repo teardown both settle) | `src/bun/worktree-git-status.test.ts` (new) | T1 |
+
+## 6. Execution waves
+
+- **Wave 1**: T1 + T2 in parallel (disjoint files; T2 imports the `WorktreeGitStatus` type T1 adds — contract fixed in both briefs; typecheck at the barrier).
+- **Wave 2**: TT1 (after review).
+
+## 7. Blast radius & risks
+
+- `deleteOrphanWorktree` behavior must stay identical from the caller's view (still returns `{ ok } | { error }`) — the closure-captured result is the load-bearing detail; covered by the existing orphan-delete tests plus TT1.
+- New git subprocesses are **on-demand only** — the 5s bulk poll stays fs+DB-only (unchanged). Per-open fan-out is capped at 5 concurrent and bounded by the (small) worktree count.
+- `merged` never false-positives: unknown default branch or a git error → `null`, rendered as "unknown", never "merged".
+- No teardown-ordering change for archive/delete; no tmux enumeration; `pendingTeardown` await retained.
+
+## 8. Open questions / assumptions
+
+1. **Auto-fetch scope**: fetch for the full loaded worktree list on open/refresh (cap 5), not literal viewport-visibility tracking — equivalent here since the list is the whole on-disk set, and it avoids refetch churn when filtering/sorting. (Assumption; trivially narrowable later.)
+2. **Merged for orphans**: computed the same way (refs reachable via the `.git` pointer's common dir); `null` if the pointer/refs can't be resolved.
+3. **`ahead` for orphans**: `baseRef` is null → `getAheadCount` returns its unknown-but-not-blocking `0`. Acceptable; the dirty/merged badges carry the signal.

--- a/docs/plans/worktrees-list-page.md
+++ b/docs/plans/worktrees-list-page.md
@@ -1,0 +1,84 @@
+# Plan — Worktrees list page (stale flag, ticket links, archive-delete, filters/sort)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-17 |
+| Source | /implement task: "add a worktrees list page with a stale flag … link them to their tickets … delete button → confirmation → ticket archiving (which deletes the worktree) … filters and sort … ticket status (column) … project per worktree" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/stale-worktrees |
+| Base SHA | d6954f6 |
+| Mode | **Autonomous** — grill + plan-approval gates bypassed; all assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+A "Worktrees" page (full-screen overlay, opened from the app header) listing every agetor-managed worktree currently materialized on disk, where the user can:
+
+1. See at a glance which worktrees are **stale** (badge + reason).
+2. Identify each worktree by its **project**, **branch**, and **ticket** (task) — and click the ticket to open its details panel.
+3. See the ticket's **status** (kanban column).
+4. **Delete** a worktree via a confirmation dialog that explains the ticket will be **archived**; archiving performs the worktree removal (existing deferred teardown).
+5. **Filter** (text, project, status, staleness) and **sort** (updated, project, status, branch; asc/desc) the list.
+
+Success: `bun run typecheck` green, `bun test` green including new backend tests for listing/staleness/force-archive/orphan-delete.
+
+## 2. Context & constraints (from investigation)
+
+- Worktrees live at `dataDir/worktrees/<task-id>` (`worktree.ts:505-507`, `WORKTREES_DIR` at `worktree.ts:12`, **not exported today**). No code enumerates that directory yet.
+- `archiveTask` (`orchestrator.ts:1854-1902`): requires `column === "done"` and no active run; stamps `archivedAt`; defers session-kill → terminal-kill → `detachWorktree` through the **per-workdir FIFO teardown queue** (`enqueueTeardown`, `orchestrator.ts:118-186`). `detachWorktree` keeps the branch and **refuses dirty worktrees** (`worktree.ts:802-830`). Fleet invariant: any path touching a worktree must `await pendingTeardown(taskId)` first; never enumerate-and-kill `agetor-*` tmux sessions.
+- `deleteTask` is the destructive path (branch + task row gone) — **not** what the user asked for; they explicitly asked for archive semantics.
+- Archived state is only `tasks.archived_at` (migration 019); worktree presence is always computed live via `existsSync` (design decision in `docs/plans/archive-worktree-cleanup.md` — no worktree-state column). `sweepArchivedTeardowns` (`orchestrator.ts:1997-2018`) is the closest existing "stale" scan.
+- Server: object-style `Bun.serve` routes, every route wrapped in `authed(...)`; long worktree ops call `server.timeout(req, 0)` first (`server.ts:3098-3105`). Archive route exists: `POST /tasks/:id/archive` (`server.ts:3118-3126`).
+- Frontend: no routing — "pages" are full-screen overlays gated by a boolean in `App.tsx` (GitHubDialog pattern, header icon buttons at `App.tsx:605-622`). Task details open via `setSelected(task)`. Confirmations via `useConfirm()` (`confirm.tsx`); delete-task usage at `App.tsx:518-536` is the template. Filters via `MultiSearchSelect`/`Select` (`KanbanFilters.tsx`); no table primitive — div-row lists are the house style. Column labels: `COLUMNS` in `shared/types.ts:20-27`. Project name: `p.name || basename(p.path)` chain; compact paths via `abbreviateHome` (`lib/utils.ts:8`).
+- Tests: `AGETOR_DATA_DIR` set at module top before imports, temp git repos via local `makeRepo()` helpers, dynamic imports after env setup, fake driver env vars (`orchestrator-archive-teardown.test.ts:6-41`).
+
+## 3. Approach & key decisions
+
+**Data source**: new `GET /worktrees` returning `WorktreeInfo[]`, computed by `orchestrator.listWorktrees()`: enumerate `WORKTREES_DIR` on disk, cross-reference `tasks.list()` by dir name (dir name == task id). **No git subprocesses in the bulk list** — staleness uses only DB + fs signals, avoiding the N+1 spawn fan-out the investigation flagged. Project name resolution happens client-side against the already-loaded `projects` list (no backend coupling).
+
+**Staleness** (`stale: boolean` + `staleReasons: WorktreeStaleReason[]`):
+- `"orphaned"` — dir on disk with no task row (crash/failed teardown leftovers).
+- `"archived"` — owning task has `archivedAt != null` but the dir is still on disk (teardown pending, failed, or skipped because dirty).
+- `"inactive"` — task not archived, no active run, and `now - task.updatedAt > WORKTREE_STALE_AFTER_MS` (7 days, constant in `shared/types.ts`).
+
+**Delete = force-archive**: `archiveTask(taskId, { force?: boolean })` — `force` bypasses the `done`-column gate (still rejects an active run; teardown queue and dirty-worktree protection unchanged). Route: existing `POST /tasks/:id/archive` accepts an optional JSON body `{ force: true }`. Orphan dirs have no ticket to archive → `DELETE /worktrees/:id` removes the dir (id validated, path confined to `WORKTREES_DIR`, refuses if a task row exists, `await pendingTeardown(id)` first, best-effort `git worktree prune` in the source repo parsed from the `.git` pointer file).
+
+**UI**: new `WorktreesDialog` full-screen overlay (GitHubDialog pattern), header icon button in `App.tsx`. Div-row list; client-side filter/sort (list is small — one row per on-disk worktree). Clicking the ticket title closes the dialog and calls `setSelected(task)`. Delete uses `useConfirm({ variant: "destructive" })` with copy explaining: ticket will be archived, worktree removed, branch + AI history preserved, and a dirty worktree is left in place to protect uncommitted work.
+
+**Alternatives considered**: (a) `deleteTask` for the delete button — rejected, user explicitly asked for archive semantics and `deleteTask` destroys the branch + history; (b) persisting a worktree-state column — rejected, contradicts the standing archive design decision (live `existsSync`); (c) bulk git dirty/merged checks in `GET /worktrees` — rejected for now (subprocess fan-out per poll), listed as a follow-up; (d) small centered `Dialog` instead of full-screen overlay — rejected, a list page with filters matches the GitHubDialog precedent.
+
+## 4. Work breakdown — implementation tasks
+
+| ID | Goal | Files owned | Deps | Acceptance |
+| --- | --- | --- | --- | --- |
+| T1 | Backend: `WorktreeInfo` type + staleness constants; export `WORKTREES_DIR`; `listWorktrees()`; `archiveTask` force option; orphan delete; routes `GET /worktrees`, `DELETE /worktrees/:id`, archive body parsing | `src/shared/types.ts`, `src/bun/worktree.ts`, `src/bun/orchestrator.ts`, `src/bun/server.ts` | — | Endpoints respond; staleness classified per §3; teardown-queue invariants respected |
+| T2 | Frontend: `WorktreesDialog` overlay + filters/sort + confirm-delete; `App.tsx` wiring (header button, open-ticket); `api.ts` client fns | `src/mainview/components/worktrees/WorktreesDialog.tsx` (new), `src/mainview/App.tsx`, `src/mainview/lib/api.ts` | contract from T1 (types provided inline in brief) | Page opens, lists, filters, sorts; ticket opens details; delete confirms then force-archives / orphan-deletes |
+
+## 5. Work breakdown — test tasks
+
+| ID | Goal | Files owned | Covers |
+| --- | --- | --- | --- |
+| TT1 | Backend tests: `listWorktrees` (linked/orphaned/archived/inactive classification), `archiveTask` force gate (non-done + force ok, active-run still rejected), orphan delete (happy path, refuses live task id, path confinement) | `src/bun/worktrees-list.test.ts` (new) | T1 |
+
+No frontend unit-test harness exists in this repo; T2 is covered by `bun run typecheck` and the review pass.
+
+## 6. Execution waves
+
+- **Wave 1**: T1 + T2 in parallel (disjoint file sets; T2 imports the shared types T1 writes — contract is fixed in both briefs; orchestrator runs typecheck at the wave barrier, not the agents mid-flight).
+- **Wave 2**: TT1 (after review).
+
+## 7. Blast radius & risks
+
+- `archiveTask` signature change — existing callers (`server.ts` archive route, tests) keep working via optional param. Archiving from a non-`done` column leaves the task hidden-in-place in that column; unarchive restores it there (UI already handles archived cards in any column via the `archivedView` filter).
+- New worktree-touching paths must respect `pendingTeardown` + never enumerate tmux sessions — orphan delete touches only the fs + `git worktree prune`, no session kills.
+- `GET /worktrees` polling: fs-only (readdir + existsSync), safe at 5s cadence.
+- Orphan delete is the only genuinely destructive new operation — mitigated by id validation, `WORKTREES_DIR` path confinement, and the task-row-exists refusal.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+1. **Stale definition** chosen by me (§3): orphaned / archived-but-present / inactive-7-days. Threshold is a named constant (`WORKTREE_STALE_AFTER_MS`) — trivial to tune.
+2. **"Delete" maps to force-archive**, not `deleteTask` — per the user's own wording ("the ticket will be archived"). Force bypasses the `done`-only gate so stale worktrees in any column can be cleaned; an active run still blocks it.
+3. **Orphan dirs** (no ticket) are included in the list with a plain delete (no ticket to archive) — the user didn't ask, but a stale-worktrees page that can't show/clean orphans would silently miss the worst offenders.
+4. **Dirty worktrees**: archive proceeds but the existing teardown skips removal (uncommitted work is never destroyed); the row will then show as stale/"archived". Confirmation copy mentions this.
+5. **Project shown** = existing `Project.name || basename(path)` chain resolved client-side from `task.workdir`; orphan rows show the source repo parsed from the `.git` pointer when available, else "—".
+6. List shows only worktrees **materialized on disk** (archived+already-detached tasks are not "worktrees" anymore and would be noise).
+7. Client-side filter/sort (no server pagination) — worktree counts are small by construction.

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -84,6 +84,9 @@ import {
   WORKTREES_DIR,
   parseWorktreeGitPointer,
   pruneWorktrees,
+  hasUncommittedChanges,
+  getAheadCount,
+  isMergedIntoDefaultBranch,
 } from "./worktree.ts";
 import { killTerminalsForTask } from "./terminals.ts";
 import { ensureInstalledForCwd } from "./hook-installer.ts";
@@ -93,6 +96,7 @@ import type {
   RunEvent,
   RunStatus,
   Task,
+  WorktreeGitStatus,
   WorktreeInfo,
   WorktreeStaleReason,
 } from "../shared/types.ts";
@@ -2113,6 +2117,27 @@ export function listWorktrees(): WorktreeInfo[] {
 }
 
 /**
+ * Resolve a worktree id (a directory basename under `WORKTREES_DIR`) to its
+ * absolute path, with the confinement checks shared by every worktree-id
+ * endpoint: no `/`, `\`, `..`, or empty string, and the resolved path must
+ * be a direct child of `WORKTREES_DIR`, never the directory itself (guards
+ * against ids like `"."` that pass the substring checks but normalize to
+ * `WORKTREES_DIR` — an `rm -rf` there would delete every task's worktree).
+ * Factored out of `deleteOrphanWorktree` so `worktreeGitStatus` shares the
+ * exact same guard rather than a hand-copied one that could drift.
+ */
+function resolveWorktreeDir(id: string): { dir: string } | { error: string } {
+  if (!id || id.includes("/") || id.includes("\\") || id.includes("..")) {
+    return { error: "invalid worktree id" };
+  }
+  const dirPath = join(WORKTREES_DIR, id);
+  if (basename(dirPath) !== id) {
+    return { error: "invalid worktree id" };
+  }
+  return { dir: dirPath };
+}
+
+/**
  * Delete an orphaned worktree directory — one with no owning task row, so
  * there's no ticket for `archiveTask` to archive. Used by the Worktrees
  * page's delete action for `WorktreeInfo` rows where `taskId` is null.
@@ -2120,8 +2145,8 @@ export function listWorktrees(): WorktreeInfo[] {
  * Refuses (rather than silently no-oping) when a task row for `id` still
  * exists — that worktree is owned, and the caller should archive the task
  * instead, which routes through the normal teardown path. `id` is validated
- * as a plain directory name (no `/`, `\`, `..`, or empty string) so the
- * resolved path can never escape `WORKTREES_DIR`.
+ * via `resolveWorktreeDir` so the resolved path can never escape
+ * `WORKTREES_DIR`.
  *
  * Awaits `pendingTeardown(id)` before touching the directory — the fleet
  * invariant every worktree-touching path follows, in case a stale teardown
@@ -2130,17 +2155,10 @@ export function listWorktrees(): WorktreeInfo[] {
  * enumerate-and-kill of `agetor-*` sessions on the shared tmux socket.
  */
 export async function deleteOrphanWorktree(id: string): Promise<{ ok: true } | { error: string }> {
-  if (!id || id.includes("/") || id.includes("\\") || id.includes("..")) {
-    return { error: "invalid worktree id" };
-  }
-  const dirPath = join(WORKTREES_DIR, id);
-  // Confinement backstop: the resolved path must be a direct child of
-  // WORKTREES_DIR, never the directory itself. Guards against ids like `"."`
-  // that pass the checks above but normalize to WORKTREES_DIR — deleting it
-  // would `rm -rf` every task's worktree.
-  if (basename(dirPath) !== id) {
-    return { error: "invalid worktree id" };
-  }
+  const resolved = resolveWorktreeDir(id);
+  if ("error" in resolved) return resolved;
+  const dirPath = resolved.dir;
+
   let isDir = false;
   try {
     isDir = statSync(dirPath).isDirectory();
@@ -2158,15 +2176,65 @@ export async function deleteOrphanWorktree(id: string): Promise<{ ok: true } | {
   // its stale `.git/worktrees/<id>` registration afterwards.
   const sourceRoot = parseWorktreeGitPointer(dirPath);
 
-  try {
-    await rm(dirPath, { recursive: true, force: true });
-  } catch (err) {
-    return { error: `failed to remove worktree directory: ${err instanceof Error ? err.message : String(err)}` };
+  // Run the rm + prune on the source repo's teardown FIFO (keyed by
+  // sourceRoot, same as archiveTask/deleteTask's teardown) so an orphan
+  // cleanup can't contend on git's `.git/worktrees/.lock` with a concurrent
+  // same-repo archive/delete teardown. `enqueueTeardown` swallows job errors
+  // — a single misbehaving teardown must not break the chain for every task
+  // queued behind it — so the closure-captured `result` is how we still
+  // surface a failed rm to the caller after the await. When the source repo
+  // can't be determined, key by `dirPath` instead: there's no shared lock
+  // domain to serialize against, so this degrades to a private one-entry
+  // chain, behaviorally the same as running it inline.
+  let result: { ok: true } | { error: string } = { ok: true };
+  await enqueueTeardown(id, sourceRoot ?? dirPath, async () => {
+    try {
+      await rm(dirPath, { recursive: true, force: true });
+    } catch (err) {
+      result = { error: `failed to remove worktree directory: ${err instanceof Error ? err.message : String(err)}` };
+      return; // don't prune if the removal failed
+    }
+    if (sourceRoot) await pruneWorktrees(sourceRoot);
+  });
+
+  return result;
+}
+
+/**
+ * On-demand live git status for a single worktree — dirty / ahead / merged —
+ * composing `hasUncommittedChanges`, `getAheadCount`, and
+ * `isMergedIntoDefaultBranch`. Deliberately not part of `listWorktrees` (fs +
+ * DB only, safe to poll): each of these spawns a git subprocess, so this is
+ * fetched per row on demand instead. Backs `GET /worktrees/:id/git-status`.
+ *
+ * Shares `resolveWorktreeDir`'s confinement with `deleteOrphanWorktree`, but
+ * — unlike delete — does not refuse task-owned ids: git status is useful for
+ * both orphan and task-backed worktrees, so callers can check staleness
+ * before deciding whether to archive.
+ *
+ * For a task-backed id, resolves the live worktree dir + pinned base ref
+ * from the task row (`worktreePath ?? workdir`, `baseRef`). For an orphan id
+ * (no task row), uses the `WORKTREES_DIR/id` path directly with no base ref
+ * — `getAheadCount` degrades to its unknown-but-not-blocking `0` in that
+ * case, same contract as everywhere else `baseRef` may be null.
+ */
+export async function worktreeGitStatus(id: string): Promise<WorktreeGitStatus | { error: string }> {
+  const resolved = resolveWorktreeDir(id);
+  if ("error" in resolved) return resolved;
+
+  const task = tasks.get(id);
+  const dir = task ? task.worktreePath ?? task.workdir : resolved.dir;
+  const baseRef = task ? task.baseRef ?? null : null;
+
+  const dirty0 = await hasUncommittedChanges(dir);
+  if (dirty0 === null) {
+    return { dirty: false, ahead: 0, merged: null, ignored: true };
   }
 
-  if (sourceRoot) {
-    await pruneWorktrees(sourceRoot);
-  }
+  const [aheadResult, merged] = await Promise.all([
+    getAheadCount(dir, baseRef),
+    isMergedIntoDefaultBranch(dir),
+  ]);
 
-  return { ok: true };
+  return { dirty: dirty0, ahead: aheadResult ?? 0, merged, ignored: false };
 }

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -2186,6 +2186,15 @@ export async function deleteOrphanWorktree(id: string): Promise<{ ok: true } | {
   // can't be determined, key by `dirPath` instead: there's no shared lock
   // domain to serialize against, so this degrades to a private one-entry
   // chain, behaviorally the same as running it inline.
+  //
+  // Caveat: archive/delete key their chains by the raw `task.workdir` string,
+  // whereas `sourceRoot` here is the realpath'd repo root git wrote into the
+  // `.git` pointer. If those aren't byte-identical (trailing slash, a symlinked
+  // path, or a workdir that's a repo *subdir*), the orphan prune lands on a
+  // different FIFO and could still race that repo's `.git/worktrees/.lock` —
+  // the same best-effort limitation `teardownTails` already documents. Harmless
+  // (a lost lock just skips one prune; the next worktree op in that repo clears
+  // the stale registration), so not worth resolving the root to reconcile keys.
   let result: { ok: true } | { error: string } = { ok: true };
   await enqueueTeardown(id, sourceRoot ?? dirPath, async () => {
     try {

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
-import { basename } from "node:path";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { basename, join } from "node:path";
 import { db, tasks, runs, harnesses, projects, subagents } from "./db.ts";
 import { spawnAgent, toClaudeModelArg } from "./agents.ts";
 import { checkHarness } from "./agent-status.ts";
@@ -72,7 +73,18 @@ import {
   orphanRunningSubagents,
   attachSubagentWatcher,
 } from "./claude-subagents.ts";
-import { prepareWorkdir, removeWorktree, detachWorktree, repoRoot, resolveRef, branchName, ensureUniqueBranch } from "./worktree.ts";
+import {
+  prepareWorkdir,
+  removeWorktree,
+  detachWorktree,
+  repoRoot,
+  resolveRef,
+  branchName,
+  ensureUniqueBranch,
+  WORKTREES_DIR,
+  parseWorktreeGitPointer,
+  pruneWorktrees,
+} from "./worktree.ts";
 import { killTerminalsForTask } from "./terminals.ts";
 import { ensureInstalledForCwd } from "./hook-installer.ts";
 import type {
@@ -81,7 +93,10 @@ import type {
   RunEvent,
   RunStatus,
   Task,
+  WorktreeInfo,
+  WorktreeStaleReason,
 } from "../shared/types.ts";
+import { WORKTREE_STALE_AFTER_MS } from "../shared/types.ts";
 import { appendReferences } from "../shared/refs.ts";
 
 type Listener = (e: RunEvent) => void;
@@ -1849,12 +1864,19 @@ export async function createTask(
  * conversation right where it left off.
  *
  * Only allowed when the task is in the `done` column — archive is the
- * terminal step of the explicit review → done → archive flow.
+ * terminal step of the explicit review → done → archive flow. Pass
+ * `{ force: true }` to bypass ONLY that column gate (e.g. the Worktrees page's
+ * delete action, which archives a stale worktree's task regardless of where
+ * it sits on the board) — the active-run rejection, `archivedAt` stamping,
+ * and deferred teardown below are unchanged either way.
  */
-export async function archiveTask(taskId: string): Promise<{ task: Task } | { error: string }> {
+export async function archiveTask(
+  taskId: string,
+  opts?: { force?: boolean },
+): Promise<{ task: Task } | { error: string }> {
   const task = tasks.get(taskId);
   if (!task) return { error: "task not found" };
-  if (task.column !== "done") {
+  if (task.column !== "done" && !opts?.force) {
     return { error: "only tasks in Done can be archived" };
   }
   // Defence-in-depth: column='done' should imply no live run, but column is
@@ -2015,4 +2037,125 @@ export function sweepArchivedTeardowns(): number {
     enqueued++;
   }
   return enqueued;
+}
+
+/**
+ * Enumerate every git worktree materialized on disk under `WORKTREES_DIR` and
+ * cross-reference it against `tasks.list()` (the directory basename equals
+ * the owning task's id by construction — see `worktreePath` in worktree.ts).
+ * Backs `GET /worktrees`.
+ *
+ * Deliberately fs + DB only — no git subprocesses — so this stays cheap
+ * enough to poll. Staleness is classified per `WorktreeStaleReason`:
+ *  - `"orphaned"` — no task row for the dir (crash/failed teardown leftover).
+ *  - `"archived"` — the owning task is archived but the dir is still present
+ *    (teardown pending, failed, or skipped because the worktree was dirty).
+ *  - `"inactive"` — not archived, no run in flight, and the task hasn't been
+ *    touched in over `WORKTREE_STALE_AFTER_MS`.
+ *
+ * Returns `[]` when `WORKTREES_DIR` doesn't exist yet (no worktree has ever
+ * been created). Non-directory entries and dotfiles are skipped.
+ */
+export function listWorktrees(): WorktreeInfo[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(WORKTREES_DIR);
+  } catch {
+    return [];
+  }
+  const taskById = new Map(tasks.list().map((t) => [t.id, t]));
+  const out: WorktreeInfo[] = [];
+  for (const name of entries) {
+    if (name.startsWith(".")) continue;
+    const dirPath = join(WORKTREES_DIR, name);
+    let isDir = false;
+    try {
+      isDir = statSync(dirPath).isDirectory();
+    } catch {
+      continue; // vanished between readdir and stat — skip rather than error
+    }
+    if (!isDir) continue;
+
+    const task = taskById.get(name);
+    const staleReasons: WorktreeStaleReason[] = [];
+    // Same active-run check archiveTask uses for its defence-in-depth guard.
+    const runActive = !!(task?.runId && active.has(task.runId));
+    if (!task) {
+      staleReasons.push("orphaned");
+    } else if (task.archivedAt != null) {
+      staleReasons.push("archived");
+    } else if (!runActive && Date.now() - task.updatedAt > WORKTREE_STALE_AFTER_MS) {
+      staleReasons.push("inactive");
+    }
+
+    out.push({
+      id: name,
+      path: dirPath,
+      taskId: task?.id ?? null,
+      taskTitle: task?.title ?? null,
+      column: task?.column ?? null,
+      archivedAt: task?.archivedAt ?? null,
+      taskUpdatedAt: task?.updatedAt ?? null,
+      branch: task?.branch ?? null,
+      // Owned worktree: the task's own workdir. Orphan: best-effort parse of
+      // the `.git` pointer file — plain fs, no git subprocess.
+      workdir: task?.workdir ?? parseWorktreeGitPointer(dirPath),
+      runActive,
+      stale: staleReasons.length > 0,
+      staleReasons,
+    });
+  }
+  return out;
+}
+
+/**
+ * Delete an orphaned worktree directory — one with no owning task row, so
+ * there's no ticket for `archiveTask` to archive. Used by the Worktrees
+ * page's delete action for `WorktreeInfo` rows where `taskId` is null.
+ *
+ * Refuses (rather than silently no-oping) when a task row for `id` still
+ * exists — that worktree is owned, and the caller should archive the task
+ * instead, which routes through the normal teardown path. `id` is validated
+ * as a plain directory name (no `/`, `\`, `..`, or empty string) so the
+ * resolved path can never escape `WORKTREES_DIR`.
+ *
+ * Awaits `pendingTeardown(id)` before touching the directory — the fleet
+ * invariant every worktree-touching path follows, in case a stale teardown
+ * from a task that used to own this id is still draining. Never kills any
+ * tmux session: an orphan has no owning task, and the fleet rule forbids
+ * enumerate-and-kill of `agetor-*` sessions on the shared tmux socket.
+ */
+export async function deleteOrphanWorktree(id: string): Promise<{ ok: true } | { error: string }> {
+  if (!id || id.includes("/") || id.includes("\\") || id.includes("..")) {
+    return { error: "invalid worktree id" };
+  }
+  const dirPath = join(WORKTREES_DIR, id);
+  let isDir = false;
+  try {
+    isDir = statSync(dirPath).isDirectory();
+  } catch {
+    return { error: "worktree not found" };
+  }
+  if (!isDir) return { error: "worktree not found" };
+  if (tasks.get(id)) {
+    return { error: "this worktree is owned by an active task — archive the task instead" };
+  }
+
+  await pendingTeardown(id);
+
+  // Best-effort: find the source repo before the dir is gone so we can prune
+  // its stale `.git/worktrees/<id>` registration afterwards.
+  const sourceRoot = parseWorktreeGitPointer(dirPath);
+
+  try {
+    await rm(dirPath, { recursive: true, force: true });
+  } catch (err) {
+    return { error: `failed to remove worktree directory: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  if (sourceRoot) {
+    await pruneWorktrees(sourceRoot);
+  }
+
+  return { ok: true };
 }

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -2081,11 +2081,15 @@ export function listWorktrees(): WorktreeInfo[] {
     // Same active-run check archiveTask uses for its defence-in-depth guard.
     const runActive = !!(task?.runId && active.has(task.runId));
     if (!task) {
+      // No owning row — nothing else applies (can't be archived or idle-by-age).
       staleReasons.push("orphaned");
-    } else if (task.archivedAt != null) {
-      staleReasons.push("archived");
-    } else if (!runActive && Date.now() - task.updatedAt > WORKTREE_STALE_AFTER_MS) {
-      staleReasons.push("inactive");
+    } else {
+      // A worktree can carry both reasons at once (archived AND past the
+      // inactivity threshold), so these are independent checks, not a chain.
+      if (task.archivedAt != null) staleReasons.push("archived");
+      if (!runActive && Date.now() - task.updatedAt > WORKTREE_STALE_AFTER_MS) {
+        staleReasons.push("inactive");
+      }
     }
 
     out.push({
@@ -2130,6 +2134,13 @@ export async function deleteOrphanWorktree(id: string): Promise<{ ok: true } | {
     return { error: "invalid worktree id" };
   }
   const dirPath = join(WORKTREES_DIR, id);
+  // Confinement backstop: the resolved path must be a direct child of
+  // WORKTREES_DIR, never the directory itself. Guards against ids like `"."`
+  // that pass the checks above but normalize to WORKTREES_DIR — deleting it
+  // would `rm -rf` every task's worktree.
+  if (basename(dirPath) !== id) {
+    return { error: "invalid worktree id" };
+  }
   let isDir = false;
   try {
     isDir = statSync(dirPath).isDirectory();

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -17,7 +17,7 @@ import {
   HarnessInUseError,
   dataDir,
 } from "./db.ts";
-import { archiveTask, createTask, deleteTask, startTask, cancelRun, reconcileTaskSession, sendInput, subscribe, subscribeGlobal, unarchiveTask } from "./orchestrator.ts";
+import { archiveTask, createTask, deleteOrphanWorktree, deleteTask, listWorktrees, startTask, cancelRun, reconcileTaskSession, sendInput, subscribe, subscribeGlobal, unarchiveTask } from "./orchestrator.ts";
 import { checkAllHarnesses } from "./agent-status.ts";
 import { listGitHubTokens, setGitHubToken, deleteGitHubToken } from "./github-tokens.ts";
 import {
@@ -3118,7 +3118,11 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       "/tasks/:id/archive": {
         POST: authed(async (req) => {
           server.timeout(req, 0);
-          const result = await archiveTask(req.params.id);
+          // Optional body — no body (or a malformed one) means force: false,
+          // same as the pre-existing behaviour. Only used by the Worktrees
+          // page's delete action to bypass the done-column gate.
+          const body = (await req.json().catch(() => ({}))) as { force?: boolean };
+          const result = await archiveTask(req.params.id, { force: body.force === true });
           return "error" in result
             ? json(result, { status: 400, headers: corsHeaders(req) })
             : json(withRunningSubagents(result.task), { headers: corsHeaders(req) });
@@ -3132,6 +3136,27 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           return "error" in result
             ? json(result, { status: 400, headers: corsHeaders(req) })
             : json(withRunningSubagents(result.task), { headers: corsHeaders(req) });
+        }),
+      },
+
+      // Every agetor-managed git worktree materialized on disk, with staleness
+      // classification — backs the Worktrees list page.
+      "/worktrees": {
+        GET: authed((req) => json(listWorktrees(), { headers: corsHeaders(req) })),
+      },
+
+      // Delete an orphaned worktree directory (no owning task row — see
+      // `deleteOrphanWorktree`). A worktree still owned by a task is deleted
+      // by archiving the task instead (`POST /tasks/:id/archive`).
+      "/worktrees/:id": {
+        DELETE: authed(async (req) => {
+          // Same rationale as DELETE /tasks/:id — `rm -rf` over a large
+          // worktree can exceed the idle timeout.
+          server.timeout(req, 0);
+          const result = await deleteOrphanWorktree(req.params.id);
+          return "error" in result
+            ? json(result, { status: 400, headers: corsHeaders(req) })
+            : new Response(null, { status: 204, headers: corsHeaders(req) });
         }),
       },
 

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -17,7 +17,7 @@ import {
   HarnessInUseError,
   dataDir,
 } from "./db.ts";
-import { archiveTask, createTask, deleteOrphanWorktree, deleteTask, listWorktrees, startTask, cancelRun, reconcileTaskSession, sendInput, subscribe, subscribeGlobal, unarchiveTask } from "./orchestrator.ts";
+import { archiveTask, createTask, deleteOrphanWorktree, deleteTask, listWorktrees, startTask, cancelRun, reconcileTaskSession, sendInput, subscribe, subscribeGlobal, unarchiveTask, worktreeGitStatus } from "./orchestrator.ts";
 import { checkAllHarnesses } from "./agent-status.ts";
 import { listGitHubTokens, setGitHubToken, deleteGitHubToken } from "./github-tokens.ts";
 import {
@@ -3157,6 +3157,18 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           return "error" in result
             ? json(result, { status: 400, headers: corsHeaders(req) })
             : new Response(null, { status: 204, headers: corsHeaders(req) });
+        }),
+      },
+
+      // On-demand live git status (dirty/ahead/merged) for a single worktree
+      // — task-backed or orphaned. Deliberately not part of `GET /worktrees`:
+      // each field spawns a git subprocess, so it's fetched per row rather
+      // than on every poll of the bulk list.
+      "/worktrees/:id/git-status": {
+        GET: authed(async (req) => {
+          const res = await worktreeGitStatus(req.params.id);
+          if ("error" in res) return json(res, { status: 400, headers: corsHeaders(req) });
+          return json(res, { headers: corsHeaders(req) });
         }),
       },
 

--- a/src/bun/worktree-git-status.test.ts
+++ b/src/bun/worktree-git-status.test.ts
@@ -1,0 +1,279 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+// Top-level: db.ts captures AGETOR_DATA_DIR at first import — `beforeAll`
+// would race with any sibling test file that already imported db.ts.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-test-"));
+// Drive claude through an in-process fake instead of tmux + the real CLI.
+// AGETOR_CLAUDE_BIN is also overridden so the agent-status preflight inside
+// startTask passes without claude installed.
+process.env.AGETOR_CLAUDE_DRIVER = "fake";
+process.env.AGETOR_CLAUDE_BIN = "/bin/echo";
+process.env.AGETOR_TMUX_BIN = "/bin/echo"; // tmux probe in agent-status passes
+process.env.AGETOR_CLAUDE_ARGS = "";
+
+// Standalone helper: run git in a directory (mirrors orchestrator.test.ts's
+// `git` helper — kept local here since this file owns no shared test util).
+async function git(args: string[], cwd: string) {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+}
+
+// Standalone helper: a real temp git repo (default branch `main`) for
+// worktree-isolation tests. Never point a task at a real repo in these tests
+// — always mkdtemp (see worktree isolation warning in CLAUDE.md).
+async function makeRepo(): Promise<string> {
+  const repo = mkdtempSync(path.join(tmpdir(), "agetor-worktree-git-status-repo-"));
+  await git(["init", "-b", "main"], repo);
+  await git(["config", "user.email", "test@example.com"], repo);
+  await git(["config", "user.name", "test"], repo);
+  writeFileSync(path.join(repo, "README"), "hi\n");
+  await git(["add", "."], repo);
+  await git(["commit", "-m", "init"], repo);
+  return repo;
+}
+
+// Local variant with a `master`-named default branch — proves the
+// main→master fallback in isMergedIntoDefaultBranch works. The sibling
+// makeRepo() helpers in worktrees-list.test.ts / orchestrator-archive-
+// teardown.test.ts always use `-b main`.
+async function makeMasterRepo(): Promise<string> {
+  const repo = mkdtempSync(path.join(tmpdir(), "agetor-worktree-git-status-master-repo-"));
+  await git(["init", "-b", "master"], repo);
+  await git(["config", "user.email", "test@example.com"], repo);
+  await git(["config", "user.name", "test"], repo);
+  writeFileSync(path.join(repo, "README"), "hi\n");
+  await git(["add", "."], repo);
+  await git(["commit", "-m", "init"], repo);
+  return repo;
+}
+
+// Materialize a real worktree-isolated task and return its prepared paths.
+async function makeWorktreeTask(repo: string, title: string) {
+  const { createTask } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { tasks } = await import("./db.ts");
+
+  const created = await createTask({
+    title,
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  const prepared = await prepareWorkdir(created.task);
+  if ("error" in prepared) throw new Error(prepared.error);
+  tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+
+  return { taskId, worktreePath: prepared.worktreePath!, branch: prepared.branch! };
+}
+
+test("isMergedIntoDefaultBranch: fresh worktree at main's tip is merged", async () => {
+  const { isMergedIntoDefaultBranch } = await import("./worktree.ts");
+  const { db } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const { taskId, worktreePath } = await makeWorktreeTask(repo, "merged fresh worktree");
+
+  try {
+    expect(await isMergedIntoDefaultBranch(worktreePath)).toBe(true);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("isMergedIntoDefaultBranch: worktree branch with a new commit is not merged", async () => {
+  const { isMergedIntoDefaultBranch } = await import("./worktree.ts");
+  const { db } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const { taskId, worktreePath } = await makeWorktreeTask(repo, "diverged worktree");
+
+  try {
+    writeFileSync(path.join(worktreePath, "new-file.txt"), "hello\n");
+    await git(["add", "."], worktreePath);
+    await git(["commit", "-m", "worktree-only commit"], worktreePath);
+
+    expect(await isMergedIntoDefaultBranch(worktreePath)).toBe(false);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("isMergedIntoDefaultBranch: master-named default branch (no main) still resolves", async () => {
+  const { isMergedIntoDefaultBranch } = await import("./worktree.ts");
+  const { db } = await import("./db.ts");
+
+  const repo = await makeMasterRepo();
+  const { taskId, worktreePath } = await makeWorktreeTask(repo, "master default worktree");
+
+  try {
+    const result = await isMergedIntoDefaultBranch(worktreePath);
+    // Proves the main→master fallback works — a fresh worktree off master's
+    // tip must resolve to a real boolean, never null (which would mean the
+    // default-branch resolution failed to find `master`).
+    expect(result).not.toBeNull();
+    expect(typeof result).toBe("boolean");
+    expect(result).toBe(true);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("isMergedIntoDefaultBranch: non-repo dir returns null", async () => {
+  const { isMergedIntoDefaultBranch } = await import("./worktree.ts");
+
+  const plainDir = mkdtempSync(path.join(tmpdir(), "agetor-worktree-git-status-nonrepo-"));
+  try {
+    expect(await isMergedIntoDefaultBranch(plainDir)).toBeNull();
+
+    const missingDir = path.join(plainDir, "does-not-exist");
+    expect(await isMergedIntoDefaultBranch(missingDir)).toBeNull();
+  } finally {
+    rmSync(plainDir, { recursive: true, force: true });
+  }
+});
+
+test("worktreeGitStatus: clean task-backed worktree reports dirty=false, merged=true, not an error", async () => {
+  const { worktreeGitStatus } = await import("./orchestrator.ts");
+  const { db } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const { taskId } = await makeWorktreeTask(repo, "clean status worktree");
+
+  try {
+    const status = await worktreeGitStatus(taskId);
+    expect("error" in status).toBe(false);
+    if ("error" in status) throw new Error(status.error);
+
+    expect(status.ignored).toBe(false);
+    expect(status.dirty).toBe(false);
+    expect(status.merged).toBe(true);
+    expect(typeof status.ahead).toBe("number");
+    expect(status.ahead).toBeGreaterThanOrEqual(0);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("worktreeGitStatus: dirty worktree (untracked file) reports dirty=true", async () => {
+  const { worktreeGitStatus } = await import("./orchestrator.ts");
+  const { db } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const { taskId, worktreePath } = await makeWorktreeTask(repo, "dirty status worktree");
+
+  try {
+    writeFileSync(path.join(worktreePath, "untracked.txt"), "scratch\n");
+
+    const status = await worktreeGitStatus(taskId);
+    expect("error" in status).toBe(false);
+    if ("error" in status) throw new Error(status.error);
+
+    expect(status.dirty).toBe(true);
+    expect(status.ignored).toBe(false);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("worktreeGitStatus: orphan dir (task row deleted, dir left behind) still resolves via WORKTREES_DIR/id", async () => {
+  const { worktreeGitStatus } = await import("./orchestrator.ts");
+  const { db } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const { taskId, worktreePath } = await makeWorktreeTask(repo, "orphaned status worktree");
+
+  // Remove only the task row — leave the on-disk worktree (with its intact
+  // `.git` pointer) behind, simulating an orphan whose owning task vanished
+  // without teardown ever running.
+  db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+
+  try {
+    expect(existsSync(worktreePath)).toBe(true);
+
+    const status = await worktreeGitStatus(taskId);
+    expect("error" in status).toBe(false);
+    if ("error" in status) throw new Error(status.error);
+
+    expect(status.ignored).toBe(false);
+    expect(status.merged === null || typeof status.merged === "boolean").toBe(true);
+    expect(status.merged).not.toBeUndefined();
+  } finally {
+    rmSync(worktreePath, { recursive: true, force: true });
+  }
+});
+
+test("worktreeGitStatus + deleteOrphanWorktree: \".\" and \"..\" are refused, WORKTREES_DIR confinement holds", async () => {
+  const { worktreeGitStatus, deleteOrphanWorktree } = await import("./orchestrator.ts");
+  const { WORKTREES_DIR } = await import("./worktree.ts");
+
+  // Sentinel dir under WORKTREES_DIR — the regression guard: if "." ever
+  // resolved to WORKTREES_DIR itself, an rm -rf there would take every
+  // task's worktree (including this sentinel) with it.
+  const sentinelId = `sentinel-${randomUUID()}`;
+  const sentinelDir = path.join(WORKTREES_DIR, sentinelId);
+  mkdirSync(sentinelDir, { recursive: true });
+
+  try {
+    const statusDot = await worktreeGitStatus(".");
+    expect("error" in statusDot).toBe(true);
+
+    const deleteDot = await deleteOrphanWorktree(".");
+    expect("error" in deleteDot).toBe(true);
+
+    const statusDotDot = await worktreeGitStatus("..");
+    expect("error" in statusDotDot).toBe(true);
+
+    expect(existsSync(sentinelDir)).toBe(true);
+    expect(existsSync(WORKTREES_DIR)).toBe(true);
+  } finally {
+    rmSync(sentinelDir, { recursive: true, force: true });
+  }
+});
+
+test("deleteOrphanWorktree still works with the queued prune", async () => {
+  const { deleteOrphanWorktree } = await import("./orchestrator.ts");
+  const { WORKTREES_DIR } = await import("./worktree.ts");
+
+  const orphanId = `orphan-${randomUUID()}`;
+  const orphanDir = path.join(WORKTREES_DIR, orphanId);
+  mkdirSync(orphanDir, { recursive: true });
+  expect(existsSync(orphanDir)).toBe(true);
+
+  const result = await deleteOrphanWorktree(orphanId);
+  expect(result).toEqual({ ok: true });
+  expect(existsSync(orphanDir)).toBe(false);
+});
+
+test("deleteOrphanWorktree: two back-to-back orphan deletes in the same source repo both settle", async () => {
+  const { deleteOrphanWorktree } = await import("./orchestrator.ts");
+  const { WORKTREES_DIR } = await import("./worktree.ts");
+
+  const repo = await makeRepo();
+
+  // Two throwaway `git worktree add`s off the same source repo, each with no
+  // owning task row — genuine orphans sharing one source-repo FIFO chain.
+  const idA = `orphan-${randomUUID()}`;
+  const idB = `orphan-${randomUUID()}`;
+  const dirA = path.join(WORKTREES_DIR, idA);
+  const dirB = path.join(WORKTREES_DIR, idB);
+
+  await git(["worktree", "add", "-b", `orphan-branch-${idA}`, dirA, "HEAD"], repo);
+  await git(["worktree", "add", "-b", `orphan-branch-${idB}`, dirB, "HEAD"], repo);
+  expect(existsSync(dirA)).toBe(true);
+  expect(existsSync(dirB)).toBe(true);
+
+  const [resultA, resultB] = await Promise.all([deleteOrphanWorktree(idA), deleteOrphanWorktree(idB)]);
+
+  expect(resultA).toEqual({ ok: true });
+  expect(resultB).toEqual({ ok: true });
+  expect(existsSync(dirA)).toBe(false);
+  expect(existsSync(dirB)).toBe(false);
+});

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, realpathSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
@@ -9,7 +9,7 @@ import type { BranchInfo, Task, TaskDiff } from "../shared/types.ts";
 
 export type { BranchInfo };
 
-const WORKTREES_DIR = path.join(dataDir, "worktrees");
+export const WORKTREES_DIR = path.join(dataDir, "worktrees");
 
 interface GitResult {
   ok: boolean;
@@ -506,6 +506,33 @@ export function worktreePath(task: Task): string {
   return path.join(WORKTREES_DIR, task.id);
 }
 
+/**
+ * Best-effort parse of a linked worktree's `.git` file — for a worktree
+ * (unlike an ordinary checkout) `.git` is a *file* containing a single line
+ * `gitdir: <repo>/.git/worktrees/<id>`, pointing back at the source repo's
+ * common dir. Used for orphaned worktree dirs (no task row to read `workdir`
+ * from) so the worktrees list can still show which repo they came from.
+ *
+ * Plain fs only — no git subprocess. Returns null when `.git` is missing,
+ * isn't a pointer file, or the path doesn't match the expected
+ * `.git/worktrees/<id>` shape.
+ */
+export function parseWorktreeGitPointer(worktreeDir: string): string | null {
+  try {
+    const gitFile = path.join(worktreeDir, ".git");
+    const contents = readFileSync(gitFile, "utf8").trim();
+    const match = /^gitdir:\s*(.+)$/.exec(contents);
+    if (!match) return null;
+    const gitdir = match[1]!;
+    const marker = `${path.sep}.git${path.sep}worktrees${path.sep}`;
+    const idx = gitdir.indexOf(marker);
+    if (idx < 0) return null;
+    return gitdir.slice(0, idx);
+  } catch {
+    return null;
+  }
+}
+
 export interface PreparedWorkdir {
   /** Where the agent should actually `spawn` from. */
   cwd: string;
@@ -775,6 +802,17 @@ export async function removeWorktree(task: Task): Promise<void> {
     try { await rm(task.worktreePath, { recursive: true, force: true }); }
     catch { /* best-effort */ }
   }
+}
+
+/**
+ * Best-effort `git worktree prune` in `root` — clears the stale
+ * `.git/worktrees/<id>` registration left behind after a worktree directory
+ * is removed outside of `git worktree remove` (e.g. `deleteOrphanWorktree`,
+ * which `rm -rf`s an orphaned dir with no task row to drive a proper
+ * removal). Never throws.
+ */
+export async function pruneWorktrees(root: string): Promise<void> {
+  await git(["worktree", "prune"], root, 10_000);
 }
 
 /**

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -114,6 +114,60 @@ export async function getAheadCount(dir: string, baseRef: string | null): Promis
   return 0;
 }
 
+/**
+ * Whether `dir`'s HEAD has already landed on the source repo's default
+ * branch — i.e. is an ancestor of it, so the worktree's work is safe to
+ * throw away. `null` means "couldn't determine" and must never be presented
+ * as merged; callers should treat it as unknown, same contract as
+ * `hasUncommittedChanges`/`getAheadCount`.
+ *
+ * Default branch resolution, most to least authoritative:
+ *
+ * 1. `git rev-parse --abbrev-ref origin/HEAD` — the remote's advertised
+ *    default (e.g. resolves to `origin/main`). Used verbatim when it
+ *    succeeds and isn't the literal unresolved `origin/HEAD` (that string
+ *    comes back when the symbolic ref exists but doesn't point anywhere
+ *    useful, e.g. no remote configured).
+ * 2. No `origin/HEAD` — try local `main`, then `master`, via
+ *    `git show-ref --verify --quiet refs/heads/<b>` (exit 0 = branch exists).
+ * 3. Neither resolves: return `null` rather than guessing.
+ *
+ * Once a default branch candidate is picked, `git merge-base --is-ancestor
+ * HEAD <default>` maps exit code 0 → `true` (HEAD is an ancestor, i.e.
+ * merged), exit code 1 → `false` (diverged/not merged), and any other exit
+ * code (git error) → `null`.
+ *
+ * Runs with `cwd` = `dir`; a linked worktree shares the source repo's refs
+ * via its common git dir, so this resolves correctly without needing the
+ * source repo's own path.
+ */
+export async function isMergedIntoDefaultBranch(dir: string): Promise<boolean | null> {
+  if (!existsSync(dir)) return null;
+  if (!(await isGitRepo(dir))) return null;
+
+  let defaultBranch: string | null = null;
+
+  const originHead = await git(["rev-parse", "--abbrev-ref", "origin/HEAD"], dir);
+  if (originHead.ok && originHead.stdout.length > 0 && originHead.stdout !== "origin/HEAD") {
+    defaultBranch = originHead.stdout;
+  } else {
+    for (const candidate of ["main", "master"]) {
+      const ref = await git(["show-ref", "--verify", "--quiet", `refs/heads/${candidate}`], dir);
+      if (ref.ok) {
+        defaultBranch = candidate;
+        break;
+      }
+    }
+  }
+
+  if (!defaultBranch || defaultBranch.startsWith("-")) return null;
+
+  const res = await git(["merge-base", "--is-ancestor", "HEAD", defaultBranch], dir);
+  if (res.exitCode === 0) return true;
+  if (res.exitCode === 1) return false;
+  return null;
+}
+
 // A directory's git top-level is stable for the lifetime of the process, so
 // resolved roots are memoized — discovery (/agent-discovery) resolves the same
 // workdir on every refresh and would otherwise spawn a `git rev-parse` for

--- a/src/bun/worktrees-list.test.ts
+++ b/src/bun/worktrees-list.test.ts
@@ -1,0 +1,335 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+// Top-level: db.ts captures AGETOR_DATA_DIR at first import — `beforeAll`
+// would race with any sibling test file that already imported db.ts.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-test-"));
+// Drive claude through an in-process fake instead of tmux + the real CLI.
+// AGETOR_CLAUDE_BIN is also overridden so the agent-status preflight inside
+// startTask passes without claude installed.
+process.env.AGETOR_CLAUDE_DRIVER = "fake";
+process.env.AGETOR_CLAUDE_BIN = "/bin/echo";
+process.env.AGETOR_TMUX_BIN = "/bin/echo"; // tmux probe in agent-status passes
+process.env.AGETOR_CLAUDE_ARGS = "";
+
+// Standalone helper: run git in a directory (mirrors orchestrator.test.ts's
+// `git` helper — kept local here since this file owns no shared test util).
+async function git(args: string[], cwd: string) {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+}
+
+// Standalone helper: a real temp git repo for worktree-isolation tests. Never
+// point a task at a real repo in these tests — always mkdtemp (see worktree
+// isolation warning in CLAUDE.md).
+async function makeRepo(): Promise<string> {
+  const repo = mkdtempSync(path.join(tmpdir(), "agetor-worktrees-list-repo-"));
+  await git(["init", "-b", "main"], repo);
+  await git(["config", "user.email", "test@example.com"], repo);
+  await git(["config", "user.name", "test"], repo);
+  writeFileSync(path.join(repo, "README"), "hi\n");
+  await git(["add", "."], repo);
+  await git(["commit", "-m", "init"], repo);
+  return repo;
+}
+
+test("listWorktrees classifies a linked worktree as fresh", async () => {
+  const { createTask, listWorktrees } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "fresh worktree",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+
+    const entries = listWorktrees();
+    const entry = entries.find((e) => e.id === taskId);
+    expect(entry).toBeDefined();
+    expect(entry?.taskId).toBe(taskId);
+    expect(entry?.taskTitle).toBe("fresh worktree");
+    expect(entry?.column).toBe(created.task.column);
+    expect(entry?.branch).toBe(prepared.branch);
+    expect(entry?.workdir).toBe(repo);
+    expect(entry?.stale).toBe(false);
+    expect(entry?.staleReasons).toEqual([]);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("listWorktrees flags an archived worktree as stale \"archived\"", async () => {
+  const { createTask, listWorktrees } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "archived worktree",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    // Stamp archivedAt directly (bypassing archiveTask, and therefore its
+    // deferred teardown) so the dir is guaranteed still present when
+    // listWorktrees runs — avoids racing the real teardown job.
+    tasks.update(taskId, { archivedAt: Date.now() });
+    expect(existsSync(prepared.worktreePath!)).toBe(true);
+
+    const entries = listWorktrees();
+    const entry = entries.find((e) => e.id === taskId);
+    expect(entry).toBeDefined();
+    expect(entry?.stale).toBe(true);
+    expect(entry?.staleReasons).toContain("archived");
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("listWorktrees flags an idle worktree as \"inactive\"", async () => {
+  const { createTask, listWorktrees } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+  const { WORKTREE_STALE_AFTER_MS } = await import("../shared/types.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "inactive worktree",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+
+    // Confirm the not-archived, no-run precondition holds before pushing
+    // updatedAt back in time.
+    const before = tasks.get(taskId);
+    expect(before?.archivedAt).toBeNull();
+    expect(before?.runId).toBeNull();
+
+    // tasks.update() force-overwrites updatedAt to Date.now() on every call
+    // (see db.ts), so we can't set an old updatedAt through it — write the
+    // row directly instead.
+    const oldTs = Date.now() - WORKTREE_STALE_AFTER_MS - 1000;
+    db.run(`UPDATE tasks SET updated_at = ? WHERE id = ?`, [oldTs, taskId]);
+
+    const entries = listWorktrees();
+    const entry = entries.find((e) => e.id === taskId);
+    expect(entry).toBeDefined();
+    expect(entry?.stale).toBe(true);
+    expect(entry?.staleReasons).toContain("inactive");
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("listWorktrees flags an orphan dir (no task row) as \"orphaned\"", async () => {
+  const { listWorktrees } = await import("./orchestrator.ts");
+  const { WORKTREES_DIR } = await import("./worktree.ts");
+  const { rmSync } = await import("node:fs");
+
+  const orphanId = `orphan-${randomUUID()}`;
+  const orphanDir = path.join(WORKTREES_DIR, orphanId);
+  mkdirSync(orphanDir, { recursive: true });
+
+  try {
+    const entries = listWorktrees();
+    const entry = entries.find((e) => e.id === orphanId);
+    expect(entry).toBeDefined();
+    expect(entry?.taskId).toBeNull();
+    expect(entry?.stale).toBe(true);
+    expect(entry?.staleReasons).toContain("orphaned");
+  } finally {
+    rmSync(orphanDir, { recursive: true, force: true });
+  }
+});
+
+test("archiveTask force bypasses the done-only column gate", async () => {
+  const { createTask, archiveTask, pendingTeardown } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "force archive from non-done",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "ready" });
+
+    const withoutForce = await archiveTask(taskId);
+    expect("error" in withoutForce).toBe(true);
+    if ("error" in withoutForce) {
+      expect(withoutForce.error).toMatch(/done/i);
+    }
+
+    const withForce = await archiveTask(taskId, { force: true });
+    expect("task" in withForce).toBe(true);
+    if (!("task" in withForce)) throw new Error(withForce.error);
+    expect(withForce.task.archivedAt).not.toBeNull();
+  } finally {
+    await pendingTeardown(taskId);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("archiveTask force still rejects an active run", async () => {
+  // The active-run guard in archiveTask runs unconditionally, before the
+  // `opts?.force` column-gate bypass is even consulted — force only waives
+  // the done-only column check, never the "don't kill tmux out from under a
+  // live run" defence. Verified here against a REAL in-flight run (via the
+  // fake claude driver), following the same timing-sensitive pattern
+  // orchestrator.test.ts uses ("sendInput folds a follow-up into the
+  // in-flight run..."): startTask must be immediately followed (no awaited
+  // work in between) by the assertion, before the fake driver's ~20ms `done`
+  // timer resolves the turn and removes the run from `active`.
+  const { createTask, startTask, archiveTask, pendingTeardown } = await import("./orchestrator.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "force vs active run",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const started = await startTask(taskId);
+    expect("runId" in started).toBe(true);
+    if (!("runId" in started)) throw new Error("expected the run to start");
+
+    // No await between startTask resolving and this call — the run must
+    // still be in `active` right now.
+    const rejected = await archiveTask(taskId, { force: true });
+    expect("error" in rejected).toBe(true);
+    if ("error" in rejected) {
+      expect(rejected.error).toMatch(/running/i);
+    }
+
+    // Let the fake turn resolve so the task settles before cleanup.
+    await new Promise((r) => setTimeout(r, 250));
+    expect(tasks.get(taskId)?.runId).toBeTruthy();
+  } finally {
+    await pendingTeardown(taskId);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("deleteOrphanWorktree happy path removes the directory", async () => {
+  const { deleteOrphanWorktree } = await import("./orchestrator.ts");
+  const { WORKTREES_DIR } = await import("./worktree.ts");
+
+  const orphanId = `orphan-${randomUUID()}`;
+  const orphanDir = path.join(WORKTREES_DIR, orphanId);
+  mkdirSync(orphanDir, { recursive: true });
+  expect(existsSync(orphanDir)).toBe(true);
+
+  const result = await deleteOrphanWorktree(orphanId);
+  expect(result).toEqual({ ok: true });
+  expect(existsSync(orphanDir)).toBe(false);
+});
+
+test("deleteOrphanWorktree refuses a live task id", async () => {
+  const { createTask, deleteTask, deleteOrphanWorktree } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "owned worktree",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+
+    const worktreePath = prepared.worktreePath!;
+    expect(existsSync(worktreePath)).toBe(true);
+
+    const result = await deleteOrphanWorktree(taskId);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toMatch(/archiv/i);
+    }
+    expect(existsSync(worktreePath)).toBe(true);
+  } finally {
+    // Normal task deletion path (not deleteOrphanWorktree) for cleanup.
+    await deleteTask(taskId);
+  }
+});
+
+test("deleteOrphanWorktree confines deletions to a direct child of WORKTREES_DIR", async () => {
+  const { deleteOrphanWorktree } = await import("./orchestrator.ts");
+  const { WORKTREES_DIR } = await import("./worktree.ts");
+  const { rmSync } = await import("node:fs");
+
+  // Sentinel dir under WORKTREES_DIR — this is what makes the "." case a
+  // meaningful regression guard: if deleteOrphanWorktree(".") ever resolved
+  // to WORKTREES_DIR itself and rm -rf'd it, this sentinel (and every other
+  // task's worktree) would vanish too.
+  const sentinelId = `sentinel-${randomUUID()}`;
+  const sentinelDir = path.join(WORKTREES_DIR, sentinelId);
+  mkdirSync(sentinelDir, { recursive: true });
+
+  try {
+    for (const badId of ["..", "a/b", ".", ""]) {
+      const result = await deleteOrphanWorktree(badId);
+      expect("error" in result).toBe(true);
+    }
+    expect(existsSync(sentinelDir)).toBe(true);
+    expect(existsSync(WORKTREES_DIR)).toBe(true);
+  } finally {
+    rmSync(sentinelDir, { recursive: true, force: true });
+  }
+});

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
-import { AlertTriangle, GitPullRequest, Settings, X } from "lucide-react";
+import { AlertTriangle, FolderGit2, GitPullRequest, Settings, X } from "lucide-react";
 import { api, type AgentModelMap } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { COLUMNS, type AgentStatus, type ColumnId, type GlobalEvent, type Harness, type Project, type Task, type TaskType } from "../shared/types.ts";
@@ -15,6 +15,7 @@ import { SettingsDialog } from "@/components/settings/SettingsDialog";
 import { TmuxInstallDialog } from "@/components/tmux/TmuxInstallDialog";
 import { TmuxMissingBanner, errorIsTmuxMissing, isTmuxMissing } from "@/components/tmux/TmuxMissingBanner";
 import { UpdateBanner } from "@/components/updater/UpdateBanner";
+import { WorktreesDialog } from "@/components/worktrees/WorktreesDialog";
 import type { UpdateSnapshot } from "@/lib/api";
 import { useConfirm } from "@/components/ui/confirm";
 import { toast } from "sonner";
@@ -88,6 +89,7 @@ export default function App() {
   const [typeFilter, setTypeFilter] = useState<TaskType[]>([]);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [githubOpen, setGithubOpen] = useState(false);
+  const [worktreesOpen, setWorktreesOpen] = useState(false);
   const [tmuxDialogOpen, setTmuxDialogOpen] = useState(false);
   const [updateSnapshot, setUpdateSnapshot] = useState<UpdateSnapshot | null>(null);
   const [homeDir, setHomeDir] = useState<string>("");
@@ -614,6 +616,15 @@ export default function App() {
           <Button
             variant="ghost"
             size="icon"
+            onClick={() => setWorktreesOpen(true)}
+            aria-label="Worktrees"
+            title="Worktrees"
+          >
+            <FolderGit2 className="size-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={() => setSettingsOpen(true)}
             aria-label="Settings"
             title="Settings"
@@ -732,6 +743,17 @@ export default function App() {
         projects={projects}
         initialProjectPath={repoFilter[0] ?? selected?.workdir ?? tasks[0]?.workdir ?? null}
         onClose={() => setGithubOpen(false)}
+      />
+      <WorktreesDialog
+        open={worktreesOpen}
+        onClose={() => setWorktreesOpen(false)}
+        tasks={tasks}
+        projects={projects}
+        homeDir={homeDir}
+        onOpenTask={(t) => {
+          setWorktreesOpen(false);
+          setSelected(t);
+        }}
       />
       <SettingsDialog
         open={settingsOpen}

--- a/src/mainview/components/worktrees/WorktreesDialog.tsx
+++ b/src/mainview/components/worktrees/WorktreesDialog.tsx
@@ -512,7 +512,11 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
                           {status.merged === true && (
                             <span
                               className="text-emerald-400"
-                              title="Already merged into the default branch — safe to delete"
+                              title={
+                                status.dirty
+                                  ? "Merged into the default branch — committed work is safe to delete, but uncommitted changes would be lost"
+                                  : "Already merged into the default branch — safe to delete"
+                              }
                             >
                               merged
                             </span>

--- a/src/mainview/components/worktrees/WorktreesDialog.tsx
+++ b/src/mainview/components/worktrees/WorktreesDialog.tsx
@@ -1,0 +1,458 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AlertCircle, ArrowDown, ArrowUp, FolderGit2, Loader2, RefreshCw, Search, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { MultiSearchSelect } from "@/components/ui/multi-search-select";
+import { Select } from "@/components/ui/select";
+import { useConfirm } from "@/components/ui/confirm";
+import { abbreviateHome, cn } from "@/lib/utils";
+import {
+  COLUMNS,
+  type ColumnId,
+  type Project,
+  type Task,
+  type WorktreeInfo,
+  type WorktreeStaleReason,
+} from "../../../shared/types.ts";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  tasks: Task[];
+  projects: Project[];
+  onOpenTask: (task: Task) => void;
+  /** For abbreviating absolute paths as "~/…" in the row subtitles — mirrors
+   *  every other path-displaying surface (TaskCard, RunPanel, SettingsDialog). */
+  homeDir: string;
+}
+
+const POLL_MS = 5_000;
+
+const basename = (p: string) => {
+  const trimmed = p.replace(/\/+$/, "");
+  const idx = trimmed.lastIndexOf("/");
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+};
+
+const STALE_REASON_LABEL: Record<WorktreeStaleReason, string> = {
+  orphaned: "orphaned",
+  archived: "archived, not cleaned up",
+  inactive: "inactive > 7 days",
+};
+
+/** "5m ago" / "3h ago" / "2d ago" — coarse relative age for the Updated
+ *  column. No existing relative-time helper covers a raw ms epoch (the one
+ *  in GitHubDialog.tsx takes an ISO date string for GitHub API payloads), so
+ *  this is a small local formatter per the plan brief. */
+function formatAge(ms: number | null): string {
+  if (ms == null) return "—";
+  const diff = Date.now() - ms;
+  if (diff < 60_000) return "just now";
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/** `Project.name || basename(p.path)` chain (KanbanFilters.tsx:58-62),
+ *  extended with the orphan/unowned fallbacks the plan calls for. */
+function resolveProjectLabel(workdir: string | null, projects: Project[]): string {
+  if (!workdir) return "—";
+  const p = projects.find((pr) => pr.path === workdir);
+  if (p) return p.name || basename(p.path) || p.path;
+  return basename(workdir) || "—";
+}
+
+/** Filter/sort value for a row's status — distinct from its display label so
+ *  "Archived" can be filtered/sorted independently of the underlying column. */
+function statusValue(w: WorktreeInfo): string {
+  if (w.archivedAt != null) return "archived";
+  return w.column ?? "";
+}
+
+function statusLabel(w: WorktreeInfo): string {
+  if (w.column == null) return "";
+  return COLUMNS.find((c) => c.id === w.column)?.label ?? w.column;
+}
+
+type SortField = "updated" | "project" | "status" | "branch";
+type StaleFilter = "all" | "stale" | "fresh";
+
+export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, homeDir }: Props) {
+  const confirm = useConfirm();
+  const [worktrees, setWorktrees] = useState<WorktreeInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
+
+  const [query, setQuery] = useState("");
+  const [projectFilter, setProjectFilter] = useState<string[]>([]);
+  const [statusFilter, setStatusFilter] = useState<string[]>([]);
+  const [staleFilter, setStaleFilter] = useState<StaleFilter>("all");
+  const [sortField, setSortField] = useState<SortField>("updated");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+
+  const refresh = useCallback(async (manual = false) => {
+    if (manual) setRefreshing(true);
+    try {
+      const list = await api.listWorktrees();
+      setWorktrees(list);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      if (manual) setRefreshing(false);
+    }
+  }, []);
+
+  // Fetch on open + poll every 5s while open; cleared on close/unmount.
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    void refresh().finally(() => setLoading(false));
+    const t = setInterval(() => { void refresh(); }, POLL_MS);
+    return () => clearInterval(t);
+  }, [open, refresh]);
+
+  // Reset filters each time the dialog is reopened — a stale filter carried
+  // across sessions would silently hide rows the user doesn't expect.
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    setProjectFilter([]);
+    setStatusFilter([]);
+    setStaleFilter("all");
+    setSortField("updated");
+    setSortDir("desc");
+  }, [open]);
+
+  const projectValue = useCallback((w: WorktreeInfo) => w.workdir ?? "__none__", []);
+  const projectLabel = useCallback((w: WorktreeInfo) => resolveProjectLabel(w.workdir, projects), [projects]);
+
+  const projectItems = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const w of worktrees) {
+      const v = projectValue(w);
+      if (!seen.has(v)) seen.set(v, projectLabel(w));
+    }
+    return Array.from(seen, ([value, label]) => ({ value, label }));
+  }, [worktrees, projectValue, projectLabel]);
+
+  const statusItems = useMemo(
+    () => [...COLUMNS.map((c) => ({ value: c.id as string, label: c.label })), { value: "archived", label: "Archived" }],
+    [],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return worktrees.filter((w) => {
+      if (q) {
+        const hay = `${w.taskTitle ?? ""}\n${w.branch ?? ""}\n${projectLabel(w)}\n${w.path}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      if (projectFilter.length > 0 && !projectFilter.includes(projectValue(w))) return false;
+      if (statusFilter.length > 0 && !statusFilter.includes(statusValue(w))) return false;
+      if (staleFilter === "stale" && !w.stale) return false;
+      if (staleFilter === "fresh" && w.stale) return false;
+      return true;
+    });
+  }, [worktrees, query, projectFilter, statusFilter, staleFilter, projectLabel, projectValue]);
+
+  const sorted = useMemo(() => {
+    const dir = sortDir === "asc" ? 1 : -1;
+    const arr = [...filtered];
+    arr.sort((a, b) => {
+      switch (sortField) {
+        case "updated":
+          return ((a.taskUpdatedAt ?? 0) - (b.taskUpdatedAt ?? 0)) * dir;
+        case "project":
+          return projectLabel(a).localeCompare(projectLabel(b)) * dir;
+        case "status":
+          return statusLabel(a).localeCompare(statusLabel(b)) * dir;
+        case "branch":
+          return (a.branch ?? "").localeCompare(b.branch ?? "") * dir;
+        default:
+          return 0;
+      }
+    });
+    return arr;
+  }, [filtered, sortField, sortDir, projectLabel]);
+
+  const anyFilterActive =
+    query !== "" || projectFilter.length > 0 || statusFilter.length > 0 || staleFilter !== "all";
+
+  const withBusy = async (id: string, fn: () => Promise<void>) => {
+    setBusyIds((cur) => new Set(cur).add(id));
+    try {
+      await fn();
+    } finally {
+      setBusyIds((cur) => {
+        const next = new Set(cur);
+        next.delete(id);
+        return next;
+      });
+    }
+  };
+
+  const deleteTaskBacked = async (w: WorktreeInfo) => {
+    if (!w.taskId) return;
+    const taskId = w.taskId;
+    const ok = await confirm({
+      title: `Delete worktree "${w.branch ?? w.id}"?`,
+      description: (
+        <>
+          The ticket "<span className="font-medium text-foreground/80">{w.taskTitle}</span>" will be{" "}
+          <strong>archived</strong> (hidden from the board, restorable via Unarchive) and its worktree
+          directory removed. The git branch and full AI history are preserved. If the worktree has
+          uncommitted changes, it is left in place to protect your work.
+        </>
+      ),
+      confirmLabel: "Archive & delete",
+      variant: "destructive",
+    });
+    if (!ok) return;
+    await withBusy(w.id, async () => {
+      try {
+        await api.archiveTask(taskId, { force: true });
+        await refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : String(e));
+      }
+    });
+  };
+
+  const deleteOrphan = async (w: WorktreeInfo) => {
+    const ok = await confirm({
+      title: "Delete orphaned worktree?",
+      description: "No ticket owns this directory; it will be permanently removed.",
+      confirmLabel: "Delete",
+      variant: "destructive",
+    });
+    if (!ok) return;
+    await withBusy(w.id, async () => {
+      try {
+        await api.deleteWorktree(w.id);
+        await refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : String(e));
+      }
+    });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      labelledBy="worktrees-dialog-title"
+      className="flex max-h-[86vh] w-full max-w-6xl flex-col p-0"
+    >
+      <header className="flex items-center justify-between gap-3 border-b border-border/60 p-3">
+        <div className="min-w-0">
+          <div id="worktrees-dialog-title" className="flex items-center gap-2 text-sm font-semibold">
+            <FolderGit2 className="size-4 shrink-0 text-muted-foreground" />
+            Worktrees
+          </div>
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            {worktrees.length === sorted.length
+              ? `${worktrees.length} worktree${worktrees.length === 1 ? "" : "s"}`
+              : `${sorted.length} of ${worktrees.length} worktrees`}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            size="icon"
+            variant="ghost"
+            title="Refresh"
+            aria-label="Refresh"
+            disabled={refreshing}
+            onClick={() => { void refresh(true); }}
+          >
+            {refreshing ? <Loader2 className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
+          </Button>
+          <Button size="sm" variant="outline" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </header>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border/60 p-3">
+        <div className="relative min-w-[200px] flex-1">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search title, branch, project, path…"
+            className="pl-8"
+          />
+        </div>
+        <MultiSearchSelect
+          values={projectFilter}
+          onChange={setProjectFilter}
+          items={projectItems}
+          emptyLabel="All projects"
+          placeholder="Search projects…"
+          className="w-48"
+        />
+        <MultiSearchSelect
+          values={statusFilter}
+          onChange={setStatusFilter}
+          items={statusItems}
+          emptyLabel="All statuses"
+          placeholder="Search statuses…"
+          className="w-44"
+        />
+        <Select
+          value={staleFilter}
+          onChange={(e) => setStaleFilter(e.target.value as StaleFilter)}
+          className="w-36"
+          title="Filter by staleness"
+        >
+          <option value="all">All</option>
+          <option value="stale">Stale only</option>
+          <option value="fresh">Fresh only</option>
+        </Select>
+        <Select
+          value={sortField}
+          onChange={(e) => setSortField(e.target.value as SortField)}
+          className="w-32"
+          title="Sort field"
+        >
+          <option value="updated">Updated</option>
+          <option value="project">Project</option>
+          <option value="status">Status</option>
+          <option value="branch">Branch</option>
+        </Select>
+        <Button
+          size="icon"
+          variant="outline"
+          title={sortDir === "asc" ? "Ascending" : "Descending"}
+          aria-label="Toggle sort direction"
+          onClick={() => setSortDir((d) => (d === "asc" ? "desc" : "asc"))}
+        >
+          {sortDir === "asc" ? <ArrowUp className="size-4" /> : <ArrowDown className="size-4" />}
+        </Button>
+        {anyFilterActive && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setQuery("");
+              setProjectFilter([]);
+              setStatusFilter([]);
+              setStaleFilter("all");
+            }}
+          >
+            Clear
+          </Button>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        {!loading && error && (
+          <div className="flex items-center justify-center gap-2 py-12 text-sm text-rose-400">
+            <AlertCircle className="size-4" /> {error}
+          </div>
+        )}
+
+        {loading && worktrees.length === 0 && (
+          <div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" /> Loading worktrees…
+          </div>
+        )}
+
+        {!loading && !error && worktrees.length === 0 && (
+          <div className="flex flex-col items-center justify-center gap-2 py-12 text-center text-sm text-muted-foreground">
+            <FolderGit2 className="size-6 opacity-40" />
+            No worktrees on disk.
+          </div>
+        )}
+
+        {!loading && !error && worktrees.length > 0 && sorted.length === 0 && (
+          <div className="flex flex-col items-center justify-center gap-2 py-12 text-center text-sm text-muted-foreground">
+            <FolderGit2 className="size-6 opacity-40" />
+            No worktrees match these filters.
+          </div>
+        )}
+
+        {sorted.length > 0 && (
+          <div className="flex flex-col gap-2">
+            {sorted.map((w) => {
+              const task = w.taskId ? tasks.find((t) => t.id === w.taskId) : undefined;
+              const busy = busyIds.has(w.id);
+              return (
+                <div key={w.id} className="flex items-start gap-3 rounded-md border border-border/60 bg-card p-3">
+                  <FolderGit2 className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                      {task ? (
+                        <button
+                          type="button"
+                          className="min-w-0 truncate text-left text-sm font-medium hover:underline"
+                          onClick={() => onOpenTask(task)}
+                          title="Open task"
+                        >
+                          {task.title}
+                        </button>
+                      ) : w.taskId ? (
+                        <span className="min-w-0 truncate text-sm font-medium text-muted-foreground">
+                          {w.taskTitle}
+                        </span>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">no ticket</span>
+                      )}
+                      {w.column != null && (
+                        <Badge variant="outline">{statusLabel(w)}</Badge>
+                      )}
+                      {w.archivedAt != null && <Badge variant="secondary">Archived</Badge>}
+                      {w.stale && (
+                        <Badge
+                          variant="destructive"
+                          title={w.staleReasons.map((r) => STALE_REASON_LABEL[r]).join(", ")}
+                        >
+                          Stale
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                      <span className="font-mono">{w.branch ?? "—"}</span>
+                      <span>{projectLabel(w)}</span>
+                      <span className="min-w-0 truncate" title={w.path}>{abbreviateHome(w.path, homeDir)}</span>
+                      <span>updated {formatAge(w.taskUpdatedAt)}</span>
+                      {w.runActive && <span className="text-emerald-400">running</span>}
+                      {w.stale && (
+                        <span className="text-rose-400/80">
+                          {w.staleReasons.map((r) => STALE_REASON_LABEL[r]).join(", ")}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    title={w.runActive ? "Stop the run first" : "Delete worktree"}
+                    aria-label="Delete worktree"
+                    disabled={w.runActive || busy}
+                    onClick={() => { void (w.taskId ? deleteTaskBacked(w) : deleteOrphan(w)); }}
+                  >
+                    {busy ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Trash2 className={cn("size-4", !w.runActive && "text-destructive")} />
+                    )}
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/src/mainview/components/worktrees/WorktreesDialog.tsx
+++ b/src/mainview/components/worktrees/WorktreesDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AlertCircle, ArrowDown, ArrowUp, FolderGit2, Loader2, RefreshCw, Search, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
@@ -15,6 +15,7 @@ import {
   type ColumnId,
   type Project,
   type Task,
+  type WorktreeGitStatus,
   type WorktreeInfo,
   type WorktreeStaleReason,
 } from "../../../shared/types.ts";
@@ -31,6 +32,11 @@ interface Props {
 }
 
 const POLL_MS = 5_000;
+
+/** On-demand `getWorktreeGitStatus` calls are subprocess-backed on the bun
+ *  side, so the auto-fetch pool caps fan-out rather than firing one request
+ *  per row simultaneously. */
+const GIT_STATUS_CONCURRENCY = 5;
 
 const basename = (p: string) => {
   const trimmed = p.replace(/\/+$/, "");
@@ -91,6 +97,13 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
+  // Live per-worktree dirty/ahead/merged, fetched on open + Refresh (not the
+  // 5s poll — see fetchGitStatuses). "loading" is a sentinel, not the
+  // WorktreeGitStatus shape itself.
+  const [gitStatus, setGitStatus] = useState<Map<string, WorktreeGitStatus | "loading">>(new Map());
+  // Bumped on every fetch pass so a superseding Refresh (or the dialog
+  // closing) makes in-flight results from an older pass a no-op.
+  const gitStatusRunRef = useRef(0);
 
   const [query, setQuery] = useState("");
   const [projectFilter, setProjectFilter] = useState<string[]>([]);
@@ -99,27 +112,77 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
   const [sortField, setSortField] = useState<SortField>("updated");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
 
-  const refresh = useCallback(async (manual = false) => {
+  // Bounded-concurrency pool: fetches live git status for every row in
+  // `list`, capped at GIT_STATUS_CONCURRENCY in flight. Marks all ids
+  // "loading" up front so the spinner shows immediately, then fills in each
+  // result (or drops the id on error — no badge, no toast spam) as it
+  // resolves. `runId` lets a superseding pass (a fresh Refresh, or the
+  // dialog closing) discard stale results instead of racing the map.
+  const fetchGitStatuses = useCallback((list: WorktreeInfo[]) => {
+    const runId = ++gitStatusRunRef.current;
+    setGitStatus((cur) => {
+      const next = new Map(cur);
+      for (const w of list) next.set(w.id, "loading");
+      return next;
+    });
+    let cursor = 0;
+    const worker = async () => {
+      while (true) {
+        const idx = cursor++;
+        const w = list[idx];
+        if (!w) return;
+        try {
+          const status = await api.getWorktreeGitStatus(w.id);
+          if (gitStatusRunRef.current !== runId) return;
+          setGitStatus((cur) => new Map(cur).set(w.id, status));
+        } catch {
+          if (gitStatusRunRef.current !== runId) return;
+          setGitStatus((cur) => {
+            const next = new Map(cur);
+            next.delete(w.id);
+            return next;
+          });
+        }
+      }
+    };
+    void Promise.all(
+      Array.from({ length: Math.min(GIT_STATUS_CONCURRENCY, list.length) }, worker),
+    );
+  }, []);
+
+  const refresh = useCallback(async (manual = false, fetchGit = false) => {
     if (manual) setRefreshing(true);
     try {
       const list = await api.listWorktrees();
       setWorktrees(list);
       setError(null);
+      if (fetchGit) fetchGitStatuses(list);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       if (manual) setRefreshing(false);
     }
-  }, []);
+  }, [fetchGitStatuses]);
 
   // Fetch on open + poll every 5s while open; cleared on close/unmount.
+  // Git status is auto-fetched on the initial open load and on manual
+  // Refresh only — not on every 5s poll tick, to avoid a git subprocess
+  // fan-out in the background while the dialog just sits open.
   useEffect(() => {
     if (!open) return;
     setLoading(true);
-    void refresh().finally(() => setLoading(false));
+    void refresh(false, true).finally(() => setLoading(false));
     const t = setInterval(() => { void refresh(); }, POLL_MS);
     return () => clearInterval(t);
   }, [open, refresh]);
+
+  // Discard any in-flight git-status pass and drop stale badges when the
+  // dialog closes (or unmounts) — reopening re-fetches fresh regardless.
+  useEffect(() => {
+    if (open) return;
+    gitStatusRunRef.current++;
+    setGitStatus(new Map());
+  }, [open]);
 
   // Reset filters each time the dialog is reopened — a stale filter carried
   // across sessions would silently hide rows the user doesn't expect.
@@ -272,7 +335,7 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
             title="Refresh"
             aria-label="Refresh"
             disabled={refreshing}
-            onClick={() => { void refresh(true); }}
+            onClick={() => { void refresh(true, true); }}
           >
             {refreshing ? <Loader2 className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
           </Button>
@@ -386,6 +449,7 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
             {sorted.map((w) => {
               const task = w.taskId ? tasks.find((t) => t.id === w.taskId) : undefined;
               const busy = busyIds.has(w.id);
+              const status = gitStatus.get(w.id);
               return (
                 <div key={w.id} className="flex items-start gap-3 rounded-md border border-border/60 bg-card p-3">
                   <FolderGit2 className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
@@ -426,6 +490,35 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
                       <span className="min-w-0 truncate" title={w.path}>{abbreviateHome(w.path, homeDir)}</span>
                       <span>updated {formatAge(w.taskUpdatedAt)}</span>
                       {w.runActive && <span className="text-emerald-400">running</span>}
+                      {status === "loading" && (
+                        <Loader2 className="size-3 animate-spin text-muted-foreground" aria-label="Loading git status" />
+                      )}
+                      {status && status !== "loading" && !status.ignored && (
+                        <>
+                          {status.dirty && (
+                            <span className="text-amber-400" title="Has uncommitted changes">
+                              uncommitted
+                            </span>
+                          )}
+                          {status.ahead > 0 && (
+                            <span
+                              className="inline-flex items-center gap-0.5"
+                              title={`${status.ahead} commit${status.ahead === 1 ? "" : "s"} ahead`}
+                            >
+                              <ArrowUp className="size-3" />
+                              {status.ahead}
+                            </span>
+                          )}
+                          {status.merged === true && (
+                            <span
+                              className="text-emerald-400"
+                              title="Already merged into the default branch — safe to delete"
+                            >
+                              merged
+                            </span>
+                          )}
+                        </>
+                      )}
                       {w.stale && (
                         <span className="text-rose-400/80">
                           {w.staleReasons.map((r) => STALE_REASON_LABEL[r]).join(", ")}

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -74,6 +74,7 @@ import type {
   TaskType,
   TerminalTab,
   UpdateStatus,
+  WorktreeInfo,
 } from "../../shared/types.ts";
 import { fetchWithRecovery } from "./net-retry.ts";
 
@@ -1027,8 +1028,25 @@ export const api = {
     j<Task>(`/tasks/${id}`, { method: "PATCH", body: JSON.stringify({ column }) }),
   deleteTask: (id: string) => j<void>(`/tasks/${id}`, { method: "DELETE" }),
   startTask: (id: string) => j<{ runId: string }>(`/tasks/${id}/start`, { method: "POST" }),
-  archiveTask: (id: string) => j<Task>(`/tasks/${id}/archive`, { method: "POST" }),
+  /** `force: true` bypasses the done-column gate (still rejects an active
+   *  run) — used by the Worktrees page's "Archive & delete" flow to archive
+   *  a stale worktree's task regardless of its current column. Omitted (the
+   *  common case) sends no body, matching the original archive-from-`done`
+   *  callers unchanged. */
+  archiveTask: (id: string, opts?: { force?: boolean }) =>
+    j<Task>(`/tasks/${id}/archive`, {
+      method: "POST",
+      ...(opts?.force ? { body: JSON.stringify({ force: true }) } : {}),
+    }),
   unarchiveTask: (id: string) => j<Task>(`/tasks/${id}/unarchive`, { method: "POST" }),
+
+  /** Every git worktree materialized on disk under `dataDir/worktrees/`,
+   *  cross-referenced against the tasks table. Drives the Worktrees page. */
+  listWorktrees: () => j<WorktreeInfo[]>("/worktrees"),
+  /** Removes an orphaned worktree directory (no owning task row) — a
+   *  task-backed worktree is torn down via `archiveTask(id, { force: true })`
+   *  instead, since deleting it destroys the ticket. */
+  deleteWorktree: (id: string) => j<void>(`/worktrees/${encodeURIComponent(id)}`, { method: "DELETE" }),
 
   // Terminal tabs. State is in-memory on the bun side; the live byte stream
   // runs over the WebSocket whose URL `terminalSocketUrl` builds.

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -74,6 +74,7 @@ import type {
   TaskType,
   TerminalTab,
   UpdateStatus,
+  WorktreeGitStatus,
   WorktreeInfo,
 } from "../../shared/types.ts";
 import { fetchWithRecovery } from "./net-retry.ts";
@@ -1047,6 +1048,11 @@ export const api = {
    *  task-backed worktree is torn down via `archiveTask(id, { force: true })`
    *  instead, since deleting it destroys the ticket. */
   deleteWorktree: (id: string) => j<void>(`/worktrees/${encodeURIComponent(id)}`, { method: "DELETE" }),
+  /** On-demand live dirty/ahead/merged status for a single worktree — not part
+   *  of the bulk listing above (that stays fs+DB-only to avoid a subprocess
+   *  fan-out per poll). Fetched per row by the Worktrees page. */
+  getWorktreeGitStatus: (id: string) =>
+    j<WorktreeGitStatus>(`/worktrees/${encodeURIComponent(id)}/git-status`),
 
   // Terminal tabs. State is in-memory on the bun side; the live byte stream
   // runs over the WebSocket whose URL `terminalSocketUrl` builds.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -637,6 +637,49 @@ export interface Task {
   runningSubagents?: number;
 }
 
+/** Why a worktree is flagged `stale` in {@link WorktreeInfo}. A worktree can
+ *  carry more than one reason at once (e.g. archived AND past the inactivity
+ *  threshold). */
+export type WorktreeStaleReason = "orphaned" | "archived" | "inactive";
+
+/** How long a task can go without an update before its worktree is flagged
+ *  `"inactive"` — 7 days. */
+export const WORKTREE_STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/**
+ * A git worktree materialized on disk under `dataDir/worktrees/`, as surfaced
+ * by `GET /worktrees`. One row per directory found on disk — computed live by
+ * `orchestrator.listWorktrees()` from fs + DB signals only (no git
+ * subprocesses in the bulk listing).
+ */
+export interface WorktreeInfo {
+  /** Directory basename under `dataDir/worktrees/` — equal to the owning task's id by construction. */
+  id: string;
+  /** Absolute worktree directory path on disk. */
+  path: string;
+  /** Owning task id, or null for an orphaned dir with no matching task row. */
+  taskId: string | null;
+  /** Owning task's title, or null when orphaned. */
+  taskTitle: string | null;
+  /** Owning task's kanban column, or null when orphaned. */
+  column: ColumnId | null;
+  /** Owning task's `archivedAt`, or null when orphaned or not archived. */
+  archivedAt: number | null;
+  /** Owning task's `updatedAt`, or null when orphaned. */
+  taskUpdatedAt: number | null;
+  /** Owning task's branch, or null when orphaned. */
+  branch: string | null;
+  /** Source repo path — `task.workdir` for an owned worktree; for an orphan, a
+   *  best-effort parse of the `.git` pointer file, or null if unreadable. */
+  workdir: string | null;
+  /** True when the owning task currently has a run in flight. */
+  runActive: boolean;
+  /** True when `staleReasons` is non-empty. */
+  stale: boolean;
+  /** Every reason this worktree is considered stale; empty when not stale. */
+  staleReasons: WorktreeStaleReason[];
+}
+
 /** A live terminal tab for a task. Returned by the terminal REST endpoints;
  *  state lives only in memory in `src/bun/terminals.ts`. */
 export interface TerminalTab {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -680,6 +680,26 @@ export interface WorktreeInfo {
   staleReasons: WorktreeStaleReason[];
 }
 
+/**
+ * On-demand live git status for a single worktree, as surfaced by
+ * `GET /worktrees/:id/git-status`. Not part of the bulk `GET /worktrees`
+ * listing — computing this spawns git subprocesses, so it's fetched per row
+ * rather than on every poll.
+ */
+export interface WorktreeGitStatus {
+  /** Working tree has uncommitted changes (staged, unstaged, or untracked). */
+  dirty: boolean;
+  /** Commits on HEAD not yet pushed / ahead of base (see getAheadCount). 0 when unknown. */
+  ahead: number;
+  /** HEAD is an ancestor of the source repo's default branch — its work already
+   *  landed, so the worktree is safe to delete. null when it can't be determined
+   *  (no resolvable default branch, or a git error) — never a false "merged". */
+  merged: boolean | null;
+  /** The dir isn't inspectable (missing, not a git repo, git failed). When true,
+   *  the other fields are not meaningful. */
+  ignored: boolean;
+}
+
 /** A live terminal tab for a task. Returned by the terminal REST endpoints;
  *  state lives only in memory in `src/bun/terminals.ts`. */
 export interface TerminalTab {


### PR DESCRIPTION
## What & why

Adds a **Worktrees** page so users can see every agetor-managed git worktree on disk, tell at a glance which are stale, trace each back to its ticket and project, and clean them up — plus optional live git signals to decide what's safe to delete. Previously worktrees were invisible except as a side effect of a task; abandoned/orphaned ones accumulated with no way to find or remove them.

Opened from a new **Worktrees** button (`FolderGit2`) in the app header.

## Features

- **Worktrees list** — a full-screen overlay listing every materialized worktree under `~/.agetor/worktrees/`, one row per worktree, backed by a new `GET /worktrees` endpoint (`listWorktrees` — fs + DB only, safe to poll every 5s).
- **Stale flag with reasons** — each row is classified as stale for one or more reasons: `orphaned` (a directory with no owning ticket), `archived` (owning task archived but the worktree wasn't cleaned up), or `inactive` (no run, untouched > 7 days). An archived-and-idle worktree reports both.
- **Ticket link, status & project** — the ticket title is clickable and opens the task's details panel; the row shows the ticket's kanban status (column) and its project, resolved from the source repo.
- **Delete → archive** — the delete button opens a destructive confirmation explaining the ticket will be **archived** (restorable, branch and AI history preserved), then force-archives it (bypassing the "Done"-only gate for stale worktrees; an in-flight run still blocks). Orphan directories with no ticket get a confined, path-checked `DELETE /worktrees/:id`.
- **Filters & sort** — client-side text search, project / status / staleness filters, and sort by updated / project / status / branch (asc-desc).
- **Live git status (on-demand)** — a separate `GET /worktrees/:id/git-status` returns `{ dirty, ahead, merged, ignored }`; the page auto-fetches it for the loaded rows on open and Refresh (never on the 5s poll) via a worker pool capped at 5 concurrent. `merged` means the worktree's HEAD is already an ancestor of the source repo's **default branch** (`origin/HEAD` → `main` → `master`) — the "work already landed, safe to delete" signal — and never false-positives (any ambiguity is reported as unknown). Rows show dirty / ahead / merged badges.

## Correctness & safety

- **Path confinement** — orphan-delete and git-status resolve the worktree dir through a shared `resolveWorktreeDir(id)` guard that rejects ids escaping `WORKTREES_DIR`, including `"."` (which normalizes to the directory itself and would otherwise `rm -rf` every worktree). Regression-tested.
- **Teardown-queue invariants respected** — the delete/archive paths keep the existing per-source-repo FIFO teardown queue and `pendingTeardown` await; the orphan-delete `rm` + `git worktree prune` now run **inside** that queue so they can't contend on git's `.git/worktrees/.lock` with a concurrent same-repo teardown, while still surfacing a failed removal to the caller.
- No new git subprocesses on the pollable bulk path; no tmux-session enumeration.

## Tests

- `src/bun/worktrees-list.test.ts` (9) — staleness classification, force-archive gate, orphan-delete happy/refuse/`.`-confinement.
- `src/bun/worktree-git-status.test.ts` (10) — merged default-branch resolution (incl. `master` fallback and the +1-commit → not-merged case), dirty/clean/orphan git-status, `.`-confinement, single and back-to-back queued orphan prune.
- Full suite: **1582 pass, 1 skip (pre-existing tmux-not-on-PATH), 0 fail**; `bun run typecheck` clean.

## Notes

- Design docs: `docs/plans/worktrees-list-page.md` and `docs/plans/worktrees-git-signals.md`.
- Known minor caveat (documented in code): the orphan-prune teardown key is the realpath'd repo root, while archive/delete key by the raw `task.workdir` string — if they differ, the prune may not serialize on the same FIFO. Harmless (a lost lock just skips one best-effort prune, cleared by the next worktree op in that repo).