### PR TITLE
feature: ask for the PR-open link in the Commit & Push instructions

### DIFF
--- a/docs/plans/commit-push-pr-link.md
+++ b/docs/plans/commit-push-pr-link.md
@@ -1,0 +1,61 @@
+# Plan — PR-open link in the Commit & Push prompt
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-23 |
+| Source | /implement conversation ask |
+| Config | AGENTS_CONFIG.yml (collapsed — single-file prose change, no fan-out) |
+| Branch | feature/add-pr-link-to-commit-and-push-button |
+| Base SHA | 4bf523249743f9c02676876eb50988c1864145ee |
+
+> **Autonomous mode:** the grill and plan-approval gates were bypassed (owner not
+> present mid-run). Assumptions are logged in §5.
+
+## 1. Objective & success criteria
+
+Extend the "Commit & push" agent instructions so that, after pushing, the agent
+also returns the **full link to open a pull request** for the branch — as plain
+text (not a code block), placed **above** the existing PR-title and
+PR-description fenced blocks. Done when `commitPushPrompt` asks for the link in
+that position, tests cover it, and typecheck + the prompt test suite are green.
+
+## 2. Context & constraints
+
+- Single source of truth: `commitPushPrompt(task)` in `src/shared/types.ts:1854`,
+  consumed identically by the webview RunPanel chip, CLI `agetor commit`, and the
+  TUI `c` key — one edit covers all three surfaces.
+- Existing structure (fleet workdone `be6642c1`): commit/push instruction → "PR
+  title:" 3-backtick block → "PR description:" 4-backtick block. The 4-backtick
+  fence is load-bearing (fleet knowledge `71eec552`) — inner ``` fences would
+  otherwise truncate the copy button. Preserve both blocks unchanged.
+- RunPanel renders agent markdown with react-markdown + remark-gfm, so a bare
+  URL in plain text autolinks (GFM autolink literals) — no fence needed for it
+  to be clickable.
+- Tests live in `src/shared/branch.test.ts` (`describe("commitPushPrompt")`).
+- The chip tooltip at `src/mainview/components/kanban/RunPanel.tsx:1413`
+  describes what the prompt asks for; update to mention the link.
+
+## 3. Approach
+
+Insert one sentence into the prompt between "push" and the two-block ask: after
+pushing, first print the full URL to open a pull request for the branch — git
+prints one in the push output ("Create a pull request…"); otherwise construct it
+from the remote URL — as plain text on its own line, not inside a code block.
+Update the function's doc comment, the tooltip, and add ordering/plain-text
+assertions to the existing test describe.
+
+## 4. Work breakdown
+
+Single wave, single task (inline — no sub-agent): edit `src/shared/types.ts`
+(prompt + doc comment), `src/mainview/components/kanban/RunPanel.tsx` (tooltip),
+`src/shared/branch.test.ts` (new assertions). Then `bun test src/shared/branch.test.ts`
+and `bun run typecheck`.
+
+## 5. Open questions / assumptions
+
+- "Full link to open the PR" = the create-PR URL for the just-pushed branch
+  (e.g. `https://github.com/<owner>/<repo>/pull/new/<branch>`), sourced from the
+  push output hint or constructed from the remote — the PR doesn't exist yet at
+  that point.
+- "Above the code blocks" = immediately after the push confirmation, before the
+  "PR title:" block.

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -1410,7 +1410,7 @@ function RunPanelBody({
                     size="sm"
                     variant="secondary"
                     onClick={() => void sendCommitPush()}
-                    title="Ask the agent to commit the working-tree changes, push the current branch to origin, and propose a PR title and description in copyable code blocks."
+                    title="Ask the agent to commit the working-tree changes, push the current branch to origin, and reply with the link to open a PR plus a PR title and description in copyable code blocks."
                   >
                     <GitCommit className="mr-1 size-3" /> Commit &amp; push
                   </Button>

--- a/src/shared/branch.test.ts
+++ b/src/shared/branch.test.ts
@@ -206,6 +206,16 @@ describe("commitPushPrompt", () => {
     expect(p).toContain("PR description:");
     expect(p.indexOf("PR title:")).toBeGreaterThan(p.indexOf("push the current branch"));
   });
+  test("asks for the PR-open link as plain text above the title/description blocks", () => {
+    const p = commitPushPrompt({ branch: "feature/add-login", taskType: "task" });
+    expect(p).toContain("full link to open a pull request");
+    expect(p).toContain("not inside a code block");
+    // The link ask sits between the push instruction and the fenced blocks.
+    expect(p.indexOf("full link to open a pull request")).toBeGreaterThan(
+      p.indexOf("push the current branch"),
+    );
+    expect(p.indexOf("full link to open a pull request")).toBeLessThan(p.indexOf("PR title:"));
+  });
   test("asks for two separate fenced blocks so agetor's copy button captures each field", () => {
     const p = commitPushPrompt({ branch: "feature/add-login", taskType: "task" });
     // Fenced blocks are what agetor's CodeBlock renders a copy button on.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1837,7 +1837,11 @@ export interface ToolResultEventData {
  * prefix. The branch is shell-quoted because git ref names may legally contain
  * shell metacharacters; `'\''` is the POSIX escape for an embedded quote.
  *
- * After the commit/push, the prompt also asks the agent to propose a pull
+ * After the commit/push, the prompt first asks for the full link to open a
+ * pull request for the branch — as plain text above the code blocks, not
+ * fenced, so react-markdown's GFM autolinking renders it clickable (git prints
+ * the link in the push output for GitHub/GitLab/Bitbucket; otherwise it can be
+ * built from the remote URL). It then asks the agent to propose a pull
  * request title and description, each emitted in its own fenced code block so
  * agetor renders a one-click copy button per field — the user copies the title
  * into the New PR composer's Title field and the description into its
@@ -1859,7 +1863,10 @@ export function commitPushPrompt(task: Pick<Task, "branch" | "taskType">): strin
     `(prefix the subject with "${ccType}:", e.g. "${ccType}: ...") summarizing the work, ` +
     `then push the current branch to origin. ` +
     `If the branch has no upstream yet, set it with \`git push -u origin ${branchLabel}\`. ` +
-    `After pushing, propose the pull request as two fenced code blocks so each can be ` +
+    `After pushing, first print the full link to open a pull request for the branch ` +
+    `(git prints one in the push output; otherwise build it from the remote URL) as ` +
+    `plain text on its own line — not inside a code block. ` +
+    `Below the link, propose the pull request as two fenced code blocks so each can be ` +
     `copied with one click: first a "PR title:" line followed by a \`\`\` block containing ` +
     `only the concise one-line title, then a "PR description:" line followed by a ` +
     `\`\`\`\` four-backtick block containing the description in markdown (what changed and ` +


### PR DESCRIPTION
## What changed

The "Commit & push" agent instructions (`commitPushPrompt` in `src/shared/types.ts`) now ask the agent to **print the full link to open a pull request** for the just-pushed branch — as plain text on its own line, **above** the PR-title and PR-description code blocks, sourced from the git push output hint (or built from the remote URL).

- **`src/shared/types.ts`** — new sentence in the prompt between the push instruction and the two-block PR ask; doc comment updated to explain why the link is plain text (react-markdown + remark-gfm autolinks bare URLs, so it renders clickable — no fence needed). The existing structure is untouched: `PR title:` in a ``` block, `PR description:` in a ```` block (4 backticks so nested ``` fences don't truncate the copy button).
- **`src/mainview/components/kanban/RunPanel.tsx`** — the Commit & push chip tooltip now mentions the link.
- **`src/shared/branch.test.ts`** — new test asserting the link ask is present, explicitly plain-text ("not inside a code block"), and ordered after "push the current branch" and before "PR title:".
- **`docs/plans/commit-push-pr-link.md`** — plan artifact for the change.

## Why

After a commit-and-push, the user's next step is opening the PR — previously they had to dig the create-PR URL out of the raw push output. Now the agent surfaces it as a clickable link right above the copyable title/description, completing the one-glance PR handoff. Since `commitPushPrompt` is the single source of truth, the webview chip, CLI `agetor commit`, and TUI `c` key all pick this up with one edit.

## Verification

- `bun test src/shared/branch.test.ts` — 53 pass / 0 fail
- `tsc --noEmit` — clean
- Full suite: **1609 pass / 1 skip / 0 fail**