### PR TITLE
fix: archive also stops the running agent (confirm → stop → archive)

### DIFF
--- a/docs/plans/archive-should-also-stop.md
+++ b/docs/plans/archive-should-also-stop.md
@@ -1,0 +1,80 @@
+# Plan — Archive stops the running agent (confirm → stop → archive)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-20 |
+| Source | /implement conversation — "archive should also stop the current agent, with a confirmation dialog" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/archive-should-also-stop |
+| Base SHA | 7e1bf09ad55d990c2be38d36fba6a2a117ca13b9 |
+
+## 1. Objective & success criteria
+
+Archiving a task that has an in-flight agent run must no longer fail with the toast
+`"task is still running — cancel the run before archiving"`. Instead:
+
+- Every archive entry point that can hit a running task shows a **confirmation dialog** stating the agent will be stopped.
+- On confirm, the server **stops the run** (kill active handle, cancel pending interactions; for the "held by background agents" state: interrupt session + orphan subagents) and **archives** in one call.
+- Archive appears on **running/blocked** task cards and the run panel, not only Done — so the user never has to move/stop a ticket first just to archive it.
+- Archiving without the stop flag on a running task still errors (server-side guard remains the backstop).
+
+Success = new orchestrator tests green, full `bun test` + `bun run typecheck` green, all three entry points behave as above.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- **Guard/toast source:** `src/bun/orchestrator.ts:1891-1893` — `if (task.runId && active.has(task.runId)) return { error: "task is still running — cancel the run before archiving" }`. Unconditional; `force` only bypasses the Done-column gate at `orchestrator.ts:1883-1885`.
+- **Stop model:** `deleteTask` (`orchestrator.ts:1966-1998`) kills the active handle + `cancelPendingForTask(taskId, …)` before teardown. `cancelRun` (`orchestrator.ts:1184-1214`) additionally handles the **held-by-background-agents** state (no `active` handle): `cancelPendingForTask` + `interruptTaskSession(taskId)` + `orphanRunningSubagents(taskId)`. Peer knowledge entry (68504e80) confirms: never assume `active.get(task.runId)` exists for a card that looks busy — `isHeldByBackgroundAgents(taskId)` (`orchestrator.ts:320-325`) is the second running-ish state.
+- **Cancel semantics:** marking every handle of the task `cancelled = true` before `.kill()` is what makes `attachDoneHandler` record `cancelled` (not `failed`) and settle the column to `ready` (`orchestrator.ts:984-988`). Post-archive column moves are invisible (UI keys off `archivedAt != null`) and actually desirable on unarchive (task reappears in `ready`).
+- **Archive teardown is already deferred + serialized** (`enqueueTeardown`; docs/plans/fix-archive-teardown-queue.md) and drops tmux sessions anyway — the kill-before-archive step just makes the stop *deliberate and immediate*, with correct `cancelled` bookkeeping instead of a session yanked out from under a live run.
+- **UI entry points today:** Archive button gated to `column === "done"` at `TaskCard.tsx:182-186` and `RunPanel.tsx:1173-1177`; App handler `archive()` at `App.tsx:497-508` (errors via custom `ErrorToast`). Worktrees page "Archive & delete" (`WorktreesDialog.tsx:267-292`) already calls `archiveTask(id, { force: true })` inside a `useConfirm()` dialog and surfaces errors via sonner `toast.error` — this is the path that produces today's toast on a running task.
+- **Confirm primitive:** `src/mainview/components/ui/confirm.tsx` (`useConfirm()` + provider), already used by `del()` in `App.tsx:520-538` and by WorktreesDialog.
+- **Tests:** `src/bun/orchestrator-archive-teardown.test.ts` is the model (temp `AGETOR_DATA_DIR`, `isolation: "none"` or temp git repo, dynamic import of orchestrator).
+
+## 3. Approach & key decisions
+
+1. **Server API: add `stopRun?: boolean` to `archiveTask` opts** (and the `POST /tasks/:id/archive` body). Chosen over "UI calls `/runs/:id/cancel` then archives" because cancel→archive from the client is racy (cancel is async; the archive guard would still see the active handle) and `deleteTask` already proves the kill-inline-then-teardown shape works.
+2. **`stopRun` covers both running states.** With `stopRun: true`:
+   - active handle: mark all of the task's handles `cancelled = true`, `cancelPendingForTask`, `kill()` (mirrors `cancelRun`'s active branch);
+   - held-by-bg-agents: `cancelPendingForTask` + `interruptTaskSession` + `orphanRunningSubagents` (mirrors `cancelRun`'s held branch). Prefer factoring a small `stopTaskRun(taskId)` helper (or reuse `cancelRun(task.runId)`) so archive and Stop can't drift.
+   - neither state (nothing to stop): proceed to archive normally — `stopRun` is then a no-op, not an error.
+3. **Column gate untouched; new UI paths send `force: true` + `stopRun: true`.** `force` already means "archive from a non-Done column" (Worktrees uses it). The board's running-card archive sends both after confirmation. The Done-column archive path is completely unchanged.
+4. **Without `stopRun`, the running guard stays** (same error string) — backstop against un-confirmed archives from stale clients.
+5. **Confirmation lives in the UI** (per request): running/blocked archive always confirms via `useConfirm()` with destructive variant and copy like *"An agent is still working on this task. Archiving will stop it."* Worktrees' existing confirm gets that sentence appended when `runActive`.
+6. **Post-kill settling is left async.** Archive stamps `archivedAt` immediately after issuing the stop; `attachDoneHandler` later records the run `cancelled` and parks the column at `ready` under the archive — harmless while archived, correct on unarchive. No new waiting/polling.
+
+## 4. Work breakdown — implementation tasks
+
+| ID | Goal | Files owned | Deps | Acceptance |
+| --- | --- | --- | --- | --- |
+| I1 | `archiveTask` gains `stopRun`: stop active/held runs (cancelled-flag + kill / interrupt + orphan + cancelPending), keep guard when absent; `server.ts` archive route parses `stopRun` from body | `src/bun/orchestrator.ts`, `src/bun/server.ts` | — | Running task + `stopRun` archives with run→`cancelled`; without `stopRun` returns the existing error; held task + `stopRun` interrupts + orphans then archives |
+| I2 | Webview: `api.archiveTask(id, opts)` carries `stopRun`; App `archive()` confirms + passes `{force,stopRun}` for running/blocked tasks; Archive shown on running/blocked in TaskCard + RunPanel; Worktrees confirm mentions the stop and passes `stopRun` | `src/mainview/lib/api.ts`, `src/mainview/App.tsx`, `src/mainview/components/kanban/TaskCard.tsx`, `src/mainview/components/kanban/RunPanel.tsx`, `src/mainview/components/worktrees/WorktreesDialog.tsx` | contract from I1 (field name `stopRun`, fixed here) | Archive visible on running card/panel; confirm dialog precedes it; Worktrees "Archive & delete" on a running task no longer errors |
+
+Both tasks are file-disjoint → one wave, two agents.
+
+## 5. Work breakdown — test tasks
+
+| ID | Goal | Files owned | Covers |
+| --- | --- | --- | --- |
+| T1 | Orchestrator tests: (a) running + no `stopRun` → error unchanged; (b) running + `stopRun` → handle killed, cancelled flag set, pending interactions cancelled, `archivedAt` set; (c) held-by-bg-agents + `stopRun` → interrupt/orphan invoked, archived; (d) `stopRun` on an idle task → plain archive | new `src/bun/orchestrator-archive-stop.test.ts` (mirror setup of `orchestrator-archive-teardown.test.ts`; fake driver / injected setters per `claude-subagents.test.ts` idiom) | I1 |
+
+UI changes are covered by typecheck + existing patterns (no webview test harness in repo).
+
+## 6. Execution waves
+
+- **Wave 1:** I1 ∥ I2 (disjoint files; contract pinned in §3).
+- **Barrier**, then Phase 5 review (opus) on `git diff 7e1bf09...HEAD`.
+- **Wave 2:** T1 (single agent), then run `bun test` + `bun run typecheck` (haiku), fix loop if needed.
+
+## 7. Blast radius & risks
+
+- `archiveTask` callers: archive route only. `force` semantics unchanged → Worktrees existing calls keep working even before I2 lands.
+- Killing the handle sets `cancelled` → `attachDoneHandler` path already exercised by `cancelRun`; the only new interleaving is "task already archived when the done-handler fires" — column write is cosmetic under archive (UI filters on `archivedAt`), and unarchive→`ready` is sensible. Watch that the done-handler doesn't null out anything unarchive depends on (it clears `runId`; unarchive doesn't need it).
+- `enqueueTeardown` runs after the kill; `dropSession` on an already-killed session is idempotent (guarded by `sessionExists`).
+- Codex: one-shot turn — active handle kill covers mid-turn; between turns there's no session and `stopRun` is a no-op. No codex-specific branch needed.
+- Stale/older webview build calling archive without `stopRun` on a running task: still gets the guard error — no behavior regression.
+
+## 8. Open questions / assumptions
+
+- Confirm-dialog copy finalized by I2 within the stated intent (title `Archive "<title>"?`, destructive confirm label "Stop & archive").
+- Blocked-column tasks usually have no active run; archive from blocked simply confirms and archives (stop is a no-op). Accepted.
+- Board archive confirmation is only added for running/blocked tasks; Done-column archive stays one-click as today.

--- a/src/bun/orchestrator-archive-stop.test.ts
+++ b/src/bun/orchestrator-archive-stop.test.ts
@@ -1,0 +1,222 @@
+import { test, expect, afterEach } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+// Top-level: db.ts captures AGETOR_DATA_DIR at first import — `beforeAll`
+// would race with any sibling test file that already imported db.ts.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-test-"));
+// Drive claude through an in-process fake instead of tmux + the real CLI.
+// AGETOR_CLAUDE_BIN is also overridden so the agent-status preflight inside
+// startTask passes without claude installed. Mirrors
+// orchestrator-archive-teardown.test.ts / worktrees-list.test.ts, both of
+// which set these same four vars at top level without restoring them —
+// established precedent that this doesn't disturb sibling files (only
+// AGETOR_CODEX_DRIVER=fake is the one that's known to break reconcile.test.ts,
+// per subagent-hold.test.ts's warning, and this file never touches codex).
+process.env.AGETOR_CLAUDE_DRIVER = "fake";
+process.env.AGETOR_CLAUDE_BIN = "/bin/echo";
+process.env.AGETOR_TMUX_BIN = "/bin/echo"; // tmux probe in agent-status passes
+process.env.AGETOR_CLAUDE_ARGS = "";
+
+/*
+ * Covers `archiveTask({ stopRun })` (docs/plans/archive-should-also-stop.md
+ * §5, task T1) — archiving a task that has an in-flight or
+ * held-by-background-agents run, via the same stop path the Stop button
+ * uses (`stopActiveHandle` / `stopHeldTask`, shared with `cancelRun`).
+ *
+ * IMPORTANT — shared-DB hygiene (see subagent-hold.test.ts and
+ * reconcile.test.ts): `bun test` runs every *.test.ts in one process against
+ * one SQLite DB, and `reconcileOrphans`' boot pass scans `runs WHERE
+ * status='running'` / `tasks WHERE column='running'` globally. Every task
+ * created here is tracked and hard-deleted in `afterEach` so a task left in
+ * `running` (or with a `running` run row) by an assertion failure can't leak
+ * into a sibling file.
+ */
+
+const createdTaskIds: string[] = [];
+
+afterEach(async () => {
+  const { db } = await import("./db.ts");
+  for (const id of createdTaskIds.splice(0)) {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [id]);
+  }
+});
+
+function wait(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// isolation: "none" — no worktree is materialized, so there's nothing for
+// archiveTask's deferred teardown to detach and no need to await
+// `pendingTeardown` in cleanup (worktree.ts's `detachWorktree` no-ops
+// immediately when `task.worktreePath` is null). Keeps these tests focused
+// on the stop-then-archive behavior rather than worktree plumbing already
+// covered by orchestrator-archive-teardown.test.ts.
+async function createClaudeTask(title: string): Promise<string> {
+  const { createTask } = await import("./orchestrator.ts");
+  const created = await createTask({
+    title,
+    prompt: "hello",
+    agent: "claude-code",
+    workdir: process.cwd(),
+    isolation: "none",
+  });
+  if ("error" in created) throw new Error(created.error);
+  createdTaskIds.push(created.task.id);
+  return created.task.id;
+}
+
+// Mirrors subagent-hold.test.ts's helper — inserts a `running` subagent row
+// so `isHeldByBackgroundAgents` reads true once the terminal run succeeds.
+async function insertRunningSubagent(taskId: string): Promise<string> {
+  const { subagents } = await import("./db.ts");
+  const id = `agent-${randomUUID()}`;
+  subagents.insertIfAbsent({
+    id,
+    taskId,
+    runId: null, // the gate only keys off task_id — see subagents.hasRunning
+    parentKind: "subagent",
+    agentType: "Explore",
+    description: "test subagent",
+    spawnDepth: 1,
+    sourcePath: `/tmp/${id}.jsonl`,
+    status: "running",
+    startedAt: Date.now(),
+    endedAt: null,
+  });
+  return id;
+}
+
+test("(a) archive without stopRun on a task with an active run returns the guard error, leaves the task unarchived, and the run active", async () => {
+  const { createTask: _unused, startTask, archiveTask } = await import("./orchestrator.ts");
+  const { tasks, runs } = await import("./db.ts");
+
+  const taskId = await createClaudeTask("no-stopRun-active-run");
+  const started = await startTask(taskId);
+  if (!("runId" in started)) throw new Error("expected the run to start");
+  const runId = started.runId;
+
+  // `force: true` is needed to get past the done-only column gate (the task
+  // is in `running`, not `done`) so the assertion actually exercises the
+  // active-run guard rather than the column gate. No await between
+  // `startTask` resolving and this call — the fake driver's ~20ms `done`
+  // timer must not have fired yet, or the run would already be out of
+  // `active` (see worktrees-list.test.ts's "force still rejects an active
+  // run" for the same timing-sensitive pattern).
+  const result = await archiveTask(taskId, { force: true });
+  expect("error" in result).toBe(true);
+  if ("error" in result) {
+    expect(result.error).toBe("task is still running — cancel the run before archiving");
+  }
+
+  expect(tasks.get(taskId)?.archivedAt).toBeNull();
+  expect(runs.get(runId)?.status).toBe("running");
+
+  // Let the fake turn resolve normally so no `status='running'` row survives
+  // this test for reconcileOrphans to trip over.
+  await wait(250);
+  expect(runs.get(runId)?.status).toBe("succeeded");
+});
+
+test("(b) archive with force+stopRun on a task with an active run kills the handle, cancels the run, and cancels pending interactions", async () => {
+  const { startTask, archiveTask } = await import("./orchestrator.ts");
+  const { tasks, runs } = await import("./db.ts");
+  const { __getFakeDriver } = await import("./agents.ts");
+  const { registerTmuxPrompt, listPendingForTask } = await import("./interactions.ts");
+
+  const taskId = await createClaudeTask("stopRun-active-run");
+  const started = await startTask(taskId);
+  if (!("runId" in started)) throw new Error("expected the run to start");
+  const runId = started.runId;
+
+  // A pending interaction for this run — mirrors what a claude tmux-pane
+  // scraper prompt looks like. `cancelPendingForTask` (called inside
+  // `stopActiveHandle`) must resolve it with the `__cancelled__` sentinel
+  // before the session is killed, so the waiting curl/MCP client unblocks
+  // immediately instead of hanging until its own timeout.
+  const pending = registerTmuxPrompt({
+    taskId,
+    runId,
+    paneText: "Do you want to proceed?",
+    choices: [{ key: "1", label: "Yes" }],
+    fingerprint: "archive-stop-fp",
+  });
+
+  // No await between `startTask` resolving and this call — the run must
+  // still be in the in-memory `active` map so this exercises
+  // `stopActiveHandle`, not the held-task branch.
+  const result = await archiveTask(taskId, { force: true, stopRun: true });
+  expect("task" in result).toBe(true);
+  if (!("task" in result)) throw new Error(result.error);
+  expect(result.task.archivedAt).not.toBeNull();
+
+  // The active handle's `kill()` was invoked synchronously inside
+  // `archiveTask` (via `stopActiveHandle`), well before the fake driver's
+  // own ~20ms `done` timer would have fired on its own.
+  const fake = __getFakeDriver(taskId);
+  expect(fake?._record).toContain("kill");
+
+  // The pending interaction was resolved with the cancellation sentinel and
+  // dropped from the registry.
+  await expect(pending.answer).resolves.toEqual({ key: "__cancelled__" });
+  expect(listPendingForTask(taskId)).toEqual([]);
+
+  // `stopActiveHandle` marks every handle for this task `cancelled = true`
+  // before killing it, so once the fake driver's `done` promise resolves,
+  // `attachDoneHandler` must record the run as "cancelled" — not
+  // "succeeded", which is what a plain, unstopped fake turn would produce.
+  await wait(250);
+  expect(runs.get(runId)?.status).toBe("cancelled");
+  expect(tasks.get(taskId)?.archivedAt).not.toBeNull();
+});
+
+test("(c) archive with force+stopRun on a held (background-agents) task interrupts the session, orphans the subagents, and archives", async () => {
+  const { startTask, archiveTask } = await import("./orchestrator.ts");
+  const { tasks, runs, subagents } = await import("./db.ts");
+
+  const taskId = await createClaudeTask("stopRun-held-task");
+  await insertRunningSubagent(taskId);
+
+  const started = await startTask(taskId);
+  if (!("runId" in started)) throw new Error("expected the run to start");
+  const runId = started.runId;
+
+  // Let the fake turn succeed and the hold gate engage: column stays
+  // `running`, the run row is `succeeded`, and the subagent row is still
+  // `running` — the exact state `isHeldByBackgroundAgents` reads. There is
+  // no `active` handle for this run anymore (it was deleted the moment
+  // `agent.done` resolved), so `archiveTask`'s `stopRun` path must take the
+  // `stopHeldTask` branch, not `stopActiveHandle`.
+  await wait(250);
+
+  expect(tasks.get(taskId)?.column).toBe("running");
+  expect(runs.get(runId)?.status).toBe("succeeded");
+  expect(subagents.hasRunning(taskId)).toBe(true);
+
+  const result = await archiveTask(taskId, { force: true, stopRun: true });
+  expect("task" in result).toBe(true);
+  if (!("task" in result)) throw new Error(result.error);
+  expect(result.task.archivedAt).not.toBeNull();
+
+  // `stopHeldTask` orphaned the running subagent row (which also fires the
+  // settle hook) — the hold is released.
+  expect(subagents.hasRunning(taskId)).toBe(false);
+});
+
+test("(d) archive with force+stopRun on an idle task (no run at all) is a plain archive — stopRun is a no-op", async () => {
+  const { archiveTask } = await import("./orchestrator.ts");
+  const { tasks } = await import("./db.ts");
+
+  const taskId = await createClaudeTask("stopRun-idle-task");
+  // No startTask — the task has never run: `runId` is null and it isn't
+  // held by background agents either.
+
+  expect(tasks.get(taskId)?.runId).toBeNull();
+
+  const result = await archiveTask(taskId, { force: true, stopRun: true });
+  expect("task" in result).toBe(true);
+  if (!("task" in result)) throw new Error(result.error);
+  expect(result.task.archivedAt).not.toBeNull();
+});

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -1181,6 +1181,37 @@ function formatModeChangeFailure(agetorMode: string, result: Extract<CycleResult
   }
 }
 
+/**
+ * Stop the active handle `h`'s task. `kill()` sends Ctrl+C to the tmux
+ * session, which also clears claude's queued-input buffer, so every queued
+ * run in this task is going down too. Mark each active handle as cancelled
+ * so their done handlers record "cancelled" (not "failed") when their
+ * slot's reject fires. Resolve any in-flight approval / question for this
+ * task BEFORE the interrupt — otherwise the hook script's curl and the MCP
+ * server's fetch would sit on a doomed HTTP response until their own
+ * timeouts. Shared by `cancelRun` (Stop button) and `archiveTask`
+ * (`stopRun`) so the two can't drift.
+ */
+function stopActiveHandle(h: ActiveRun, reason: string): void {
+  for (const [, handle] of active) {
+    if (handle.taskId === h.taskId) handle.cancelled = true;
+  }
+  cancelPendingForTask(h.taskId, reason);
+  h.kill();
+}
+
+/**
+ * Stop a task that's "held" (see `isHeldByBackgroundAgents`) — its terminal
+ * run already succeeded but background agents are still running, so there's
+ * no `active` handle to kill. Interrupt the live session and release the
+ * hold. Shared by `cancelRun` (Stop button) and `archiveTask` (`stopRun`).
+ */
+function stopHeldTask(taskId: string, reason: string): void {
+  cancelPendingForTask(taskId, reason);
+  interruptTaskSession(taskId);
+  orphanRunningSubagents(taskId);
+}
+
 export function cancelRun(runId: string): boolean {
   const h = active.get(runId);
   if (!h) {
@@ -1192,24 +1223,11 @@ export function cancelRun(runId: string): boolean {
     // already succeeded, so the card advances to `review`.
     const taskId = runs.get(runId)?.taskId;
     if (!taskId || !isHeldByBackgroundAgents(taskId)) return false;
-    cancelPendingForTask(taskId, "cancelled by user");
-    interruptTaskSession(taskId);
-    orphanRunningSubagents(taskId);
+    stopHeldTask(taskId, "cancelled by user");
     return true;
   }
-  // Stop targets the whole task, not just one run. `kill()` sends Ctrl+C
-  // to the tmux session, which also clears claude's queued-input buffer,
-  // so every queued run in this task is going down too. Mark each
-  // active handle as cancelled so their done handlers record "cancelled"
-  // (not "failed") when their slot's reject fires.
-  for (const [, handle] of active) {
-    if (handle.taskId === h.taskId) handle.cancelled = true;
-  }
-  // Resolve any in-flight approval / question for this task BEFORE the
-  // interrupt — otherwise the hook script's curl and the MCP server's
-  // fetch would sit on a doomed HTTP response until their own timeouts.
-  cancelPendingForTask(h.taskId, "cancelled by user");
-  h.kill();
+  // Stop targets the whole task, not just one run.
+  stopActiveHandle(h, "cancelled by user");
   return true;
 }
 
@@ -1873,10 +1891,16 @@ export async function createTask(
  * delete action, which archives a stale worktree's task regardless of where
  * it sits on the board) — the active-run rejection, `archivedAt` stamping,
  * and deferred teardown below are unchanged either way.
+ *
+ * Pass `{ stopRun: true }` to archive a task with an in-flight (or
+ * held-by-background-agents) run anyway: the run is stopped exactly the way
+ * the Stop button stops it (`stopActiveHandle`/`stopHeldTask`, shared with
+ * `cancelRun`) before the normal archive path below proceeds. Without it,
+ * the active-run guard stays in place as a backstop.
  */
 export async function archiveTask(
   taskId: string,
-  opts?: { force?: boolean },
+  opts?: { force?: boolean; stopRun?: boolean },
 ): Promise<{ task: Task } | { error: string }> {
   const task = tasks.get(taskId);
   if (!task) return { error: "task not found" };
@@ -1887,9 +1911,16 @@ export async function archiveTask(
   // freely PATCHable (drag-to-Done on a running card is allowed today). If a
   // run is still active, refuse rather than killing tmux out from under it —
   // the exit handler would then flip the now-archived task to 'ready' and
-  // leave the row in a contradictory state.
+  // leave the row in a contradictory state — UNLESS the caller explicitly
+  // asked us to stop it first (`stopRun`), in which case we do exactly what
+  // the Stop button does before proceeding.
   if (task.runId && active.has(task.runId)) {
-    return { error: "task is still running — cancel the run before archiving" };
+    if (!opts?.stopRun) {
+      return { error: "task is still running — cancel the run before archiving" };
+    }
+    stopActiveHandle(active.get(task.runId)!, "task archived");
+  } else if (opts?.stopRun && isHeldByBackgroundAgents(taskId)) {
+    stopHeldTask(taskId, "task archived");
   }
   if (task.archivedAt != null) {
     return { task };

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -3118,11 +3118,13 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       "/tasks/:id/archive": {
         POST: authed(async (req) => {
           server.timeout(req, 0);
-          // Optional body — no body (or a malformed one) means force: false,
-          // same as the pre-existing behaviour. Only used by the Worktrees
-          // page's delete action to bypass the done-column gate.
-          const body = (await req.json().catch(() => ({}))) as { force?: boolean };
-          const result = await archiveTask(req.params.id, { force: body.force === true });
+          // Optional body — no body (or a malformed one) means force: false
+          // and stopRun: false, same as the pre-existing behaviour. `force`
+          // bypasses the done-column gate (Worktrees page's delete action);
+          // `stopRun` additionally stops an in-flight/held run before
+          // archiving instead of erroring.
+          const body = (await req.json().catch(() => ({}))) as { force?: boolean; stopRun?: boolean };
+          const result = await archiveTask(req.params.id, { force: body.force === true, stopRun: body.stopRun === true });
           return "error" in result
             ? json(result, { status: 400, headers: corsHeaders(req) })
             : json(withRunningSubagents(result.task), { headers: corsHeaders(req) });

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -495,11 +495,22 @@ export default function App() {
     }
   };
   const archive = async (t: Task) => {
+    const active = t.column === "running" || t.column === "blocked";
+    if (active) {
+      const ok = await confirm({
+        title: `Archive "${t.title}"?`,
+        description:
+          "An agent is still working on this task. Archiving will stop it.",
+        confirmLabel: "Stop & archive",
+        variant: "destructive",
+      });
+      if (!ok) return;
+    }
     const now = Date.now();
     setTasks((cur) => cur.map((x) => (x.id === t.id ? { ...x, archivedAt: now } : x)));
     try {
       setError(null);
-      await api.archiveTask(t.id);
+      await api.archiveTask(t.id, active ? { force: true, stopRun: true } : undefined);
       await refresh();
     } catch (e) {
       surfaceError(e);

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -745,6 +745,10 @@ function RunPanelBody({
   const canControl = !!liveRunId
     && (task.column === "running" || task.column === "blocked")
     && !liveRunTerminal;
+  // Archive gate mirrors TaskCard's `active` — running/blocked, regardless of
+  // whether a live run row has been polled in yet, so Archive shows up as
+  // soon as the board would call this task "active" too.
+  const active = task.column === "running" || task.column === "blocked";
   const resumableRunId = liveRunId
     ?? (kind === "claude-code" && runs.length > 0 ? runs[0]!.id : null);
   // Send is enabled whenever the task has ever been run. While a turn is
@@ -1170,8 +1174,13 @@ function RunPanelBody({
               <Square className="mr-1 size-3" /> Stop
             </Button>
           )}
-          {!archived && task.column === "done" && (
-            <Button size="sm" variant="outline" onClick={() => onArchive(task)} title="Archive task">
+          {!archived && (task.column === "done" || active) && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onArchive(task)}
+              title={active ? "Stop the running agent and archive task" : "Archive task"}
+            >
               <Archive className="mr-1 size-3" /> Archive
             </Button>
           )}

--- a/src/mainview/components/kanban/TaskCard.tsx
+++ b/src/mainview/components/kanban/TaskCard.tsx
@@ -179,8 +179,13 @@ export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen, o
               <CheckCircle2 className="mr-1 size-3" /> Done
             </Button>
           )}
-          {!archived && task.column === "done" && (
-            <Button size="icon" variant="ghost" onClick={() => onArchive(task)} title="Archive task">
+          {!archived && (task.column === "done" || active) && (
+            <Button
+              size="icon"
+              variant="ghost"
+              onClick={() => onArchive(task)}
+              title={active ? "Stop the running agent and archive task" : "Archive task"}
+            >
               <Archive className="size-3" />
             </Button>
           )}

--- a/src/mainview/components/worktrees/WorktreesDialog.tsx
+++ b/src/mainview/components/worktrees/WorktreesDialog.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { MultiSearchSelect } from "@/components/ui/multi-search-select";
 import { Select } from "@/components/ui/select";
 import { useConfirm } from "@/components/ui/confirm";
-import { abbreviateHome, cn } from "@/lib/utils";
+import { abbreviateHome } from "@/lib/utils";
 import {
   COLUMNS,
   type ColumnId,
@@ -275,6 +275,7 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
           <strong>archived</strong> (hidden from the board, restorable via Unarchive) and its worktree
           directory removed. The git branch and full AI history are preserved. If the worktree has
           uncommitted changes, it is left in place to protect your work.
+          {w.runActive && " An agent is still working on this task — archiving will stop it."}
         </>
       ),
       confirmLabel: "Archive & delete",
@@ -283,7 +284,7 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
     if (!ok) return;
     await withBusy(w.id, async () => {
       try {
-        await api.archiveTask(taskId, { force: true });
+        await api.archiveTask(taskId, { force: true, stopRun: true });
         await refresh();
       } catch (e) {
         toast.error(e instanceof Error ? e.message : String(e));
@@ -533,15 +534,19 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
                   <Button
                     size="icon"
                     variant="ghost"
-                    title={w.runActive ? "Stop the run first" : "Delete worktree"}
+                    title={
+                      w.runActive
+                        ? (w.taskId ? "Stop the running agent and delete worktree" : "Stop the run first")
+                        : "Delete worktree"
+                    }
                     aria-label="Delete worktree"
-                    disabled={w.runActive || busy}
+                    disabled={(w.runActive && !w.taskId) || busy}
                     onClick={() => { void (w.taskId ? deleteTaskBacked(w) : deleteOrphan(w)); }}
                   >
                     {busy ? (
                       <Loader2 className="size-4 animate-spin" />
                     ) : (
-                      <Trash2 className={cn("size-4", !w.runActive && "text-destructive")} />
+                      <Trash2 className="size-4 text-destructive" />
                     )}
                   </Button>
                 </div>

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -1031,13 +1031,18 @@ export const api = {
   startTask: (id: string) => j<{ runId: string }>(`/tasks/${id}/start`, { method: "POST" }),
   /** `force: true` bypasses the done-column gate (still rejects an active
    *  run) — used by the Worktrees page's "Archive & delete" flow to archive
-   *  a stale worktree's task regardless of its current column. Omitted (the
-   *  common case) sends no body, matching the original archive-from-`done`
-   *  callers unchanged. */
-  archiveTask: (id: string, opts?: { force?: boolean }) =>
+   *  a stale worktree's task regardless of its current column. `stopRun:
+   *  true` additionally stops any in-flight run/background agents before
+   *  archiving — required (server-enforced) to archive a running/blocked
+   *  task at all; the caller is expected to confirm with the user first.
+   *  Omitted (the common case) sends no body, matching the original
+   *  archive-from-`done` callers unchanged. */
+  archiveTask: (id: string, opts?: { force?: boolean; stopRun?: boolean }) =>
     j<Task>(`/tasks/${id}/archive`, {
       method: "POST",
-      ...(opts?.force ? { body: JSON.stringify({ force: true }) } : {}),
+      ...(opts?.force || opts?.stopRun
+        ? { body: JSON.stringify({ force: !!opts.force, stopRun: !!opts.stopRun }) }
+        : {}),
     }),
   unarchiveTask: (id: string) => j<Task>(`/tasks/${id}/unarchive`, { method: "POST" }),
 


### PR DESCRIPTION
## Problem

Archiving a task that still had an agent running failed with the toast **"task is still running — cancel the run before archiving"** (the guard in `archiveTask`). The only way out was to stop the run and move the ticket first, then archive — two manual steps for what should be one action.

## What changed

### Server
- `archiveTask` gains a `stopRun` option. With it, the archive stops the work first:
  - **Active run** — stopped exactly like the Stop button: `cancelled` flag set on the task's active handles, pending interactions cancelled (reason `"task archived"`), handle killed. The run settles as `cancelled`, not `failed`.
  - **Held by background agents** (card looks busy but the main turn already finished — no `active` handle): `interruptTaskSession` + `orphanRunningSubagents`, so "archive means everything stops".
  - **Nothing running** — `stopRun` is a no-op and the archive proceeds normally.
- Without `stopRun`, the original guard error is preserved verbatim as a backstop for stale clients.
- `cancelRun`'s two stop branches were factored into shared `stopActiveHandle` / `stopHeldTask` helpers, so the Stop button and archive can never drift (behavior byte-identical, verified in review).
- `POST /tasks/:id/archive` now parses `stopRun` from the body. The Done-column gate and `force` semantics are untouched — new UI paths send `{ force: true, stopRun: true }`.

### UI
- The **Archive** button now also appears on running/blocked task cards and in the run panel — behind a destructive confirm dialog: *"An agent is still working on this task. Archiving will stop it."* / **Stop & archive**. Done-column archive stays one-click as before.
- The Worktrees page's **Archive & delete** (the path that produced the toast) passes `stopRun`, mentions the stop in its confirm, and its button is now enabled for running task-backed rows (orphan rows with no task remain blocked — there's nothing to stop).

### Tests
- New `src/bun/orchestrator-archive-stop.test.ts`:
  - archive without `stopRun` on a running task → guard error unchanged, nothing archived;
  - archive with `stopRun` → handle killed with `cancelled` flag, pending interactions cancelled, `archivedAt` set;
  - held-by-background-agents + `stopRun` → session interrupted, subagents orphaned, archived;
  - idle task + `stopRun` → plain archive (no-op stop).

## Notes
- Post-archive settling stays async: the done-handler later records the run `cancelled` and parks the column at `ready` under the archive — invisible while archived, and exactly where the task should land on unarchive.
- Pre-existing (not a regression, unchanged): the CLI's `api-client.ts` `archiveTask` takes no options, so archiving a running task from the CLI still errors.
- Verified: `bun run typecheck` clean, full `bun test` 1586 pass / 0 fail. Plan: `docs/plans/archive-should-also-stop.md`.