### PR TITLE
feature: X close button on the Diff Modal header

### DIFF
--- a/docs/plans/diff-dialog-close-button.md
+++ b/docs/plans/diff-dialog-close-button.md
@@ -1,0 +1,55 @@
+# Plan — X close button on the Diff Modal
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-23 |
+| Source | /implement "add an X Icon Button to close the Diff Modal opened through the task card or task details" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/diff-close-button |
+| Base SHA | 4bf523249743f9c02676876eb50988c1864145ee |
+| Mode | **Autonomous** — grill (Phase 2) and plan approval (Phase 3) gates bypassed; all assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+Add a top-right "X" icon button to `DiffDialog` that closes it, matching the app's existing dialog convention. Done when:
+
+- The X is visible in the dialog header in **every** state (loading, error, empty diff, populated diff) from both entry points (task card `GitCompare` button, RunPanel "Diff" button).
+- Clicking it calls `onClose` (same path Escape/backdrop already use).
+- `bun run typecheck` and `bun test` stay green.
+
+## 2. Context & constraints
+
+- `DiffDialog` (`src/mainview/components/kanban/DiffDialog.tsx:48`) renders a `<header className="flex items-start justify-between gap-3 border-b border-border/60 p-3">` (:279) with a title block and a **conditional** right-side toolbar (`diff && diff.files.length > 0`, :290-302: file counts + Collapse/Expand all).
+- The `Dialog` primitive (`src/mainview/components/ui/dialog.tsx`) is hand-rolled — no shadcn `DialogContent`, so no built-in X; each dialog renders its own. Escape (:70-74) and backdrop click (:119-125) already call `onClose`.
+- Established X convention (SettingsDialog.tsx:326-333, TmuxInstallDialog.tsx:119-121, BranchNamingDialog.tsx:110-112):
+  `<Button variant="ghost" size="icon" onClick={onClose} aria-label="Close"><X className="size-4" /></Button>` — last element on the header's right side.
+- `X` from `lucide-react` is already imported in DiffDialog (:4, used by the selection "Clear" button).
+- Open state lives in `App.tsx:81` (`diffTask`); both surfaces call the same setter — one change in DiffDialog covers both entry points.
+
+## 3. Approach & key decisions
+
+Wrap the existing conditional toolbar and a new always-rendered X button in a right-side flex container (`flex items-center gap-2`, mirroring SettingsDialog's grouped right side), so the X is the last element and present regardless of diff-load state. No changes to the Dialog primitive, App.tsx, or the openers — the alternative (adding a built-in X to the `ui/dialog.tsx` primitive) was rejected because it would change every dialog in the app (blast radius) for a request scoped to the Diff Modal.
+
+## 4. Work breakdown — implementation tasks
+
+- **T1** — Add the X close button to DiffDialog's header. Owns: `src/mainview/components/kanban/DiffDialog.tsx` only. Deps: none. Acceptance: §1 criteria; follows the exact SettingsDialog button pattern; toolbar behavior unchanged when diff is populated.
+
+## 5. Work breakdown — test tasks
+
+None. `src/mainview` has no component-render harness (all `*.test.ts` are pure-logic `bun:test` files); the change is pure JSX wiring an existing prop with no extractable logic. The sibling X-button dialogs ship untested too. Verification = typecheck + full existing suite (Phase 7) in place of new tests.
+
+## 6. Execution waves
+
+Wave 1: T1 (single agent, `implementation` runner = sonnet). No further waves.
+
+## 7. Blast radius & risks
+
+- Single file; no API/data/shared-types changes. Both entry points funnel through the same mount, so no per-surface risk.
+- Only layout risk: regrouping the header's right side must not visually shift the existing toolbar (keep `justify-between` header, counts + buttons order intact).
+- GitHubDialog has the same header shape and also lacks an X — intentionally out of scope; noted as a possible follow-up for consistency.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+- **A1**: X always visible (all load states), not only when a diff rendered — assumed from "close the Diff Modal", which applies regardless of content.
+- **A2**: Scope is DiffDialog only; GitHubDialog left as-is (follow-up candidate).
+- **A3**: No new tests (see §5) — typecheck + existing suite is the verification bar.

--- a/src/mainview/components/kanban/DiffDialog.tsx
+++ b/src/mainview/components/kanban/DiffDialog.tsx
@@ -287,7 +287,7 @@ export function DiffDialog({ open, task, onClose }: Props) {
             {diff?.base && <> · vs base <span className="font-mono">{diff.base}</span></>}
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           {diff && diff.files.length > 0 && (
             <div className="flex shrink-0 items-center gap-3 text-xs">
               <span className="font-mono">

--- a/src/mainview/components/kanban/DiffDialog.tsx
+++ b/src/mainview/components/kanban/DiffDialog.tsx
@@ -287,19 +287,24 @@ export function DiffDialog({ open, task, onClose }: Props) {
             {diff?.base && <> · vs base <span className="font-mono">{diff.base}</span></>}
           </div>
         </div>
-        {diff && diff.files.length > 0 && (
-          <div className="flex shrink-0 items-center gap-3 text-xs">
-            <span className="font-mono">
-              {diff.files.length} {diff.files.length === 1 ? "file" : "files"}
-              {" "}
-              <span className="text-emerald-400">+{totals.additions}</span>{" "}
-              <span className="text-rose-400">−{totals.deletions}</span>
-            </span>
-            <Button size="sm" variant="ghost" onClick={() => setAll(!allOpen)}>
-              {allOpen ? "Collapse all" : "Expand all"}
-            </Button>
-          </div>
-        )}
+        <div className="flex items-center gap-2">
+          {diff && diff.files.length > 0 && (
+            <div className="flex shrink-0 items-center gap-3 text-xs">
+              <span className="font-mono">
+                {diff.files.length} {diff.files.length === 1 ? "file" : "files"}
+                {" "}
+                <span className="text-emerald-400">+{totals.additions}</span>{" "}
+                <span className="text-rose-400">−{totals.deletions}</span>
+              </span>
+              <Button size="sm" variant="ghost" onClick={() => setAll(!allOpen)}>
+                {allOpen ? "Collapse all" : "Expand all"}
+              </Button>
+            </div>
+          )}
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+            <X className="size-4" />
+          </Button>
+        </div>
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto p-3">


### PR DESCRIPTION
## What

Adds a top-right **X icon button** to the Diff Modal (`DiffDialog`) header that closes the dialog. It covers both entry points — the task card's `GitCompare` button and the task details (RunPanel) "Diff" button — since both open the same single `DiffDialog` mount owned by `App.tsx`.

## Why

The Diff Modal could previously only be dismissed via Escape or clicking the backdrop. Our `Dialog` primitive (`src/mainview/components/ui/dialog.tsx`) is hand-rolled — unlike stock shadcn `DialogContent` it has no built-in close button, so each dialog renders its own. DiffDialog was missing the affordance that SettingsDialog, TmuxInstallDialog, and BranchNamingDialog already have.

## How

- Follows the app's established close-button convention exactly:

  ```tsx
  <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
    <X className="size-4" />
  </Button>
  ```

- The header's right side is now a single `flex shrink-0 items-center gap-2` group wrapping the existing **conditional** toolbar (file count / +− totals / Collapse all) plus the always-rendered X — so the close button is visible in every dialog state (loading, error, empty, populated) and can't compress at narrow widths. Toolbar content and behavior are unchanged.
- Single-file change: `src/mainview/components/kanban/DiffDialog.tsx` (plus the plan doc under `docs/plans/`).

## Verification

- `bun run typecheck` green.
- `bun test`: 1606 pass. (`daemon-boot` / `daemon-handoff` fail only in shells where `bun` isn't on the spawned subprocess `PATH` — environmental; both pass with `~/.bun/bin` on `PATH`.)
- Reviewed (approve, no must-fix); the one actionable nit (`shrink-0` on the wrapper) is included.

## Out of scope

`GitHubDialog` shares the same header shape and still has no X — left as a follow-up candidate for consistency.