### PR TITLE
feature: add Claude Opus 5 to the claude-code picker and make it the default

### DIFF
--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -151,6 +151,16 @@ test("claude-code 'opus-4.8' maps to --model claude-opus-4-8", () => {
   ]);
 });
 
+test("claude-code 'opus-5' maps to --model claude-opus-5", () => {
+  const { cmd } = buildCommand(builtin("claude-code"), "do thing", { ...claudeDefaults, model: "opus-5", mode: "auto" });
+  expect(cmd).toEqual([
+    "claude",
+    "--model", "claude-opus-5",
+    "--permission-mode", "auto",
+    "--", "do thing",
+  ]);
+});
+
 test("claude-code 'fable-5' maps to --model claude-fable-5", () => {
   const { cmd } = buildCommand(builtin("claude-code"), "do thing", { ...claudeDefaults, model: "fable-5", mode: "auto" });
   expect(cmd).toEqual([

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -90,6 +90,7 @@ export interface AgentRunOptions {
 // so it doesn't need a translation table.
 const CLAUDE_MODEL_FLAG: Record<string, string> = {
   "fable-5": "claude-fable-5",
+  "opus-5": "claude-opus-5",
   "opus-4.8": "claude-opus-4-8",
   "opus-4.7": "claude-opus-4-7",
   "opus-4.6": "claude-opus-4-6",

--- a/src/bun/effort-support.test.ts
+++ b/src/bun/effort-support.test.ts
@@ -1,6 +1,15 @@
 import { test, expect } from "bun:test";
 import { DEFAULT_MODEL, supportedEfforts } from "../shared/types.ts";
 
+test("claude opus-5 supports xhigh + max", () => {
+  const ids = supportedEfforts("claude-code", "opus-5").map((o) => o.id);
+  expect(ids).toContain("max");
+  expect(ids).toContain("xhigh");
+  expect(ids).toContain("high");
+  expect(ids).toContain("medium");
+  expect(ids).toContain("low");
+});
+
 test("claude opus-4.8 supports xhigh + max", () => {
   const ids = supportedEfforts("claude-code", "opus-4.8").map((o) => o.id);
   expect(ids).toContain("max");
@@ -42,10 +51,10 @@ test("claude haiku-4.5 exposes no effort options (CLI doesn't accept the flag)",
   expect(ids).toEqual([]);
 });
 
-test("claude null model falls back to DEFAULT_MODEL support set (opus-4.8)", () => {
+test("claude null model falls back to DEFAULT_MODEL support set (opus-5)", () => {
   // No model specified → use the agent's default model's support set. Since
-  // claude-code's DEFAULT_MODEL is opus-4.8, xhigh + max are both available.
-  expect(DEFAULT_MODEL["claude-code"]).toBe("opus-4.8");
+  // claude-code's DEFAULT_MODEL is opus-5, xhigh + max are both available.
+  expect(DEFAULT_MODEL["claude-code"]).toBe("opus-5");
   const ids = supportedEfforts("claude-code", null).map((o) => o.id);
   expect(ids).toContain("xhigh");
   expect(ids).toContain("max");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -771,9 +771,10 @@ export interface AgentOptions {
  * CLI happens to default to.
  */
 export const DEFAULT_MODEL: Record<AgentKind, string> = {
-  // Default to Opus 4.8 — Fable 5 sits above it in the picker but costs 2x the
+  // Default to Opus 5 — the most-capable Opus, priced identically to Opus 4.8
+  // ($5/$25 per MTok). Fable 5 sits above it in the picker but costs 2x the
   // usage, so the default stays on the most-capable non-premium tier.
-  "claude-code": "opus-4.8",
+  "claude-code": "opus-5",
   "codex": "gpt-5.5",
 };
 export const DEFAULT_EFFORT: Record<AgentKind, string> = {
@@ -823,7 +824,7 @@ export const CODE_PLAN_MODE: Record<AgentKind, { code: string; plan: string }> =
  */
 export const EFFORT_OPTIONS: AgentOption[] = [
   { id: "max", label: "Max", hint: "Absolute maximum effort. Slowest, most thorough." },
-  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Fable 5 / Opus 4.8 / 4.7 / 4.6 / Sonnet 5 / codex." },
+  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Fable 5 / Opus 5 / 4.8 / 4.7 / 4.6 / Sonnet 5 / codex." },
   { id: "high", label: "High", hint: "Deep reasoning. The API default where supported." },
   { id: "medium", label: "Medium", hint: "Balanced speed vs. capability." },
   { id: "low", label: "Low", hint: "Most efficient. Best for simple tasks." },
@@ -848,7 +849,7 @@ export const EFFORT_OPTIONS: AgentOption[] = [
  */
 export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> = {
   // Per https://platform.claude.com/docs/en/build-with-claude/effort the
-  // effort parameter is API-supported on Fable 5 / Opus 4.8 / 4.7 / 4.6 /
+  // effort parameter is API-supported on Fable 5 / Opus 5 / 4.8 / 4.7 / 4.6 /
   // Sonnet 5 / Sonnet 4.6 / Opus 4.5 (xhigh is Fable-5-, Opus-, and Sonnet-5-only;
   // Sonnet 4.6 has no xhigh; Haiku 4.5 doesn't support effort at all). The
   // `/effort` CLI command accepts more
@@ -857,6 +858,8 @@ export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> =
   "claude-code": {
     // Fable 5 shares Opus 4.7/4.8's request surface (effort low→max, xhigh).
     "fable-5": ["max", "xhigh", "high", "medium", "low"],
+    // Opus 5 supports the full effort ladder incl. xhigh (per claude-api skill).
+    "opus-5": ["max", "xhigh", "high", "medium", "low"],
     "opus-4.8": ["max", "xhigh", "high", "medium", "low"],
     "opus-4.7": ["max", "xhigh", "high", "medium", "low"],
     "opus-4.6": ["max", "xhigh", "high", "medium", "low"],
@@ -904,6 +907,7 @@ export function supportedEfforts(agent: AgentKind, model: string | null): AgentO
 const MODEL_MODE_DENY: Record<AgentKind, Record<string, string[]>> = {
   "claude-code": {
     "fable-5": [],
+    "opus-5": [],
     "opus-4.8": [],
     "opus-4.7": [],
     "opus-4.6": [],
@@ -928,7 +932,8 @@ export const AGENT_OPTIONS: Record<AgentKind, AgentOptions> = {
   "claude-code": {
     models: [
       { id: "fable-5", label: "Fable 5", hint: "Most powerful tier — above Opus. Uses 2x the usage of Opus." },
-      { id: "opus-4.8", label: "Opus 4.8", hint: "Most capable Opus; slower." },
+      { id: "opus-5", label: "Opus 5", hint: "Most capable Opus; same usage cost as 4.8." },
+      { id: "opus-4.8", label: "Opus 4.8", hint: "Prior Opus flagship." },
       { id: "opus-4.7", label: "Opus 4.7", hint: "Prior flagship; same effort range as 4.8." },
       { id: "opus-4.6", label: "Opus 4.6", hint: "Earlier Opus generation." },
       { id: "sonnet-5", label: "Sonnet 5", hint: "Near-Opus quality on coding/agentic work at Sonnet cost." },


### PR DESCRIPTION
## What

Adds the just-announced **Claude Opus 5** (`claude-opus-5`) as a selectable model for the `claude-code` harness, and promotes it to the harness **default** (replacing Opus 4.8).

## Why

Opus 5 is priced **identically to Opus 4.8** ($5/$25 per MTok) — it is *not* a premium 2× tier like Fable 5 ($10/$50). Making it the default is therefore cost-neutral versus the old default while giving a more capable model, which stays consistent with the existing "default stays on the most-capable non-premium tier" rationale in `DEFAULT_MODEL`.

## Changes

`src/shared/types.ts`
- `AGENT_OPTIONS["claude-code"].models` — insert `Opus 5` between Fable 5 and Opus 4.8 (Fable 5 stays at the top as the premium tier); relabel Opus 4.8's hint to "Prior Opus flagship."
- `MODEL_EFFORT_SUPPORT["claude-code"]["opus-5"]` — full effort ladder (`max/xhigh/high/medium/low`).
- `MODEL_MODE_DENY["claude-code"]["opus-5"]` — `[]` (all permission modes allowed).
- `DEFAULT_MODEL["claude-code"]` — `opus-4.8` → `opus-5`.
- `EFFORT_OPTIONS` xhigh hint updated to list Opus 5.

`src/bun/agents.ts`
- `CLAUDE_MODEL_FLAG["opus-5"] = "claude-opus-5"` (the exact `--model` string the CLI expects). `CLAUDE_EFFORT_VALUES` already covered all five effort ids.

Tests
- `agents.test.ts` — `opus-5` → `--model claude-opus-5` mapping.
- `effort-support.test.ts` — new Opus 5 effort test; `DEFAULT_MODEL` assertions updated to `opus-5`.

## Notes

- **No DB migration:** `DEFAULT_MODEL` only seeds the new-task form; existing task rows keep their stored model.
- Both UI pickers (`NewTaskForm.tsx`, `RunPanel.tsx`) read `AGENT_OPTIONS`, so Opus 5 appears automatically; the Fable-5-only "2× usage" helper is unaffected.

## Verification

- `bun run typecheck` — clean.
- `bun test` — **1610 pass, 1 skip, 0 fail** across 115 files.