### PR TITLE
feature: GitHub setup guide modal — token creation walkthrough with full permission list

### DIFF
--- a/docs/plans/github-setup-instructions-modal.md
+++ b/docs/plans/github-setup-instructions-modal.md
@@ -1,0 +1,125 @@
+# Plan — GitHub Setup Instructions Modal
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-23 |
+| Source | /implement: "add a modal with full instructions of how to configure Agetor for connecting to GitHub for having full access to the GitHub integration, including all permissions they need to setup in GitHub" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/configure-github-for-pull-requests-info |
+| Base SHA | 4bf523249743f9c02676876eb50988c1864145ee (tree clean apart from this plan file) |
+| Mode | **Autonomous** — the grill gate (Phase 2) and plan-approval gate (Phase 3) were bypassed because the run is unattended (agetor-driven `/implement`); every assumption is logged in §8. |
+
+## 1. Objective & success criteria
+
+Add an in-app instructions modal that walks a user through configuring Agetor's GitHub
+integration end-to-end: creating a token (fine-grained or classic), granting **every
+permission the integration actually uses**, and storing the token in Agetor.
+
+Done means:
+- A "Setup guide" affordance opens the modal from Settings → GitHub tokens (the place
+  tokens are pasted) — including from its "No tokens stored yet" empty state.
+- The modal explains: what the integration can do; the three auth resolution steps;
+  fine-grained PAT click-path + full permission list; classic PAT click-path + scope
+  list; ssh host-alias / multi-identity handling; org caveats (fine-grained approval,
+  SAML SSO authorize); "Open GitHub settings" buttons via `api.openExternal`.
+- Permission data lives in a pure, unit-tested lib module.
+- `bun run typecheck` green, `bun test` green, `vite build` green.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- **Auth resolution** (`src/bun/github.ts:856-863`): stored token (`tokenForHost` —
+  exact raw-host match, then `github.com` default entry; `src/bun/github-tokens.ts:159`)
+  → `GITHUB_TOKEN` / `GH_TOKEN` env → `gh auth token`.
+- **Token store**: `~/.agetor/github-tokens.json`, per-host entries keyed by the *raw*
+  ssh remote host (multi-identity via `~/.ssh/config` aliases like `github-work.com`);
+  managed in Settings → GitHub tokens (`src/mainview/components/settings/GitHubTokensSection.tsx`),
+  routes `/github/tokens` (+ `/:host` DELETE) in `src/bun/server.ts:2427,2446`.
+- **Integration surface** (~70 `/github/*` routes, `src/bun/server.ts:630-2446`): PR
+  lifecycle (list/search/diff/commits/create/merge/close/reopen/draft/auto-merge/
+  update-branch/mergeability/reviews/reviewers/line comments + replies + suggestions/
+  review-thread resolve/linked issues/checks/commit status), issues (create/update/
+  lock/pin/transfer/sub-issues), comments CRUD, labels + milestones CRUD, releases +
+  tags, Actions (workflows/runs/re-run/cancel/dispatch), Projects v2, Discussions,
+  reactions, notifications + thread subscriptions, viewer, repo-permissions.
+  GraphQL (`api.github.com/graphql`, `src/bun/github.ts:2812+`) powers draft toggle,
+  pin, transfer, Projects v2, Discussions, review-thread resolve.
+- **UI conventions**: `Dialog` primitive (`src/mainview/components/ui/dialog.tsx`,
+  `open`/`onClose`/`labelledBy`/`describedBy`, `max-w-lg` default overridable via
+  `className`); dark mode only; `api.openExternal(url)` (`src/mainview/lib/api.ts:1133`)
+  for browser links (webview sandbox — no `target="_blank"`); pure view logic extracted
+  to `src/mainview/lib/*.ts` with bun tests (`github-dialog-view.ts` pattern — no DOM).
+- **Provider note**: GitLab/Bitbucket share the token store, but this modal is
+  GitHub-scoped per the request; the guide text mentions that only GitHub is covered.
+- Permission facts verified against docs.github.com by a web-research agent
+  (fine-grained permission names, classic scopes, click-paths, org caveats) — its
+  findings are encoded in `github-setup-guide.ts`.
+
+## 3. Approach & key decisions
+
+- **One new dialog component** `GitHubSetupDialog.tsx` under
+  `src/mainview/components/settings/`, rendered from `GitHubTokensSection` (a small
+  "Setup guide" button next to the section header + a link in the empty state).
+  No changes to `GitHubDialog.tsx` (8.7k lines, active peer overlap risk) — the
+  Settings section is where tokens are pasted, so it's where the guide belongs.
+- **Content as data**: `src/mainview/lib/github-setup-guide.ts` exports typed constants
+  (fine-grained permission rows {name, level, usedFor}, classic scope rows, auth
+  resolution steps, GitHub settings URLs). The component maps over them; the lib gets
+  a bun test (uniqueness, https-only URLs, non-empty coverage of the major op groups).
+- **No server changes** — purely static instructional UI; token CRUD already exists.
+- Alternatives considered: markdown-rendered doc (no markdown renderer in mainview —
+  rejected); putting the guide inside GitHubDialog (peer `hollow-haven-4527` /
+  `deep-glade-ea8c` are near that surface; higher collision + review cost — rejected).
+
+## 4. Work breakdown — implementation tasks
+
+- **T1** — `src/mainview/lib/github-setup-guide.ts`: typed guide content (permission
+  tables, scopes, URLs, resolution steps, org caveats). Owns only this file.
+  Acceptance: exports consumed by T2 compile; content covers every op group in §2.
+- **T2** — `src/mainview/components/settings/GitHubSetupDialog.tsx` (new) +
+  `src/mainview/components/settings/GitHubTokensSection.tsx` (trigger button + empty-state
+  link + render the dialog). Owns those two files. Acceptance: modal opens/closes,
+  scrolls (`max-h` + `overflow-y-auto`), external links via `api.openExternal`,
+  matches dark-mode styling conventions.
+
+Wave 1: T1 + T2 are file-disjoint but T2 imports T1's types — run as ONE agent
+(single wave, single task) since the combined scope is small; splitting would only
+add an interface-drift risk.
+
+## 5. Work breakdown — test tasks
+
+- **TT1** — `src/mainview/lib/github-setup-guide.test.ts`: no duplicate permission/
+  scope names; all URLs https + on github.com/docs.github.com; fine-grained table
+  includes the load-bearing permissions (Contents, Pull requests, Issues, Actions,
+  Checks, Commit statuses, Discussions, Projects, Metadata…); classic table includes
+  repo/workflow/notifications/project/write:discussion; resolution steps mention the
+  env vars and gh CLI verbatim (`GITHUB_TOKEN`, `GH_TOKEN`, `gh auth token`).
+
+## 6. Execution waves
+
+- Wave 1 (Phase 4): one implementation agent → T1 + T2.
+- Phase 5: code-review agent (opus) on the diff.
+- Wave 2 (Phase 6): one test agent → TT1.
+- Phase 7: test-run agent (haiku): `bun run typecheck` + `bun test` (+ `bunx vite build`).
+
+## 7. Blast radius & risks
+
+- Touches only Settings surface; no server, db, or orchestration changes.
+- Peer overlap: active fleet agents are working on Commit&Push button, Diff-modal
+  close button, and stream rendering — none own `GitHubTokensSection.tsx`.
+- Permissions accuracy is the main product risk — mitigated by doc-verified research;
+  UNVERIFIED items are phrased conservatively in the guide text.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+1. **Trigger location**: Settings → GitHub tokens section (primary + empty state).
+   Not added to GitHubDialog to avoid colliding with peers on that file.
+2. **Scope**: GitHub only (per request); GitLab/Bitbucket setup is out.
+3. **Both token types documented** — but research (docs.github.com) showed the
+   Notifications API is classic-PAT-only, the Checks API is not grantable to
+   fine-grained PATs, and Discussions has no fine-grained permission. So the guide
+   recommends a **classic PAT (repo, workflow, notifications, project, read:org)**
+   for FULL integration access, and documents fine-grained PATs as the
+   least-privilege alternative with an explicit "what won't work" list.
+4. **No screenshots/images** — text steps + deep links (consistent with app style).
+5. Modal is informational only — it does not embed the token form itself (the form
+   is directly behind it in the same Settings section).

--- a/src/mainview/components/settings/GitHubSetupDialog.tsx
+++ b/src/mainview/components/settings/GitHubSetupDialog.tsx
@@ -26,7 +26,13 @@ import {
  */
 export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   return (
-    <Dialog open={open} onClose={onClose} className="max-w-2xl" labelledBy="github-setup-dialog-title">
+    <Dialog
+      open={open}
+      onClose={onClose}
+      className="max-w-2xl"
+      labelledBy="github-setup-dialog-title"
+      describedBy="github-setup-dialog-desc"
+    >
       <div className="flex items-center justify-between border-b border-border/60 pb-3">
         <h2 id="github-setup-dialog-title" className="text-base font-semibold">
           Connect Agetor to GitHub
@@ -38,7 +44,7 @@ export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: (
 
       <div className="max-h-[70vh] space-y-5 overflow-y-auto pt-3 text-sm">
         <section className="space-y-1">
-          <p className="text-[11px] leading-snug text-muted-foreground">
+          <p id="github-setup-dialog-desc" className="text-[11px] leading-snug text-muted-foreground">
             Agetor talks to GitHub using a personal access token (PAT) that you create and
             paste into this Settings section. The integration covers pull requests, issues,
             reviews, checks, Actions, releases, Projects, Discussions, and notifications —
@@ -82,7 +88,7 @@ export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: (
             ))}
           </div>
           <div className="space-y-1 rounded-md border border-border/60 px-3 py-2">
-            <p className="text-[11px] font-medium uppercase tracking-wide text-amber-400">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-amber-500">
               Not available with fine-grained tokens
             </p>
             <ul className="list-disc space-y-1 pl-4 text-[11px] leading-snug text-muted-foreground">

--- a/src/mainview/components/settings/GitHubSetupDialog.tsx
+++ b/src/mainview/components/settings/GitHubSetupDialog.tsx
@@ -1,0 +1,161 @@
+import type { ReactNode } from "react";
+import { X } from "lucide-react";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import {
+  AUTH_RESOLUTION_STEPS,
+  CLASSIC_CREATE_STEPS,
+  CLASSIC_SCOPES,
+  FINE_GRAINED_CREATE_STEPS,
+  FINE_GRAINED_LIMITATIONS,
+  FINE_GRAINED_PERMISSIONS,
+  GITHUB_URLS,
+  MULTI_ACCOUNT_NOTE,
+  ORG_CAVEATS,
+  type GuideStep,
+} from "@/lib/github-setup-guide";
+
+/**
+ * "Connect Agetor to GitHub" instructions modal, opened from
+ * `GitHubTokensSection` (the header button and the empty-state link). Purely
+ * informational — it does not embed the token form itself, which lives
+ * directly behind it in the same Settings section. All copy is sourced from
+ * `lib/github-setup-guide.ts`; this component only supplies section
+ * headings/intro sentences and layout.
+ */
+export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  return (
+    <Dialog open={open} onClose={onClose} className="max-w-2xl" labelledBy="github-setup-dialog-title">
+      <div className="flex items-center justify-between border-b border-border/60 pb-3">
+        <h2 id="github-setup-dialog-title" className="text-base font-semibold">
+          Connect Agetor to GitHub
+        </h2>
+        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+          <X className="size-4" />
+        </Button>
+      </div>
+
+      <div className="max-h-[70vh] space-y-5 overflow-y-auto pt-3 text-sm">
+        <section className="space-y-1">
+          <p className="text-[11px] leading-snug text-muted-foreground">
+            Agetor talks to GitHub using a personal access token (PAT) that you create and
+            paste into this Settings section. The integration covers pull requests, issues,
+            reviews, checks, Actions, releases, Projects, Discussions, and notifications —
+            how much of that works depends on which permissions the token you save actually
+            has.
+          </p>
+        </section>
+
+        <GuideSection heading="How Agetor finds a token">
+          <StepList steps={AUTH_RESOLUTION_STEPS} />
+        </GuideSection>
+
+        <GuideSection heading="Recommended: classic token (full access)">
+          <StepList steps={CLASSIC_CREATE_STEPS} />
+          <div className="space-y-1.5">
+            {CLASSIC_SCOPES.map((row) => (
+              <div key={row.scope} className="rounded-md border border-border/60 px-3 py-2">
+                <div className="font-mono text-xs">{row.scope}</div>
+                <div className="text-[11px] leading-snug text-muted-foreground">{row.usedFor}</div>
+              </div>
+            ))}
+          </div>
+          <div className="flex justify-end">
+            <Button size="sm" variant="outline" onClick={() => void api.openExternal(GITHUB_URLS.classicTokens)}>
+              Open GitHub → Tokens (classic)
+            </Button>
+          </div>
+        </GuideSection>
+
+        <GuideSection heading="Alternative: fine-grained token (least privilege)">
+          <StepList steps={FINE_GRAINED_CREATE_STEPS} />
+          <div className="space-y-1.5">
+            {FINE_GRAINED_PERMISSIONS.map((row) => (
+              <div key={row.name} className="rounded-md border border-border/60 px-3 py-2">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">{row.name}</span>
+                  <span className="text-[10px] uppercase text-muted-foreground">{row.level}</span>
+                </div>
+                <div className="text-[11px] leading-snug text-muted-foreground">{row.usedFor}</div>
+              </div>
+            ))}
+          </div>
+          <div className="space-y-1 rounded-md border border-border/60 px-3 py-2">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-amber-400">
+              Not available with fine-grained tokens
+            </p>
+            <ul className="list-disc space-y-1 pl-4 text-[11px] leading-snug text-muted-foreground">
+              {FINE_GRAINED_LIMITATIONS.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void api.openExternal(GITHUB_URLS.fineGrainedTokens)}
+            >
+              Open GitHub → Fine-grained tokens
+            </Button>
+          </div>
+        </GuideSection>
+
+        <GuideSection heading="Working with organizations">
+          <ul className="list-disc space-y-1 pl-4 text-[11px] leading-snug text-muted-foreground">
+            {ORG_CAVEATS.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </GuideSection>
+
+        <GuideSection heading="Multiple GitHub accounts">
+          <p className="text-[11px] leading-snug text-muted-foreground">{MULTI_ACCOUNT_NOTE}</p>
+        </GuideSection>
+
+        <GuideSection heading="Save the token in Agetor">
+          <p className="text-[11px] leading-snug text-muted-foreground">
+            Back in this Settings section, paste the host (github.com, or your ssh alias host),
+            an optional label, and the token itself into the fields below, then click Save
+            token.
+          </p>
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              variant="link"
+              className="h-auto p-0"
+              onClick={() => void api.openExternal(GITHUB_URLS.tokenDocs)}
+            >
+              GitHub's token documentation
+            </Button>
+          </div>
+        </GuideSection>
+      </div>
+    </Dialog>
+  );
+}
+
+function GuideSection({ heading, children }: { heading: string; children: ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-xs font-medium">{heading}</h3>
+      {children}
+    </section>
+  );
+}
+
+function StepList({ steps }: { steps: GuideStep[] }) {
+  return (
+    <ol className="space-y-1.5">
+      {steps.map((step, i) => (
+        <li key={step.title} className="rounded-md border border-border/60 px-3 py-2">
+          <div className="text-xs font-medium">
+            {i + 1}. {step.title}
+          </div>
+          <div className="text-[11px] leading-snug text-muted-foreground">{step.detail}</div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/mainview/components/settings/GitHubTokensSection.tsx
+++ b/src/mainview/components/settings/GitHubTokensSection.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
-import { Trash2 } from "lucide-react";
+import { BookOpen, Trash2 } from "lucide-react";
 import { api, type GitHubTokensResult } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { GitHubSetupDialog } from "@/components/settings/GitHubSetupDialog";
 
 const DATALIST_ID = "github-token-hosts";
 
@@ -28,6 +29,7 @@ export function GitHubTokensSection() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [deletingHost, setDeletingHost] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [guideOpen, setGuideOpen] = useState(false);
 
   const refresh = async () => {
     setLoading(true);
@@ -95,12 +97,22 @@ export function GitHubTokensSection() {
 
   return (
     <section className="space-y-2">
-      <div>
-        <label className="text-xs text-muted-foreground">GitHub tokens</label>
-        <p className="text-[11px] leading-snug text-muted-foreground">
-          Repos reached through an ssh host alias (git@github-work.com:…) authenticate with the
-          token stored for that alias; github.com acts as the default.
-        </p>
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <label className="text-xs text-muted-foreground">GitHub tokens</label>
+          <p className="text-[11px] leading-snug text-muted-foreground">
+            Repos reached through an ssh host alias (git@github-work.com:…) authenticate with the
+            token stored for that alias; github.com acts as the default.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setGuideOpen(true)}
+          className="shrink-0"
+        >
+          <BookOpen className="mr-1 size-3.5" /> Setup guide
+        </Button>
       </div>
 
       {loadError && (
@@ -139,7 +151,16 @@ export function GitHubTokensSection() {
             </div>
           ))}
           {data.tokens.length === 0 && (
-            <p className="text-xs text-muted-foreground">No tokens stored yet.</p>
+            <p className="text-xs text-muted-foreground">
+              No tokens stored yet.{" "}
+              <button
+                type="button"
+                onClick={() => setGuideOpen(true)}
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                How to create one →
+              </button>
+            </p>
           )}
           {hostsWithoutToken.map((h) => (
             <div
@@ -206,6 +227,8 @@ export function GitHubTokensSection() {
           {saving ? "Saving…" : "Save token"}
         </Button>
       </div>
+
+      <GitHubSetupDialog open={guideOpen} onClose={() => setGuideOpen(false)} />
     </section>
   );
 }

--- a/src/mainview/components/ui/dialog.tsx
+++ b/src/mainview/components/ui/dialog.tsx
@@ -28,6 +28,15 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(",");
 
+// Dialogs can nest (Settings → GitHub setup guide, confirm.tsx overlays over
+// another Dialog): each open Dialog registers its own document-level keydown
+// listener, and listeners fire in registration order — so the OUTER dialog's
+// handler runs first on a shared Escape/Tab keypress. Track panels in
+// open-order here so onKey can bail out unless it belongs to the topmost
+// (last-registered) panel; that keeps Escape/Tab scoped to the dialog
+// actually on top instead of always resolving to the outermost one.
+const openDialogStack: HTMLElement[] = [];
+
 /**
  * Overlay dialog with proper modal manners:
  *
@@ -67,7 +76,19 @@ export function Dialog({
     const prevOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
 
+    // Register this panel as the topmost open dialog. Guard for null: the
+    // ref is only populated once the panel has rendered, and this effect
+    // runs post-render (post-commit) so it's safe here.
+    const panel = panelRef.current;
+    if (panel) openDialogStack.push(panel);
+
     const onKey = (e: KeyboardEvent) => {
+      // Only the topmost dialog reacts — with dialogs nested (Settings →
+      // setup guide, confirm.tsx overlays), document listeners fire in
+      // registration order, so the OUTER dialog's handler would otherwise
+      // run first and close the wrong layer.
+      if (panelRef.current !== openDialogStack[openDialogStack.length - 1]) return;
+
       if (e.key === "Escape") {
         e.preventDefault();
         onCloseRef.current();
@@ -98,6 +119,13 @@ export function Dialog({
     return () => {
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = prevOverflow;
+      // Splice by identity — unmount order isn't guaranteed to match open
+      // order (e.g. an inner dialog can close first), so don't assume this
+      // panel is last in the stack.
+      if (panel) {
+        const idx = openDialogStack.indexOf(panel);
+        if (idx !== -1) openDialogStack.splice(idx, 1);
+      }
       // Return focus to whatever opened us. Guard against the trigger having
       // been removed from the DOM in the meantime.
       if (trigger && document.contains(trigger)) trigger.focus();

--- a/src/mainview/lib/github-setup-guide.test.ts
+++ b/src/mainview/lib/github-setup-guide.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AUTH_RESOLUTION_STEPS,
+  CLASSIC_CREATE_STEPS,
+  CLASSIC_SCOPES,
+  FINE_GRAINED_CREATE_STEPS,
+  FINE_GRAINED_LIMITATIONS,
+  FINE_GRAINED_PERMISSIONS,
+  GITHUB_URLS,
+  MULTI_ACCOUNT_NOTE,
+  ORG_CAVEATS,
+} from "./github-setup-guide.ts";
+
+describe("GITHUB_URLS", () => {
+  for (const [key, url] of Object.entries(GITHUB_URLS)) {
+    test(`${key} starts with https:// and points at a github.com host`, () => {
+      expect(url.startsWith("https://")).toBe(true);
+      const parsed = new URL(url);
+      expect(["github.com", "docs.github.com"]).toContain(parsed.host);
+    });
+  }
+});
+
+describe("AUTH_RESOLUTION_STEPS", () => {
+  test("has exactly 3 steps", () => {
+    expect(AUTH_RESOLUTION_STEPS).toHaveLength(3);
+  });
+
+  test("step 1 mentions stored tokens / Settings", () => {
+    const step = AUTH_RESOLUTION_STEPS[0]!;
+    const combined = `${step.title} ${step.detail}`.toLowerCase();
+    expect(combined).toContain("token");
+    expect(combined).toContain("settings");
+  });
+
+  test("step 2 mentions both GITHUB_TOKEN and GH_TOKEN verbatim", () => {
+    const step = AUTH_RESOLUTION_STEPS[1]!;
+    const combined = `${step.title} ${step.detail}`;
+    expect(combined).toContain("GITHUB_TOKEN");
+    expect(combined).toContain("GH_TOKEN");
+  });
+
+  test("step 3 mentions gh auth token verbatim", () => {
+    const step = AUTH_RESOLUTION_STEPS[2]!;
+    const combined = `${step.title} ${step.detail}`;
+    expect(combined).toContain("gh auth token");
+  });
+});
+
+describe("CLASSIC_SCOPES", () => {
+  test("scope names are unique", () => {
+    const names = CLASSIC_SCOPES.map((row) => row.scope);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("includes exactly the expected scope set", () => {
+    const names = CLASSIC_SCOPES.map((row) => row.scope).sort();
+    const expected = ["notifications", "project", "read:org", "repo", "workflow"].sort();
+    expect(names).toEqual(expected);
+  });
+
+  test("every usedFor is non-empty", () => {
+    for (const row of CLASSIC_SCOPES) {
+      expect(row.usedFor.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("FINE_GRAINED_PERMISSIONS", () => {
+  test("permission names are unique", () => {
+    const names = FINE_GRAINED_PERMISSIONS.map((row) => row.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("levels are only Read-only or Read and write", () => {
+    for (const row of FINE_GRAINED_PERMISSIONS) {
+      expect(["Read-only", "Read and write"]).toContain(row.level);
+    }
+  });
+
+  test("Contents, Pull requests, Issues, and Actions are Read and write", () => {
+    const byName = new Map(FINE_GRAINED_PERMISSIONS.map((row) => [row.name, row.level]));
+    for (const name of ["Contents", "Pull requests", "Issues", "Actions"]) {
+      expect(byName.get(name)).toBe("Read and write");
+    }
+  });
+
+  test("Commit statuses and Metadata are Read-only", () => {
+    const byName = new Map(FINE_GRAINED_PERMISSIONS.map((row) => [row.name, row.level]));
+    for (const name of ["Commit statuses", "Metadata"]) {
+      expect(byName.get(name)).toBe("Read-only");
+    }
+  });
+
+  test("every usedFor is non-empty", () => {
+    for (const row of FINE_GRAINED_PERMISSIONS) {
+      expect(row.usedFor.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("FINE_GRAINED_LIMITATIONS", () => {
+  test("is non-empty", () => {
+    expect(FINE_GRAINED_LIMITATIONS.length).toBeGreaterThan(0);
+  });
+
+  test("collectively mention notifications, discussions, checks, and projects", () => {
+    const combined = FINE_GRAINED_LIMITATIONS.join(" ").toLowerCase();
+    for (const term of ["notifications", "discussions", "checks", "projects"]) {
+      expect(combined).toContain(term);
+    }
+  });
+});
+
+describe("ORG_CAVEATS", () => {
+  test("is non-empty", () => {
+    expect(ORG_CAVEATS.length).toBeGreaterThan(0);
+  });
+
+  test("mentions SSO somewhere", () => {
+    const combined = ORG_CAVEATS.join(" ");
+    expect(combined).toContain("SSO");
+  });
+});
+
+describe("MULTI_ACCOUNT_NOTE", () => {
+  test("mentions github.com", () => {
+    expect(MULTI_ACCOUNT_NOTE).toContain("github.com");
+  });
+});
+
+describe("FINE_GRAINED_CREATE_STEPS", () => {
+  test("is non-empty with non-empty titles and details", () => {
+    expect(FINE_GRAINED_CREATE_STEPS.length).toBeGreaterThan(0);
+    for (const step of FINE_GRAINED_CREATE_STEPS) {
+      expect(step.title.trim().length).toBeGreaterThan(0);
+      expect(step.detail.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test("mentions Fine-grained somewhere", () => {
+    const combined = FINE_GRAINED_CREATE_STEPS.map((s) => `${s.title} ${s.detail}`).join(" ");
+    expect(combined).toContain("Fine-grained");
+  });
+});
+
+describe("CLASSIC_CREATE_STEPS", () => {
+  test("is non-empty with non-empty titles and details", () => {
+    expect(CLASSIC_CREATE_STEPS.length).toBeGreaterThan(0);
+    for (const step of CLASSIC_CREATE_STEPS) {
+      expect(step.title.trim().length).toBeGreaterThan(0);
+      expect(step.detail.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test('mentions "Tokens (classic)" somewhere', () => {
+    const combined = CLASSIC_CREATE_STEPS.map((s) => `${s.title} ${s.detail}`).join(" ");
+    expect(combined).toContain("Tokens (classic)");
+  });
+});

--- a/src/mainview/lib/github-setup-guide.ts
+++ b/src/mainview/lib/github-setup-guide.ts
@@ -1,0 +1,229 @@
+/**
+ * Content for the "Connect Agetor to GitHub" setup guide (`GitHubSetupDialog.tsx`).
+ *
+ * This module is the **single source of truth** for that guide's copy — the
+ * component only maps over these exports; no permission/scope/step text is
+ * hardcoded in JSX. Keeping it as plain data (rather than markdown, which the
+ * webview has no renderer for) means the dialog stays typed end-to-end and a
+ * future test file can assert coverage (no duplicate scope names, https-only
+ * URLs, every load-bearing permission present) without touching React.
+ *
+ * Permission facts (scope names, fine-grained permission names, what each
+ * token type can and can't do) were verified against docs.github.com as of
+ * July 2026. **Classic tokens are recommended for full Agetor access**
+ * because three of the ~70 `/github/*` integration surfaces
+ * (`src/bun/server.ts`) are classic-token-only or otherwise unreachable with
+ * a fine-grained PAT: the Notifications API only accepts classic tokens, the
+ * Checks API has no grantable fine-grained permission (commit statuses still
+ * work), and repository Discussions has no fine-grained permission at all.
+ * Fine-grained tokens are documented as the least-privilege alternative with
+ * an explicit list of what won't work.
+ */
+
+/** One row in a fine-grained-token permission table. */
+export type GuidePermissionRow = {
+  name: string;
+  level: "Read-only" | "Read and write";
+  usedFor: string;
+};
+
+/** One row in a classic-token scope table. */
+export type GuideScopeRow = {
+  scope: string;
+  usedFor: string;
+};
+
+/** One numbered step in a click-path (token creation, auth resolution, …). */
+export type GuideStep = {
+  title: string;
+  detail: string;
+};
+
+/** GitHub URLs the guide links out to via `api.openExternal` (the webview is
+ *  sandboxed — no `<a target="_blank">`, see `src/mainview/lib/api.ts`). */
+export const GITHUB_URLS = {
+  fineGrainedTokens: "https://github.com/settings/personal-access-tokens",
+  classicTokens: "https://github.com/settings/tokens",
+  tokenDocs:
+    "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens",
+} as const;
+
+/**
+ * How Agetor resolves the token used to authenticate a GitHub request, in
+ * order — mirrors `githubToken()` in `src/bun/github.ts:856-863` exactly.
+ * Keep this in lockstep with that function; it's documentation of real
+ * runtime behavior, not aspirational copy.
+ */
+export const AUTH_RESOLUTION_STEPS: GuideStep[] = [
+  {
+    title: "A token saved in this Settings section",
+    detail:
+      "Agetor looks up the token stored for the repo's remote host (the raw ssh host — " +
+      "e.g. github-work.com for an ssh alias remote). If none is stored for that exact " +
+      "host, it falls back to whatever token is stored under the github.com entry.",
+  },
+  {
+    title: "Environment variables",
+    detail:
+      "If no token is stored for the host, Agetor reads the GITHUB_TOKEN or GH_TOKEN " +
+      "environment variable from the process it was launched with.",
+  },
+  {
+    title: "GitHub CLI login",
+    detail:
+      "If neither of the above resolves a token, Agetor shells out to `gh auth token` " +
+      "and uses whatever the GitHub CLI has you logged in as, if anything.",
+  },
+];
+
+/** Recommended classic-token scopes for FULL Agetor access. */
+export const CLASSIC_SCOPES: GuideScopeRow[] = [
+  {
+    scope: "repo",
+    usedFor:
+      "Pull requests, issues, comments, reviews, labels, milestones, releases, commit " +
+      "statuses, check runs, diffs, and repository Discussions.",
+  },
+  {
+    scope: "workflow",
+    usedFor:
+      "GitHub Actions — re-running, cancelling, and dispatching workflows, and pushing " +
+      "any changes to workflow files.",
+  },
+  {
+    scope: "notifications",
+    usedFor:
+      "The repo's notifications inbox and thread subscribe/unsubscribe. This API only " +
+      "accepts classic tokens — a fine-grained token cannot reach it.",
+  },
+  {
+    scope: "project",
+    usedFor: "The Projects panel (classic and Projects v2 boards).",
+  },
+  {
+    scope: "read:org",
+    usedFor: "Org-owned Projects and other org context needed to resolve them.",
+  },
+];
+
+/** Fine-grained-token permissions for least-privilege access. All are
+ *  Repository permissions unless the row's `usedFor` says otherwise. */
+export const FINE_GRAINED_PERMISSIONS: GuidePermissionRow[] = [
+  {
+    name: "Contents",
+    level: "Read and write",
+    usedFor: "Merging pull requests, applying review suggestions, releases and tags.",
+  },
+  {
+    name: "Pull requests",
+    level: "Read and write",
+    usedFor:
+      "Listing, creating, merging, closing, drafting, and auto-merging PRs; reviews, " +
+      "line comments, suggestions, and review threads.",
+  },
+  {
+    name: "Issues",
+    level: "Read and write",
+    usedFor:
+      "Issues, comments, labels, milestones, locking/pinning/transferring, and sub-issues.",
+  },
+  {
+    name: "Actions",
+    level: "Read and write",
+    usedFor: "Listing, re-running, cancelling, and dispatching workflow runs.",
+  },
+  {
+    name: "Commit statuses",
+    level: "Read-only",
+    usedFor: "The commit status panel.",
+  },
+  {
+    name: "Metadata",
+    level: "Read-only",
+    usedFor: "Added automatically by GitHub — collaborators and repository info.",
+  },
+  {
+    name: "Projects (Organization permission)",
+    level: "Read and write",
+    usedFor: "Org-owned Projects v2.",
+  },
+];
+
+/** What a fine-grained PAT cannot reach in Agetor, even with every
+ *  permission above granted — phrased for the dialog's warning list. */
+export const FINE_GRAINED_LIMITATIONS: string[] = [
+  "The notifications inbox — GitHub's Notifications API only supports classic tokens.",
+  "Repository Discussions — there is no fine-grained permission for repo discussions.",
+  "Check-run details — the Checks API can't be granted to fine-grained tokens (commit statuses still work).",
+  "User-owned (non-organization) Projects.",
+];
+
+/** Caveats specific to organization-owned repositories. */
+export const ORG_CAVEATS: string[] = [
+  "A fine-grained token used against an organization's repos may need the organization to allow fine-grained tokens at all, and can sit in a \"Pending\" state until an org admin approves it.",
+  "Classic tokens for organizations with SAML SSO enabled must be authorized per-organization via the token's \"Configure SSO\" menu before they'll work against that org's repos.",
+  "Organization policies may cap how long any token — classic or fine-grained — is allowed to live.",
+];
+
+/** Why the same GitHub identity resolves differently across repos, and how
+ *  to run multiple GitHub accounts side by side. */
+export const MULTI_ACCOUNT_NOTE: string =
+  "Tokens are stored per remote host, not globally. A repo reached through an ssh host " +
+  "alias (e.g. git@github-work.com:org/repo.git) authenticates with whatever token is " +
+  "stored for that alias host; the github.com entry is the default used for ordinary " +
+  "github.com remotes. This is how multiple GitHub identities — a personal account and " +
+  "a work account, say — can coexist in the same Agetor install.";
+
+/** Click-path to create a fine-grained personal access token. */
+export const FINE_GRAINED_CREATE_STEPS: GuideStep[] = [
+  {
+    title: "Open GitHub → Settings → Developer settings",
+    detail: "From your GitHub profile picture, go to Settings, then Developer settings in the left sidebar.",
+  },
+  {
+    title: "Personal access tokens → Fine-grained tokens",
+    detail: "Choose \"Fine-grained tokens\", then click \"Generate new token\".",
+  },
+  {
+    title: "Name, expiration, and resource owner",
+    detail:
+      "Pick a name and expiration. Set \"Resource owner\" to your personal account, or " +
+      "the organization that owns the repositories you want Agetor to work with.",
+  },
+  {
+    title: "Repository access",
+    detail:
+      "Choose \"Only select repositories\" and pick the repos Agetor should touch (or " +
+      "\"All repositories\" if you want it to cover everything under that owner).",
+  },
+  {
+    title: "Set permissions",
+    detail: "Grant the permissions listed below, then click \"Generate token\" and copy it — it's shown only once.",
+  },
+];
+
+/** Click-path to create a classic personal access token. */
+export const CLASSIC_CREATE_STEPS: GuideStep[] = [
+  {
+    title: "Open GitHub → Settings → Developer settings",
+    detail: "From your GitHub profile picture, go to Settings, then Developer settings in the left sidebar.",
+  },
+  {
+    title: "Personal access tokens → Tokens (classic)",
+    detail: "Choose \"Tokens (classic)\", then \"Generate new token\" → \"Generate new token (classic)\".",
+  },
+  {
+    title: "Note and expiration",
+    detail: "Give the token a note describing what it's for, and pick an expiration.",
+  },
+  {
+    title: "Select scopes",
+    detail: "Tick the scopes listed below, then click \"Generate token\" and copy it — it's shown only once.",
+  },
+  {
+    title: "SAML SSO organizations",
+    detail:
+      "If the token needs to reach an org with SAML SSO enabled, open the token's " +
+      "\"Configure SSO\" menu afterward and authorize it for that organization.",
+  },
+];


### PR DESCRIPTION
## What

Adds a **"Connect Agetor to GitHub" setup-guide modal** so users can configure the GitHub integration end-to-end without leaving the app — including the exact GitHub-side permissions needed for full access.

- **`GitHubSetupDialog.tsx`** (Settings surface): a scrollable modal with 7 sections — what the integration covers, how Agetor resolves a token (stored per-host token → `GITHUB_TOKEN`/`GH_TOKEN` → `gh auth token`), a classic-PAT walkthrough, a fine-grained-PAT walkthrough with an explicit "not available with fine-grained tokens" warning, organization caveats (pending-approval flow, SAML "Configure SSO"), multi-account/ssh-alias handling, and how to save the token in Agetor. External links go through `api.openExternal` (the webview is sandboxed).
- **Triggers**: a "Setup guide" button in Settings → GitHub tokens, plus a "How to create one →" link in the section's empty state.
- **`lib/github-setup-guide.ts`**: all guide content as typed, unit-tested data (permission tables, scopes, click-paths, URLs) — single source of truth, no prose hardcoded in the component.

## Why the guide recommends a classic PAT for *full* access

Verified against docs.github.com: three integration surfaces are effectively **classic-token-only** — the Notifications API rejects fine-grained PATs, the Checks API permission can't be granted to fine-grained PATs, and repo Discussions have no fine-grained permission. So the guide recommends `repo`, `workflow`, `notifications`, `project`, `read:org` (classic) for everything Agetor's GitHub modal can do, and documents fine-grained PATs (Contents RW, Pull requests RW, Issues RW, Actions RW, Commit statuses R, org Projects RW, Metadata auto) as the least-privilege alternative with its limitations spelled out.

## Bonus fix: stacked dialogs

Opening the guide over Settings was the first real Dialog-inside-Dialog stack, and it exposed a bug in the shared `ui/dialog.tsx` primitive: every open dialog registered its own document-level `keydown` listener, so one <kbd>Esc</kbd> closed **both** layers. The primitive now keeps a module-level open-dialog stack and only the topmost dialog handles Escape/Tab (also hardens `confirm.tsx` overlays).

## Tests / verification

- New `github-setup-guide.test.ts`: 24 tests asserting content invariants (exact scope set, permission levels, URL hosts, resolution-order wording), e.g.:

  ```ts
  expect([...new Set(CLASSIC_SCOPES.map((s) => s.scope))].sort())
    .toEqual(["notifications", "project", "read:org", "repo", "workflow"]);
  ```
- `bun run typecheck` ✓, `bunx vite build` ✓, full `bun test` 1632 pass / 1 skip / 0 real failures.
- Reviewed (0 must-fix; the Escape finding + 2 nits were fixed in the second commit).

Plan with logged assumptions: `docs/plans/github-setup-instructions-modal.md`.