### PR TITLE
feature: structured slash-command message UI in the task stream

### DIFF
--- a/docs/plans/better-skill-command-message-ui.md
+++ b/docs/plans/better-skill-command-message-ui.md
@@ -1,0 +1,126 @@
+# Plan — Better skill/command message UI in the stream list
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-23 |
+| Source | /implement task: "make the skill/command message UI look better … without the command tags, in the stream messages list in the task details modal" + screenshot `screenshot-2026-07-23_18-36-43-d5ba31a5.png` |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/better-skill-command-message-ui |
+| Base SHA | 4bf523249743f9c02676876eb50988c1864145ee |
+| Mode | **Autonomous** — grill + plan-approval gates bypassed (agetor-driven unattended session); assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+When a task (or follow-up) is started with a slash command, the "YOU" bubble in the
+task-details stream currently shows claude CLI's raw expansion:
+
+```
+<command-message>implement</command-message> <command-name>/implement</command-name>
+<command-args>make the skill/command message UI look better … </command-args>
+```
+
+Success:
+- No raw `<command-*>` tags visible anywhere in the stream list.
+- A command invocation renders as a structured bubble: a `/command` badge, the
+  arguments as normal markdown body, and any trailing "Referenced files/folders:"
+  block as compact reference chips instead of a raw bullet list.
+- The live echo (`/implement …`) and the JSONL twin (XML expansion) collapse into
+  **one** bubble instead of today's two.
+- `<local-command-stdout>` user lines render as a labeled output block, not raw tags.
+- Non-command user messages render exactly as before.
+- `bun run typecheck` green; `bun test` green.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- `renderEvent` dispatches `case "user"` → `UserMessageBlock` at
+  `src/mainview/components/kanban/RunPanel.tsx:2220`; the block itself is
+  `RunPanel.tsx:2466-2537` — memoized, sticky bubble, ~3-line collapse cap with
+  Show more/less, body via `<ReactMarkdown components={USER_MD_COMPONENTS}>` (2521).
+- Markdown `components` maps are hoisted to module scope on purpose
+  (`RunPanel.tsx:2421-2425`) — a fresh object per render re-parses every block
+  every poll. Any new rendering must keep that invariant and be `memo`'d.
+- Every user message is emitted twice (live echo + JSONL twin); dedup is
+  `src/mainview/lib/event-dedup.ts` keying `user|runId|first-200-normalized-chars`.
+  For slash commands the two texts differ (plain `/cmd args` vs XML expansion),
+  so they slip past dedup → duplicate bubbles.
+- The XML twin's `<command-args>` includes the full args *and* the
+  "Referenced files/folders:" block agetor appended (verified against a real
+  transcript), so canonicalizing the XML shape back to `/name args` reproduces
+  the echo text and makes the existing 200-char key collapse them.
+- `REFS_HEADING = "Referenced files/folders:"` and bullet shape live in
+  `src/shared/refs.ts` (`formatReferences`) — parse with the same constant, never
+  a re-typed string.
+- Bun side (`claude-tmux.ts:743-772`) only strips tags for `isMeta` entries;
+  real human turns pass through untouched. We fix rendering client-side; no Bun
+  changes needed.
+- Repo convention: no DOM test harness. Pure logic goes in
+  `src/mainview/lib/*.ts` with a co-located `*.test.ts` (`bun:test`, flat
+  `test`/`expect`) — e.g. `prompt-noise.ts`, `diff-selection.ts`.
+- Codex never emits `user` events from its wire mapper (echo only), so this is
+  claude-shape-specific but harmless for codex.
+
+## 3. Approach & key decisions
+
+- **Parse client-side, upstream of ReactMarkdown** — a new pure lib
+  `src/mainview/lib/command-message.ts`. Rejected: stripping tags Bun-side in
+  `claude-tmux.ts` (would bake presentation into persisted events and not fix
+  already-persisted history; client-side parsing fixes old transcripts too).
+- **Dedup by canonicalization** — `eventDedupKey` canonicalizes user text
+  (XML shape → `/name args`) before slicing 200 chars, so echo + twin share a
+  key. Rejected: fuzzy merge in the render path (stateful, riskier).
+- **Render both shapes identically** — even if dedup ever misses, both bubbles
+  look the same.
+- **Strict XML parse** — require `<command-name>`; leftover non-whitespace
+  outside recognized tags → bail to raw rendering (never mis-render a message
+  that merely resembles the shape).
+- **Plain-echo detection** is conservative: `^/[a-z0-9][a-z0-9_:-]*(\s|$)` —
+  lowercase command names only, so `/Users/...` paths can't match; `/tmp/foo`
+  fails the boundary.
+
+## 4. Work breakdown — implementation tasks
+
+**T1 (wave 1, one agent)** — owns all three files (they interlock; splitting
+would collide on imports/types):
+- `src/mainview/lib/command-message.ts` (new): `parseCommandMessage`,
+  `parseLocalCommandStdout`, `splitReferences`, `canonicalizeUserText`.
+- `src/mainview/lib/event-dedup.ts`: apply `canonicalizeUserText` in the user key.
+- `src/mainview/components/kanban/RunPanel.tsx`: `UserMessageBlock` renders the
+  parsed command (badge + args markdown + ref chips) or local-command-stdout
+  block; falls back to current rendering otherwise.
+
+Acceptance: criteria in §1, typecheck green, no changes outside the three files.
+
+## 5. Work breakdown — test tasks
+
+**T2 (after review)** — `src/mainview/lib/command-message.test.ts` (new) +
+extend `src/mainview/lib/event-dedup.test.ts`: XML shape (with/without args,
+with refs, reordered tags, `\r` newlines), plain echo shape, path false-positives,
+leftover-content bail, local-command-stdout, echo↔twin key collapse, non-command
+key unchanged.
+
+## 6. Execution waves
+
+Wave 1: T1 (single agent — no partition needed). Barrier. Review. Barrier. T2.
+Barrier. Test run. Fixes if red.
+
+## 7. Blast radius & risks
+
+- `eventDedupKey` change affects all user events: canonicalization must be
+  identity for non-command text or existing dedup behavior shifts. Covered by tests.
+- `UserMessageBlock` renders every user bubble ever persisted — the fallback
+  path must be byte-identical behavior for plain messages.
+- Collapse-cap + scroll-compensation machinery in `UserMessageBlock` must keep
+  working for the new command layout (content div still wraps the whole body).
+- Perf: parser runs per user bubble per render unless memoized — memoize on
+  `text` inside the memo'd component.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+- **A1**: Reference chips are in scope as part of "better formatted and
+  structured" (the refs bullet list is part of the same visual noise). Chips are
+  display-only (basename + icon, full path in `title`), no click action.
+- **A2**: `[screenshot-….png]` inline tokens stay as plain text in the args body.
+- **A3**: `<local-command-stdout>` handling is included (same family of raw-tag
+  noise), rendered as a muted mono block labeled "command output".
+- **A4**: No Bun-side/DB changes — presentation only.
+- **A5**: Both gates (grill, plan approval) self-approved per autonomous mode.

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -2485,11 +2485,14 @@ const UserMessageBlock = memo(function UserMessageBlock({ text }: { text: string
   // is always rendered so short messages don't flash full-height first;
   // the toggle button only surfaces when scrollHeight exceeds clientHeight,
   // i.e. content actually overflows the cap. When a command has no args (no
-  // `contentRef` div rendered at all), `contentRef.current` is null and this
-  // early-returns — no toggle, which is correct since there's nothing to cap.
+  // `contentRef` div rendered at all), reset rather than early-return so a
+  // stale toggle can't survive a text change that removed the capped div.
   useEffect(() => {
     const el = contentRef.current;
-    if (!el) return;
+    if (!el) {
+      setNeedsToggle(false);
+      return;
+    }
     setNeedsToggle(el.scrollHeight > el.clientHeight + 2);
   }, [text]);
 

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -4,7 +4,7 @@ import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
 import {
   Archive, ArchiveRestore, ArrowDown, ArrowUp, BookmarkPlus, Bot, Check, ClipboardList, Copy, CornerDownRight, Eye, FolderOpen, FileText, FilePenLine, FilePlus, Folder,
-  GitCommit, GitCompare, Globe, HelpCircle, ListTodo, Plug, Search, Send, Slash,
+  GitCommit, GitCompare, Globe, HelpCircle, ListTodo, Plug, Search, Send, Slash, SquareSlash,
   Sparkles, Square, Terminal, Trash2, Wrench, X,
 } from "lucide-react";
 import { api, commitPushPrompt, type AgentModelMap, type AvailableCommand, type AvailableExtension, type PendingInteraction } from "@/lib/api";
@@ -38,6 +38,7 @@ import { createEventDeduper } from "@/lib/event-dedup";
 import { createEventBuffer } from "@/lib/event-buffer";
 import { invalidatesRebuiltSnapshot } from "@/lib/rebuilt-mask";
 import { cleanPromptPane } from "@/lib/prompt-noise";
+import { parseUserMessage } from "@/lib/command-message";
 import { AgentIcon } from "./AgentIcon";
 import {
   ReferencesPicker,
@@ -2474,10 +2475,18 @@ const UserMessageBlock = memo(function UserMessageBlock({ text }: { text: string
   // visual position after expand/collapse.
   const pendingAdjustRef = useRef<{ scroller: HTMLElement; prevHeight: number } | null>(null);
 
+  // Recognize slash-command invocations (XML expansion or plain echo) and
+  // `<local-command-stdout>` blocks so they render as structured UI instead
+  // of literal `<command-*>` tags. `null` for an ordinary message — the
+  // fallback branch below renders exactly what this component always has.
+  const parsed = useMemo(() => parseUserMessage(text), [text]);
+
   // Default to the collapsed ~3-line cap and measure once mounted. The cap
   // is always rendered so short messages don't flash full-height first;
   // the toggle button only surfaces when scrollHeight exceeds clientHeight,
-  // i.e. content actually overflows the cap.
+  // i.e. content actually overflows the cap. When a command has no args (no
+  // `contentRef` div rendered at all), `contentRef.current` is null and this
+  // early-returns — no toggle, which is correct since there's nothing to cap.
   useEffect(() => {
     const el = contentRef.current;
     if (!el) return;
@@ -2504,24 +2513,74 @@ const UserMessageBlock = memo(function UserMessageBlock({ text }: { text: string
     setExpanded((v) => !v);
   };
 
+  const collapseClassName = cn(
+    "agetor-md",
+    expanded ? "max-h-[40vh] overflow-y-auto" : "max-h-[4.5rem] overflow-hidden",
+  );
+
   return (
     <div className="sticky top-0 z-10 flex justify-end">
       <div ref={bubbleRef} className="max-w-[85%] rounded-2xl rounded-br-md border border-primary/30 bg-card/50 px-3 py-1.5 text-foreground shadow-sm backdrop-blur-md">
-        <div className="mb-0.5 text-[9px] font-semibold uppercase tracking-wide text-primary/80">
-          you
-        </div>
-        <div
-          ref={contentRef}
-          className={cn(
-            "agetor-md",
-            expanded
-              ? "max-h-[40vh] overflow-y-auto"
-              : "max-h-[4.5rem] overflow-hidden",
-          )}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]} components={USER_MD_COMPONENTS}>
-            {text}
-          </ReactMarkdown>
-        </div>
+        {parsed?.kind === "command-output" ? (
+          <>
+            <div className="mb-0.5 text-[9px] font-semibold uppercase tracking-wide text-primary/80">
+              command output
+            </div>
+            <div ref={contentRef} className={collapseClassName}>
+              <div className="whitespace-pre-wrap font-mono text-[11px] text-muted-foreground">
+                {parsed.output || "—"}
+              </div>
+            </div>
+          </>
+        ) : parsed?.kind === "command" ? (
+          <>
+            <div className="mb-0.5 text-[9px] font-semibold uppercase tracking-wide text-primary/80">
+              you
+            </div>
+            <div className="mb-1">
+              <span className="inline-flex items-center gap-1 rounded-md border border-primary/40 bg-primary/15 px-1.5 py-0.5 font-mono text-[11px] font-medium text-primary">
+                <SquareSlash className="size-3" />
+                {parsed.command.name}
+              </span>
+            </div>
+            {parsed.command.args && (
+              <div ref={contentRef} className={collapseClassName}>
+                <ReactMarkdown remarkPlugins={[remarkGfm]} components={USER_MD_COMPONENTS}>
+                  {parsed.command.args}
+                </ReactMarkdown>
+              </div>
+            )}
+            {parsed.command.references.length > 0 && (
+              <div className="mt-1 flex flex-wrap gap-1">
+                {parsed.command.references.map((ref) => {
+                  const isDir = ref.endsWith("/");
+                  const Icon = isDir ? Folder : FileText;
+                  return (
+                    <span
+                      key={ref}
+                      title={ref}
+                      className="inline-flex max-w-full items-center gap-1 rounded border border-border/60 bg-muted/40 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                    >
+                      <Icon className="size-3 shrink-0" />
+                      <span className="truncate">{refBasename(ref)}</span>
+                    </span>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        ) : (
+          <>
+            <div className="mb-0.5 text-[9px] font-semibold uppercase tracking-wide text-primary/80">
+              you
+            </div>
+            <div ref={contentRef} className={collapseClassName}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]} components={USER_MD_COMPONENTS}>
+                {text}
+              </ReactMarkdown>
+            </div>
+          </>
+        )}
         {needsToggle && (
           <button
             type="button"

--- a/src/mainview/lib/command-message.test.ts
+++ b/src/mainview/lib/command-message.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test } from "bun:test";
+import {
+  canonicalizeUserText,
+  parseUserMessage,
+  splitReferences,
+} from "./command-message.ts";
+import { appendReferences } from "../../shared/refs.ts";
+import type { TaskReference } from "../../shared/types.ts";
+
+const REFS: TaskReference[] = [
+  { path: "/a/b.png", isDirectory: false },
+  { path: "/c/d", isDirectory: true },
+];
+
+describe("parseUserMessage — XML expansion shape", () => {
+  test("full three-tag message parses to a command with name + args", () => {
+    const xml = [
+      "<command-message>implement</command-message>",
+      "<command-name>/implement</command-name>",
+      "<command-args>do the thing</command-args>",
+    ].join("\n");
+    expect(parseUserMessage(xml)).toEqual({
+      kind: "command",
+      command: { name: "/implement", args: "do the thing", references: [] },
+    });
+  });
+
+  test("args containing markdown, a fenced code block, a screenshot token, and blank lines survive verbatim", () => {
+    const argsBody = [
+      "Do the following:",
+      "",
+      "1. Update **bold** stuff",
+      "",
+      "```js",
+      "const x = 1;",
+      "```",
+      "",
+      "See [screenshot-1.png] for reference.",
+    ].join("\n");
+    const xml = [
+      "<command-message>run</command-message>",
+      "<command-name>/run</command-name>",
+      `<command-args>${argsBody}</command-args>`,
+    ].join("\n");
+    expect(parseUserMessage(xml)).toEqual({
+      kind: "command",
+      command: { name: "/run", args: argsBody, references: [] },
+    });
+  });
+
+  test("trailing Referenced files/folders block inside command-args is split off; folder bullets keep trailing slash", () => {
+    const argsRaw = appendReferences("do the thing", REFS);
+    const xml = [
+      "<command-message>implement</command-message>",
+      "<command-name>/implement</command-name>",
+      `<command-args>${argsRaw}</command-args>`,
+    ].join("\n");
+    expect(parseUserMessage(xml)).toEqual({
+      kind: "command",
+      command: {
+        name: "/implement",
+        args: "do the thing",
+        references: ["/a/b.png", "/c/d/"],
+      },
+    });
+  });
+
+  test("no command-args tag at all yields empty args and no references", () => {
+    const xml = [
+      "<command-message>compact</command-message>",
+      "<command-name>/compact</command-name>",
+    ].join("\n");
+    expect(parseUserMessage(xml)).toEqual({
+      kind: "command",
+      command: { name: "/compact", args: "", references: [] },
+    });
+  });
+
+  test("tags in a different order (name before message) still parse", () => {
+    const xml = [
+      "<command-name>/implement</command-name>",
+      "<command-message>implement</command-message>",
+      "<command-args>do it</command-args>",
+    ].join("\n");
+    expect(parseUserMessage(xml)).toEqual({
+      kind: "command",
+      command: { name: "/implement", args: "do it", references: [] },
+    });
+  });
+
+  test("tolerates \\r\\n tag separators; bare \\r inside tag content is normalized to \\n", () => {
+    const xml = [
+      "<command-message>run</command-message>",
+      "<command-name>/run</command-name>",
+      "<command-args>line one\rline two</command-args>",
+    ].join("\r\n");
+    expect(parseUserMessage(xml)).toEqual({
+      kind: "command",
+      command: { name: "/run", args: "line one\nline two", references: [] },
+    });
+  });
+});
+
+describe("parseUserMessage — strict-parse guards (bail to null)", () => {
+  test("duplicate command-name tags → null", () => {
+    const xml =
+      "<command-name>/implement</command-name><command-name>/other</command-name><command-args>x</command-args>";
+    expect(parseUserMessage(xml)).toBeNull();
+  });
+
+  test("leftover non-whitespace text before the tags → null", () => {
+    const xml = `hello <command-name>/implement</command-name><command-args>x</command-args>`;
+    expect(parseUserMessage(xml)).toBeNull();
+  });
+
+  test("leftover non-whitespace text between tags → null", () => {
+    const xml = `<command-name>/implement</command-name> extra text <command-args>x</command-args>`;
+    expect(parseUserMessage(xml)).toBeNull();
+  });
+
+  test("leftover non-whitespace text after the tags → null", () => {
+    const xml = `<command-name>/implement</command-name><command-args>x</command-args> trailing`;
+    expect(parseUserMessage(xml)).toBeNull();
+  });
+
+  test("missing command-name (only message + args) → null", () => {
+    const xml = "<command-message>implement</command-message><command-args>x</command-args>";
+    expect(parseUserMessage(xml)).toBeNull();
+  });
+
+  test("a command-name tag appearing mid-sentence in ordinary prose → null", () => {
+    const text = "Check out <command-name>/foo</command-name> for details";
+    expect(parseUserMessage(text)).toBeNull();
+  });
+});
+
+describe("parseUserMessage — plain echo shape", () => {
+  test("/implement do the thing → command /implement with args", () => {
+    expect(parseUserMessage("/implement do the thing")).toEqual({
+      kind: "command",
+      command: { name: "/implement", args: "do the thing", references: [] },
+    });
+  });
+
+  test("/vercel:deploy prod → colon-qualified command name", () => {
+    expect(parseUserMessage("/vercel:deploy prod")).toEqual({
+      kind: "command",
+      command: { name: "/vercel:deploy", args: "prod", references: [] },
+    });
+  });
+
+  test("/compact alone → empty args", () => {
+    expect(parseUserMessage("/compact")).toEqual({
+      kind: "command",
+      command: { name: "/compact", args: "", references: [] },
+    });
+  });
+
+  test("plain echo with a trailing refs block splits references", () => {
+    const text = appendReferences("/implement do the thing", REFS);
+    expect(parseUserMessage(text)).toEqual({
+      kind: "command",
+      command: {
+        name: "/implement",
+        args: "do the thing",
+        references: ["/a/b.png", "/c/d/"],
+      },
+    });
+  });
+});
+
+describe("parseUserMessage — plain echo false-positive guards", () => {
+  test("an absolute path with an uppercase segment is never a command", () => {
+    expect(parseUserMessage("/Users/foo/bar.png")).toBeNull();
+  });
+
+  test("a path continuing past a slash boundary is never a command", () => {
+    expect(parseUserMessage("/tmp/foo")).toBeNull();
+  });
+
+  test("bare /tmp DOES parse as a (contentless) command — accepted conservative tradeoff, not a bug (plan §3 / review finding)", () => {
+    expect(parseUserMessage("/tmp")).toEqual({
+      kind: "command",
+      command: { name: "/tmp", args: "", references: [] },
+    });
+  });
+});
+
+describe("parseUserMessage — local-command-stdout shape", () => {
+  test("basic stdout body is trimmed", () => {
+    expect(parseUserMessage("<local-command-stdout>some output</local-command-stdout>")).toEqual(
+      { kind: "command-output", output: "some output" },
+    );
+  });
+
+  test("stdout with surrounding whitespace is trimmed to empty", () => {
+    expect(
+      parseUserMessage("<local-command-stdout>   \n  </local-command-stdout>"),
+    ).toEqual({ kind: "command-output", output: "" });
+  });
+
+  test("self-closing form yields empty output", () => {
+    expect(parseUserMessage("<local-command-stdout/>")).toEqual({
+      kind: "command-output",
+      output: "",
+    });
+    expect(parseUserMessage("<local-command-stdout />")).toEqual({
+      kind: "command-output",
+      output: "",
+    });
+  });
+});
+
+describe("parseUserMessage — ordinary text stays null", () => {
+  test("ordinary prose", () => {
+    expect(parseUserMessage("just a normal reply about the bug")).toBeNull();
+  });
+
+  test("empty string", () => {
+    expect(parseUserMessage("")).toBeNull();
+  });
+
+  test("markdown heading", () => {
+    expect(parseUserMessage("# Section title\n\nSome body text.")).toBeNull();
+  });
+});
+
+describe("splitReferences — newline contract", () => {
+  // splitReferences itself expects \n-based text: its blank-line paragraph
+  // split (`/\n\s*\n/`) never fires on bare-\r-only input. That's fine as an
+  // internal contract because the rendering entry point, parseUserMessage,
+  // normalizes \r / \r\n → \n up front (the JSONL twin of a send can be
+  // \r-only via tmux's paste-buffer — see event-dedup.ts). Both halves are
+  // pinned here: the raw helper's limitation, and the entry point covering it.
+  test("a refs block is NOT split by the raw helper when the whole text uses bare \\r with no \\n", () => {
+    const argsRaw = appendReferences("do the thing", REFS).replace(/\n/g, "\r");
+    expect(splitReferences(argsRaw)).toEqual({ args: argsRaw, references: [] });
+  });
+
+  test("a refs block IS split when \\r\\n is used (an actual \\n is present)", () => {
+    const argsRaw = appendReferences("do the thing", REFS).replace(/\n/g, "\r\n");
+    expect(splitReferences(argsRaw)).toEqual({
+      args: "do the thing",
+      references: ["/a/b.png", "/c/d/"],
+    });
+  });
+
+  test("parseUserMessage splits the refs block of a bare-\\r-only XML twin (entry-point normalization)", () => {
+    const argsRaw = appendReferences("do the thing", REFS);
+    const xml = [
+      "<command-message>implement</command-message>",
+      "<command-name>/implement</command-name>",
+      `<command-args>${argsRaw}</command-args>`,
+    ]
+      .join("\n")
+      .replace(/\n/g, "\r");
+    expect(parseUserMessage(xml)).toEqual({
+      kind: "command",
+      command: { name: "/implement", args: "do the thing", references: ["/a/b.png", "/c/d/"] },
+    });
+  });
+
+  test("parseUserMessage splits the refs block of a bare-\\r-only plain echo", () => {
+    const echo = appendReferences("/implement do the thing", REFS).replace(/\n/g, "\r");
+    expect(parseUserMessage(echo)).toEqual({
+      kind: "command",
+      command: { name: "/implement", args: "do the thing", references: ["/a/b.png", "/c/d/"] },
+    });
+  });
+});
+
+describe("canonicalizeUserText", () => {
+  test("the XML twin of a command with a refs block canonicalizes to exactly the live echo text", () => {
+    const baseArgs = "do this and that across the codebase";
+    const echoText = appendReferences(`/implement ${baseArgs}`, REFS);
+    const argsRaw = appendReferences(baseArgs, REFS);
+    const xml = [
+      "<command-message>implement</command-message>",
+      "<command-name>/implement</command-name>",
+      `<command-args>${argsRaw}</command-args>`,
+    ].join("\n");
+    expect(canonicalizeUserText(xml)).toBe(echoText);
+  });
+
+  test("non-command text is returned identically", () => {
+    const text = "  just some ordinary reply with   odd spacing\n\n";
+    expect(canonicalizeUserText(text)).toBe(text);
+  });
+
+  test("plain echo text (no XML tags) is returned identically", () => {
+    const text = "/implement do the thing";
+    expect(canonicalizeUserText(text)).toBe(text);
+  });
+
+  test("near-miss XML (leftover content) is returned identically", () => {
+    const text = "hello <command-name>/implement</command-name> world";
+    expect(canonicalizeUserText(text)).toBe(text);
+  });
+});

--- a/src/mainview/lib/command-message.ts
+++ b/src/mainview/lib/command-message.ts
@@ -1,0 +1,185 @@
+// Parsing for slash-command user messages in the task-details stream.
+//
+// Background: when a task/follow-up is sent as a recognized slash command
+// (e.g. "/implement do the thing"), claude CLI's JSONL transcribes the send
+// as an XML expansion — `<command-message>…</command-message>
+// <command-name>/implement</command-name> <command-args>do the
+// thing</command-args>` — rather than the plain text the user actually typed.
+// Rendered verbatim that's raw-tag noise in the "you" bubble. This module
+// turns that shape (and the two other raw-tag shapes claude emits for local
+// commands) into structured data the UI can render as a badge + markdown body
+// + reference chips, instead of literal `<command-*>` text.
+//
+// Kept free of React imports so it's plain, unit-testable logic — same
+// convention as `prompt-noise.ts` / `diff-selection.ts`.
+import { REFS_HEADING } from "../../shared/refs.ts";
+
+export interface CommandInvocation {
+  /** Command name including the leading slash, e.g. "/implement". */
+  name: string;
+  /** Argument text (may be ""), with any trailing references block removed. */
+  args: string;
+  /** Paths parsed from a trailing "Referenced files/folders:" block ("" if
+   *  none — i.e. an empty array). Folders keep their trailing slash. */
+  references: string[];
+}
+
+export type ParsedUserMessage =
+  | { kind: "command"; command: CommandInvocation }
+  | { kind: "command-output"; output: string };
+
+/** Result of locating the three recognized XML tags, before the
+ *  references-block split is applied to the args content. Kept separate from
+ *  `CommandInvocation` because `canonicalizeUserText` needs the *unsplit*
+ *  args (references block still inline) to reproduce the original send. */
+interface RawCommandXml {
+  name: string;
+  argsRaw: string;
+}
+
+/**
+ * Locate `<command-message>` (optional), `<command-name>` (required),
+ * `<command-args>` (optional) anywhere in `text`, in any order, tolerating
+ * `\r`/`\r\n` newlines (plain `\s` already matches those). Strict on purpose:
+ * a duplicate of any tag, or any non-whitespace content left over once all
+ * recognized tags are stripped, means this isn't really the expansion shape
+ * and we bail to `null` rather than risk mis-rendering an ordinary message
+ * that merely contains a `<command-name>`-shaped substring.
+ */
+function matchCommandXml(text: string): RawCommandXml | null {
+  const messageMatches = [...text.matchAll(/<command-message>[\s\S]*?<\/command-message>/g)];
+  const nameMatches = [...text.matchAll(/<command-name>([\s\S]*?)<\/command-name>/g)];
+  const argsMatches = [...text.matchAll(/<command-args>([\s\S]*?)<\/command-args>/g)];
+
+  if (nameMatches.length !== 1) return null; // required, exactly once
+  if (messageMatches.length > 1) return null;
+  if (argsMatches.length > 1) return null;
+
+  const nameMatch = nameMatches[0];
+  if (!nameMatch) return null; // unreachable given the length check above; narrows for TS
+
+  let remainder = text;
+  for (const m of messageMatches) remainder = remainder.replace(m[0], "");
+  remainder = remainder.replace(nameMatch[0], "");
+  for (const m of argsMatches) remainder = remainder.replace(m[0], "");
+  if (remainder.trim() !== "") return null;
+
+  const rawName = (nameMatch[1] ?? "").trim();
+  if (!rawName) return null;
+  const name = `/${rawName.replace(/^\/+/, "")}`; // normalize to exactly one leading slash
+  const argsMatch = argsMatches[0];
+  const argsRaw = argsMatch ? (argsMatch[1] ?? "").trim() : "";
+  return { name, argsRaw };
+}
+
+/**
+ * Split a trailing "Referenced files/folders:" block off the end of a
+ * command's argument text. The block is the LAST blank-line-separated
+ * paragraph, its first line must be the exact `REFS_HEADING`, and every
+ * following line in that paragraph must be a `- <path>` bullet — this is
+ * exactly the shape `formatReferences` (src/shared/refs.ts) produces via
+ * `appendReferences`'s `"${text}\n\n${block}"` join. Any deviation (heading
+ * not alone on its line, a non-bullet line mixed in, no heading at all) means
+ * don't split: return `text` unchanged with no references, rather than
+ * guess.
+ */
+export function splitReferences(text: string): { args: string; references: string[] } {
+  const paragraphs = text.split(/\n\s*\n/);
+  const last = paragraphs[paragraphs.length - 1];
+  if (last === undefined) return { args: text, references: [] }; // unreachable — split() always yields >= 1 element
+
+  const lines = last.split(/\r\n|\r|\n/);
+
+  if (lines[0]?.trim() !== REFS_HEADING) {
+    return { args: text, references: [] };
+  }
+  const bulletLines = lines.slice(1);
+  if (bulletLines.length === 0) {
+    return { args: text, references: [] };
+  }
+
+  const references: string[] = [];
+  for (const line of bulletLines) {
+    const m = /^- (.+)$/.exec(line);
+    if (!m) return { args: text, references: [] };
+    references.push(m[1] ?? "");
+  }
+
+  const args = paragraphs.slice(0, -1).join("\n\n").trimEnd();
+  return { args, references };
+}
+
+/** (a) claude CLI's JSONL expansion of a recognized slash command. */
+function tryParseCommandXml(text: string): CommandInvocation | null {
+  const raw = matchCommandXml(text);
+  if (!raw) return null;
+  const { args, references } = splitReferences(raw.argsRaw);
+  return { name: raw.name, args, references };
+}
+
+// Lowercase-only command name so an absolute path ("/Users/...") can never
+// match (uppercase first segment fails the char class), and the lookahead
+// boundary means "/tmp/foo" fails too (next char after "tmp" is "/", neither
+// whitespace nor end of string). Colons are allowed for plugin/skill names
+// like "vercel:deploy".
+const PLAIN_ECHO_NAME_RE = /^\/[a-z0-9][a-z0-9_:-]*(?=\s|$)/;
+
+/** (b) the raw text the user typed, echoed live by the orchestrator before
+ *  claude ever transcribes it — no XML wrapping at all. */
+function tryParsePlainEcho(text: string): CommandInvocation | null {
+  const m = PLAIN_ECHO_NAME_RE.exec(text);
+  if (!m) return null;
+  const name = m[0];
+  const argsRaw = text.slice(name.length).trim();
+  const { args, references } = splitReferences(argsRaw);
+  return { name, args, references };
+}
+
+const LOCAL_STDOUT_SELF_CLOSING_RE = /^\s*<local-command-stdout\s*\/>\s*$/;
+const LOCAL_STDOUT_RE = /^\s*<local-command-stdout>([\s\S]*?)<\/local-command-stdout>\s*$/;
+
+/** (c) output of a local (non-slash) command, wrapped by claude CLI in
+ *  `<local-command-stdout>`. Returns `null` (not `""`) when the shape doesn't
+ *  match at all, so callers can distinguish "no match" from "matched, empty
+ *  output". */
+function tryParseLocalCommandStdout(text: string): string | null {
+  if (LOCAL_STDOUT_SELF_CLOSING_RE.test(text)) return "";
+  const m = LOCAL_STDOUT_RE.exec(text);
+  return m ? (m[1] ?? "").trim() : null;
+}
+
+/**
+ * Recognize a user message as a slash-command invocation or local-command
+ * output, trying each shape in turn. Returns `null` for an ordinary message,
+ * which callers must render completely unchanged from today's behavior.
+ */
+export function parseUserMessage(text: string): ParsedUserMessage | null {
+  const xml = tryParseCommandXml(text);
+  if (xml) return { kind: "command", command: xml };
+
+  const echo = tryParsePlainEcho(text);
+  if (echo) return { kind: "command", command: echo };
+
+  const stdout = tryParseLocalCommandStdout(text);
+  if (stdout !== null) return { kind: "command-output", output: stdout };
+
+  return null;
+}
+
+/**
+ * Reduce a user message to the text form that would appear as the LIVE echo
+ * of the same send. A slash-command send produces a live echo
+ * ("/implement args…") the instant it's submitted, and later a JSONL twin —
+ * claude CLI's `<command-name>`/`<command-args>` XML expansion of that same
+ * send — whose text differs byte-for-byte from the echo. Canonicalizing the
+ * XML shape back to the echo shape here lets `eventDedupKey`'s existing
+ * echo-vs-twin key collapse the two into one bubble. For every other input
+ * (including messages that merely resemble the XML shape but fail the strict
+ * parse) this is the identity function — no trimming, no normalization — so
+ * it must not shift the dedup key of ordinary messages.
+ */
+export function canonicalizeUserText(text: string): string {
+  const raw = matchCommandXml(text);
+  if (!raw) return text;
+  return raw.argsRaw ? `${raw.name} ${raw.argsRaw}` : raw.name;
+}

--- a/src/mainview/lib/command-message.ts
+++ b/src/mainview/lib/command-message.ts
@@ -152,8 +152,15 @@ function tryParseLocalCommandStdout(text: string): string | null {
  * Recognize a user message as a slash-command invocation or local-command
  * output, trying each shape in turn. Returns `null` for an ordinary message,
  * which callers must render completely unchanged from today's behavior.
+ *
+ * Newlines are normalized to `\n` up front: the JSONL twin of a send can carry
+ * bare `\r` newlines (tmux's paste-buffer artifact — see event-dedup.ts), and
+ * `splitReferences`' blank-line paragraph split needs real `\n`s to find a
+ * trailing refs block. Rendering-only — `canonicalizeUserText` stays a strict
+ * byte identity on non-command input and must not normalize.
  */
 export function parseUserMessage(text: string): ParsedUserMessage | null {
+  text = text.replace(/\r\n?/g, "\n");
   const xml = tryParseCommandXml(text);
   if (xml) return { kind: "command", command: xml };
 

--- a/src/mainview/lib/event-dedup.test.ts
+++ b/src/mainview/lib/event-dedup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createEventDeduper, eventDedupKey } from "./event-dedup.ts";
-import type { RunEvent } from "../../shared/types.ts";
+import { appendReferences } from "../../shared/refs.ts";
+import type { RunEvent, TaskReference } from "../../shared/types.ts";
 
 const ev = (e: Partial<RunEvent>): RunEvent => ({
   runId: "run-1",
@@ -90,5 +91,71 @@ describe("createEventDeduper", () => {
     }
     // The oldest user key has been evicted past the cap, so it re-accepts.
     expect(d.accept(ev({ stream: "user", data: "msg", runId: "run-0", ts: 0 }))).toBe(true);
+  });
+});
+
+const REFS: TaskReference[] = [{ path: "/a/b.png", isDirectory: false }];
+
+describe("eventDedupKey / createEventDeduper — slash-command echo/twin collapse", () => {
+  test("live echo + JSONL XML twin (with \\r newlines) share a key and collapse to one bubble", () => {
+    const baseArgs = "do this and that with the whole implementation, in detail";
+    const liveText = appendReferences(`/implement ${baseArgs}`, REFS);
+    const argsRaw = appendReferences(baseArgs, REFS).replace(/\n/g, "\r");
+    const xmlTwin = [
+      "<command-message>implement</command-message>",
+      "<command-name>/implement</command-name>",
+      `<command-args>${argsRaw}</command-args>`,
+    ].join("\r");
+
+    const live = ev({ stream: "user", data: liveText, ts: 1, runId: "run-42" });
+    const twin = ev({ stream: "user", data: xmlTwin, ts: 99999, runId: "run-42" });
+
+    expect(eventDedupKey(live)).toBe(eventDedupKey(twin));
+
+    const d = createEventDeduper();
+    expect(d.accept(live)).toBe(true);
+    expect(d.accept(twin)).toBe(false);
+  });
+
+  test("the same XML twin on a DIFFERENT runId is not treated as a duplicate", () => {
+    const baseArgs = "do the thing";
+    const argsRaw = appendReferences(baseArgs, REFS);
+    const xmlTwin = [
+      "<command-message>implement</command-message>",
+      "<command-name>/implement</command-name>",
+      `<command-args>${argsRaw}</command-args>`,
+    ].join("\n");
+
+    const d = createEventDeduper();
+    expect(d.accept(ev({ stream: "user", data: xmlTwin, ts: 1, runId: "run-a" }))).toBe(true);
+    expect(d.accept(ev({ stream: "user", data: xmlTwin, ts: 2, runId: "run-b" }))).toBe(true);
+  });
+
+  test("two different commands whose args only diverge after canonicalization get different keys", () => {
+    const xmlAlpha = [
+      "<command-message>alpha</command-message>",
+      "<command-name>/alpha</command-name>",
+      "<command-args>x</command-args>",
+    ].join("\n");
+    const xmlBeta = [
+      "<command-message>beta</command-message>",
+      "<command-name>/beta</command-name>",
+      "<command-args>x</command-args>",
+    ].join("\n");
+
+    const a = ev({ stream: "user", data: xmlAlpha, runId: "run-1", ts: 1 });
+    const b = ev({ stream: "user", data: xmlBeta, runId: "run-1", ts: 2 });
+    expect(eventDedupKey(a)).not.toBe(eventDedupKey(b));
+  });
+
+  test("an ordinary (non-command) user event's key is byte-identical to the pre-change formula", () => {
+    const text = "just a regular reply, nothing special here";
+    const runId = "run-plain";
+    const e = ev({ stream: "user", data: text, runId, ts: 12345 });
+    // Reimplements the pre-canonicalization formula inline: normalize CR
+    // newlines, slice first 200 chars — no XML involved, so canonicalization
+    // is a no-op and this must match exactly.
+    const expectedKey = `user|${runId}|${text.replace(/\r\n?/g, "\n").slice(0, 200)}`;
+    expect(eventDedupKey(e)).toBe(expectedKey);
   });
 });

--- a/src/mainview/lib/event-dedup.ts
+++ b/src/mainview/lib/event-dedup.ts
@@ -8,6 +8,7 @@
 // must collapse duplicates client-side — this is that collapse, extracted as a
 // pure helper so it can be unit-tested apart from the React effect.
 import type { RunEvent } from "../../shared/types.ts";
+import { canonicalizeUserText } from "./command-message.ts";
 
 /** Normalize CR-only / CRLF newlines to `\n`. tmux's paste-buffer delivers our
  *  `\n`-separated prompt to claude as `\r`, and the JSONL stores those `\r`s
@@ -25,6 +26,13 @@ const normalizeForKey = (s: string) => s.replace(/\r\n?/g, "\n");
  * stamped with the same `Date.now()` ms — `ts` is what keeps genuinely
  * distinct same-tick events apart.
  *
+ * A slash-command send produces a live echo ("/implement args…") the instant
+ * it's submitted, and a JSONL twin — claude CLI's `<command-name>`/
+ * `<command-args>` XML expansion of that same send — whose text differs
+ * byte-for-byte from the echo. `canonicalizeUserText` reduces the XML shape
+ * back to the plain echo shape before the key is sliced, so the existing
+ * 200-char key collapses the two into one bubble instead of two.
+ *
  * Consequence of the ts-less `user` key: two genuinely-identical user sends in
  * the SAME run (e.g. folding `"continue"` twice into one in-flight turn) share
  * a key and render as a single bubble. This is intentional — there is no
@@ -35,7 +43,7 @@ const normalizeForKey = (s: string) => s.replace(/\r\n?/g, "\n");
  */
 export function eventDedupKey(e: RunEvent): string {
   return e.stream === "user"
-    ? `user|${e.runId}|${normalizeForKey(e.data ?? "").slice(0, 200)}`
+    ? `user|${e.runId}|${canonicalizeUserText(normalizeForKey(e.data ?? "")).slice(0, 200)}`
     : `${e.ts}|${e.runId}|${e.stream}|${(e.data ?? "").slice(0, 200)}`;
 }
 


### PR DESCRIPTION
## What

User messages that invoke a slash command currently render claude CLI's raw JSONL expansion as literal text in the task-details stream:

```
<command-message>implement</command-message> <command-name>/implement</command-name>
<command-args>make the UI better …</command-args>
```

This PR renders them as a structured bubble instead — a `/command` badge (always visible, even collapsed), the arguments as normal markdown, and the trailing "Referenced files/folders:" block as compact file/folder chips — and collapses the duplicate bubble every command send used to produce.

## Why the duplicate bubble

A slash-command send emits two `user` events with *different* text: the orchestrator's live echo (`/implement args…`) and claude CLI's JSONL transcription, which expands the same send into the `<command-*>` XML shape. `eventDedupKey` keys on the first 200 chars, so the differing texts slipped past dedup and rendered as two bubbles.

## Changes

- **`src/mainview/lib/command-message.ts` (new)** — pure parser for the three raw-tag shapes: the XML expansion (strict: `<command-name>` required exactly once, any tag order, leftover content outside the tags bails to `null` so lookalike messages never mis-render), the plain `/cmd args` echo (lowercase-only name regex, so `/Users/…` paths can't match), and `<local-command-stdout>`. Splits the trailing refs block using `REFS_HEADING` from `shared/refs.ts`. Newlines are CR-normalized at the entry point — JSONL twins can arrive with bare `\r` newlines (tmux paste-buffer artifact).
- **`src/mainview/lib/event-dedup.ts`** — `canonicalizeUserText` reduces the XML twin back to the exact echo text before keying, so both copies collapse into one bubble. It's a strict byte identity for every other input, so no historical dedup keys shift.
- **`src/mainview/components/kanban/RunPanel.tsx`** — `UserMessageBlock` three-way render: command badge + args markdown + reference chips; `<local-command-stdout>` as a labeled muted mono block; ordinary messages byte-identical to before. Perf invariants preserved (memoized block, module-scope markdown `components` map). Already-persisted transcripts get the new rendering too, since parsing happens client-side at render time.

## Testing

- 46 unit tests across `command-message.test.ts` (new) and `event-dedup.test.ts` (extended): tag-order/newline tolerance, strict-parse bail-outs, path false-positive guards, refs splitting, echo↔twin key collapse, and the identity pin for ordinary messages.
- `bun run typecheck` green; full `bun test`: 1644 pass / 1 skip / 0 fail.
- Opus code review: approve — no critical/major/medium findings; two documented low-severity tradeoffs (a message that is exactly a bare lowercase root path like `/tmp` gets a command badge; the echo↔twin collapse is whitespace-sensitive, worst case a cosmetic duplicate that still renders structured).

Plan: `docs/plans/better-skill-command-message-ui.md`