### PR TITLE
fix: catch claude TUI "Unknown command: /…" and move the task to blocked

### DIFF
--- a/docs/plans/catch-unknown-command-error.md
+++ b/docs/plans/catch-unknown-command-error.md
@@ -1,0 +1,87 @@
+# Plan — Catch claude TUI "Unknown command: /…" and move the task to blocked
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-20 |
+| Source | agetor task (screenshot: `Unknown command: /skill-creator` after user message) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/untraecable-unknown-command-error |
+| Base SHA | a1911e2a873dfd85ce4b516e11bf63d2452a43ae |
+| Mode | **Autonomous** — grill & plan-approval gates bypassed (agetor-driven session, no owner present); assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+When a user message whose first line starts with `/` is delivered to a claude-code task and claude's TUI rejects it with `Unknown command: /<name>` (no turn starts, no JSONL is ever written), agetor must:
+
+- detect it within ~10s (scraper cadence),
+- emit a `status` stream line explaining what happened,
+- resolve the stuck turn, record the run as `failed`,
+- move the card to `blocked` with a new reason `"unknown-command"`,
+- show a distinct toast in the UI.
+
+Success = orchestrator contract test proves blocked+failed+reason; matcher/signal unit tests pass; full suite + typecheck green.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- Prompt delivery is verbatim: `pastePromptSync` (claude-tmux.ts:4742) does `load-buffer`/`paste-buffer -p`/`send-keys Enter`; bracketed paste does **not** stop claude's Ink TUI from dispatching a first line starting with `/` as a slash command. No escaping exists anywhere.
+- When the command is unknown, **no JSONL line is ever written** and the tmux session stays alive → the death watch (`startDeathWatch`, gated on `tmux has-session`) structurally cannot see it, and there is **no turn timeout**. `turnInFlight` stays true forever; the run sits in `running`.
+- The pane scraper (`startScraper` → `scrapeOnce`, claude-tmux.ts:3147/3317, 1s cadence throttled to 2s/10s when JSONL-idle) already captures the pane tail (40 lines) and is the right detection hook.
+- The settle template is `signalSessionDeath` (claude-tmux.ts:3371): emit sentinel `status` chunk via the head slot's `onChunk` (or `onEndOfTurn` for reattach), resolve the slot with code 0, let an orchestrator handle-flag drive `failed` + `blocked`. **Unlike** session-death, we must NOT tear down watchers/timers — the session and claude process remain alive and reusable.
+- Orchestrator consumption pattern: `makeChunkHandler` (orchestrator.ts:859) has parallel branches for `CLAUDE_API_ERROR_STATUS_PREFIX` (873-886) and `SESSION_DIED_STATUS_PREFIX` (891-900) → set `ActiveRun` flag + `updateColumn(taskId, runId, "blocked", <reason>)`; `attachDoneHandler` (926) maps flag → run `failed`, column `blocked`.
+- Reason union lives in exactly two places: `updateColumn` param (orchestrator.ts:303) and `GlobalEvent` column variant (shared/types.ts:1737). UI branch: App.tsx:377-389; toasts in mainview/lib/toasts.ts (98/105/112). Unknown reasons fall through to the generic `toastPending` — fine as fallback but we add a distinct toast.
+- Test seams: fake driver (`AGETOR_CLAUDE_DRIVER=fake`, agents.ts:485-535/570) with per-scenario env flags (`AGETOR_FAKE_CLAUDE_API_ERROR`, `AGETOR_FAKE_CLAUDE_SESSION_DIED`); `orchestrator-blocked.test.ts` asserts the contract; `claude-tmux-death.test.ts` drives `__forTest.installSession`/`pushTurnSlot`/`signalSessionDeath` against a synthetic SessionState; `claude-tmux-scraper.test.ts` feeds pane-text fixtures to pure matcher fns.
+
+## 3. Approach & key decisions
+
+**Detect, don't prevent.** Defanging the leading `/` (e.g. prefixing a space) would break *legitimate* slash-command use (`/compact`, real skills) — users do send those on purpose. The task asks for detection → blocked. (Logged as assumption A1.)
+
+**Armed, token-matched scrape detection.** To make false positives ~impossible (e.g. a bash tool printing "Unknown command:" into the pane, or an assistant quoting it):
+
+1. When a prompt whose **first line starts with `/`** is delivered (`sendTurn`, `pasteFollowUp`, and the spawn paths — argv prompt + `deferredPrompt`), record the slash token on `SessionState` (e.g. `pendingSlashToken: string | null = "/skill-creator"`). Non-slash prompts clear it. It is also cleared whenever a turn resolves (`popEndOfTurn` / slot resolution) and on first JSONL append after the paste (the command was real and ran).
+2. `scrapeOnce` gains a matcher `matchUnknownCommand(tailLines)`: scans only the last ~12 non-blank lines for a line that (after stripping a leading `●`/whitespace) starts with `Unknown command: /<token>`; returns the token.
+3. Fire only when: `pendingSlashToken` is set **AND** matcher's token equals it **AND** `turnInFlight(state)`.
+4. On fire → new `signalUnknownCommand(state)`: emit sentinel `status` chunk, clear `pendingEndTurn` + `holdUntilIdle` + `pendingSlashToken`, resolve head slot with 0 (or fire `onEndOfTurn`), one-shot re-entry guard. **Do not** stop scrape/death/poll timers.
+
+**Sentinel & reason.** New `CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX = "unknown command: "` defined in claude-tmux.ts (claude-only, mirrors `CLAUDE_API_ERROR_STATUS_PREFIX`; shared/types.ts is only for cross-driver sentinels). New reason literal `"unknown-command"` in both union sites. Orchestrator: `ActiveRun.unknownCommand` flag, `makeChunkHandler` branch mirroring the api-error one (gated `kind === "claude-code"`), `attachDoneHandler` → run `failed`, column `blocked`.
+
+**Message content.** Sentinel payload: `unknown command: /skill-creator — claude treated the message as a slash command; it was not delivered. Edit the message so it doesn't start with "/" and resend.` (prefix + detail, mirroring the other sentinels).
+
+**Alternatives considered.** (a) JSONL-silence timeout on every turn — rejected: long tool runs are legitimately silent; timeout value is unknowable. (b) Un-gated pane regex — rejected: tool output / quoted text false positives. (c) Prevention by escaping — rejected above.
+
+## 4. Work breakdown — implementation (one wave, one task)
+
+The change is a single coherent seam (sentinel name, state field, reason literal must agree across files) — splitting it across parallel agents risks drift, so it is **one task, one agent**.
+
+**T1 — full vertical slice.** Owns: `src/bun/claude-tmux.ts`, `src/bun/orchestrator.ts`, `src/bun/agents.ts`, `src/shared/types.ts`, `src/mainview/App.tsx`, `src/mainview/lib/toasts.ts`. Must NOT touch any `*.test.ts`.
+- claude-tmux.ts: sentinel const; `pendingSlashToken` on SessionState (cleared in dispose); arm/clear at the four delivery points; `matchUnknownCommand`; `scrapeOnce` hook; `signalUnknownCommand`; export new pieces via `__forTest`.
+- orchestrator.ts: import sentinel; `unknownCommand` on `ActiveRun` + `registerActiveRun` default; `makeChunkHandler` branch; `attachDoneHandler` `wasUnknownCommand` → `failed`/`blocked`; `updateColumn` reason type.
+- shared/types.ts: `"unknown-command"` in GlobalEvent reason union.
+- agents.ts: `AGETOR_FAKE_CLAUDE_UNKNOWN_COMMAND === "1"` branch in `makeFakeAgent` (mirror the session-died branch).
+- toasts.ts + App.tsx: `toastUnknownCommand` + reason branch.
+- Acceptance: `bun run typecheck` green; existing suite untouched-green.
+
+## 5. Work breakdown — tests (one wave, two tasks, disjoint files)
+
+- **TT1** — new `src/bun/claude-tmux-unknown-command.test.ts` (style of `claude-tmux-death.test.ts` + `claude-tmux-scraper.test.ts`): matcher positives (with/without `●` bullet, args line present), negatives (token mismatch, mid-pane quoted text outside the tail window, no token armed); `signalUnknownCommand` in-flight settles + emits sentinel + preserves timers; idle no-op; reattach `onEndOfTurn` path; arming/clearing semantics.
+- **TT2** — extend `src/bun/orchestrator-blocked.test.ts`: with fake driver + `AGETOR_FAKE_CLAUDE_UNKNOWN_COMMAND=1` assert column `blocked`, run `failed`, GlobalEvent reason `"unknown-command"` (mirror existing api-error/session-died cases).
+
+## 6. Execution waves
+
+1. Wave A: T1 (implementation) → typecheck + suite → commit.
+2. Phase 5: code review (opus) on `git diff a1911e2...HEAD`.
+3. Wave B: TT1 ∥ TT2 (disjoint files) → run suite (haiku) → fix loop ≤3 rounds → commit.
+
+## 7. Blast radius & risks
+
+- `scrapeOnce` runs on every claude session — matcher must be cheap and only run when armed (`pendingSlashToken !== null`).
+- The reattach path sets `onEndOfTurn` — `signalUnknownCommand` must fire it like `signalSessionDeath` does; but `pendingSlashToken` is in-memory, so post-restart re-detection is impossible (see limitation L2).
+- Do **not** clear scrape/death timers on fire — next turn reuses the live session (a follow-up send routes through `sendTurn` normally since the session exists).
+- The fold-while-busy case (`pasteFollowUp`) races the 800ms `END_TURN_IDLE_FIRE_MS` idle-fire: the staged end_turn may resolve the run (→ review) before the ~1-2s scraper tick sees the error (limitation L1). When the scraper wins, the guard set (armed + in-flight) behaves correctly.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+- **A1**: Detection (→ blocked) is wanted, not prevention (escaping the `/`), since legitimate slash commands must keep working. This matches the task wording ("catch this kind of error and move the ticket to blocked").
+- **A2**: Scope is the `Unknown command:` TUI error specifically (the reported case). Other TUI-level errors (rate-limit banners etc.) are out of scope; the matcher/signal shape is extensible.
+- **A3**: Run status on detection is `failed` (mirrors api-error/session-died exactly — zero new status plumbing).
+- **L1** (limitation): the fold-while-busy race above — if the idle-fire wins, the run resolves to review and the swallowed message is only visible in the pane. Rare (requires sending a slash message while a turn is mid-flight) and non-destructive.
+- **L2** (limitation): a crash in the window between sentinel emit and run settle loses the in-memory armed token; after restart the reattached run is not re-detected. Window is milliseconds; accepted.

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { MODEL_EFFORT_SUPPORT, SESSION_DIED_STATUS_PREFIX, type AgentKind, type Harness } from "../shared/types.ts";
 import {
   CLAUDE_API_ERROR_STATUS_PREFIX,
+  CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX,
   spawnClaudeViaTmux,
   toClaudeModeString,
   type ChunkHandler,
@@ -518,6 +519,24 @@ function makeFakeAgent(taskId: string, prompt: string, onChunk: ChunkHandler): S
     const resolveDelayMs = Number(process.env.AGETOR_FAKE_CLAUDE_RESOLVE_DELAY_MS ?? 5) || 5;
     setTimeout(() => {
       onChunk("status", `${SESSION_DIED_STATUS_PREFIX}tmux session agetor-fake ended unexpectedly — task blocked`);
+    }, 5);
+    setTimeout(() => { resolveDone(0); }, resolveDelayMs);
+  } else if (process.env.AGETOR_FAKE_CLAUDE_UNKNOWN_COMMAND === "1") {
+    // Test hook: simulate claude's TUI rejecting the message as an unknown
+    // slash command. Mirrors what `signalUnknownCommand` (claude-tmux.ts)
+    // emits from the pane scraper — the `CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX`
+    // sentinel status chunk that makeChunkHandler pattern-matches to flip the
+    // column to `blocked`, then resolves the turn with code 0 (the handle
+    // `unknownCommand` flag, not the exit code, drives the failed/blocked
+    // outcome). Optional resolve delay lets cancellation-precedence tests
+    // fire cancelRun between the column flip and the done resolution.
+    const resolveDelayMs = Number(process.env.AGETOR_FAKE_CLAUDE_RESOLVE_DELAY_MS ?? 5) || 5;
+    setTimeout(() => {
+      onChunk(
+        "status",
+        `${CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX}/fake-command — claude treated the message as a `
+          + `slash command; it was not delivered. Edit the message so it doesn't start with "/" and resend.`,
+      );
     }, 5);
     setTimeout(() => { resolveDone(0); }, resolveDelayMs);
   } else {

--- a/src/bun/claude-tmux-unknown-command.test.ts
+++ b/src/bun/claude-tmux-unknown-command.test.ts
@@ -1,0 +1,289 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+// Pre-set AGETOR_DATA_DIR before claude-tmux.ts's transitive db.ts import.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-tmux-unknown-cmd-"));
+
+const { __forTest, CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX } = await import("./claude-tmux.ts");
+// Dynamic import (not a static top-level one) so it resolves AFTER the
+// AGETOR_DATA_DIR assignment above — a static import would be hoisted and
+// run before that assignment, capturing the wrong data dir (db.ts reads the
+// env var at module load). Mirrors claude-tmux-death.test.ts exactly.
+
+const { signalUnknownCommand, matchUnknownCommand, slashTokenOf, dispatchLine, turnInFlight } = __forTest;
+
+interface Recorded { stream: string; data: string }
+function recorder() {
+  const out: Recorded[] = [];
+  return {
+    out,
+    onChunk: (stream: string, data: string) => out.push({ stream, data }),
+  };
+}
+
+function freshSession() {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-unknown-cmd-"));
+  const jsonlPath = path.join(dir, `${randomUUID()}.jsonl`);
+  writeFileSync(jsonlPath, "");
+  const taskId = randomUUID();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  return { taskId, jsonlPath, state };
+}
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * slashTokenOf
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("slashTokenOf: extracts the leading slash token, ignoring the rest of the line", () => {
+  expect(slashTokenOf("/skill-creator do X")).toBe("/skill-creator");
+});
+
+test("slashTokenOf: only the FIRST line is considered", () => {
+  // First line is a real slash command — the rest of the prompt is ignored.
+  expect(slashTokenOf("/skill-creator arg1 arg2\nsecond line ignored\nthird line")).toBe(
+    "/skill-creator",
+  );
+  // First line is plain text — a slash on a LATER line must not arm anything,
+  // since claude's TUI only ever interprets the first line as a command.
+  expect(slashTokenOf("hello there\n/not-a-command")).toBeNull();
+});
+
+test("slashTokenOf: plain text (no leading slash) returns null", () => {
+  expect(slashTokenOf("hello world")).toBeNull();
+  expect(slashTokenOf("please run /compact for me")).toBeNull();
+});
+
+test("slashTokenOf: leading whitespace before the slash means the line does not 'start with /'", () => {
+  // firstLine.startsWith("/") is a strict check — a space-indented slash is
+  // not treated as a command token by this function (whatever claude's TUI
+  // itself does with leading whitespace is a separate concern).
+  expect(slashTokenOf(" /skill-creator do X")).toBeNull();
+  expect(slashTokenOf("\t/skill-creator")).toBeNull();
+});
+
+test("slashTokenOf: a bare '/' is its own token", () => {
+  expect(slashTokenOf("/")).toBe("/");
+});
+
+test("slashTokenOf: empty string returns null", () => {
+  expect(slashTokenOf("")).toBeNull();
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * matchUnknownCommand — positives
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("matchUnknownCommand: matches claude's bulleted status line", () => {
+  const tail = ["some earlier output", "● Unknown command: /skill-creator", "more output"];
+  expect(matchUnknownCommand(tail, "/skill-creator")).toBe(true);
+});
+
+test("matchUnknownCommand: matches without the '●' bullet prefix", () => {
+  const tail = ["Unknown command: /skill-creator"];
+  expect(matchUnknownCommand(tail, "/skill-creator")).toBe(true);
+});
+
+test("matchUnknownCommand: still matches when an 'Args from unknown skill:' line follows", () => {
+  const tail = [
+    "● Unknown command: /skill-creator",
+    "  Args from unknown skill: do the thing",
+  ];
+  expect(matchUnknownCommand(tail, "/skill-creator")).toBe(true);
+});
+
+test("matchUnknownCommand: matches when the error line is among (not necessarily last of) the last 12 non-blank lines", () => {
+  const before = Array.from({ length: 15 }, (_, i) => `filler before ${i}`);
+  const after = ["trailing note 1", "trailing note 2", "trailing note 3"];
+  const tail = [...before, "● Unknown command: /skill-creator", ...after];
+  // 15 + 1 + 3 = 19 non-blank lines; the error sits at index 15, well inside
+  // the last 12 (indices 7..18), but is not itself the final line.
+  expect(matchUnknownCommand(tail, "/skill-creator")).toBe(true);
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * matchUnknownCommand — negatives
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("matchUnknownCommand: word-boundary — a shorter armed token does not match a longer one in the pane", () => {
+  const tail = ["● Unknown command: /skill-creator"];
+  // Armed "/skill" must NOT match "/skill-creator" (it's a prefix, not the
+  // whole token — "-creator" isn't whitespace/end-of-line).
+  expect(matchUnknownCommand(tail, "/skill")).toBe(false);
+});
+
+test("matchUnknownCommand: word-boundary — a longer armed token does not match a shorter one in the pane", () => {
+  const tail = ["● Unknown command: /skill"];
+  expect(matchUnknownCommand(tail, "/skill-creator")).toBe(false);
+});
+
+test("matchUnknownCommand: a match ONLY above the last-12-non-blank window is not seen", () => {
+  const after = Array.from({ length: 12 }, (_, i) => `filler after ${i}`);
+  const tail = ["● Unknown command: /skill-creator", ...after];
+  // 1 + 12 = 13 non-blank lines; slice(-12) drops the error line entirely.
+  expect(matchUnknownCommand(tail, "/skill-creator")).toBe(false);
+});
+
+test("matchUnknownCommand: regex metacharacters in the token don't crash and aren't treated as wildcards", () => {
+  const token = "/skill+creator.v2";
+  const literalMatch = ["● Unknown command: /skill+creator.v2"];
+  expect(() => matchUnknownCommand(literalMatch, token)).not.toThrow();
+  expect(matchUnknownCommand(literalMatch, token)).toBe(true);
+
+  // If '+' / '.' were interpreted as regex metacharacters instead of literal
+  // characters, this substituted pane line would spuriously match too. It
+  // must not.
+  const wouldFalselyMatchIfUnescaped = ["● Unknown command: /skillXcreatorXv2"];
+  expect(matchUnknownCommand(wouldFalselyMatchIfUnescaped, token)).toBe(false);
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * signalUnknownCommand
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("signalUnknownCommand: settles an in-flight slot, emits the sentinel, and clears armed state", async () => {
+  const { taskId, state } = freshSession();
+  const rec = recorder();
+  try {
+    const done = __forTest.pushTurnSlot(state, rec.onChunk);
+    state.pendingSlashToken = "/skill-creator";
+    state.pendingEndTurn = { messageId: null, uuid: undefined, emitBanner: true, stagedAt: Date.now() };
+    state.holdUntilIdle = true;
+    expect(turnInFlight(state)).toBe(true);
+
+    signalUnknownCommand(state);
+
+    const code = await done;
+    expect(code).toBe(0);
+
+    const sentinel = rec.out.find(
+      (c) => c.stream === "status" && c.data.startsWith(CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX),
+    );
+    expect(sentinel).toBeDefined();
+    expect(sentinel!.data).toContain("/skill-creator");
+
+    expect(state.pendingSlashToken).toBeNull();
+    expect(state.pendingEndTurn).toBeNull();
+    expect(state.holdUntilIdle).toBe(false);
+    expect(turnInFlight(state)).toBe(false);
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("signalUnknownCommand: does NOT clear scrape/death timers (session stays alive, unlike signalSessionDeath)", async () => {
+  const { taskId, state } = freshSession();
+  const rec = recorder();
+  // Sentinel live timers standing in for the real scrape/death watchers —
+  // signalUnknownCommand must leave them untouched so the session keeps
+  // being polled/scraped for the NEXT turn.
+  const scrapeTimer = setInterval(() => {}, 1_000_000);
+  const deathTimer = setInterval(() => {}, 1_000_000);
+  state.scrapeTimer = scrapeTimer;
+  state.deathTimer = deathTimer;
+  try {
+    __forTest.pushTurnSlot(state, rec.onChunk);
+    state.pendingSlashToken = "/skill-creator";
+
+    signalUnknownCommand(state);
+
+    expect(state.scrapeTimer).toBe(scrapeTimer);
+    expect(state.deathTimer).toBe(deathTimer);
+  } finally {
+    clearInterval(scrapeTimer);
+    clearInterval(deathTimer);
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("signalUnknownCommand: second call is a no-op (one-shot)", async () => {
+  const { taskId, state } = freshSession();
+  const rec = recorder();
+  try {
+    const done = __forTest.pushTurnSlot(state, rec.onChunk);
+    state.pendingSlashToken = "/skill-creator";
+
+    signalUnknownCommand(state);
+    await done;
+    const firstEmitCount = rec.out.length;
+    expect(firstEmitCount).toBeGreaterThan(0);
+
+    // pendingSlashToken is already null and the slot already consumed — a
+    // stray second call (e.g. a late scrapeOnce tick) must not emit again or
+    // throw.
+    expect(() => signalUnknownCommand(state)).not.toThrow();
+    expect(rec.out.length).toBe(firstEmitCount);
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("signalUnknownCommand: no-op when there's no in-flight turn and no armed token", () => {
+  const { taskId, state } = freshSession();
+  const rec = recorder();
+  state.lastChunk = rec.onChunk;
+  try {
+    expect(turnInFlight(state)).toBe(false);
+    expect(state.pendingSlashToken).toBeNull();
+
+    signalUnknownCommand(state);
+
+    expect(rec.out.length).toBe(0);
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+test("signalUnknownCommand: reattach path fires the onEndOfTurn hook when there's no in-process slot", () => {
+  const { taskId, state } = freshSession();
+  const rec = recorder();
+  try {
+    // Reattached in-flight run: no in-process slot, but an onEndOfTurn hook
+    // the orchestrator installed so it can flip the run row on completion.
+    // The sentinel routes through state.lastChunk (the last known handler)
+    // since there's no live slot.onChunk on this path.
+    let fired = false;
+    state.onEndOfTurn = () => { fired = true; };
+    state.lastChunk = rec.onChunk;
+    state.pendingSlashToken = "/skill-creator";
+    expect(turnInFlight(state)).toBe(true);
+
+    signalUnknownCommand(state);
+
+    expect(fired).toBe(true);
+    // Fire-once: the hook is cleared so a stray later tick can't double-fire.
+    expect(state.onEndOfTurn).toBeNull();
+    expect(state.pendingSlashToken).toBeNull();
+    expect(turnInFlight(state)).toBe(false);
+
+    const sentinel = rec.out.find(
+      (c) => c.stream === "status" && c.data.startsWith(CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX),
+    );
+    expect(sentinel).toBeDefined();
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Arming / disarm through dispatchLine
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("dispatchLine disarms pendingSlashToken — any real JSONL line proves the message was delivered", () => {
+  const { taskId, state } = freshSession();
+  try {
+    state.pendingSlashToken = "/skill-creator";
+    expect(state.pendingSlashToken).toBe("/skill-creator");
+
+    const uuid = randomUUID();
+    dispatchLine(state, JSON.stringify({
+      type: "system", uuid, permissionMode: "default",
+    }));
+
+    expect(state.pendingSlashToken).toBeNull();
+  } finally {
+    __forTest.uninstallSession(taskId);
+  }
+});

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -2998,6 +2998,11 @@ function sha1(s: string): string {
  * word-boundary match on `token`: `"Unknown command: /skill-creator"` must
  * NOT match an armed token of `"/skill"` (a prefix), so the token is
  * followed by whitespace or end-of-line.
+ *
+ * Known non-matches, accepted because claude's error line is short and
+ * always "● "-prefixed: a leading glyph other than "●", trailing
+ * punctuation right after the token, and a command name tmux hard-wrapped
+ * across physical lines (`capture-pane` without `-J`).
  */
 function matchUnknownCommand(tail: string[], token: string): boolean {
   const nonBlank = tail.filter((l) => l.trim().length > 0).slice(-12);
@@ -3550,6 +3555,10 @@ function signalUnknownCommand(state: SessionState): void {
     slot.reject = null;
     resolve(0);
   } else if (state.onEndOfTurn) {
+    // Symmetry with `signalSessionDeath`; in production this branch can't
+    // fire on a genuinely reattached run — `pendingSlashToken` is in-memory
+    // and never re-armed after a restart (plan limitation L2) — so it's
+    // reachable only from synthetic test states.
     const handler = state.onEndOfTurn;
     state.onEndOfTurn = null;
     handler();
@@ -4256,6 +4265,10 @@ export function pasteFollowUp(taskId: string, prompt: string): boolean {
   state.holdUntilIdle = true;
   // Arm (or disarm) the unknown-command lookout for the folded-in prompt —
   // same rule as `sendTurn`: only a first line starting with "/" arms it.
+  // Best-effort here: the in-flight turn's own JSONL lines clear the token
+  // (`dispatchLine`), so a folded slash command is only caught when the turn
+  // has already gone JSONL-quiet before claude replays it (plan limitation
+  // L1 in docs/plans/catch-unknown-command-error.md).
   state.pendingSlashToken = slashTokenOf(prompt);
   void queuePaste(taskId, state.sessionName, prompt, 0, state, { bracketed: true });
   return true;

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -476,6 +476,25 @@ interface ParsedJsonlEvent {
  *  consumer (orchestrator) can't drift. */
 export const CLAUDE_API_ERROR_STATUS_PREFIX = "api error: ";
 
+/** Status-chunk prefix for the "claude's TUI rejected the message as an
+ *  unknown slash command" sentinel — mirrors `CLAUDE_API_ERROR_STATUS_PREFIX`
+ *  exactly (producer here, consumer in orchestrator.ts's `makeChunkHandler`).
+ *  See `signalUnknownCommand` for the emit site and `matchUnknownCommand` /
+ *  `slashTokenOf` for detection. */
+export const CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX = "unknown command: ";
+
+/** Returns the first whitespace-delimited token of `prompt`'s first line iff
+ *  that line starts with `/` (e.g. `"/skill-creator do the thing"` →
+ *  `"/skill-creator"`), else null. Used to arm/disarm
+ *  `SessionState.pendingSlashToken` at every prompt-delivery point — a prompt
+ *  starting with `/` is the one case claude's Ink TUI may swallow as a slash
+ *  command instead of delivering it as a message. */
+function slashTokenOf(prompt: string): string | null {
+  const firstLine = prompt.split("\n", 1)[0] ?? "";
+  if (!firstLine.startsWith("/")) return null;
+  return firstLine.match(/^(\S+)/)?.[1] ?? null;
+}
+
 /**
  * True for an assistant JSONL line that claims to end a turn. Used by
  * `dispatchLine` to decide whether to stage a pending end_turn. The claim
@@ -1596,6 +1615,20 @@ interface SessionState {
    *  been quiet for `END_TURN_IDLE_FIRE_MS`. Cleared in `popEndOfTurn` when the
    *  slot finally pops (the whole busy period is over). */
   holdUntilIdle: boolean;
+  /** First whitespace-delimited token of the current turn's prompt, iff its
+   *  FIRST line starts with `/` (e.g. `/skill-creator`) — null otherwise. Set
+   *  by every prompt-delivery point (`sendTurn`, `pasteFollowUp`, the
+   *  deferred-prompt paste and argv-prompt spawn path in
+   *  `spawnClaudeViaTmux`), which lets `scrapeOnce` arm a token-matched
+   *  lookout for claude's TUI rejecting the message with `Unknown command:
+   *  /<token>` — no JSONL is ever written for that case, so nothing else
+   *  would ever unstick the run. Cleared (a) on the next real JSONL line
+   *  (`dispatchLine` — the message was delivered/ran for real), (b) when a
+   *  turn resolves normally (`popEndOfTurn`), (c) on session death
+   *  (`signalSessionDeath`), and (d) by `signalUnknownCommand` itself, which
+   *  doubles as its one-shot re-entry guard (`scrapeOnce` only calls it while
+   *  this is non-null). */
+  pendingSlashToken: string | null;
   /** Watches `<sessionId>/subagents/` for background/sub agents this session
    *  spawns, tailing each into the task's event stream (tagged by subagent id)
    *  for the run panel's read-only tabs. Armed in `attachTailer`, released in
@@ -1716,6 +1749,7 @@ function makeSessionState(o: MakeSessionStateOpts): SessionState {
     askFirstSeenAt: null,
     pendingEndTurn: null,
     holdUntilIdle: false,
+    pendingSlashToken: null,
     subagentWatcher: null,
     continuationWatchdog: null,
   };
@@ -1825,6 +1859,9 @@ function popEndOfTurn(state: SessionState): void {
   // The busy period (the active turn plus any folded follow-ups) is ending —
   // clear the hold so the next genuinely-sequential turn resolves normally.
   state.holdUntilIdle = false;
+  // The turn resolved normally (real end_turn) — whatever was armed for the
+  // unknown-command lookout no longer applies to it.
+  state.pendingSlashToken = null;
   // A turn resolving through the normal end-turn machinery means any
   // notification-triggered continuation watchdog has nothing left to guard
   // against — cancel it. Safe unconditionally: the watchdog is only ever
@@ -2436,6 +2473,11 @@ function maybeAdoptContinuation(
 }
 
 function dispatchLine(state: SessionState, line: string): void {
+  // Any JSONL line reaching us at all is proof claude accepted the
+  // last-pasted message as a real turn (an unknown-slash-command rejection
+  // never writes one) — disarm the lookout so a later, unrelated pane match
+  // can't misfire against a stale token.
+  state.pendingSlashToken = null;
   let evt: ParsedJsonlEvent;
   try {
     evt = JSON.parse(line);
@@ -2944,6 +2986,32 @@ function sha1(s: string): string {
 }
 
 /**
+ * Recognise claude's Ink TUI rejecting a pasted message as an unknown slash
+ * command, e.g.:
+ *
+ *   ● Unknown command: /skill-creator
+ *
+ * No JSONL line is ever written for this — the message was never delivered
+ * as a turn — so this pane scrape is the only signal. Scans only the last
+ * ~12 NON-BLANK lines of the tail (a stale sighting further up the pane
+ * shouldn't false-fire on a later, unrelated turn) and requires an exact
+ * word-boundary match on `token`: `"Unknown command: /skill-creator"` must
+ * NOT match an armed token of `"/skill"` (a prefix), so the token is
+ * followed by whitespace or end-of-line.
+ */
+function matchUnknownCommand(tail: string[], token: string): boolean {
+  const nonBlank = tail.filter((l) => l.trim().length > 0).slice(-12);
+  const escapedToken = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^Unknown command: ${escapedToken}(?:\\s|$)`);
+  return nonBlank.some((raw) => {
+    // Strip leading whitespace and an optional "●" bullet + following
+    // whitespace — claude prefixes its own status lines with "● ".
+    const stripped = raw.replace(/^\s*(?:●\s*)?/, "");
+    return re.test(stripped);
+  });
+}
+
+/**
  * One-time *startup consent* dialogs claude can draw before it ever reaches
  * the REPL. These are special because they block JSONL creation entirely:
  * the normal scraper only arms after the JSONL exists (`attachTailer`), so it
@@ -3167,7 +3235,24 @@ function scrapeOnce(state: SessionState): void {
     return;
   }
   const lines = cap.stdout.split("\n");
-  const tail = lines.slice(Math.max(0, lines.length - SCRAPE_TAIL_LINES)).join("\n");
+  const tailLines = lines.slice(Math.max(0, lines.length - SCRAPE_TAIL_LINES));
+  const tail = tailLines.join("\n");
+
+  // Armed, token-matched lookout for claude's TUI rejecting the last-pasted
+  // message as an unknown slash command. Cheap and early-guarded — only
+  // evaluated while a token is armed AND a turn is genuinely in flight — so
+  // this never runs for the (overwhelmingly common) non-slash-prompt case.
+  // No JSONL line is ever written when this fires, so this scrape is the
+  // only place that can catch it. Runs before the modal-detection block
+  // below; ordering doesn't otherwise matter (an unknown-command error never
+  // coexists with a modal) since `signalUnknownCommand` is one-shot (it
+  // clears `pendingSlashToken`, so a re-check later in the same tick — there
+  // isn't one — or the next tick can't double-fire).
+  if (state.pendingSlashToken !== null
+    && turnInFlight(state)
+    && matchUnknownCommand(tailLines, state.pendingSlashToken)) {
+    signalUnknownCommand(state);
+  }
 
   // JSONL-recency gate: claude is actively writing. The pane content
   // is mid-render, not a stable modal — defer matching until things
@@ -3371,6 +3456,9 @@ export const DEATH_JSONL_QUIET_MS = 3_000;
 function signalSessionDeath(state: SessionState): void {
   const inFlight = turnInFlight(state);
   if (!inFlight && !heldProbeSafe(state.taskId)) return;
+  // The turn (if any) is being settled by a different sentinel below — an
+  // armed slash token has nothing left to watch for.
+  state.pendingSlashToken = null;
   const slot = state.turnQueue[0];
   const onChunk = slot?.onChunk ?? state.lastChunk ?? (() => {});
   onChunk(
@@ -3420,6 +3508,52 @@ function signalSessionDeath(state: SessionState): void {
   // that no longer exists. Release it the same way the run itself is
   // released above.
   orphanRunningSubagents(state.taskId);
+}
+
+/**
+ * Settle an in-flight turn because claude's Ink TUI rejected the last-pasted
+ * message as an unknown slash command (`Unknown command: /<token>`). No
+ * JSONL line is ever written for this — the message was never delivered as
+ * a turn — so `scrapeOnce`'s pane scrape is the only signal, gated on
+ * `state.pendingSlashToken` being armed (see `slashTokenOf`) and a turn
+ * genuinely being in flight (checked by the caller).
+ *
+ * Mirrors `signalSessionDeath`'s settle mechanics exactly — emit the
+ * sentinel `status` chunk via the head slot's `onChunk` (or `onEndOfTurn` on
+ * the reattach path), resolve the slot with code 0 — but, UNLIKE session
+ * death, the tmux session and claude process stay alive and reusable: we do
+ * NOT stop the scrape/death/poll timers or the JSONL watcher. The next turn
+ * on this task routes through `sendTurn` exactly as if nothing happened.
+ *
+ * One-shot: clearing `state.pendingSlashToken` up front is both the disarm
+ * and the re-entry guard — a second call (or a stale timer callback) with
+ * nothing armed is a no-op.
+ */
+function signalUnknownCommand(state: SessionState): void {
+  const token = state.pendingSlashToken;
+  if (!token) return;
+  state.pendingSlashToken = null;
+  state.pendingEndTurn = null;
+  state.holdUntilIdle = false;
+  const slot = state.turnQueue[0];
+  const onChunk = slot?.onChunk ?? state.lastChunk ?? (() => {});
+  onChunk(
+    "status",
+    `${CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX}${token} — claude treated the message as a slash `
+      + `command; it was not delivered. Edit the message so it doesn't start with "/" and resend.`,
+  );
+  if (slot && slot.resolve) {
+    state.turnQueue.shift();
+    state.lastChunk = slot.onChunk;
+    const resolve = slot.resolve;
+    slot.resolve = null;
+    slot.reject = null;
+    resolve(0);
+  } else if (state.onEndOfTurn) {
+    const handler = state.onEndOfTurn;
+    state.onEndOfTurn = null;
+    handler();
+  }
 }
 
 /** Whether a turn is currently in flight on this session — a live head slot
@@ -3644,6 +3778,22 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
   // the opening run's stream.
   state.lastChunk = opts.onChunk;
 
+  // Argv-prompt spawn path: the small-prompt case already embedded the
+  // opening message as the final `-- <prompt>` pair in `opts.argv`, baked
+  // into the `tmux new-session` command dispatched above — there is no
+  // separate paste call after this point to arm at, so arm right here, as
+  // soon as the SessionState exists. (Mirrors `sendTurn`/`pasteFollowUp`;
+  // the large-prompt `deferredPrompt` case arms itself right where it's
+  // actually pasted, further down.) A no-op (armed to null) when
+  // `deferredPrompt` is set — that branch below owns arming for its prompt.
+  if (!opts.deferredPrompt) {
+    const argv = opts.argv;
+    const embeddedPrompt = argv.length >= 2 && argv[argv.length - 2] === "--"
+      ? argv[argv.length - 1]
+      : undefined;
+    state.pendingSlashToken = embeddedPrompt ? slashTokenOf(embeddedPrompt) : null;
+  }
+
   // Large-prompt delivery: `buildCommand` (agents.ts) omits any prompt over
   // CLAUDE_PROMPT_ARGV_MAX_BYTES from argv — embedding it would blow tmux's
   // client-command cap and fail `new-session` outright — and hands it back
@@ -3704,6 +3854,12 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
         if (!ready) {
           opts.onChunk("status", "claude readiness never confirmed — delivering prompt anyway");
         }
+        // Arm the unknown-command lookout right at the actual delivery point
+        // — mirrors `sendTurn`/`pasteFollowUp`. (The small-prompt argv case
+        // arms right after SessionState is created instead, since its
+        // "paste" already happened via the launch argv before this function
+        // even returned.)
+        state.pendingSlashToken = slashTokenOf(deferredPrompt);
         void queuePaste(opts.taskId, sessionName, deferredPrompt, 0, state, {
           bracketed: true,
           onPasteFailure: () => {
@@ -4023,6 +4179,10 @@ export function sendTurn(taskId: string, prompt: string, onChunk: ChunkHandler):
   // pop it immediately. After flushSync, the queue head reflects the
   // truly in-flight turn (or is empty if the previous turn just ended).
   flushSync(state);
+  // Arm (or disarm) the unknown-command lookout for THIS turn's prompt —
+  // must happen after flushSync (which may itself clear a stale token left
+  // over from the previous turn) so the new value sticks.
+  state.pendingSlashToken = slashTokenOf(prompt);
   // Keep a handle on the pushed slot (rather than only closing over
   // resolve/reject) so a paste failure below can settle *this specific*
   // slot in-process instead of leaving the run stuck `running` until the
@@ -4094,6 +4254,9 @@ export function pasteFollowUp(taskId: string, prompt: string): boolean {
   const state = sessions.get(taskId);
   if (!state) return false;
   state.holdUntilIdle = true;
+  // Arm (or disarm) the unknown-command lookout for the folded-in prompt —
+  // same rule as `sendTurn`: only a first line starting with "/" arms it.
+  state.pendingSlashToken = slashTokenOf(prompt);
   void queuePaste(taskId, state.sessionName, prompt, 0, state, { bracketed: true });
   return true;
 }
@@ -4541,6 +4704,11 @@ export const __forTest = {
   /** Death-watch settlement — exposed so the death test can drive it against a
    *  synthetic session without a real tmux server. */
   signalSessionDeath,
+  /** Unknown-slash-command settlement — exposed so the matcher/signal test
+   *  can drive it against a synthetic session without a real tmux server. */
+  signalUnknownCommand,
+  matchUnknownCommand,
+  slashTokenOf,
   turnInFlight,
   matchNumberedModal,
   matchYesNoModal,

--- a/src/bun/orchestrator-blocked.test.ts
+++ b/src/bun/orchestrator-blocked.test.ts
@@ -192,6 +192,119 @@ test("orchestrator moves task to 'blocked' when a running tmux session dies mid-
   }
 });
 
+test("orchestrator moves task to 'blocked' when claude's TUI rejects the message as an unknown slash command", async () => {
+  const { createTask, startTask, subscribeGlobal } = await import("./orchestrator.ts");
+  const { tasks, runs } = await import("./db.ts");
+  const { CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX } = await import("./claude-tmux.ts");
+
+  // The fake driver emits the same `CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX`
+  // sentinel the real pane scraper emits when claude's TUI rejects a
+  // slash-leading message with "Unknown command: /…", then resolves
+  // done(0). The orchestrator's chunk handler should flip the column to
+  // `blocked` (reason `unknown-command`), and the done handler should keep
+  // it there and record the run `failed` — mirroring the api-error and
+  // session-died contracts above.
+  process.env.AGETOR_CLAUDE_DRIVER = "fake";
+  process.env.AGETOR_FAKE_CLAUDE_UNKNOWN_COMMAND = "1";
+
+  const globals: GlobalEvent[] = [];
+  const unsub = subscribeGlobal((e) => globals.push(e));
+
+  try {
+    const created = await createTask({
+      title: "unknown command",
+      prompt: "/fake-command anything",
+      agent: "claude-code",
+      workdir: process.cwd(),
+      isolation: "none",
+    });
+    if ("error" in created) throw new Error(created.error);
+    const task = created.task;
+
+    const res = await startTask(task.id);
+    if ("error" in res) throw new Error(`startTask failed: ${res.error}`);
+    const runId = res.runId;
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    const after = tasks.get(task.id);
+    expect(after?.column).toBe("blocked");
+
+    const runRow = runs.get(runId);
+    expect(runRow?.status).toBe("failed");
+
+    // The `unknown-command` reason on the column event is what routes the UI
+    // to the dedicated toast (not the generic "Waiting on you"). Assert it
+    // explicitly so a dropped 4th arg to updateColumn is caught.
+    const unknownCommandCol = globals.find(
+      (e) => e.kind === "column" && e.taskId === task.id && e.column === "blocked",
+    );
+    expect(unknownCommandCol).toBeDefined();
+    if (unknownCommandCol?.kind !== "column") throw new Error("expected column event");
+    expect(unknownCommandCol.reason).toBe("unknown-command");
+
+    // The sentinel status chunk must actually be persisted to run_events —
+    // it's the only record of *why* the run failed once the in-memory
+    // ActiveRun handle is gone (e.g. after a restart), and it's what the
+    // reattach/history views render back to the user.
+    const events = runs.events(runId);
+    const sentinelEvent = events.find(
+      (e) => e.stream === "status" && e.data.startsWith(CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX),
+    );
+    expect(sentinelEvent).toBeDefined();
+  } finally {
+    unsub();
+    delete process.env.AGETOR_CLAUDE_DRIVER;
+    delete process.env.AGETOR_FAKE_CLAUDE_UNKNOWN_COMMAND;
+  }
+});
+
+test("orchestrator: cancellation wins over unknown-command (cancelled task → 'ready', not 'blocked')", async () => {
+  const { createTask, startTask, cancelRun } = await import("./orchestrator.ts");
+  const { tasks, runs } = await import("./db.ts");
+
+  // Unknown-command flips the column to `blocked` immediately, but a user
+  // cancel arriving before the delayed done(0) must still win — a cancelled
+  // run lands in `ready`/`cancelled`, matching the api-error and
+  // session-death precedence tests above.
+  process.env.AGETOR_CLAUDE_DRIVER = "fake";
+  process.env.AGETOR_FAKE_CLAUDE_UNKNOWN_COMMAND = "1";
+  process.env.AGETOR_FAKE_CLAUDE_RESOLVE_DELAY_MS = "120";
+
+  try {
+    const created = await createTask({
+      title: "unknown command then cancel",
+      prompt: "/fake-command anything",
+      agent: "claude-code",
+      workdir: process.cwd(),
+      isolation: "none",
+    });
+    if ("error" in created) throw new Error(created.error);
+    const task = created.task;
+
+    const res = await startTask(task.id);
+    if ("error" in res) throw new Error(`startTask failed: ${res.error}`);
+    const runId = res.runId;
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(tasks.get(task.id)?.column).toBe("blocked");
+
+    cancelRun(runId);
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    const after = tasks.get(task.id);
+    expect(after?.column).toBe("ready");
+
+    const runRow = runs.get(runId);
+    expect(runRow?.status).toBe("cancelled");
+  } finally {
+    delete process.env.AGETOR_CLAUDE_DRIVER;
+    delete process.env.AGETOR_FAKE_CLAUDE_UNKNOWN_COMMAND;
+    delete process.env.AGETOR_FAKE_CLAUDE_RESOLVE_DELAY_MS;
+  }
+});
+
 test("orchestrator: cancellation wins over session-death (cancelled task → 'ready', not 'blocked')", async () => {
   const { createTask, startTask, cancelRun } = await import("./orchestrator.ts");
   const { tasks, runs } = await import("./db.ts");

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -41,6 +41,7 @@ import {
 } from "./interactions.ts";
 import {
   CLAUDE_API_ERROR_STATUS_PREFIX,
+  CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX,
   cycleToMode,
   type CycleResult,
   type ContinuationHooks,
@@ -133,6 +134,13 @@ interface ActiveRun {
    *  handler reads this on resolution to keep it there (record the run as
    *  `failed`, not bounce to `ready`). */
   sessionDied: boolean;
+  /** Set when claude's TUI rejected the pasted message as an unknown slash
+   *  command (the driver emitted the `CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX`
+   *  sentinel — no JSONL line was ever written for that turn). Like
+   *  `apiError`/`sessionDied`, the chunk handler flips the column to
+   *  `blocked` immediately and the done handler reads this on resolution to
+   *  keep it there (record the run as `failed`, not bounce to `ready`). */
+  unknownCommand: boolean;
 }
 const active = new Map<string, ActiveRun>(); // runId -> handle
 
@@ -300,7 +308,7 @@ function updateColumn(
   taskId: string,
   runId: string | null,
   next: ColumnId,
-  reason?: "api-error" | "approval" | "session-died",
+  reason?: "api-error" | "approval" | "session-died" | "unknown-command",
 ): void {
   const before = tasks.get(taskId);
   const prev: ColumnId | null = before?.column ?? null;
@@ -898,6 +906,26 @@ function makeChunkHandler(
         }
       }
     }
+    // Unknown-slash-command path (claude-code only): claude's TUI rejected
+    // the pasted message as an unknown slash command — no JSONL line was
+    // ever written for it, so claude-tmux's pane scraper is the only source
+    // of this sentinel. Flip to `blocked` here so the card stops sitting in
+    // `running`, and mark the handle so `attachDoneHandler` doesn't bounce
+    // it back to `ready` when the resolution lands a moment later.
+    if (
+      kind === "claude-code"
+      && stream === "status"
+      && data.startsWith(CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX)
+    ) {
+      const handle = active.get(runId);
+      if (handle && !handle.unknownCommand) {
+        handle.unknownCommand = true;
+        const task = tasks.get(taskId);
+        if (task && task.runId === runId) {
+          updateColumn(taskId, runId, "blocked", "unknown-command");
+        }
+      }
+    }
   };
 }
 
@@ -914,6 +942,7 @@ function registerActiveRun(
     cancelled: false,
     apiError: false,
     sessionDied: false,
+    unknownCommand: false,
     writeInput: (line) => agent.writeInput(line),
   });
 }
@@ -934,15 +963,16 @@ function attachDoneHandler(
       const wasCancelled = handle?.cancelled ?? false;
       const wasApiError = handle?.apiError ?? false;
       const wasSessionDied = handle?.sessionDied ?? false;
+      const wasUnknownCommand = handle?.unknownCommand ?? false;
       active.delete(runId);
 
-      // API error / session-death override the exit-code mapping: the driver
-      // resolves the turn with code 0 (a clean end_turn was staged), but the
-      // run really failed — record it as such so the badge and history are
-      // honest.
+      // API error / session-death / unknown-command override the exit-code
+      // mapping: the driver resolves the turn with code 0 (a clean end_turn
+      // was staged), but the run really failed — record it as such so the
+      // badge and history are honest.
       const newStatus: RunStatus = wasCancelled
         ? "cancelled"
-        : (wasApiError || wasSessionDied) ? "failed"
+        : (wasApiError || wasSessionDied || wasUnknownCommand) ? "failed"
         : code === 0 ? "succeeded" : "failed";
       runs.update(runId, { status: newStatus, endedAt: Date.now(), exitCode: code });
       // Only flip the task's column when the run that just resolved is
@@ -967,6 +997,7 @@ function attachDoneHandler(
           && !wasCancelled
           && !wasApiError
           && !wasSessionDied
+          && !wasUnknownCommand
           && subagents.hasRunning(taskId);
         if (holdForSubagents) {
           const runningCount = subagents.runningCountForTask(taskId);
@@ -983,7 +1014,7 @@ function attachDoneHandler(
           // `blocked` just because it had previously hit an API error.
           const nextColumn: ColumnId = wasCancelled
             ? "ready"
-            : (wasApiError || wasSessionDied) ? "blocked"
+            : (wasApiError || wasSessionDied || wasUnknownCommand) ? "blocked"
             : newStatus === "succeeded" ? "review" : "ready";
           updateColumn(taskId, runId, nextColumn);
         }
@@ -1005,16 +1036,18 @@ function attachDoneHandler(
       const handle = active.get(runId);
       const wasCancelled = handle?.cancelled ?? false;
       const wasSessionDied = handle?.sessionDied ?? false;
+      const wasUnknownCommand = handle?.unknownCommand ?? false;
       active.delete(runId);
       const newStatus: RunStatus = wasCancelled ? "cancelled" : "failed";
       runs.update(runId, { status: newStatus, endedAt: Date.now(), exitCode: -1 });
       const task = tasks.get(taskId);
       const isTerminalRun = !!task && task.runId === runId;
       if (isTerminalRun) {
-        // A session-death that reaches the reject path (not the case today —
-        // both drivers resolve on death — but keep the column consistent with
-        // the resolve path if a future refactor ever rejects instead).
-        updateColumn(taskId, runId, wasSessionDied ? "blocked" : "ready");
+        // A session-death / unknown-command that reaches the reject path (not
+        // the case today — both drivers resolve on these — but keep the
+        // column consistent with the resolve path if a future refactor ever
+        // rejects instead).
+        updateColumn(taskId, runId, (wasSessionDied || wasUnknownCommand) ? "blocked" : "ready");
       }
       emit({
         runId,

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -20,7 +20,7 @@ import type { UpdateSnapshot } from "@/lib/api";
 import { useConfirm } from "@/components/ui/confirm";
 import { toast } from "sonner";
 import { Toaster } from "@/components/ui/sonner";
-import { dismissPending, notifyWaitingInput, toastApiError, toastError, toastPending, toastSessionEnded, toastSuccess } from "@/lib/toasts";
+import { dismissPending, notifyWaitingInput, toastApiError, toastError, toastPending, toastSessionEnded, toastSuccess, toastUnknownCommand } from "@/lib/toasts";
 import { PendingInputTracker } from "@/lib/pending-input-tracker";
 import { findTaskById } from "@/lib/notification-open";
 import { cn } from "@/lib/utils";
@@ -379,6 +379,8 @@ export default function App() {
           toastApiError({ taskId: ev.taskId, title, subtitle, isSelected, isFocused, onOpen });
         } else if (ev.reason === "session-died") {
           toastSessionEnded({ taskId: ev.taskId, title, subtitle, isSelected, isFocused, onOpen });
+        } else if (ev.reason === "unknown-command") {
+          toastUnknownCommand({ taskId: ev.taskId, title, subtitle, isSelected, isFocused, onOpen });
         } else {
           toastPending({ taskId: ev.taskId, title, subtitle, isSelected, isFocused, onOpen });
         }

--- a/src/mainview/lib/toasts.ts
+++ b/src/mainview/lib/toasts.ts
@@ -113,6 +113,17 @@ export function toastSessionEnded(args: ToastArgs): void {
   showBlockingToast({ method: toast.error, heading: "Session ended" }, args);
 }
 
+/** Variant of `toastPending` for the `blocked → unknown-command` transition —
+ *  claude's TUI rejected the pasted message as an unrecognized slash command,
+ *  so the turn never started. Reads as "your message didn't go through," not
+ *  "the agent is waiting on you." */
+export function toastUnknownCommand(args: ToastArgs): void {
+  showBlockingToast(
+    { method: toast.error, heading: "Message not delivered" },
+    args,
+  );
+}
+
 /**
  * Alert the user that a question / permission prompt is waiting on them.
  * Distinct from `toastPending` (the `blocked`-column path) in one crucial way:

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1734,7 +1734,7 @@ export type GlobalEvent =
        *  than the generic "waiting on you" used for permission prompts.
        *  Unset for transitions whose reason is fully implied by the
        *  (prev, column) pair (e.g. plain success → review). */
-      reason?: "api-error" | "approval" | "session-died";
+      reason?: "api-error" | "approval" | "session-died" | "unknown-command";
     }
   | {
       kind: "update";


### PR DESCRIPTION
## Problem

When a user message whose **first line starts with `/`** (e.g. `/skill-creator we need this as a skill…`) is delivered to a claude-code task, claude's Ink TUI dispatches it as a slash command — bracketed paste (`paste-buffer -p`) does **not** prevent this, contrary to the assumption in the paste helper. If the command is unknown, the TUI prints:

```
● Unknown command: /skill-creator
● Args from unknown skill: …
```

…and nothing else happens: **no turn starts, no JSONL is ever written, and the tmux session stays alive**. Both existing failure detectors are structurally blind to this — the death-watch only fires when `tmux has-session` fails, and there is deliberately no turn timeout (long tool runs are legitimately JSONL-silent). Result: the run sat green in `running` forever and the swallowed message was untraceable from the UI.

## Fix

A third sentinel path alongside the existing `api-error` and `session-died` ones:

- **Arming** — every prompt-delivery point (`sendTurn`, `pasteFollowUp`, argv-embedded spawn prompt, `deferredPrompt` paste) records the leading slash token on `SessionState.pendingSlashToken` when the prompt's first line starts with `/` (and clears it otherwise). The token is disarmed by any real JSONL line (proof the command was real and ran), by normal turn resolution, and by session death.
- **Detection** — the existing pane scraper, only while armed **and** a turn is in flight, scans the last 12 non-blank pane lines for `Unknown command: <exact armed token>` (word-boundary match, `●` bullet stripped, token regex-escaped). The armed-token gate makes false positives from tool output or quoted text ~impossible; detection lands within the ~1–2s scrape cadence.
- **Settling** — new `signalUnknownCommand` mirrors `signalSessionDeath`'s mechanics (emit sentinel `status` chunk `unknown command: /… — claude treated the message as a slash command; it was not delivered…`, resolve the head slot with 0) but **keeps the session, timers, and watcher alive** — the session is reusable and a follow-up send routes through `sendTurn` normally.
- **Orchestration** — `makeChunkHandler` matches the new `CLAUDE_UNKNOWN_COMMAND_STATUS_PREFIX`, sets an `ActiveRun.unknownCommand` flag, records the run **`failed`**, and moves the card to **`blocked`** with new reason `"unknown-command"` (union extended in `updateColumn` + `GlobalEvent`), surfaced by a dedicated "Message not delivered" toast.
- **Test seam** — `AGETOR_FAKE_CLAUDE_UNKNOWN_COMMAND=1` on the fake driver, mirroring the api-error/session-died flags.

## Tests

- `claude-tmux-unknown-command.test.ts` (new, 20 tests): `slashTokenOf` semantics, matcher positives/negatives (word boundary, 12-line window, regex metacharacters), `signalUnknownCommand` settle mechanics (timers untouched, one-shot guard, reattach hook), `dispatchLine` disarm.
- `orchestrator-blocked.test.ts` (+2): fake-driver contract — `blocked` column, `failed` run, `reason: "unknown-command"` on the GlobalEvent, sentinel persisted in `run_events`, and cancellation precedence (cancel still wins → `ready`/`cancelled`).
- Full suite: **1608 pass / 0 fail**, `bun run typecheck` clean.

## Known limitations (documented in `docs/plans/catch-unknown-command-error.md`)

- **L1** — fold-while-busy (`pasteFollowUp`): the in-flight turn's own JSONL clears the armed token, so a slash message folded into a running turn is only caught if the turn is already JSONL-quiet; otherwise the run resolves normally and the swallowed message is only visible in the pane. Rare and non-destructive.
- **L2** — the armed token is in-memory, so a crash in the milliseconds between sentinel emit and run settle isn't re-detected after restart.

Reviewed (opus, code-review skill): approve — 0 critical/major findings; doc-comment clarifications applied.