### PR TITLE
fix: Worktrees "Archive & delete" actually removes the worktree

### DIFF
--- a/docs/plans/worktrees-archive-delete-noop.md
+++ b/docs/plans/worktrees-archive-delete-noop.md
@@ -1,0 +1,156 @@
+# Plan — Worktrees page "Archive & delete" actually deletes
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-28 |
+| Source | Bug report: "archive and delete button on the new stale modal seems to not be working… the worktree seems to not be cleaned up and the list doesn't refresh… not sure if it's because the task is already archived but not clean up" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | `fix/archive-and-delete-seems-to-not-be-worki` |
+| Base SHA | `ce9177b34816982f2aeebbba15fefb8dde8bd827` (clean tree) |
+
+## 1. Objective & success criteria
+
+Clicking the trash icon on a **task-backed** row in the Worktrees dialog and confirming must, in every case:
+
+1. Actually remove the worktree directory from disk — including when the task is **already archived** (today's headline failure) and when the checkout is **dirty**.
+2. Keep the spinner up until removal has genuinely finished, then drop the row from the list on the very next refresh.
+3. Tell the user when it *didn't* work, and why.
+4. Warn **before** destroying uncommitted work, and never destroy the branch or the run/AI history.
+
+Success = the reporter's existing stuck rows clear on one click, with no migration or one-off script.
+
+## 2. Context & constraints (grounded)
+
+Three independent defects compound into the reported symptom.
+
+**D1 — already-archived is a total no-op.** `src/bun/orchestrator.ts:2003-2005`:
+
+```ts
+if (task.archivedAt != null) {
+  return { task };            // returns BEFORE the enqueueTeardown at :2024
+}
+```
+
+`listWorktrees` flags exactly this state as `staleReasons: ["archived"]` (`orchestrator.ts:2202`), rendered as *"archived, not cleaned up"* (`WorktreesDialog.tsx:49`). So the one row the page most wants you to clean is the one row the button cannot clean. The server returns `200` with the unchanged task (`server.ts:3120-3134`), the client refreshes, nothing has changed.
+
+**D2 — a dirty worktree can never be detached.** `src/bun/worktree.ts:946-947`:
+
+```ts
+const dirty = await hasUncommittedChanges(task.worktreePath);
+if (dirty !== false) return { removed: false, reason: "dirty" };
+```
+
+`hasUncommittedChanges` returns `boolean | null`, with `null` on missing dir / non-repo / failing `git status` (`worktree.ts:63-69`) — and `null !== false`, so **git errors are treated as dirty too**. `sweepArchivedTeardowns` (`orchestrator.ts:2132-2153`, called from `index.ts:126`) re-enqueues these every boot and they fail identically every boot, forever, with only a `console.warn` inside `enqueueTeardown`'s catch (`orchestrator.ts:184-186`). There is no force path from this page: `removeWorktree` does force (`worktree.ts:880-904`) but is only reachable via `deleteTask`, and `deleteOrphanWorktree` hard-refuses task-owned ids (`orchestrator.ts:2278-2280`).
+
+**D3 — the outcome is computed, then discarded; the refresh races the teardown.** `detachWorktree` returns `{ removed, reason }` but both call sites drop it (`orchestrator.ts:2034`, `orchestrator.ts:2148`). Teardown is intentionally deferred and fire-and-forget (`void enqueueTeardown`, knowledge `7a0e88ac`), so `WorktreesDialog.tsx:288`'s `await refresh()` runs *before* removal completes — even on the happy path the row lingers until the 5s poll (`POLL_MS`, `WorktreesDialog.tsx:34`).
+
+**Constraints that must survive the fix:**
+
+- The per-workdir teardown queue is load-bearing (knowledge `7a0e88ac`): chains keyed by `task.workdir` keep same-repo `git worktree remove`/`prune` FIFO-serialized against git's locks. **Do not bypass `enqueueTeardown`.** Any new awaiting path routes *through* the queue, exactly as `deleteTask` (`orchestrator.ts:2095`) and `deleteOrphanWorktree` (`orchestrator.ts:2308`) already do.
+- `enqueueTeardown` swallows job errors so the chain never breaks — the established idiom for getting a result out is a **closure-captured variable** read after awaiting the enqueued promise (`deleteOrphanWorktree`, per knowledge `a8549bc4`). Use that; don't change `enqueueTeardown`'s error contract.
+- Archive semantics are *detach, not destroy*: the branch, commits, `runs`/`run_events`, and claude's JSONL transcript all survive so unarchive can rematerialize (`orchestrator.ts:1954-1964`, `unarchiveTask` at `:2058-2067`). **Force must discard only the uncommitted working tree — never `git branch -D`.**
+- Teardown ordering inside a job is load-bearing: sessions/terminals cwd'd in the worktree die before `git worktree remove` (`orchestrator.ts:2028-2034`).
+- The kanban archive button (`App.tsx:499-521`) must keep its fast fire-and-forget behavior. Only this explicit cleanup action opts into waiting.
+
+## 3. Approach & key decisions
+
+Owner decisions from the Phase 2 grill (all three as recommended):
+
+| Decision | Choice |
+| --- | --- |
+| Dirty worktrees | **Warn in the dialog, then force.** Pre-fetch git status for the row, surface an explicit "uncommitted changes will be discarded" warning in the confirm, force on confirm. |
+| Sync vs async | **Await and report.** Opt-in `awaitTeardown` flag on the archive route; spinner holds; response carries the detach outcome. |
+| Backfill | **The fixed button clears them.** Fixing D1 is sufficient; no migration, no boot-time auto-force. |
+
+Key design calls:
+
+- **`detachWorktree(task, opts?: { force?: boolean })`** — `force` skips the `hasUncommittedChanges` gate only. It reuses the same `git worktree remove --force` + `prune` + confined `rm -rf` body, and still deliberately omits `git branch -D`. This keeps one code path rather than routing archive through `removeWorktree` (which *does* delete the branch and would break unarchive).
+- **Re-enqueue on already-archived rather than early-returning.** `archiveTask` gains a shared `enqueueArchiveTeardown(task, { force })` helper, called from both the fresh-archive and the already-archived branches — and reused by `sweepArchivedTeardowns` so the three call sites can't drift. The already-archived branch only enqueues when the worktree is still on disk (the exact condition the boot sweep already uses, `orchestrator.ts:2140`), so an ordinary repeat-archive stays a cheap no-op.
+- **Result plumbing via closure capture**, matching `deleteOrphanWorktree`. `archiveTask` returns `{ task, teardown? }` where `teardown` is only populated when `awaitTeardown` was requested.
+- **`reason` triage on the client**: `"already-absent"` and `"no-worktree"` mean *nothing to remove* — treat as success, not failure. Only a genuinely failed removal toasts.
+- **Rejected:** adding a new `WorktreeStaleReason` (e.g. `archived-dirty`). With force always available the dirty state is no longer a dead end, and the toast covers the residual failures — a new union member would ripple through `listWorktrees`, the shared types, the filter UI, and its tests for little gain.
+- **Rejected:** auto-forcing in `sweepArchivedTeardowns`. Discarding uncommitted work with no human in the loop, at boot, is not a trade the owner asked for.
+
+I write `src/shared/types.ts` myself before the fan-out, so the two implementation agents have a fixed contract and disjoint file sets.
+
+## 4. Work breakdown — implementation tasks
+
+**T0 (orchestrator, inline before the fan-out) — shared contract.**
+Owns `src/shared/types.ts`. Adds:
+
+```ts
+/** Outcome of the worktree teardown an archive triggered … */
+export interface WorktreeTeardownResult {
+  removed: boolean;
+  reason?: "dirty" | "no-worktree" | "already-absent" | "failed";
+}
+```
+
+**T1 — backend: force detach, re-enqueue, await, report.**
+Owns `src/bun/worktree.ts`, `src/bun/orchestrator.ts`, `src/bun/server.ts`.
+
+- `detachWorktree(task, opts?: { force?: boolean })` — `force: true` skips the dirty gate; everything else unchanged; still no `git branch -D`.
+- Extract `enqueueArchiveTeardown(task, opts)` from `archiveTask`'s existing deferred job; reuse in `sweepArchivedTeardowns`.
+- `archiveTask(taskId, { force?, stopRun?, forceWorktree?, awaitTeardown? })` → `{ task, teardown? } | { error }`:
+  - already-archived + `worktreePath` still on disk → enqueue teardown instead of bare-returning.
+  - `awaitTeardown` → await the enqueued promise, return the closure-captured `WorktreeTeardownResult`.
+  - `forceWorktree` → threaded to `detachWorktree`.
+- `POST /tasks/:id/archive` parses `forceWorktree`/`awaitTeardown` off the body (same `=== true` idiom as `force`/`stopRun`, `server.ts:3122`), returns `{ ...task, teardown }`-shaped payload without breaking existing callers. Route needs `server.timeout(req, 0)` like `DELETE /tasks/:id` (`server.ts:3100-3107`) since it can now block on a real `git worktree remove`.
+
+*Acceptance:* archiving an already-archived task with a live worktree removes the directory; a dirty worktree survives without `forceWorktree` and is removed with it; the branch survives both; `awaitTeardown` responses carry a truthful `removed`.
+
+**T2 — client: warn, force, await, report.**
+Owns `src/mainview/lib/api.ts`, `src/mainview/components/worktrees/WorktreesDialog.tsx`.
+
+- `api.archiveTask(id, opts)` gains `forceWorktree`/`awaitTeardown`; return type carries optional `teardown`.
+- `deleteTaskBacked`: fetch `api.getWorktreeGitStatus(w.id)` fresh before the confirm (the cached `gitStatus` map may be `"loading"`/absent); when `dirty && !ignored`, add a prominent warning to the confirm description and switch the confirm label to reflect discarding changes.
+- Call with `{ force: true, stopRun: true, forceWorktree: true, awaitTeardown: true }`; keep `withBusy` up for the whole await.
+- On `teardown.removed === false` with a real failure reason → `toast.error` naming the branch and reason. `already-absent`/`no-worktree` → silent success.
+- Add `await refresh()` to the catch branch, matching `App.tsx:517-519`.
+- Fix the confirm copy for an already-archived row: it currently promises the ticket "will be **archived**" when it already is.
+
+*Acceptance:* one click clears a stuck archived row; a dirty row shows the warning first; a failure toasts instead of silently refreshing.
+
+## 5. Work breakdown — test tasks
+
+**T3 — backend tests.** Owns `src/bun/orchestrator-archive-teardown.test.ts`, `src/bun/worktree.test.ts`. Covers T1:
+- `archiveTask` on an already-archived task with the worktree still on disk enqueues teardown and removes it (the regression test for D1).
+- Repeat-archive with the worktree already gone stays a no-op (no spurious enqueue).
+- `detachWorktree(task, { force: true })` removes a dirty worktree; the branch and its commits survive; without `force` the existing `{ removed: false, reason: "dirty" }` behavior is unchanged.
+- `awaitTeardown: true` resolves only after the directory is gone and reports `removed: true`; the dirty-without-force path reports `removed: false, reason: "dirty"`.
+- Steady-state regression: archive → dirty skip → `sweepArchivedTeardowns` → still stuck → explicit force clears it.
+
+Setup idiom is fixed by the existing files: `process.env.AGETOR_DATA_DIR = mkdtempSync(...)` at **module top-level** before importing `db.ts`, and a throwaway `makeRepo()` git repo — never `process.cwd()`.
+
+**T4 — client-logic tests.** Owns `src/mainview/components/worktrees/worktree-delete-intent.ts` + `.test.ts`. There are **zero** `.test.tsx` files in this app; the house pattern is to extract pure logic beside the component and unit-test that (`github-dialog-view.test.ts`). Extract the two decisions worth testing — confirm-copy/warning selection from `(WorktreeInfo, WorktreeGitStatus | null)`, and outcome triage from `WorktreeTeardownResult` → `silent | error(message)` — and test those.
+
+## 6. Execution waves
+
+- **Wave 0 (inline, me):** T0 — `src/shared/types.ts`.
+- **Wave 1 (parallel, 2 agents):** T1 (bun) ‖ T2 (mainview). Disjoint files, contract fixed by T0.
+- **Barrier:** typecheck + commit.
+- **Wave 2:** code review of `ce9177b…HEAD`.
+- **Wave 3 (parallel, 2 agents):** T3 ‖ T4. Disjoint files.
+- **Wave 4:** run suite; fix to green.
+
+T2 lands `worktree-delete-intent.ts`'s *usage*; T4 lands the file itself and its test — so T2's brief must specify that module's exact exported signatures, and T4 must not touch `WorktreesDialog.tsx`. Alternative if that proves awkward: T2 owns both the module and its usage, T4 owns only the `.test.ts`.
+
+## 7. Blast radius & risks
+
+| Risk | Mitigation |
+| --- | --- |
+| `archiveTask`'s signature/return shape changes and it has other callers | Only two webview call sites (`App.tsx:499`, `WorktreesDialog.tsx:287`) plus tests. New opts are optional and default to today's behavior; `teardown` is an added field, so `{ task }` consumers are unaffected. |
+| Re-enqueue on already-archived fires on every kanban archive | Gated on `worktreePath && existsSync(worktreePath)` — the same condition the boot sweep uses. Ordinary repeat-archive is still a bare return. |
+| `awaitTeardown` blocks the HTTP request behind same-repo teardowns | Exactly the tradeoff `deleteTask` already makes (`orchestrator.ts:2095`, `server.ts:3100-3107` sets `server.timeout(req, 0)`). Opt-in only; the kanban path stays async. |
+| Force destroys uncommitted work | Requires an explicit confirm carrying a fresh, per-row git-status warning. Branch + commits + run history untouched. |
+| Bypassing `enqueueTeardown` reintroduces the git-lock race | Explicitly forbidden in both agent briefs; the new path routes through the queue. |
+| A `null` from `hasUncommittedChanges` (git error) now silently force-deletes | Force is only reachable from an explicit confirmed user action on this page, and only removes the checkout — the branch survives, so the work is recoverable. |
+
+Rollback: revert the branch; no migration, no schema change, no persisted state.
+
+## 8. Open questions / assumptions
+
+- **Assumed** the confirm dialog is the right place for the dirty warning (rather than a second dialog) — follows directly from the owner's "warn in the dialog, then force" choice.
+- **Assumed** `already-absent` / `no-worktree` count as success for toast purposes.
+- **Assumed** the kanban archive button keeps fire-and-forget semantics; only the Worktrees page opts into `awaitTeardown`.
+- **Not doing:** a new `WorktreeStaleReason`, boot-time auto-force, or any change to `enqueueTeardown`'s error-swallowing contract.

--- a/src/bun/orchestrator-archive-teardown.test.ts
+++ b/src/bun/orchestrator-archive-teardown.test.ts
@@ -345,6 +345,310 @@ test("FIFO ordering: pendingTeardown(b) resolving implies a's teardown (enqueued
   }
 });
 
+test("regression: repeat-archiving an already-archived task whose worktree is still on disk (crash-before-teardown) actually tears it down now — before the fix this was a total no-op", async () => {
+  const { createTask, archiveTask, pendingTeardown } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "already-archived, worktree still on disk",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+    expect(existsSync(worktreePath)).toBe(true);
+
+    // Simulate the reported bug's precondition directly: `archivedAt` is
+    // already set (e.g. from a previous instance that crashed before its
+    // deferred teardown ran, or whose teardown never finished) but the
+    // worktree directory is still on disk — bypassing `archiveTask` entirely,
+    // same as the "sweepArchivedTeardowns" stranding test above.
+    tasks.update(taskId, { archivedAt: Date.now() });
+    expect(existsSync(worktreePath)).toBe(true);
+
+    // The Worktrees page's delete button calls this exact thing: archive an
+    // already-archived row with `force: true`. Before the fix, the
+    // `task.archivedAt != null` branch bare-returned `{ task }` here with no
+    // teardown enqueued whatsoever — the row could never be cleaned up.
+    const archived = await archiveTask(taskId, { force: true });
+    expect("task" in archived).toBe(true);
+    if (!("task" in archived)) throw new Error(archived.error);
+
+    await pendingTeardown(taskId);
+    expect(existsSync(worktreePath)).toBe(false);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("repeat-archive when the worktree is already gone stays a cheap no-op — archivedAt doesn't change and no spurious teardown runs", async () => {
+  const { createTask, archiveTask, pendingTeardown } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "repeat-archive after worktree gone",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+
+    const first = await archiveTask(taskId);
+    if (!("task" in first)) throw new Error(first.error);
+    await pendingTeardown(taskId);
+    expect(existsSync(worktreePath)).toBe(false);
+    const archivedAtAfterFirst = first.task.archivedAt;
+    expect(archivedAtAfterFirst).not.toBeNull();
+
+    // A repeat archive (e.g. a double click) with the worktree already gone
+    // must take the bare no-op return — observable here as `archivedAt`
+    // staying byte-for-byte the same as the first archive (a fresh
+    // `tasks.update({ archivedAt: Date.now() })` would very likely produce a
+    // different timestamp).
+    const second = await archiveTask(taskId);
+    if (!("task" in second)) throw new Error(second.error);
+    expect(second.task.archivedAt).toBe(archivedAtAfterFirst);
+    expect(existsSync(worktreePath)).toBe(false);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("awaitTeardown: true doesn't resolve until the worktree is actually gone, and reports { removed: true }", async () => {
+  const { createTask, archiveTask } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "awaitTeardown removed",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+    expect(existsSync(worktreePath)).toBe(true);
+
+    // Contrast with the default (fire-and-forget) path tested at `:89` above,
+    // where the directory is (usually) still present the instant archiveTask
+    // resolves — with `awaitTeardown: true` it must be gone by the time this
+    // call resolves, every time, deterministically.
+    const archived = await archiveTask(taskId, { awaitTeardown: true });
+    expect("task" in archived).toBe(true);
+    if (!("task" in archived)) throw new Error(archived.error);
+    expect(archived.teardown).toEqual({ removed: true });
+    expect(existsSync(worktreePath)).toBe(false);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("awaitTeardown: true on a dirty worktree reports { removed: false, reason: \"dirty\" } and leaves it in place; forceWorktree clears it", async () => {
+  const { createTask, archiveTask } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "awaitTeardown dirty then forced",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+    writeFileSync(path.join(worktreePath, "dirty.txt"), "uncommitted\n");
+
+    const withoutForce = await archiveTask(taskId, { awaitTeardown: true });
+    expect("task" in withoutForce).toBe(true);
+    if (!("task" in withoutForce)) throw new Error(withoutForce.error);
+    expect(withoutForce.teardown).toEqual({ removed: false, reason: "dirty" });
+    expect(existsSync(worktreePath)).toBe(true);
+    expect(existsSync(path.join(worktreePath, "dirty.txt"))).toBe(true);
+
+    // Already archived from the call above — this exercises the
+    // already-archived re-enqueue branch with `forceWorktree` threaded
+    // through to `detachWorktree`'s `force`.
+    const withForce = await archiveTask(taskId, { forceWorktree: true, awaitTeardown: true });
+    expect("task" in withForce).toBe(true);
+    if (!("task" in withForce)) throw new Error(withForce.error);
+    expect(withForce.teardown).toEqual({ removed: true });
+    expect(existsSync(worktreePath)).toBe(false);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("steady-state regression: a dirty archived worktree survives every unattended boot sweep and is only cleared by an explicit forced archive", async () => {
+  const { createTask, archiveTask, pendingTeardown, sweepArchivedTeardowns } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+  const created = await createTask({
+    title: "stuck-dirty steady state",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  try {
+    const prepared = await prepareWorkdir(created.task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    tasks.update(taskId, { branch: prepared.branch, worktreePath: prepared.worktreePath });
+    tasks.update(taskId, { column: "done" });
+
+    const worktreePath = prepared.worktreePath!;
+    writeFileSync(path.join(worktreePath, "dirty.txt"), "uncommitted\n");
+
+    // Plain archive — detach skips the dirty checkout, exactly the reported
+    // "delete button does nothing" symptom.
+    const archived = await archiveTask(taskId);
+    if (!("task" in archived)) throw new Error(archived.error);
+    await pendingTeardown(taskId);
+    expect(existsSync(worktreePath)).toBe(true);
+
+    // The unattended boot sweep re-enqueues teardown for this row (worktree
+    // still on disk, archivedAt set) but deliberately never forces — it must
+    // fail again, every time, exactly like the reported "stuck forever,
+    // retried and failed every boot" cycle.
+    for (let i = 0; i < 2; i++) {
+      const enqueued = sweepArchivedTeardowns();
+      expect(enqueued).toBeGreaterThanOrEqual(1);
+      await pendingTeardown(taskId);
+      expect(existsSync(worktreePath)).toBe(true);
+    }
+
+    // Only an explicit, user-confirmed forced archive from the Worktrees page
+    // finally clears it.
+    const forced = await archiveTask(taskId, { force: true, forceWorktree: true, awaitTeardown: true });
+    expect("task" in forced).toBe(true);
+    if (!("task" in forced)) throw new Error(forced.error);
+    expect(forced.teardown).toEqual({ removed: true });
+    expect(existsSync(worktreePath)).toBe(false);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("bail on un-archive: a queued teardown job whose task's archivedAt clears before the job executes must not remove the worktree", async () => {
+  // The real `unarchiveTask` always `await pendingTeardown(taskId)` BEFORE
+  // clearing `archivedAt` (see orchestrator.ts), so it can never itself
+  // observe this race through the front door — by the time it nulls
+  // `archivedAt`, the queued job has already run. To exercise the job's
+  // defensive re-read (`cur.archivedAt == null` bail) at all, this test
+  // occupies the shared per-workdir teardown chain with a first task (A)
+  // whose real `detachWorktree` (actual `git status`/`worktree remove`/
+  // `prune` subprocess calls) takes long enough in wall-clock time that
+  // task B's job — chained right behind A's on the same workdir — is still
+  // queued when we clear B's `archivedAt` directly (bypassing
+  // `unarchiveTask`, which is the only way to land in this state at all).
+  // This is the same timing idiom the file already relies on at `:89`
+  // ("archiveTask responds before teardown runs") — if it ever flakes, the
+  // signal is that B's teardown ran before the race could land.
+  const { createTask, archiveTask, pendingTeardown } = await import("./orchestrator.ts");
+  const { prepareWorkdir } = await import("./worktree.ts");
+  const { db, tasks } = await import("./db.ts");
+
+  const repo = await makeRepo();
+
+  const createdA = await createTask({
+    title: "chain occupier",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in createdA) throw new Error(createdA.error);
+  const idA = createdA.task.id;
+
+  const createdB = await createTask({
+    title: "un-archived before job runs",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: repo,
+    isolation: "worktree",
+  });
+  if ("error" in createdB) throw new Error(createdB.error);
+  const idB = createdB.task.id;
+
+  try {
+    const preparedA = await prepareWorkdir(createdA.task);
+    if ("error" in preparedA) throw new Error(preparedA.error);
+    tasks.update(idA, { branch: preparedA.branch, worktreePath: preparedA.worktreePath });
+    tasks.update(idA, { column: "done" });
+
+    const preparedB = await prepareWorkdir(createdB.task);
+    if ("error" in preparedB) throw new Error(preparedB.error);
+    tasks.update(idB, { branch: preparedB.branch, worktreePath: preparedB.worktreePath });
+    tasks.update(idB, { column: "done" });
+    const worktreePathB = preparedB.worktreePath!;
+
+    await archiveTask(idA); // enqueues A's job first on the shared workdir chain
+    await archiveTask(idB); // enqueues B's job right behind A's — still queued
+
+    // Simulate "un-archived before the job runs" directly, since the public
+    // `unarchiveTask` cannot land in this state (see comment above).
+    tasks.update(idB, { archivedAt: null });
+
+    await pendingTeardown(idB);
+
+    // The job re-read the row, saw `archivedAt == null`, and bailed — B's
+    // worktree was never touched.
+    expect(existsSync(worktreePathB)).toBe(true);
+    expect(tasks.get(idB)?.worktreePath).toBe(worktreePathB);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [idA]);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [idB]);
+  }
+});
+
 test("independent workdirs: teardowns for two tasks in different source repos don't share a chain and both complete", async () => {
   // Unlike the FIFO test above (same repo → same chain), these two tasks are
   // each created against their OWN temp source repo, so they key into

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -101,6 +101,7 @@ import type {
   WorktreeGitStatus,
   WorktreeInfo,
   WorktreeStaleReason,
+  WorktreeTeardownResult,
 } from "../shared/types.ts";
 import { WORKTREE_STALE_AFTER_MS } from "../shared/types.ts";
 import { appendReferences } from "../shared/refs.ts";
@@ -1952,6 +1953,44 @@ export async function createTask(
 }
 
 /**
+ * Shared teardown job for archiving a task — tmux/codex session kill, then
+ * open terminal tabs, then `detachWorktree` — in that exact order, because a
+ * live shell cwd'd inside the worktree would block `git worktree remove`.
+ * Both `archiveTask` (the fresh-archive path AND the already-archived
+ * re-enqueue path below) and the boot-time `sweepArchivedTeardowns` route
+ * through this one function so the three call sites can never drift apart.
+ *
+ * The harness kind is resolved synchronously here, before the job closure is
+ * built and handed to `enqueueTeardown` — same as the original inline code,
+ * just no longer duplicated at each call site.
+ *
+ * `enqueueTeardown` deliberately swallows job errors to keep its per-workdir
+ * FIFO chain alive for every other task queued behind this one (see its doc
+ * comment) — so it can't just return the `detachWorktree` result. Instead the
+ * result is captured in a closure variable (`result`, exposed via the
+ * returned getter) that a caller reads AFTER awaiting `promise`. This is the
+ * same idiom `deleteOrphanWorktree` already uses to get a real outcome out of
+ * a swallowed job.
+ */
+function enqueueArchiveTeardown(
+  task: Task,
+  opts?: { force?: boolean },
+): { promise: Promise<void>; result: () => WorktreeTeardownResult | undefined } {
+  const kind = resolveHarness(task.agent)?.kind;
+  let result: WorktreeTeardownResult | undefined;
+  const promise = enqueueTeardown(task.id, task.workdir, async () => {
+    // Same contract as deleteTask: dropSession is non-throwing (it
+    // best-efforts tmux teardown internally). Don't wrap — a silent catch
+    // would hide a regression in claude-tmux from the next reviewer.
+    if (kind === "claude-code") dropSession(task.id);
+    else if (kind === "codex") dropCodexSession(task.id);
+    await killTerminalsForTask(task.id);
+    result = await detachWorktree(task, { force: opts?.force });
+  });
+  return { promise, result: () => result };
+}
+
+/**
  * Archive a finished task: stamp `archivedAt`, kill its claude tmux session
  * AND any open terminal tabs (both best-effort) so no background shell outlives
  * the user's interest in the task — once archived the card is hidden, so the
@@ -1975,11 +2014,23 @@ export async function createTask(
  * the Stop button stops it (`stopActiveHandle`/`stopHeldTask`, shared with
  * `cancelRun`) before the normal archive path below proceeds. Without it,
  * the active-run guard stays in place as a backstop.
+ *
+ * Pass `{ forceWorktree: true }` to have the detach discard uncommitted
+ * changes in the checkout rather than leaving it in place (threaded straight
+ * through to `detachWorktree`'s `force` option) — an explicit, user-confirmed
+ * opt-in from the Worktrees page, since it's a destructive, unrecoverable
+ * discard of anything not committed.
+ *
+ * Pass `{ awaitTeardown: true }` to block until the deferred teardown above
+ * has actually run and get its real `WorktreeTeardownResult` back as
+ * `teardown` — the Worktrees page's delete action needs to know the
+ * directory is truly gone before it refreshes the list, unlike the kanban
+ * archive button, which stays fire-and-forget by leaving this unset.
  */
 export async function archiveTask(
   taskId: string,
-  opts?: { force?: boolean; stopRun?: boolean },
-): Promise<{ task: Task } | { error: string }> {
+  opts?: { force?: boolean; stopRun?: boolean; forceWorktree?: boolean; awaitTeardown?: boolean },
+): Promise<{ task: Task; teardown?: WorktreeTeardownResult } | { error: string }> {
   const task = tasks.get(taskId);
   if (!task) return { error: "task not found" };
   if (task.column !== "done" && !opts?.force) {
@@ -2001,13 +2052,33 @@ export async function archiveTask(
     stopHeldTask(taskId, "task archived");
   }
   if (task.archivedAt != null) {
+    // Already archived is normally a cheap no-op — repeat-archives (e.g. a
+    // double click) shouldn't re-enqueue teardown work every time. But when
+    // the worktree is STILL on disk, the previous teardown either never ran
+    // (this instance crashed before the boot sweep got to it) or never
+    // finished — and this is exactly the reported bug: the Worktrees page's
+    // "archive & delete" action calls archive on a row that's already
+    // archived, and the old bare `return { task }` here meant that row could
+    // never be cleaned up. Re-enqueue instead, gated on the same
+    // `worktreePath && existsSync(...)` condition `sweepArchivedTeardowns`
+    // already uses at boot, so an ordinary repeat-archive with nothing left
+    // to remove stays a bare return.
+    if (task.worktreePath && existsSync(task.worktreePath)) {
+      const { promise, result } = enqueueArchiveTeardown(task, { force: opts?.forceWorktree });
+      if (opts?.awaitTeardown) {
+        await promise;
+        // A requested outcome should never come back silently absent — if
+        // the job threw and enqueueTeardown swallowed it, `result()` is
+        // still undefined here, so report it as a failed removal instead of
+        // omitting `teardown` from the response.
+        return { task, teardown: result() ?? { removed: false, reason: "failed" } };
+      }
+      void promise;
+    }
     return { task };
   }
   const updated = tasks.update(taskId, { archivedAt: Date.now() });
   if (!updated) return { error: "task not found" };
-  // Resolved up front (before enqueueing) — same as before, just no longer
-  // re-read inside the deferred job.
-  const archiveKind = resolveHarness(task.agent)?.kind;
   // codexTurnQueue is cheap in-memory bookkeeping (no I/O), so it's dropped
   // inline rather than folded into the deferred job.
   codexTurnQueue.delete(taskId);
@@ -2020,19 +2091,15 @@ export async function archiveTask(
   // workdir, see `enqueueTeardown`), just off the request's critical path;
   // tasks in a different workdir proceed independently. Callers that must
   // not race a deferred teardown (unarchive, start, delete, the boot sweep)
-  // await `pendingTeardown(taskId)` first.
-  void enqueueTeardown(taskId, task.workdir, async () => {
-    // Same contract as deleteTask: dropSession is non-throwing (it
-    // best-efforts tmux teardown internally). Don't wrap — a silent catch
-    // would hide a regression in claude-tmux from the next reviewer.
-    if (archiveKind === "claude-code") dropSession(taskId);
-    else if (archiveKind === "codex") dropCodexSession(taskId);
-    // Tear down terminal tabs before detaching the worktree — a live shell
-    // cwd'd inside the worktree would block `git worktree remove`, exactly
-    // like deleteTask's ordering.
-    await killTerminalsForTask(taskId);
-    await detachWorktree(updated);
-  });
+  // await `pendingTeardown(taskId)` first. `awaitTeardown` is the one opt-in
+  // exception: the Worktrees page explicitly wants to block on this specific
+  // teardown to get a truthful result back.
+  const { promise, result } = enqueueArchiveTeardown(updated, { force: opts?.forceWorktree });
+  if (opts?.awaitTeardown) {
+    await promise;
+    return { task: updated, teardown: result() ?? { removed: false, reason: "failed" } };
+  }
+  void promise;
   return { task: updated };
 }
 
@@ -2139,14 +2206,11 @@ export function sweepArchivedTeardowns(): number {
     // refuses to archive one), but mirror that guard here too rather than
     // risk tearing down a worktree out from under an in-flight run.
     if (task.runId && active.has(task.runId)) continue;
-    const taskId = task.id;
-    const kind = resolveHarness(task.agent)?.kind;
-    enqueueTeardown(taskId, task.workdir, async () => {
-      if (kind === "claude-code") dropSession(taskId);
-      else if (kind === "codex") dropCodexSession(taskId);
-      await killTerminalsForTask(taskId);
-      await detachWorktree(task);
-    });
+    // No `force` — an explicit owner decision (see the plan doc): discarding
+    // uncommitted work with no human in the loop, unattended at boot, is not
+    // a trade worth making. A dirty worktree just stays stuck until the user
+    // forces it from the Worktrees page.
+    enqueueArchiveTeardown(task);
     enqueued++;
   }
   return enqueued;

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -1979,13 +1979,49 @@ function enqueueArchiveTeardown(
   const kind = resolveHarness(task.agent)?.kind;
   let result: WorktreeTeardownResult | undefined;
   const promise = enqueueTeardown(task.id, task.workdir, async () => {
+    // `enqueueTeardown` only guarantees this job runs after everything already
+    // queued for `task.workdir` — it can sit behind other jobs for seconds,
+    // and `task` was captured at ENQUEUE time by every call site (fresh
+    // archive, already-archived re-enqueue, boot sweep). The
+    // `pendingTeardown(taskId)` discipline elsewhere only protects
+    // materialize-AFTER-teardown; it does nothing about the opposite
+    // interleaving: `sendInput`/`startTask` clear `archivedAt` and start
+    // `prepareWorkdir`'s multi-second `git worktree add` BEFORE a fresh
+    // `archiveTask` call (e.g. the Worktrees page's delete button) can see the
+    // half-built directory and enqueue a teardown job right behind it. By the
+    // time that job reaches the front of the queue, the task has moved on —
+    // tearing down with the stale `task` snapshot would rip out a worktree the
+    // agent is (or is about to be) running in. So re-read the row here, at job
+    // execution time, and bail if it moved: gone entirely, un-archived
+    // (`archivedAt == null` — both `sendInput` and `startTask` clear it
+    // *before* calling `prepareWorkdir`, so this check is the same signal that
+    // closes the window), or a run has since started. A bail is reported as
+    // `"failed"` (not `"no-worktree"`/`"already-absent"`, which the client
+    // reads as silent success) because the directory is still there — the
+    // caller should retry, not assume it's clean.
+    //
+    // The live-run check keys on `cancelled`, NOT on `active.has(runId)`:
+    // `archiveTask({ stopRun: true })` — what the Worktrees page's delete
+    // button always sends — stops the run via `stopActiveHandle`, which
+    // flags the handle `cancelled` and kills it, but the `active.delete`
+    // only happens later in the async exit handler. A bare `active.has`
+    // would therefore see the run we ourselves just stopped, bail, and
+    // report a bogus failure for every delete of a *running* worktree. A
+    // handle that's present and NOT cancelled is the real signal: a run
+    // that started after we enqueued, which we must not tear down under.
+    const cur = tasks.get(task.id);
+    const liveHandle = cur?.runId ? active.get(cur.runId) : undefined;
+    if (!cur || cur.archivedAt == null || (liveHandle && !liveHandle.cancelled)) {
+      result = { removed: false, reason: "failed" };
+      return;
+    }
     // Same contract as deleteTask: dropSession is non-throwing (it
     // best-efforts tmux teardown internally). Don't wrap — a silent catch
     // would hide a regression in claude-tmux from the next reviewer.
-    if (kind === "claude-code") dropSession(task.id);
-    else if (kind === "codex") dropCodexSession(task.id);
-    await killTerminalsForTask(task.id);
-    result = await detachWorktree(task, { force: opts?.force });
+    if (kind === "claude-code") dropSession(cur.id);
+    else if (kind === "codex") dropCodexSession(cur.id);
+    await killTerminalsForTask(cur.id);
+    result = await detachWorktree(cur, { force: opts?.force });
   });
   return { promise, result: () => result };
 }
@@ -2074,6 +2110,18 @@ export async function archiveTask(
         return { task, teardown: result() ?? { removed: false, reason: "failed" } };
       }
       void promise;
+    } else if (opts?.awaitTeardown) {
+      // Same "never come back silently absent" contract as the branch above,
+      // for the case where there was never anything to tear down. Both
+      // outcomes are successes for the client (nothing left to remove) — this
+      // only stops the response from omitting `teardown` when it was asked
+      // for, matching `WorktreeTeardownResult`'s documented contract.
+      return {
+        task,
+        teardown: task.worktreePath
+          ? { removed: false, reason: "already-absent" }
+          : { removed: false, reason: "no-worktree" },
+      };
     }
     return { task };
   }

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -3119,17 +3119,42 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
 
       "/tasks/:id/archive": {
         POST: authed(async (req) => {
+          // Worktree teardown can now be awaited inline (`awaitTeardown`)
+          // behind a real `git worktree remove`, which — like DELETE
+          // /tasks/:id — can exceed the idle timeout ceiling on large repos.
           server.timeout(req, 0);
-          // Optional body — no body (or a malformed one) means force: false
-          // and stopRun: false, same as the pre-existing behaviour. `force`
+          // Optional body — no body (or a malformed one) means every flag
+          // defaults to false, same as the pre-existing behaviour. `force`
           // bypasses the done-column gate (Worktrees page's delete action);
           // `stopRun` additionally stops an in-flight/held run before
-          // archiving instead of erroring.
-          const body = (await req.json().catch(() => ({}))) as { force?: boolean; stopRun?: boolean };
-          const result = await archiveTask(req.params.id, { force: body.force === true, stopRun: body.stopRun === true });
-          return "error" in result
-            ? json(result, { status: 400, headers: corsHeaders(req) })
-            : json(withRunningSubagents(result.task), { headers: corsHeaders(req) });
+          // archiving instead of erroring; `forceWorktree` discards
+          // uncommitted changes in the checkout instead of leaving a dirty
+          // worktree in place; `awaitTeardown` blocks until the deferred
+          // teardown has actually run and surfaces its outcome.
+          const body = (await req.json().catch(() => ({}))) as {
+            force?: boolean;
+            stopRun?: boolean;
+            forceWorktree?: boolean;
+            awaitTeardown?: boolean;
+          };
+          const result = await archiveTask(req.params.id, {
+            force: body.force === true,
+            stopRun: body.stopRun === true,
+            forceWorktree: body.forceWorktree === true,
+            awaitTeardown: body.awaitTeardown === true,
+          });
+          if ("error" in result) {
+            return json(result, { status: 400, headers: corsHeaders(req) });
+          }
+          // Nest `teardown` as a sibling key rather than spreading its fields
+          // onto the task, so it can never collide with an actual Task
+          // column — the client only reads it when it explicitly asked for
+          // `awaitTeardown`, and it's absent (not `undefined`-valued) on the
+          // ordinary fire-and-forget path.
+          const payload: ReturnType<typeof withRunningSubagents> & { teardown?: typeof result.teardown } =
+            withRunningSubagents(result.task);
+          if (result.teardown) payload.teardown = result.teardown;
+          return json(payload, { headers: corsHeaders(req) });
         }),
       },
 

--- a/src/bun/worktree.test.ts
+++ b/src/bun/worktree.test.ts
@@ -1102,4 +1102,66 @@ describe("detachWorktree", () => {
     await branchProc.exited;
     expect(branchOut).toContain(created.branch!);
   });
+
+  test("force: true removes a dirty worktree, and the branch plus its commits survive", async () => {
+    const { prepareWorkdir, detachWorktree } = await import("./worktree.ts");
+    const repo = await makeRepo();
+    const task = fakeTask({ workdir: repo });
+    const created = await prepareWorkdir(task);
+    if ("error" in created) throw new Error(created.error);
+
+    // A real commit made inside the worktree — this is what must survive on
+    // the branch after a forced detach, same as the plain (non-dirty) detach
+    // test above.
+    writeFileSync(path.join(created.cwd, "committed.txt"), "agent output\n");
+    await git(["add", "."], created.cwd);
+    await git(["commit", "-m", "committed work"], created.cwd);
+
+    // Uncommitted changes on top — without `force` this alone would block
+    // removal (see "skips removal when the worktree has uncommitted changes"
+    // above).
+    writeFileSync(path.join(created.cwd, "dirty.txt"), "uncommitted\n");
+
+    const live = { ...task, worktreePath: created.worktreePath, branch: created.branch };
+    const result = await detachWorktree(live, { force: true });
+    expect(result).toEqual({ removed: true });
+    expect(existsSync(created.cwd)).toBe(false);
+
+    // The whole point of force-detach vs `removeWorktree`: the branch (and
+    // every commit on it) survives in the source repo even though the dirty
+    // checkout was discarded.
+    const branchProc = Bun.spawn(["git", "branch", "--list", created.branch!], {
+      cwd: repo,
+      stdout: "pipe",
+    });
+    const branchOut = (await new Response(branchProc.stdout).text()).trim();
+    await branchProc.exited;
+    expect(branchOut).toContain(created.branch!);
+
+    const logProc = Bun.spawn(["git", "log", "--oneline", created.branch!], {
+      cwd: repo,
+      stdout: "pipe",
+    });
+    const log = (await new Response(logProc.stdout).text()).trim();
+    await logProc.exited;
+    expect(log).toContain("committed work");
+  });
+
+  test("force: true does not paper over no-worktree or already-absent", async () => {
+    const { prepareWorkdir, detachWorktree } = await import("./worktree.ts");
+    const repo = await makeRepo();
+
+    const neverMaterialized = fakeTask({ workdir: repo, worktreePath: null, branch: null });
+    const noWorktree = await detachWorktree(neverMaterialized, { force: true });
+    expect(noWorktree).toEqual({ removed: false, reason: "no-worktree" });
+
+    const task = fakeTask({ workdir: repo });
+    const created = await prepareWorkdir(task);
+    if ("error" in created) throw new Error(created.error);
+    rmSync(created.cwd, { recursive: true, force: true });
+
+    const live = { ...task, worktreePath: created.worktreePath, branch: created.branch };
+    const alreadyAbsent = await detachWorktree(live, { force: true });
+    expect(alreadyAbsent).toEqual({ removed: false, reason: "already-absent" });
+  });
 });

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { dataDir } from "./db.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
 import { LEGACY_BRANCH_PREFIX } from "../shared/types.ts";
-import type { BranchInfo, Task, TaskDiff } from "../shared/types.ts";
+import type { BranchInfo, Task, TaskDiff, WorktreeTeardownResult } from "../shared/types.ts";
 
 export type { BranchInfo };
 
@@ -935,16 +935,28 @@ export async function pruneWorktrees(root: string): Promise<void> {
  * checks), path not a git repo, or `git status` failing on a broken/pruned
  * registration; all of those are "can't confirm clean" → skip removal.
  *
+ * Pass `{ force: true }` to skip that dirty gate entirely — the Worktrees
+ * page's delete action offers this as an explicit, user-confirmed "discard
+ * uncommitted changes" option once the ordinary path above has left a row
+ * permanently stuck (dirty checkouts, or a `git status` that keeps failing on
+ * a broken registration, would otherwise never clear). Force only ever skips
+ * the dirty check — the rest of the body, including the branch-preserving
+ * guarantee below, is unchanged: `git branch -D` is never called, forced or
+ * not, so the branch and every commit on it survive for a later re-attach.
+ *
  * Never throws — best-effort, mirroring `removeWorktree`.
  */
 export async function detachWorktree(
   task: Task,
-): Promise<{ removed: boolean; reason?: string }> {
+  opts?: { force?: boolean },
+): Promise<WorktreeTeardownResult> {
   if (!task.worktreePath) return { removed: false, reason: "no-worktree" };
   if (!existsSync(task.worktreePath)) return { removed: false, reason: "already-absent" };
 
-  const dirty = await hasUncommittedChanges(task.worktreePath);
-  if (dirty !== false) return { removed: false, reason: "dirty" };
+  if (!opts?.force) {
+    const dirty = await hasUncommittedChanges(task.worktreePath);
+    if (dirty !== false) return { removed: false, reason: "dirty" };
+  }
 
   const root = await repoRoot(task.workdir);
   if (root) {
@@ -964,5 +976,6 @@ export async function detachWorktree(
     try { await rm(task.worktreePath, { recursive: true, force: true }); }
     catch { /* best-effort */ }
   }
-  return { removed: !existsSync(task.worktreePath) };
+  const removed = !existsSync(task.worktreePath);
+  return removed ? { removed } : { removed, reason: "failed" };
 }

--- a/src/mainview/components/worktrees/WorktreesDialog.tsx
+++ b/src/mainview/components/worktrees/WorktreesDialog.tsx
@@ -19,6 +19,7 @@ import {
   type WorktreeInfo,
   type WorktreeStaleReason,
 } from "../../../shared/types.ts";
+import { buildDeleteConfirmCopy, triageDeleteOutcome } from "./worktree-delete-intent.ts";
 
 interface Props {
   open: boolean;
@@ -267,27 +268,68 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
   const deleteTaskBacked = async (w: WorktreeInfo) => {
     if (!w.taskId) return;
     const taskId = w.taskId;
-    const ok = await confirm({
-      title: `Delete worktree "${w.branch ?? w.id}"?`,
-      description: (
-        <>
-          The ticket "<span className="font-medium text-foreground/80">{w.taskTitle}</span>" will be{" "}
-          <strong>archived</strong> (hidden from the board, restorable via Unarchive) and its worktree
-          directory removed. The git branch and full AI history are preserved. If the worktree has
-          uncommitted changes, it is left in place to protect your work.
-          {w.runActive && " An agent is still working on this task — archiving will stop it."}
-        </>
-      ),
-      confirmLabel: "Archive & delete",
-      variant: "destructive",
-    });
-    if (!ok) return;
+    // Busy spans fetch → confirm → archive as one continuous stretch so the
+    // trash icon spins the whole time (rather than appearing frozen during
+    // the status fetch) and a second click can never double-fire while the
+    // confirm dialog is up or the archive request is in flight.
     await withBusy(w.id, async () => {
+      // The cached `gitStatus` map is only populated on open + manual
+      // Refresh — by the time the user clicks delete it's frequently
+      // "loading" or missing entirely, which would undersell what's about
+      // to be discarded. Fetch fresh; a failed check falls back to the
+      // no-warning copy rather than blocking the delete.
+      let status: WorktreeGitStatus | null = null;
       try {
-        await api.archiveTask(taskId, { force: true, stopRun: true });
+        status = await api.getWorktreeGitStatus(w.id);
+      } catch {
+        status = null;
+      }
+      const copy = buildDeleteConfirmCopy(w, status);
+      const ok = await confirm({
+        title: copy.title,
+        description: (
+          <>
+            {copy.alreadyArchived ? (
+              <>
+                The ticket "<span className="font-medium text-foreground/80">{w.taskTitle}</span>" is
+                already <strong>archived</strong>; its worktree directory will be removed. The git
+                branch and full AI history are preserved.
+              </>
+            ) : (
+              <>
+                The ticket "<span className="font-medium text-foreground/80">{w.taskTitle}</span>" will
+                be <strong>archived</strong> (hidden from the board, restorable via Unarchive) and its
+                worktree directory removed. The git branch and full AI history are preserved.
+              </>
+            )}
+            {copy.showDirtyWarning && (
+              <div className="mt-2 font-medium text-rose-400">
+                This worktree has uncommitted changes — they will be permanently discarded.
+              </div>
+            )}
+            {w.runActive && " An agent is still working on this task — archiving will stop it."}
+          </>
+        ),
+        confirmLabel: copy.confirmLabel,
+        variant: "destructive",
+      });
+      if (!ok) return;
+      try {
+        const result = await api.archiveTask(taskId, {
+          force: true,
+          stopRun: true,
+          forceWorktree: true,
+          awaitTeardown: true,
+        });
+        const outcome = triageDeleteOutcome(result.teardown, w.branch);
+        // Silent on success — the house convention for destructive list
+        // mutations (SettingsDialog.tsx) is that the row vanishing from the
+        // refreshed list IS the feedback. Only a genuine failure toasts.
+        if (outcome.kind === "error") toast.error(outcome.message);
         await refresh();
       } catch (e) {
         toast.error(e instanceof Error ? e.message : String(e));
+        await refresh();
       }
     });
   };

--- a/src/mainview/components/worktrees/WorktreesDialog.tsx
+++ b/src/mainview/components/worktrees/WorktreesDialog.tsx
@@ -307,6 +307,13 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
                 This worktree has uncommitted changes — they will be permanently discarded.
               </div>
             )}
+            {copy.unknown && (
+              <div className="mt-2 font-medium text-rose-400">
+                agetor couldn't check this worktree for uncommitted changes — its git
+                registration may be broken. Anything uncommitted will be permanently
+                discarded.
+              </div>
+            )}
             {w.runActive && " An agent is still working on this task — archiving will stop it."}
           </>
         ),

--- a/src/mainview/components/worktrees/worktree-delete-intent.test.ts
+++ b/src/mainview/components/worktrees/worktree-delete-intent.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+import { buildDeleteConfirmCopy, triageDeleteOutcome } from "./worktree-delete-intent.ts";
+import type { WorktreeGitStatus, WorktreeInfo, WorktreeTeardownResult } from "../../../shared/types.ts";
+
+function worktree(overrides: Partial<WorktreeInfo> = {}): WorktreeInfo {
+  return {
+    id: "task-1",
+    path: "/home/user/.agetor/worktrees/task-1",
+    taskId: "task-1",
+    taskTitle: "Do the thing",
+    column: "ready",
+    archivedAt: null,
+    taskUpdatedAt: 1700000000000,
+    branch: "agetor/task-1-do-the-thing",
+    workdir: "/home/user/project",
+    runActive: false,
+    stale: false,
+    staleReasons: [],
+    ...overrides,
+  };
+}
+
+function gitStatus(overrides: Partial<WorktreeGitStatus> = {}): WorktreeGitStatus {
+  return {
+    dirty: false,
+    ahead: 0,
+    merged: null,
+    ignored: false,
+    ...overrides,
+  };
+}
+
+describe("buildDeleteConfirmCopy", () => {
+  describe("dirty classification (three-state, mutually exclusive)", () => {
+    test("confirmed-clean: status resolved with dirty=false, ignored=false -> no warning, non-destructive label", () => {
+      const copy = buildDeleteConfirmCopy(worktree(), gitStatus({ dirty: false, ignored: false }));
+      expect(copy.showDirtyWarning).toBe(false);
+      expect(copy.unknown).toBe(false);
+      expect(copy.confirmLabel).toBe("Archive & delete");
+    });
+
+    test("confirmed-dirty: status resolved with dirty=true, ignored=false -> dirty warning, destructive label", () => {
+      const copy = buildDeleteConfirmCopy(worktree(), gitStatus({ dirty: true, ignored: false }));
+      expect(copy.showDirtyWarning).toBe(true);
+      expect(copy.unknown).toBe(false);
+      expect(copy.confirmLabel).toBe("Discard changes & delete");
+    });
+
+    test("unknown: status is null -> unknown flag, destructive label, no dirty warning", () => {
+      const copy = buildDeleteConfirmCopy(worktree(), null);
+      expect(copy.unknown).toBe(true);
+      expect(copy.showDirtyWarning).toBe(false);
+      expect(copy.confirmLabel).toBe("Discard changes & delete");
+    });
+
+    // Load-bearing case: the server's worktreeGitStatus sets ignored: true
+    // precisely when hasUncommittedChanges returned null (not a git repo, or
+    // `git status` failed on a broken worktree registration) — it means
+    // "couldn't determine", never "clean". Before this was fixed, a status
+    // with ignored: true but dirty: false (its zero-value default) was
+    // treated as confirmed-clean, so the UI force-deleted the worktree
+    // (deleteTaskBacked always sends forceWorktree: true) with no warning at
+    // all, silently discarding whatever uncommitted work was actually there.
+    test("unknown: status.ignored=true (even with dirty=false) is NOT treated as clean — must not silently force-delete uncommitted work", () => {
+      const copy = buildDeleteConfirmCopy(worktree(), gitStatus({ dirty: false, ignored: true }));
+      expect(copy.unknown).toBe(true);
+      expect(copy.showDirtyWarning).toBe(false);
+      expect(copy.confirmLabel).toBe("Discard changes & delete");
+    });
+
+    test("unknown: status.ignored=true with dirty=true is still classified unknown, not dirty", () => {
+      const copy = buildDeleteConfirmCopy(worktree(), gitStatus({ dirty: true, ignored: true }));
+      expect(copy.unknown).toBe(true);
+      expect(copy.showDirtyWarning).toBe(false);
+    });
+
+    test("the three states are mutually exclusive: showDirtyWarning and unknown are never both true", () => {
+      const cases: Array<WorktreeGitStatus | null> = [
+        null,
+        gitStatus({ dirty: false, ignored: false }),
+        gitStatus({ dirty: true, ignored: false }),
+        gitStatus({ dirty: false, ignored: true }),
+        gitStatus({ dirty: true, ignored: true }),
+      ];
+      for (const status of cases) {
+        const copy = buildDeleteConfirmCopy(worktree(), status);
+        expect(copy.showDirtyWarning && copy.unknown).toBe(false);
+      }
+    });
+
+    test("the three states are exhaustive across the input space: every case is clean, dirty, or unknown", () => {
+      const cases: Array<WorktreeGitStatus | null> = [
+        null,
+        gitStatus({ dirty: false, ignored: false }),
+        gitStatus({ dirty: true, ignored: false }),
+        gitStatus({ dirty: false, ignored: true }),
+        gitStatus({ dirty: true, ignored: true }),
+      ];
+      for (const status of cases) {
+        const copy = buildDeleteConfirmCopy(worktree(), status);
+        const isClean = !copy.showDirtyWarning && !copy.unknown;
+        const isDirty = copy.showDirtyWarning && !copy.unknown;
+        const isUnknown = !copy.showDirtyWarning && copy.unknown;
+        // Exactly one of the three states is true.
+        expect([isClean, isDirty, isUnknown].filter(Boolean).length).toBe(1);
+      }
+    });
+  });
+
+  describe("alreadyArchived crossed with dirty classification", () => {
+    test("not archived + confirmed-clean", () => {
+      const copy = buildDeleteConfirmCopy(worktree({ archivedAt: null }), gitStatus({ dirty: false }));
+      expect(copy.alreadyArchived).toBe(false);
+      expect(copy.showDirtyWarning).toBe(false);
+    });
+
+    test("not archived + confirmed-dirty", () => {
+      const copy = buildDeleteConfirmCopy(worktree({ archivedAt: null }), gitStatus({ dirty: true }));
+      expect(copy.alreadyArchived).toBe(false);
+      expect(copy.showDirtyWarning).toBe(true);
+    });
+
+    test("not archived + unknown", () => {
+      const copy = buildDeleteConfirmCopy(worktree({ archivedAt: null }), null);
+      expect(copy.alreadyArchived).toBe(false);
+      expect(copy.unknown).toBe(true);
+    });
+
+    test("already archived + confirmed-clean", () => {
+      const copy = buildDeleteConfirmCopy(worktree({ archivedAt: 1700000000000 }), gitStatus({ dirty: false }));
+      expect(copy.alreadyArchived).toBe(true);
+      expect(copy.showDirtyWarning).toBe(false);
+    });
+
+    test("already archived + confirmed-dirty", () => {
+      const copy = buildDeleteConfirmCopy(worktree({ archivedAt: 1700000000000 }), gitStatus({ dirty: true }));
+      expect(copy.alreadyArchived).toBe(true);
+      expect(copy.showDirtyWarning).toBe(true);
+    });
+
+    test("already archived + unknown", () => {
+      const copy = buildDeleteConfirmCopy(worktree({ archivedAt: 1700000000000 }), null);
+      expect(copy.alreadyArchived).toBe(true);
+      expect(copy.unknown).toBe(true);
+    });
+  });
+
+  describe("title", () => {
+    test("uses the branch name when present", () => {
+      const copy = buildDeleteConfirmCopy(worktree({ branch: "agetor/abc-fix-thing" }), gitStatus());
+      expect(copy.title).toBe('Delete worktree "agetor/abc-fix-thing"?');
+    });
+
+    test("falls back to the worktree id when branch is null", () => {
+      const copy = buildDeleteConfirmCopy(worktree({ branch: null, id: "orphan-dir-1" }), gitStatus());
+      expect(copy.title).toBe('Delete worktree "orphan-dir-1"?');
+    });
+  });
+});
+
+describe("triageDeleteOutcome", () => {
+  test("removed: true -> silent (the obvious success case)", () => {
+    const teardown: WorktreeTeardownResult = { removed: true };
+    expect(triageDeleteOutcome(teardown, "feature-branch")).toEqual({ kind: "silent" });
+  });
+
+  test("undefined teardown -> silent (caller didn't await teardown; list refresh speaks for itself)", () => {
+    expect(triageDeleteOutcome(undefined, "feature-branch")).toEqual({ kind: "silent" });
+  });
+
+  test('reason "no-worktree" -> silent, NOT an error: nothing left to remove is success, not failure', () => {
+    const teardown: WorktreeTeardownResult = { removed: false, reason: "no-worktree" };
+    expect(triageDeleteOutcome(teardown, "feature-branch")).toEqual({ kind: "silent" });
+  });
+
+  test('reason "already-absent" -> silent, NOT an error: nothing left to remove is success, not failure', () => {
+    const teardown: WorktreeTeardownResult = { removed: false, reason: "already-absent" };
+    expect(triageDeleteOutcome(teardown, "feature-branch")).toEqual({ kind: "silent" });
+  });
+
+  test('reason "dirty" -> error, naming the branch', () => {
+    const teardown: WorktreeTeardownResult = { removed: false, reason: "dirty" };
+    const outcome = triageDeleteOutcome(teardown, "feature-branch");
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") {
+      expect(outcome.message).toContain("feature-branch");
+      expect(outcome.message).toContain("uncommitted");
+    }
+  });
+
+  test('reason "failed" -> error, naming the branch', () => {
+    const teardown: WorktreeTeardownResult = { removed: false, reason: "failed" };
+    const outcome = triageDeleteOutcome(teardown, "feature-branch");
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") {
+      expect(outcome.message).toContain("feature-branch");
+      expect(outcome.message).toContain("removal");
+    }
+  });
+
+  test("unrecognized/absent reason with removed: false falls into the default arm -> error", () => {
+    // Cast to bypass the reason union — simulating a future/unknown server value
+    // reaching the default arm, which the switch must still treat as a failure.
+    const teardown = { removed: false } as WorktreeTeardownResult;
+    const outcome = triageDeleteOutcome(teardown, "feature-branch");
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") {
+      expect(outcome.message).toContain("feature-branch");
+      expect(outcome.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("error messages fall back sensibly when branch is null", () => {
+    const teardown: WorktreeTeardownResult = { removed: false, reason: "failed" };
+    const outcome = triageDeleteOutcome(teardown, null);
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") {
+      expect(outcome.message).toContain("this worktree");
+      expect(outcome.message.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/mainview/components/worktrees/worktree-delete-intent.ts
+++ b/src/mainview/components/worktrees/worktree-delete-intent.ts
@@ -2,18 +2,38 @@ import type { WorktreeGitStatus, WorktreeInfo, WorktreeTeardownResult } from "..
 
 /**
  * What the "Archive & delete" confirm dialog should say for a given row, given
- * its freshly-fetched git status. Two independent facts change the copy —
- * whether the checkout is dirty (uncommitted work is about to be discarded)
- * and whether the task is already archived (the "will be archived" phrasing
- * is simply wrong for a row that's already in that state) — and they can
- * co-occur, so this is a small cross-product rather than a single flag.
- * `status: null` means the git-status fetch failed or hasn't resolved; we
- * fall back to the no-warning copy rather than block the delete on it.
+ * its freshly-fetched git status. The copy is driven by a three-state dirty
+ * classification crossed with whether the task is already archived (the
+ * "will be archived" phrasing is simply wrong for a row that's already in
+ * that state) — the two axes can co-occur, so this is a small cross-product
+ * rather than a single flag.
+ *
+ * The dirty classification's three states are mutually exclusive and
+ * exhaustive:
+ *  - confirmed-clean: `status` resolved and reports no uncommitted changes.
+ *    No warning.
+ *  - confirmed-dirty: `status` resolved and reports uncommitted changes.
+ *    The existing red "will be discarded" warning.
+ *  - unknown: `status` is `null` (the pre-confirm `getWorktreeGitStatus` call
+ *    threw) OR `status.ignored` is `true` (the dir wasn't inspectable — not a
+ *    git repo, or `git status` itself failed, e.g. a broken/pruned worktree
+ *    registration). Critically, `deleteTaskBacked` sends `forceWorktree: true`
+ *    unconditionally, so an unknown status still force-deletes — we just
+ *    can't tell the user whether that's discarding anything. Treating
+ *    "unknown" the same as "confirmed clean" would silently drop this
+ *    warning in exactly the case `forceWorktree` exists to unstick (a
+ *    worktree whose git registration is broken), which is how uncommitted
+ *    work gets lost with no red flag ever shown. So "unknown" gets its own,
+ *    harder-worded warning instead of falling back to silence.
  */
 export interface DeleteConfirmCopy {
   title: string;
-  /** True when the checkout has uncommitted changes worth calling out. */
+  /** True only for confirmed-dirty: `status` resolved and reports real
+   *  uncommitted changes worth calling out. */
   showDirtyWarning: boolean;
+  /** True for the unknown state: agetor could not determine whether the
+   *  checkout is dirty, but is still about to force-delete it. */
+  unknown: boolean;
   /** True when the task is already archived — the body copy must not repeat
    *  "will be archived" for a ticket that already is. */
   alreadyArchived: boolean;
@@ -25,16 +45,19 @@ export interface DeleteConfirmCopy {
  * component (which has no render tests in this app) so the branching itself
  * is unit-testable — see `github-dialog-view.ts` for the same idiom. The JSX
  * description itself still lives in the component (this module has no React
- * dependency); it reads `alreadyArchived`/`showDirtyWarning` off the result.
+ * dependency); it reads `alreadyArchived`/`showDirtyWarning`/`unknown` off the
+ * result.
  */
 export function buildDeleteConfirmCopy(w: WorktreeInfo, status: WorktreeGitStatus | null): DeleteConfirmCopy {
-  const dirty = status != null && status.dirty === true && !status.ignored;
+  const unknown = status == null || status.ignored === true;
+  const dirty = !unknown && status!.dirty === true;
   const alreadyArchived = w.archivedAt != null;
   return {
     title: `Delete worktree "${w.branch ?? w.id}"?`,
     showDirtyWarning: dirty,
+    unknown,
     alreadyArchived,
-    confirmLabel: dirty ? "Discard changes & delete" : "Archive & delete",
+    confirmLabel: dirty || unknown ? "Discard changes & delete" : "Archive & delete",
   };
 }
 

--- a/src/mainview/components/worktrees/worktree-delete-intent.ts
+++ b/src/mainview/components/worktrees/worktree-delete-intent.ts
@@ -1,0 +1,78 @@
+import type { WorktreeGitStatus, WorktreeInfo, WorktreeTeardownResult } from "../../../shared/types.ts";
+
+/**
+ * What the "Archive & delete" confirm dialog should say for a given row, given
+ * its freshly-fetched git status. Two independent facts change the copy —
+ * whether the checkout is dirty (uncommitted work is about to be discarded)
+ * and whether the task is already archived (the "will be archived" phrasing
+ * is simply wrong for a row that's already in that state) — and they can
+ * co-occur, so this is a small cross-product rather than a single flag.
+ * `status: null` means the git-status fetch failed or hasn't resolved; we
+ * fall back to the no-warning copy rather than block the delete on it.
+ */
+export interface DeleteConfirmCopy {
+  title: string;
+  /** True when the checkout has uncommitted changes worth calling out. */
+  showDirtyWarning: boolean;
+  /** True when the task is already archived — the body copy must not repeat
+   *  "will be archived" for a ticket that already is. */
+  alreadyArchived: boolean;
+  confirmLabel: string;
+}
+
+/**
+ * Pure decision logic for `deleteTaskBacked`'s confirm dialog. Kept out of the
+ * component (which has no render tests in this app) so the branching itself
+ * is unit-testable — see `github-dialog-view.ts` for the same idiom. The JSX
+ * description itself still lives in the component (this module has no React
+ * dependency); it reads `alreadyArchived`/`showDirtyWarning` off the result.
+ */
+export function buildDeleteConfirmCopy(w: WorktreeInfo, status: WorktreeGitStatus | null): DeleteConfirmCopy {
+  const dirty = status != null && status.dirty === true && !status.ignored;
+  const alreadyArchived = w.archivedAt != null;
+  return {
+    title: `Delete worktree "${w.branch ?? w.id}"?`,
+    showDirtyWarning: dirty,
+    alreadyArchived,
+    confirmLabel: dirty ? "Discard changes & delete" : "Archive & delete",
+  };
+}
+
+/** Outcome of triaging a `WorktreeTeardownResult` (or its absence) into
+ *  something the UI can act on: either nothing to say (the row disappearing
+ *  on refresh IS the feedback, per house convention for destructive list
+ *  mutations) or a message worth toasting. */
+export type DeleteOutcome = { kind: "silent" } | { kind: "error"; message: string };
+
+/**
+ * Decide whether an archive's `teardown` result is a success or a failure
+ * worth surfacing. `removed: true` is the obvious success; `"no-worktree"`
+ * and `"already-absent"` are *also* success — there was simply nothing left
+ * to remove, which is not a failure of this action. `"dirty"` shouldn't occur
+ * given we always pass `forceWorktree: true`, but the server can still report
+ * it (e.g. a race), so it's treated as a real failure rather than swallowed.
+ * `undefined` means the caller didn't request `awaitTeardown` (or the server
+ * predates it) — nothing to report, so treat it as silent success and let the
+ * list refresh speak for itself.
+ */
+export function triageDeleteOutcome(teardown: WorktreeTeardownResult | undefined, branch: string | null): DeleteOutcome {
+  if (teardown === undefined) return { kind: "silent" };
+  if (teardown.removed) return { kind: "silent" };
+  const name = branch ?? "this worktree";
+  switch (teardown.reason) {
+    case "no-worktree":
+    case "already-absent":
+      return { kind: "silent" };
+    case "dirty":
+      return {
+        kind: "error",
+        message: `Couldn't delete ${name}: it still has uncommitted changes.`,
+      };
+    case "failed":
+    default:
+      return {
+        kind: "error",
+        message: `Couldn't delete ${name}: the worktree removal failed. Try again or remove it manually.`,
+      };
+  }
+}

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -76,6 +76,7 @@ import type {
   UpdateStatus,
   WorktreeGitStatus,
   WorktreeInfo,
+  WorktreeTeardownResult,
 } from "../../shared/types.ts";
 import { fetchWithRecovery } from "./net-retry.ts";
 
@@ -1043,13 +1044,31 @@ export const api = {
    *  true` additionally stops any in-flight run/background agents before
    *  archiving — required (server-enforced) to archive a running/blocked
    *  task at all; the caller is expected to confirm with the user first.
-   *  Omitted (the common case) sends no body, matching the original
-   *  archive-from-`done` callers unchanged. */
-  archiveTask: (id: string, opts?: { force?: boolean; stopRun?: boolean }) =>
-    j<Task>(`/tasks/${id}/archive`, {
+   *  `forceWorktree: true` discards uncommitted changes in the worktree's
+   *  checkout during teardown (never the branch, commits, or run/AI
+   *  history) — also part of the Worktrees page's "Archive & delete", after
+   *  the caller has warned the user. `awaitTeardown: true` makes the
+   *  request block until the worktree removal has actually finished (no
+   *  timeout is set server-side), and the response then carries a
+   *  `teardown` outcome describing whether the directory is really gone —
+   *  omit it and the archive returns immediately with teardown deferred to
+   *  a background queue, as before. Omitting all four flags sends no body,
+   *  matching the original archive-from-`done` callers unchanged. */
+  archiveTask: (
+    id: string,
+    opts?: { force?: boolean; stopRun?: boolean; forceWorktree?: boolean; awaitTeardown?: boolean },
+  ) =>
+    j<Task & { teardown?: WorktreeTeardownResult }>(`/tasks/${id}/archive`, {
       method: "POST",
-      ...(opts?.force || opts?.stopRun
-        ? { body: JSON.stringify({ force: !!opts.force, stopRun: !!opts.stopRun }) }
+      ...(opts?.force || opts?.stopRun || opts?.forceWorktree || opts?.awaitTeardown
+        ? {
+            body: JSON.stringify({
+              force: !!opts.force,
+              stopRun: !!opts.stopRun,
+              forceWorktree: !!opts.forceWorktree,
+              awaitTeardown: !!opts.awaitTeardown,
+            }),
+          }
         : {}),
     }),
   unarchiveTask: (id: string) => j<Task>(`/tasks/${id}/unarchive`, { method: "POST" }),

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -1053,7 +1053,20 @@ export const api = {
    *  `teardown` outcome describing whether the directory is really gone —
    *  omit it and the archive returns immediately with teardown deferred to
    *  a background queue, as before. Omitting all four flags sends no body,
-   *  matching the original archive-from-`done` callers unchanged. */
+   *  matching the original archive-from-`done` callers unchanged.
+   *
+   *  `retry: false` only when `awaitTeardown` is set — matching
+   *  `createTask`/`sendRunInput`'s idiom above. The route sets an unbounded
+   *  server timeout and blocks on the *entire* per-workdir teardown FIFO
+   *  (every same-repo teardown queued ahead of this one), which can run well
+   *  past WKWebView's own request timeout even though the operation is
+   *  succeeding server-side. A default retry on that timeout would silently
+   *  re-issue a second, non-idempotent archive against a task the user may
+   *  have already resumed (re-running `dropSession`/`killTerminalsForTask`,
+   *  re-queuing a second worktree teardown behind the first). The
+   *  fire-and-forget archive (no `awaitTeardown`, e.g. the kanban button)
+   *  returns fast and keeps the default retry — it isn't the non-idempotent
+   *  hazard this guards against. */
   archiveTask: (
     id: string,
     opts?: { force?: boolean; stopRun?: boolean; forceWorktree?: boolean; awaitTeardown?: boolean },
@@ -1070,7 +1083,7 @@ export const api = {
             }),
           }
         : {}),
-    }),
+    }, opts?.awaitTeardown ? { retry: false } : undefined),
   unarchiveTask: (id: string) => j<Task>(`/tasks/${id}/unarchive`, { method: "POST" }),
 
   /** Every git worktree materialized on disk under `dataDir/worktrees/`,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -700,6 +700,32 @@ export interface WorktreeInfo {
 }
 
 /**
+ * Outcome of the worktree teardown an archive triggered, as surfaced by
+ * `POST /tasks/:id/archive` when the caller passes `awaitTeardown: true`.
+ *
+ * Archive normally defers teardown onto a per-workdir background queue and
+ * responds in milliseconds, so the response carries no outcome at all. The
+ * Worktrees page's "Archive & delete" is the one caller that needs to know
+ * whether the directory is *actually* gone before it refreshes the list — it
+ * opts in, and gets this back.
+ *
+ * `reason` is only meaningful when `removed` is false:
+ * - `"dirty"` — the checkout had uncommitted changes and `forceWorktree` was
+ *   not set, so it was deliberately left in place. (`hasUncommittedChanges`
+ *   folds git errors into this too — it returns null on a failing `git
+ *   status`, which the caller treats as "don't touch".)
+ * - `"no-worktree"` / `"already-absent"` — there was nothing to remove. Not a
+ *   failure; callers should treat these as success.
+ * - `"failed"` — removal was attempted and the directory is still there.
+ */
+export interface WorktreeTeardownResult {
+  /** True when the worktree directory is no longer on disk after the teardown. */
+  removed: boolean;
+  /** Why `removed` is false. Absent when `removed` is true. */
+  reason?: "dirty" | "no-worktree" | "already-absent" | "failed";
+}
+
+/**
  * On-demand live git status for a single worktree, as surfaced by
  * `GET /worktrees/:id/git-status`. Not part of the bulk `GET /worktrees`
  * listing — computing this spawns git subprocesses, so it's fetched per row


### PR DESCRIPTION
Fixes the reported bug: clicking the delete icon on a row in the Worktrees modal and confirming did nothing — the worktree stayed on disk and the row never went away.

The reporter's hunch ("not sure if it's because the task is already archived but not cleaned up") was exactly right, and it was the primary defect. There were three, and they compounded.

## What was broken

**1. Already-archived made the button a literal no-op.** `archiveTask` bare-returned when `task.archivedAt != null` — *before* its `enqueueTeardown` call:

```ts
if (task.archivedAt != null) {
  return { task };   // returns BEFORE the enqueueTeardown below
}
```

`listWorktrees` flags exactly that state as `staleReasons: ["archived"]`, rendered as *"archived, not cleaned up"*. So the one row the page most wants you to clean was the one row the button could not clean. The server returned `200`, the list refreshed correctly, and nothing had changed.

**2. Once dirty, permanently unrecoverable.** `detachWorktree` refused to remove whenever `hasUncommittedChanges() !== false` — and that helper returns `null` on a missing dir, a non-repo, or a failing `git status`, and `null !== false`, so **git errors counted as dirty too**. `sweepArchivedTeardowns` retried on every boot and failed identically every boot, forever, with only a `console.warn`. No force path was reachable from this page: `removeWorktree` forces but is `deleteTask`-only (and deletes the branch), and `deleteOrphanWorktree` hard-refuses task-owned ids.

**3. The outcome was computed, then discarded.** `detachWorktree` returns `{ removed, reason }`; both call sites dropped it. Teardown is deliberately fire-and-forget, so the client's `refresh()` raced it — even on the happy path the row lingered until the next 5s poll.

## The fix

- **`detachWorktree(task, { force })`** skips *only* the dirty gate. `git branch -D` is still never called, forced or not — the branch, its commits, the run/`run_events` history, and claude's JSONL transcript all survive so `unarchiveTask`/`prepareWorkdir` can rematerialize. (This is why archive doesn't just route through `removeWorktree`, which does delete the branch.)
- **`archiveTask` re-enqueues teardown** when already archived, gated on `worktreePath && existsSync(worktreePath)` — the same condition `sweepArchivedTeardowns` already uses — so an ordinary repeat-archive stays a cheap bare return.
- **Opt-in `awaitTeardown`** blocks until removal actually finishes and returns a real `WorktreeTeardownResult`. It routes *through* the existing `enqueueTeardown` queue, so the per-workdir FIFO that keeps same-repo `git worktree remove`/`prune` from contending on git's locks is untouched; the result is extracted via the same closure-capture idiom `deleteOrphanWorktree` already uses. The kanban archive button keeps its fast fire-and-forget path.
- **The teardown job body is extracted** into `enqueueArchiveTeardown`, shared by both `archiveTask` paths and `sweepArchivedTeardowns`, so the three sites can't drift.
- **Client:** fetches git status fresh before the confirm (the cached map is usually still `"loading"`), warns explicitly before discarding uncommitted work, fixes the "will be archived" copy for rows that already are, holds the spinner through the real removal, toasts genuine failures, and resyncs on error like `App.tsx` does.

The boot sweep deliberately **never** forces — discarding uncommitted work unattended at boot isn't a trade worth making.

## Review findings folded in (`43e246c`)

A review of the first cut returned FIX-THEN-SHIP with four findings, all addressed:

- **must-fix, silent data loss:** `worktreeGitStatus` returns `ignored: true` *precisely* when `hasUncommittedChanges` returns `null` — so `ignored` means "couldn't determine", **not** "clean". Folding it into clean meant the broken-`.git`-registration case, exactly what force exists to unstick, force-deleted with no warning. Now a distinct third UNKNOWN state with its own warning copy and destructive label.
- The teardown job closed over a `Task` snapshot from enqueue time and could tear down a worktree being rematerialized underneath it (`sendInput`/`startTask` clear `archivedAt` *before* a multi-second `prepareWorkdir`; `pendingTeardown` only guards the opposite interleaving). It now re-reads the row and bails.
- `awaitTeardown` archives are long non-idempotent POSTs on an untimed route that blocks on the whole per-workdir FIFO tail, but `j()` defaults to `retry: true` — a WKWebView timeout would replay the archive. Now `retry: false` when `awaitTeardown` is set.
- `awaitTeardown` silently omitted `teardown` when the worktree was already gone, contradicting its own contract.

One regression the suggested fix itself introduced was caught before landing: the bail keyed on `active.has(runId)`, but `stopActiveHandle` flags `cancelled` and kills without deleting from `active` — that happens later in the async exit handler. Since the Worktrees button always sends `stopRun: true`, every delete of a **running** worktree would have reported a bogus failure. Keyed on `handle.cancelled` instead.

## Deliberately not done

- A new `WorktreeStaleReason` (e.g. `archived-dirty`) — with force available, dirty is no longer a dead end, and it would ripple through the shared types, filter UI, and their tests for little gain.
- Auto-forcing in `sweepArchivedTeardowns`.

## Testing

`bun run typecheck` clean. Suite **1755 pass / 1 skip / 0 fail** (verified across three consecutive full runs).

New coverage in `orchestrator-archive-teardown.test.ts`, `worktree.test.ts`, and a new `worktree-delete-intent.test.ts`:

- regression: repeat-archiving an already-archived task whose worktree is still on disk now actually tears it down
- repeat-archive with the worktree already gone stays a no-op
- `awaitTeardown` resolves only once the dir is gone; reports `dirty` without `forceWorktree` and `removed: true` with it
- steady-state: a dirty archived worktree survives every unattended boot sweep and is only cleared by an explicit forced archive
- the job bails rather than removing a worktree un-archived under it
- `detachWorktree` force removes a dirty checkout **while the branch and its commits survive**
- the three dirty states are mutually exclusive and exhaustive, including that `ignored: true` is never folded into clean

Existing stuck worktrees clear on one click — no migration or one-off script.

Plan: `docs/plans/worktrees-archive-delete-noop.md`