### PR TITLE
feature: search in the task details message stream

### DIFF
--- a/docs/plans/task-details-messages-search.md
+++ b/docs/plans/task-details-messages-search.md
@@ -1,0 +1,87 @@
+# Plan — Search in the task details message stream
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-29 |
+| Source | /implement "Add Search support in task details messages" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/task-details-messages-search |
+| Base SHA | ce9177b34816982f2aeebbba15fefb8dde8bd827 |
+| Mode | **Autonomous** — grill and plan-approval gates bypassed; all assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+Add an in-panel search over the task details modal's unified message stream (RunPanel):
+
+- A search toggle (Search icon) in the panel header opens a search bar; Cmd/Ctrl+F also opens it while the panel is open.
+- Typing a query matches events in the **currently displayed stream** (main tab or the active subagent tab) case-insensitively against their human-visible text.
+- The bar shows `current/total` match count with prev/next navigation (buttons + Enter / Shift+Enter); navigating scrolls the matched event block into view and visually highlights it (ring on the block — no intra-markdown `<mark>` in v1).
+- Escape closes the search bar (and only then, on a second Escape, the panel). Closing clears the highlight.
+- `bun run typecheck` and `bun test` green.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- `RunPanel.tsx` holds `events: StreamEvent[]` (`RunEvent & { id: number }`, client-assigned monotonic ids) at `RunPanel.tsx:258`; `displayedEvents` (`RunPanel.tsx:666-671`) is what the active tab renders — search must operate on exactly this slice.
+- `RunEventList` (`RunPanel.tsx:2368-2517`) groups events into sections split on `user` messages via a perf-critical `sections` useMemo; block components are module-scope `memo()` wrappers. **No per-event DOM identity exists** — scroll-to-match needs a `data-evid` attribute added at render time.
+- Autoscroll: two pin-to-bottom effects (`RunPanel.tsx:539-556`) gated on `nearBottomRef` (updated by native `onScroll`). Jumping to a mid-stream match moves scrollTop away from bottom, which flips `nearBottomRef` false via onScroll — no explicit suppression needed, but scrollIntoView must use the log container, `block: "center"`.
+- Markdown perf trap: `ReactMarkdown` `components` maps are hoisted for identity stability (`RunPanel.tsx:2644-2687`). Per-keystroke intra-markdown highlighting would defeat this → **out of scope for v1**.
+- Event shapes (`src/shared/types.ts:1660-1698`): `user|assistant|thinking` carry markdown text in `data`; `tool_use|tool_result|interaction` carry JSON strings; `status|stderr|stdout` plain text; `interaction|interaction_resolved|subagent` streams are not rendered in the log list.
+- Repo conventions: pure logic in `src/mainview/lib/*.ts` (no React imports) + co-located `bun:test` file; no DOM test harness exists. Header button row at `RunPanel.tsx:1355-1418`; existing search-input visual pattern in `KanbanFilters.tsx:110-118` (relative div + `Search` icon + `Input` with `pl-8`).
+- Escape-to-close-panel document keydown listener exists (`RunPanel.tsx:176-186` area); search's Escape handling must take precedence when the bar is open.
+- Active peer `large-fern-b9b5` is working on an "Open PR" button feature that may also touch RunPanel — messaged; merge conflicts, if any, resolve at PR time.
+
+## 3. Approach & key decisions
+
+- **Match on extracted searchable text, event-level granularity.** A pure helper extracts a searchable string per event (markdown/plain text verbatim; tool events → tool name + input/result text best-effort from JSON). Matches are event ids; navigation steps between matched events, not per-occurrence. Alternative (per-occurrence with intra-text `<mark>`) rejected for v1 due to the ReactMarkdown identity/perf constraint.
+- **Active-tab scope.** Search runs over `displayedEvents` only; switching tabs recomputes matches automatically (useMemo dep) and resets the active index. Cross-tab search deferred.
+- **Highlight = ring on the active matched block wrapper** (`data-evid` div gets a highlight class when active). Cheap, no markdown re-render.
+- **Matching recomputes per keystroke** in a useMemo (O(total text)); acceptable for realistic log sizes; the extraction of searchable text is a per-event pure function so it can be trivially cached later if needed.
+- Search is read-only → **no `activeStream === "main"` gating** (works on subagent tabs and archived tasks).
+
+## 4. Work breakdown — implementation tasks
+
+### Task A (single implementation agent — sequential internally, disjoint from nothing else in flight)
+1. **`src/mainview/lib/event-search.ts`** (new): pure module, no React imports, top-of-file "why" comment. Exports:
+   - `searchableEventText(stream: RunEventStream, data: string): string | null` — null for non-rendered streams (`interaction`, `interaction_resolved`, `subagent`); tool events parse JSON best-effort (never throw) and concatenate name/input/result text.
+   - `findMatchingEventIds(events: ReadonlyArray<{ id: number; stream: RunEventStream; data: string }>, query: string): number[]` — trimmed, case-insensitive substring; empty query → `[]`.
+   - `stepMatchIndex(matchCount: number, current: number, dir: 1 | -1): number` — wraparound navigation; `resolveActiveMatchIndex(matches: number[], prevActiveId: number | null): number` — keep the previously-active match selected across recomputes when still present, else clamp to last/first sensibly.
+2. **`src/mainview/components/kanban/RunPanel.tsx`** wiring:
+   - State: `searchOpen`, `searchQuery`, `activeMatchId: number | null`.
+   - `matches = useMemo(findMatchingEventIds(displayedEvents, searchQuery), [displayedEvents, searchQuery])`.
+   - Header: Search icon toggle button (ghost, before close X), tooltip/`title="Search messages"`.
+   - Search bar row rendered between header and the log scroller when open: Input (auto-focused, `KanbanFilters` visual pattern), `n/N` counter, ChevronUp/ChevronDown prev/next buttons, X close. Enter → next, Shift+Enter → prev, Escape → close (stopPropagation so the panel stays open).
+   - Panel-level Cmd/Ctrl+F keydown → open + focus (preventDefault); guard consistent with existing Escape listener's dialog guards.
+   - `RunEventList`: wrap each rendered event block in a `div` carrying `data-evid={e.id}` and a conditional highlight class when `e.id === activeMatchId` (pass `activeMatchId` as a prop; sections useMemo gains that dep — keep the ring styling on the wrapper so memoized block components are untouched).
+   - Effect: on `activeMatchId` change, `logRef.current?.querySelector('[data-evid="..."]')?.scrollIntoView({ block: "center" })`.
+   - Reset `activeMatchId` on tab switch / task switch; closing search clears query + highlight.
+
+Acceptance: typecheck green; behavior per §1.
+
+## 5. Work breakdown — test tasks
+
+### Task T1 — `src/mainview/lib/event-search.test.ts` (new)
+`bun:test` over the pure module: extraction per stream type (markdown passthrough, tool_use/tool_result JSON incl. malformed JSON, null streams), match filtering (case-insensitivity, trim, empty query, no matches), navigation math (wraparound both directions, active-match preservation across recompute, clamping when matches shrink).
+
+## 6. Execution waves
+
+- Wave 1: Task A (one sonnet agent).
+- Phase 5: opus review of the diff vs `ce9177b`.
+- Phase 6: Task T1 (one sonnet agent) — file-disjoint from nothing in flight.
+- Phase 7: haiku agent runs `bun run typecheck` + `bun test`.
+- Phase 8: fixes if needed.
+
+## 7. Blast radius & risks
+
+- `RunEventList` sections useMemo gains an `activeMatchId` dep — changing the active match re-renders the section list wrapper divs, but memoized block components keep bailing out (props unchanged). Risk: accidental prop identity churn — reviewer should check.
+- Wrapper `div` per event block changes DOM nesting inside sections — verify no CSS relies on direct-child selectors there.
+- Escape precedence vs the existing panel-close listener; and Cmd+F must not fire while other dialogs (diff, confirm) are open.
+- Autoscroll: while a run is streaming, a new event burst pins to bottom only when `nearBottomRef` is true; after jumping to a match the user is mid-stream so pinning stays off — matches existing reading behavior.
+- Peer branch may conflict in RunPanel at merge time (coordinated via fleet message).
+
+## 8. Open questions / assumptions (autonomous mode — gates bypassed)
+
+1. **Scope**: active tab only; no cross-subagent-tab search. (Assumed simplest v1.)
+2. **Granularity**: event-level matches, not per-occurrence text highlighting; no `<mark>` inside markdown in v1 (perf constraint).
+3. **Persistence**: search state is ephemeral — resets on panel close/task switch; not persisted like the composer draft.
+4. **Match source**: raw event text (plus tool JSON best-effort), not post-`prompt-noise`/`command-message` transformed text; acceptable v1 approximation.
+5. **Shortcut**: Cmd/Ctrl+F is intercepted only while the task panel is open and no other dialog is open.

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -3,15 +3,17 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
 import {
-  Archive, ArchiveRestore, ArrowDown, ArrowUp, BookmarkPlus, Bot, Check, ClipboardList, Copy, CornerDownRight, Eye, FolderOpen, FileText, FilePenLine, FilePlus, Folder,
+  Archive, ArchiveRestore, ArrowDown, ArrowUp, BookmarkPlus, Bot, Check, ChevronDown, ChevronUp, ClipboardList, Copy, CornerDownRight, Eye, FolderOpen, FileText, FilePenLine, FilePlus, Folder,
   GitCommit, GitCompare, Globe, HelpCircle, ListTodo, Plug, Search, Send, Slash, SquareSlash,
   Sparkles, Square, Terminal, Trash2, Wrench, X,
 } from "lucide-react";
 import { api, commitPushPrompt, type AgentModelMap, type AvailableCommand, type AvailableExtension, type PendingInteraction } from "@/lib/api";
 import { shouldShowSubagentTabs, resolveActiveStream, splitTabsForOverflow, sortSubagentTabs } from "@/lib/subagent-tabs";
 import { shouldOfferCommitPush, type TaskGitStatus } from "@/lib/commit-push";
+import { findMatchingEventIds, resolveActiveMatchIndex, stepMatchIndex } from "@/lib/event-search";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { abbreviateHome, cn } from "@/lib/utils";
@@ -160,9 +162,10 @@ export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClos
 
   // Escape closes the panel — but only when no higher-priority dismissable
   // layer is up: a modal Dialog (confirm, edit, settings, tmux-missing —
-  // each renders `[role="dialog"][aria-modal="true"]`) or an open
-  // search-select / multi-search-select popover (marked with
-  // `[data-popover-open]`). Esc peels one layer at a time, top down.
+  // each renders `[role="dialog"][aria-modal="true"]`), an open search-select
+  // / multi-search-select popover (marked with `[data-popover-open]`), or the
+  // in-panel message search bar (marked with `[data-search-open]` — see
+  // RunPanelBody). Esc peels one layer at a time, top down.
   //
   // Note: stopPropagation/stopImmediatePropagation can't help here because
   // both the panel and the popovers attach to `document`, so DOM markers
@@ -177,7 +180,7 @@ export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClos
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
-      if (document.querySelector('[role="dialog"][aria-modal="true"], [data-popover-open]')) return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"], [data-popover-open], [data-search-open]')) return;
       e.preventDefault();
       onCloseRef.current();
     };
@@ -282,6 +285,19 @@ function RunPanelBody({
    *  subagent id. Background-agent streams are READ-ONLY — the composer is
    *  hidden while one is active. */
   const [activeStream, setActiveStream] = useState<string>("main");
+  /** In-panel search over whichever stream is currently displayed (see
+   *  lib/event-search.ts). Read-only and deliberately NOT gated on
+   *  `activeStream === "main"` or archival state — it works identically on a
+   *  subagent tab or an archived task's frozen log. */
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  /** The selected match, as an index into `displayedEvents` (see
+   *  `searchableEvents` below) — NOT a `StreamEvent.id`. A JSONL-rebuilt event
+   *  has no client-assigned id at all (see `StreamEvent`'s doc comment
+   *  above), so `searchableEvents` assigns fresh 0..N-1 ids scoped to
+   *  whatever's currently displayed. `null` means no match is selected. */
+  const [activeMatchId, setActiveMatchId] = useState<number | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const logRef = useRef<HTMLDivElement>(null);
   // Tracks whether the log was scrolled near the bottom at the last user
   // interaction. Auto-scroll-to-bottom on new events only fires when this is
@@ -308,6 +324,9 @@ function RunPanelBody({
     setInteractions([]);
     setSubagentList([]);
     setActiveStream("main");
+    setSearchOpen(false);
+    setSearchQuery("");
+    setActiveMatchId(null);
     nearBottomRef.current = true;
   }, [task.id]);
 
@@ -675,6 +694,111 @@ function RunPanelBody({
    *  (see lib/todo-progress.ts). Memoized on `displayedEvents` alone — it is
    *  recomputed on every SSE frame, so it must stay a single O(n) pass. */
   const todoProgress = useMemo(() => deriveTodoProgress(displayedEvents), [displayedEvents]);
+
+  /** `displayedEvents` re-keyed with a fresh 0..N-1 id per position — the
+   *  input shape `event-search.ts` needs. `displayedEvents` is typed as plain
+   *  `RunEvent[]`: the "main" branch's live events happen to carry the
+   *  client-assigned `StreamEvent.id`, but a `rebuilt` (JSONL-reparsed) splice
+   *  does NOT, so a real `.id` can't be relied on here — a positional index
+   *  scoped to this exact array is the only id every entry is guaranteed to
+   *  have, and it's exactly what `data-evid` below is keyed on too. */
+  const searchableEvents = useMemo(
+    () => displayedEvents.map((e, i) => ({ id: i, stream: e.stream, data: e.data })),
+    [displayedEvents],
+  );
+  const matches = useMemo(
+    () => findMatchingEventIds(searchableEvents, searchQuery),
+    [searchableEvents, searchQuery],
+  );
+
+  // Resolve which match is active whenever the match set changes — either
+  // because the query changed, or because `displayedEvents` shifted under an
+  // open search (new streamed events, a JSONL rebuild splice, or a tab/task
+  // switch). `activeMatchId` is read directly from the render closure rather
+  // than a ref: since this effect's callback is recreated fresh every render
+  // but only *invoked* when `matches` changes, the value captured is exactly
+  // "whatever was active before this recompute" — precisely the `prevActiveId`
+  // `resolveActiveMatchIndex` wants. Deliberately excludes `activeMatchId`
+  // from deps: including it would make the effect re-fire the moment it sets
+  // it, driven by its own write instead of a genuine match-set change (the
+  // `nextId !== activeMatchId` guard would still no-op on that redundant run,
+  // but there's no reason to pay for it).
+  //
+  // A tab or task switch reuses this SAME effect rather than a separate reset:
+  // `matches` are positional indices scoped to `displayedEvents`, so an id
+  // that was active on the previous stream is a coincidence, not a carry-over,
+  // once `activeStream`/`task.id` changes the underlying array out from under
+  // it — `searchScopeRef` detects that and forces `prevActiveId` to `null` so
+  // the resolution can't accidentally "keep" an unrelated index that happens
+  // to also be a match in the new scope.
+  const searchScopeRef = useRef<string>(`${task.id}:${activeStream}`);
+  useEffect(() => {
+    const scopeKey = `${task.id}:${activeStream}`;
+    const scopeChanged = scopeKey !== searchScopeRef.current;
+    searchScopeRef.current = scopeKey;
+    const prevActiveId = scopeChanged ? null : activeMatchId;
+    const idx = resolveActiveMatchIndex(matches, prevActiveId);
+    const nextId = idx >= 0 ? matches[idx]! : null;
+    if (nextId !== activeMatchId) setActiveMatchId(nextId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [matches, task.id, activeStream]);
+
+  // Scroll the active match into view. Runs after the resolve effect above
+  // (and after any tab/task switch), so by the time this fires `activeMatchId`
+  // already points at an event rendered in the CURRENT `displayedEvents`.
+  useEffect(() => {
+    if (activeMatchId === null) return;
+    const el = logRef.current?.querySelector(`[data-evid="${activeMatchId}"]`);
+    el?.scrollIntoView({ block: "center" });
+  }, [activeMatchId]);
+
+  const closeSearch = useCallback(() => {
+    setSearchOpen(false);
+    setSearchQuery("");
+    setActiveMatchId(null);
+  }, []);
+
+  const stepSearch = useCallback((dir: 1 | -1) => {
+    setActiveMatchId((cur) => {
+      const idx = matches.indexOf(cur ?? -1);
+      const next = stepMatchIndex(matches.length, idx, dir);
+      return next >= 0 ? matches[next]! : null;
+    });
+  }, [matches]);
+
+  // Cmd/Ctrl+F opens the search bar and focuses its input, while the panel is
+  // mounted. Guarded the same way the panel's own Escape-to-close listener
+  // guards against a higher-priority dismissable layer (modal dialog / open
+  // search-select popover) so it doesn't hijack the browser/OS's own find
+  // behavior — or a dialog's own input — while one of those is up.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() !== "f" || !(e.metaKey || e.ctrlKey)) return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"], [data-popover-open]')) return;
+      e.preventDefault();
+      setSearchOpen(true);
+      // The input isn't mounted yet on the render this triggers (the bar
+      // renders conditionally on `searchOpen`) — focus after the next paint.
+      requestAnimationFrame(() => searchInputRef.current?.focus());
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Escape closes the search bar regardless of where focus currently is
+  // within the panel (not just while the input itself is focused) — matching
+  // "Escape peels one layer at a time" from the panel's own listener. Gated
+  // on `searchOpen` so it's only attached while there's something to close.
+  useEffect(() => {
+    if (!searchOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      closeSearch();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [searchOpen, closeSearch]);
 
   /** Indicator mode for the bottom-pinned heartbeat. A follow-up sent while
    *  the agent is working is folded into the active run (the backend pastes it
@@ -1412,11 +1536,80 @@ function RunPanelBody({
               <ArchiveRestore className="mr-1 size-3" /> Unarchive
             </Button>
           )}
+          <Button
+            size="icon"
+            variant="ghost"
+            title="Search messages"
+            onClick={() => {
+              if (searchOpen) {
+                closeSearch();
+                return;
+              }
+              setSearchOpen(true);
+              // The input isn't mounted yet on the render this triggers (the
+              // bar renders conditionally on `searchOpen`) — focus after the
+              // next paint.
+              requestAnimationFrame(() => searchInputRef.current?.focus());
+            }}
+          >
+            <Search className="size-4" />
+          </Button>
           <Button size="icon" variant="ghost" onClick={onClose}>
             <X className="size-4" />
           </Button>
         </div>
       </header>
+
+      {searchOpen && (
+        <div data-search-open="" className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
+          <div className="relative flex-1">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden />
+            <Input
+              ref={searchInputRef}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  stepSearch(e.shiftKey ? -1 : 1);
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  closeSearch();
+                }
+              }}
+              placeholder="Search messages…"
+              className="h-8 pl-8 text-xs"
+            />
+          </div>
+          <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+            {matches.length === 0 ? "0/0" : `${matches.indexOf(activeMatchId ?? -1) + 1}/${matches.length}`}
+          </span>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-7"
+            disabled={matches.length === 0}
+            title="Previous match"
+            onClick={() => stepSearch(-1)}
+          >
+            <ChevronUp className="size-3.5" />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-7"
+            disabled={matches.length === 0}
+            title="Next match"
+            onClick={() => stepSearch(1)}
+          >
+            <ChevronDown className="size-3.5" />
+          </Button>
+          <Button size="icon" variant="ghost" className="size-7" title="Close search" onClick={closeSearch}>
+            <X className="size-3.5" />
+          </Button>
+        </div>
+      )}
 
       <FileMentions task={task} events={events} />
 
@@ -1502,6 +1695,7 @@ function RunPanelBody({
               onInteractionResolved={dismissInteraction}
               runStatus={activeRunStatus}
               indicatorMode={indicatorMode}
+              activeMatchId={activeMatchId}
             />
           </>
         )}
@@ -2371,12 +2565,19 @@ function RunEventList({
   onInteractionResolved,
   runStatus,
   indicatorMode = "off",
+  activeMatchId = null,
 }: {
   events: RunEvent[];
   interactions?: PendingInteraction[];
   onInteractionResolved?: (id: string) => void;
   runStatus?: Run["status"] | null;
   indicatorMode?: RunIndicatorMode;
+  /** Index (into `events`, matching `event-search.ts`'s id scheme) of the
+   *  currently-selected search match, or null when search is closed / has no
+   *  selection. Drives the `data-evid` scroll target + highlight ring below —
+   *  purely a rendering concern, so it's threaded straight through rather than
+   *  re-derived here. */
+  activeMatchId?: number | null;
 }) {
   // Index tool_results by their tool_use_id so the tool-use card can show
   // Normalise legacy `[tool: Name] {...}` / `[thinking] ...` / `[result] ...`
@@ -2438,34 +2639,50 @@ function RunEventList({
   // live inside so their captured deps (`resultByToolId`, `onInteractionResolved`)
   // are tracked explicitly.
   const sections = useMemo(() => {
-    const renderEvent = (e: RunEvent, key: string): React.ReactNode[] => {
+    // Wrap a rendered block in the `data-evid` carrier the search bar scrolls
+    // to (`logRef.current?.querySelector('[data-evid="…"]')` in RunPanelBody)
+    // and, when it's the active match, a highlight ring. `evid` is `i` from
+    // the loop below — the position of this event within `normalised` (and so
+    // within `events`/`displayedEvents`), which is exactly the id scheme
+    // `event-search.ts` uses. The wrapper carries the key so the memoized
+    // block components underneath keep their identity/props untouched.
+    const wrap = (key: string, evid: number, node: React.ReactNode): React.ReactNode => (
+      <div
+        key={key}
+        data-evid={evid}
+        className={cn(evid === activeMatchId && "rounded-md ring-1 ring-primary/60 bg-primary/5")}
+      >
+        {node}
+      </div>
+    );
+    const renderEvent = (e: RunEvent, key: string, evid: number): React.ReactNode[] => {
       switch (e.stream) {
         case "user":
-          return [<UserMessageBlock key={key} text={e.data} />];
+          return [wrap(key, evid, <UserMessageBlock text={e.data} />)];
         case "assistant":
-          return [<AssistantBlock key={key} text={e.data} />];
+          return [wrap(key, evid, <AssistantBlock text={e.data} />)];
         case "thinking":
-          return [<ThinkingBlock key={key} text={e.data} />];
+          return [wrap(key, evid, <ThinkingBlock text={e.data} />)];
         case "tool_use": {
           const parsed = safeParse<ParsedToolUse>(e.data);
-          if (!parsed) return [<RawText key={key} text={e.data} muted />];
+          if (!parsed) return [wrap(key, evid, <RawText text={e.data} muted />)];
           const result = resultByToolId.get(parsed.id);
-          return [<ToolUseBlock key={key} call={parsed} result={result} />];
+          return [wrap(key, evid, <ToolUseBlock call={parsed} result={result} />)];
         }
         case "tool_result": {
           const parsed = safeParse<ParsedToolResult>(e.data);
           if (parsed && parsed.toolUseId && resultByToolId.get(parsed.toolUseId)) return [];
-          return [<ToolResultBlock key={key} result={parsed} />];
+          return [wrap(key, evid, <ToolResultBlock result={parsed} />)];
         }
         case "status":
-          return [<StatusDivider key={key} text={e.data} />];
+          return [wrap(key, evid, <StatusDivider text={e.data} />)];
         case "stderr":
-          return [<ErrorBlock key={key} text={e.data} />];
+          return [wrap(key, evid, <ErrorBlock text={e.data} />)];
         case "stdout":
         case "interaction":
         default:
           if (e.stream === "interaction") return [];
-          return [<RawText key={key} text={e.data} />];
+          return [wrap(key, evid, <RawText text={e.data} />)];
       }
     };
     const renderInteraction = (it: PendingInteraction) => {
@@ -2489,17 +2706,17 @@ function RunEventList({
       const before = (interactionByIndex.get(i) ?? []).map(renderInteraction);
       if (e.stream === "user") {
         if (current.header !== null || current.body.length > 0) out.push(current);
-        current = { key, header: renderEvent(e, key)[0] ?? null, body: [...before] };
+        current = { key, header: renderEvent(e, key, i)[0] ?? null, body: [...before] };
       } else {
         if (current.key === "") current.key = key;
-        current.body.push(...before, ...renderEvent(e, key));
+        current.body.push(...before, ...renderEvent(e, key, i));
       }
     }
     const tail = (interactionByIndex.get(normalised.length) ?? []).map(renderInteraction);
     current.body.push(...tail);
     if (current.header !== null || current.body.length > 0) out.push(current);
     return out;
-  }, [normalised, interactionByIndex, resultByToolId, onInteractionResolved]);
+  }, [normalised, interactionByIndex, resultByToolId, onInteractionResolved, activeMatchId]);
 
   return (
     <div className="flex flex-col gap-4">

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -104,6 +104,14 @@ const STATUS_VARIANT: Record<Run["status"], "default" | "secondary" | "outline" 
 
 export const EXIT_DURATION_MS = 250;
 
+// Computed once at module load rather than per keystroke — used by the
+// Cmd/Ctrl+F handler below to pick the platform-appropriate modifier
+// (`metaKey` on macOS, `ctrlKey` elsewhere). Agetor packages arm64-only for
+// macOS, but the dev webview (Vite) can run in any browser during
+// development, so this still branches rather than assuming Mac.
+const IS_MAC_PLATFORM =
+  typeof navigator !== "undefined" && /mac/i.test(navigator.platform || navigator.userAgent || "");
+
 function formatDuration(r: Run): string {
   const end = r.endedAt ?? Date.now();
   const ms = end - r.startedAt;
@@ -213,6 +221,7 @@ export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClos
           harnesses={harnesses}
           agentModels={agentModels}
           homeDir={homeDir}
+          open={open}
           onClose={onClose}
           onShowDiff={onShowDiff}
           onArchive={onArchive}
@@ -233,6 +242,7 @@ function RunPanelBody({
   harnesses,
   agentModels,
   homeDir,
+  open,
   onClose,
   onShowDiff,
   onArchive,
@@ -243,6 +253,11 @@ function RunPanelBody({
   harnesses: Harness[];
   agentModels: AgentModelMap;
   homeDir: string;
+  /** Whether the panel is in its "open" (not mid-close-animation, not
+   *  pre-mount) state — mirrors `RunPanel`'s own `open` state. Gates the
+   *  Cmd/Ctrl+F listener below so it doesn't hijack the shortcut while the
+   *  panel is animating out or not actually visible. */
+  open: boolean;
   onClose: () => void;
   onShowDiff: (task: Task) => void;
   onArchive: (t: Task) => void;
@@ -291,14 +306,19 @@ function RunPanelBody({
    *  subagent tab or an archived task's frozen log. */
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  /** The selected match, as an index into `displayedEvents` (see
-   *  `searchableEvents` below) — NOT a `StreamEvent.id`. A JSONL-rebuilt event
-   *  has no client-assigned id at all (see `StreamEvent`'s doc comment
-   *  above), so `searchableEvents` assigns fresh 0..N-1 ids scoped to
-   *  whatever's currently displayed. `null` means no match is selected. */
+  /** The selected match, as an index into `displayedEvents` — NOT a
+   *  `StreamEvent.id`. A JSONL-rebuilt event has no client-assigned id at
+   *  all (see `StreamEvent`'s doc comment above), so `findMatchingEventIds`
+   *  (lib/event-search.ts) uses each event's position in `displayedEvents`
+   *  as its id, scoped to whatever's currently displayed. `null` means no
+   *  match is selected. */
   const [activeMatchId, setActiveMatchId] = useState<number | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const logRef = useRef<HTMLDivElement>(null);
+  // The DOM element currently carrying the search-match highlight classes
+  // (imperatively toggled, not driven by a React prop/memo dep — see the
+  // effect below). `null` when nothing is highlighted.
+  const highlightedElRef = useRef<HTMLElement | null>(null);
   // Tracks whether the log was scrolled near the bottom at the last user
   // interaction. Auto-scroll-to-bottom on new events only fires when this is
   // true, so a user who scrolls up to read history isn't yanked back down on
@@ -695,21 +715,29 @@ function RunPanelBody({
    *  recomputed on every SSE frame, so it must stay a single O(n) pass. */
   const todoProgress = useMemo(() => deriveTodoProgress(displayedEvents), [displayedEvents]);
 
-  /** `displayedEvents` re-keyed with a fresh 0..N-1 id per position — the
-   *  input shape `event-search.ts` needs. `displayedEvents` is typed as plain
-   *  `RunEvent[]`: the "main" branch's live events happen to carry the
-   *  client-assigned `StreamEvent.id`, but a `rebuilt` (JSONL-reparsed) splice
-   *  does NOT, so a real `.id` can't be relied on here — a positional index
-   *  scoped to this exact array is the only id every entry is guaranteed to
-   *  have, and it's exactly what `data-evid` below is keyed on too. */
-  const searchableEvents = useMemo(
-    () => displayedEvents.map((e, i) => ({ id: i, stream: e.stream, data: e.data })),
-    [displayedEvents],
-  );
+  // `findMatchingEventIds` (lib/event-search.ts) takes `displayedEvents`
+  // straight — it derives each event's search id from its own position in
+  // the array, so there's no separate pre-mapped/id-tagged array to build
+  // or memoize here.
   const matches = useMemo(
-    () => findMatchingEventIds(searchableEvents, searchQuery),
-    [searchableEvents, searchQuery],
+    () => findMatchingEventIds(displayedEvents, searchQuery),
+    [displayedEvents, searchQuery],
   );
+
+  // Derived purely for display — no state, so there's no "0/0" flash before
+  // an effect catches up and no risk of the position silently desyncing from
+  // `activeMatchId`/`matches`. `-1` (no match) renders as "0/0" below.
+  const activeMatchPosition = resolveActiveMatchIndex(matches, activeMatchId);
+
+  // A splice/clear of the JSONL-rebuild snapshot swaps `displayedEvents` out
+  // from under the current scope exactly like a tab/task switch does (the
+  // positional ids `matches` holds no longer refer to the same events), so
+  // its identity has to be part of the scope key below. `maxLiveEventIdAtSnapshot`
+  // is set fresh every time a snapshot is (re)captured for a session, so
+  // `sessionId:maxLiveEventIdAtSnapshot` is a stable id for "this particular
+  // rebuild snapshot" — distinct from both "no snapshot" and any prior
+  // snapshot of the same session.
+  const rebuiltScopeKey = rebuilt ? `${rebuilt.sessionId}:${rebuilt.maxLiveEventIdAtSnapshot}` : "";
 
   // Resolve which match is active whenever the match set changes — either
   // because the query changed, or because `displayedEvents` shifted under an
@@ -724,16 +752,16 @@ function RunPanelBody({
   // `nextId !== activeMatchId` guard would still no-op on that redundant run,
   // but there's no reason to pay for it).
   //
-  // A tab or task switch reuses this SAME effect rather than a separate reset:
-  // `matches` are positional indices scoped to `displayedEvents`, so an id
-  // that was active on the previous stream is a coincidence, not a carry-over,
-  // once `activeStream`/`task.id` changes the underlying array out from under
-  // it — `searchScopeRef` detects that and forces `prevActiveId` to `null` so
-  // the resolution can't accidentally "keep" an unrelated index that happens
-  // to also be a match in the new scope.
-  const searchScopeRef = useRef<string>(`${task.id}:${activeStream}`);
+  // A tab/task switch OR a rebuild-snapshot splice reuses this SAME effect
+  // rather than a separate reset: `matches` are positional indices scoped to
+  // `displayedEvents`, so an id that was active before any of those changes
+  // is a coincidence, not a carry-over — `searchScopeRef` detects the change
+  // and forces `prevActiveId` to `null` so the resolution can't accidentally
+  // "keep" an unrelated index that happens to also be a match in the new
+  // scope.
+  const searchScopeRef = useRef<string>(`${task.id}:${activeStream}:${rebuiltScopeKey}`);
   useEffect(() => {
-    const scopeKey = `${task.id}:${activeStream}`;
+    const scopeKey = `${task.id}:${activeStream}:${rebuiltScopeKey}`;
     const scopeChanged = scopeKey !== searchScopeRef.current;
     searchScopeRef.current = scopeKey;
     const prevActiveId = scopeChanged ? null : activeMatchId;
@@ -741,15 +769,35 @@ function RunPanelBody({
     const nextId = idx >= 0 ? matches[idx]! : null;
     if (nextId !== activeMatchId) setActiveMatchId(nextId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [matches, task.id, activeStream]);
+  }, [matches, task.id, activeStream, rebuilt, rebuiltScopeKey]);
 
-  // Scroll the active match into view. Runs after the resolve effect above
-  // (and after any tab/task switch), so by the time this fires `activeMatchId`
-  // already points at an event rendered in the CURRENT `displayedEvents`.
+  // Highlight + scroll the active match imperatively rather than through a
+  // React prop/memo dep: `RunEventList`'s `sections` memo used to take
+  // `activeMatchId` as a dep purely so it could stamp a highlight class on
+  // one wrapper div, which meant re-deriving (and re-diffing) the ENTIRE
+  // section tree on every match navigation. Toggling classList directly on
+  // the previous/next `[data-evid]` element is O(1) instead. Runs after the
+  // resolve effect above (and after any tab/task/rebuild-scope switch), so by
+  // the time this fires `activeMatchId` already points at an event rendered
+  // in the CURRENT `displayedEvents`.
   useEffect(() => {
+    const HIGHLIGHT_CLASSES = ["ring-1", "ring-primary/60", "bg-primary/5", "rounded-md"];
+    const prev = highlightedElRef.current;
+    if (prev) {
+      prev.classList.remove(...HIGHLIGHT_CLASSES);
+      highlightedElRef.current = null;
+    }
     if (activeMatchId === null) return;
-    const el = logRef.current?.querySelector(`[data-evid="${activeMatchId}"]`);
-    el?.scrollIntoView({ block: "center" });
+    const el = logRef.current?.querySelector<HTMLElement>(`[data-evid="${activeMatchId}"]`);
+    if (!el) return;
+    el.classList.add(...HIGHLIGHT_CLASSES);
+    highlightedElRef.current = el;
+    el.scrollIntoView({ block: "center" });
+    // The scrollIntoView above can land the log outside the "near bottom"
+    // band (or an SSE flush landing in the same tick could otherwise yank
+    // the view back to the bottom before the browser paints the scroll) —
+    // clear it immediately so neither auto-scroll path fights the jump.
+    nearBottomRef.current = false;
   }, [activeMatchId]);
 
   const closeSearch = useCallback(() => {
@@ -766,33 +814,56 @@ function RunPanelBody({
     });
   }, [matches]);
 
-  // Cmd/Ctrl+F opens the search bar and focuses its input, while the panel is
-  // mounted. Guarded the same way the panel's own Escape-to-close listener
-  // guards against a higher-priority dismissable layer (modal dialog / open
-  // search-select popover) so it doesn't hijack the browser/OS's own find
-  // behavior — or a dialog's own input — while one of those is up.
+  // Cmd/Ctrl+F opens the search bar and focuses its input (or, if the bar is
+  // already open, re-selects the existing query so typing replaces it
+  // outright) while the panel is actually open — not mid-close-animation or
+  // pre-mount, matching the panel's own Escape-to-close listener's `if
+  // (!open) return;` gate. Guarded the same way that listener guards against
+  // a higher-priority dismissable layer (modal dialog / open search-select
+  // popover) so it doesn't hijack the browser/OS's own find behavior — or a
+  // dialog's own input — while one of those is up. Also bails when focus is
+  // inside a terminal pane (`.xterm` — see TerminalView.tsx, which mounts
+  // xterm.js's own container carrying that class): Cmd/Ctrl+F there should
+  // reach the shell/program running in the PTY, not this panel's search.
   useEffect(() => {
+    if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key.toLowerCase() !== "f" || !(e.metaKey || e.ctrlKey)) return;
+      if (e.key.toLowerCase() !== "f" || e.altKey) return;
+      const wantsFind = IS_MAC_PLATFORM ? (e.metaKey && !e.ctrlKey) : e.ctrlKey;
+      if (!wantsFind) return;
       if (document.querySelector('[role="dialog"][aria-modal="true"], [data-popover-open]')) return;
+      if ((e.target as Element | null)?.closest?.(".xterm")) return;
       e.preventDefault();
+      if (searchOpen) {
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+        return;
+      }
       setSearchOpen(true);
       // The input isn't mounted yet on the render this triggers (the bar
       // renders conditionally on `searchOpen`) — focus after the next paint.
-      requestAnimationFrame(() => searchInputRef.current?.focus());
+      requestAnimationFrame(() => {
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      });
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, []);
+  }, [open, searchOpen]);
 
   // Escape closes the search bar regardless of where focus currently is
   // within the panel (not just while the input itself is focused) — matching
   // "Escape peels one layer at a time" from the panel's own listener. Gated
-  // on `searchOpen` so it's only attached while there's something to close.
+  // on `searchOpen` so it's only attached while there's something to close,
+  // and bails on the same higher-priority dismissable layer (modal dialog /
+  // open search-select popover) as every other document-level listener here
+  // so Escape closes the topmost layer first instead of skipping straight to
+  // the search bar underneath it.
   useEffect(() => {
     if (!searchOpen) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"], [data-popover-open]')) return;
       e.preventDefault();
       closeSearch();
     };
@@ -1566,6 +1637,7 @@ function RunPanelBody({
             <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden />
             <Input
               ref={searchInputRef}
+              aria-label="Search messages"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={(e) => {
@@ -1582,8 +1654,8 @@ function RunPanelBody({
               className="h-8 pl-8 text-xs"
             />
           </div>
-          <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
-            {matches.length === 0 ? "0/0" : `${matches.indexOf(activeMatchId ?? -1) + 1}/${matches.length}`}
+          <span aria-live="polite" className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+            {matches.length === 0 ? "0/0" : `${activeMatchPosition + 1}/${matches.length}`}
           </span>
           <Button
             size="icon"
@@ -1695,7 +1767,6 @@ function RunPanelBody({
               onInteractionResolved={dismissInteraction}
               runStatus={activeRunStatus}
               indicatorMode={indicatorMode}
-              activeMatchId={activeMatchId}
             />
           </>
         )}
@@ -2565,19 +2636,12 @@ function RunEventList({
   onInteractionResolved,
   runStatus,
   indicatorMode = "off",
-  activeMatchId = null,
 }: {
   events: RunEvent[];
   interactions?: PendingInteraction[];
   onInteractionResolved?: (id: string) => void;
   runStatus?: Run["status"] | null;
   indicatorMode?: RunIndicatorMode;
-  /** Index (into `events`, matching `event-search.ts`'s id scheme) of the
-   *  currently-selected search match, or null when search is closed / has no
-   *  selection. Drives the `data-evid` scroll target + highlight ring below —
-   *  purely a rendering concern, so it's threaded straight through rather than
-   *  re-derived here. */
-  activeMatchId?: number | null;
 }) {
   // Index tool_results by their tool_use_id so the tool-use card can show
   // Normalise legacy `[tool: Name] {...}` / `[thinking] ...` / `[result] ...`
@@ -2640,25 +2704,46 @@ function RunEventList({
   // are tracked explicitly.
   const sections = useMemo(() => {
     // Wrap a rendered block in the `data-evid` carrier the search bar scrolls
-    // to (`logRef.current?.querySelector('[data-evid="…"]')` in RunPanelBody)
-    // and, when it's the active match, a highlight ring. `evid` is `i` from
-    // the loop below — the position of this event within `normalised` (and so
-    // within `events`/`displayedEvents`), which is exactly the id scheme
-    // `event-search.ts` uses. The wrapper carries the key so the memoized
-    // block components underneath keep their identity/props untouched.
-    const wrap = (key: string, evid: number, node: React.ReactNode): React.ReactNode => (
-      <div
-        key={key}
-        data-evid={evid}
-        className={cn(evid === activeMatchId && "rounded-md ring-1 ring-primary/60 bg-primary/5")}
-      >
-        {node}
-      </div>
-    );
+    // to and imperatively highlights (`logRef.current?.querySelector('[data-
+    // evid="…"]')` in RunPanelBody — see the highlight effect there). `evid`
+    // is `i` from the loop below — the position of this event within
+    // `normalised` (and so within `events`/`displayedEvents`), which is
+    // exactly the id scheme `event-search.ts` uses. The wrapper carries the
+    // key so the memoized block components underneath keep their
+    // identity/props untouched. Only STATIC classes belong here — the
+    // highlight ring itself is toggled by the DOM effect in RunPanelBody, not
+    // by a render-time class, so this memo doesn't need `activeMatchId` as a
+    // dep (re-deriving the whole section tree on every match navigation was
+    // the point being fixed). `extraClassName` lets a specific stream (only
+    // `user`, below) opt into a class that has to live on THIS wrapper rather
+    // than on the block's own root — sticky positioning needs to be applied
+    // to the element that's actually the flex child of the scroll container.
+    // Returns `null` (no wrapper at all) when `node` is nullish, so an event
+    // with nothing to render (e.g. an unparseable orphan tool_result — see
+    // the `tool_result` case below) doesn't still leave a phantom empty div
+    // consuming a `gap-4` slot in the section's flex column.
+    const wrap = (
+      key: string,
+      evid: number,
+      node: React.ReactNode,
+      extraClassName?: string,
+    ): React.ReactNode => {
+      if (node === null || node === undefined) return null;
+      return (
+        <div key={key} data-evid={evid} className={extraClassName}>
+          {node}
+        </div>
+      );
+    };
     const renderEvent = (e: RunEvent, key: string, evid: number): React.ReactNode[] => {
       switch (e.stream) {
         case "user":
-          return [wrap(key, evid, <UserMessageBlock text={e.data} />)];
+          // Sticky positioning lives on this wrapper, not on
+          // `UserMessageBlock`'s own root — the wrapper is the actual flex
+          // child of the scroll container (`sections.map` below renders one
+          // `<section>` per user-message group), so THIS is the element that
+          // has to pin to `top-0` for the sticky header to work at all.
+          return [wrap(key, evid, <UserMessageBlock text={e.data} />, "sticky top-0 z-10")];
         case "assistant":
           return [wrap(key, evid, <AssistantBlock text={e.data} />)];
         case "thinking":
@@ -2671,7 +2756,11 @@ function RunEventList({
         }
         case "tool_result": {
           const parsed = safeParse<ParsedToolResult>(e.data);
-          if (parsed && parsed.toolUseId && resultByToolId.get(parsed.toolUseId)) return [];
+          // Unparseable JSON — `ToolResultBlock` would render nothing for it
+          // anyway (its `!result` guard), so skip the wrapper entirely rather
+          // than emitting an empty `data-evid` div.
+          if (!parsed) return [];
+          if (parsed.toolUseId && resultByToolId.get(parsed.toolUseId)) return [];
           return [wrap(key, evid, <ToolResultBlock result={parsed} />)];
         }
         case "status":
@@ -2716,7 +2805,7 @@ function RunEventList({
     current.body.push(...tail);
     if (current.header !== null || current.body.length > 0) out.push(current);
     return out;
-  }, [normalised, interactionByIndex, resultByToolId, onInteractionResolved, activeMatchId]);
+  }, [normalised, interactionByIndex, resultByToolId, onInteractionResolved]);
 
   return (
     <div className="flex flex-col gap-4">
@@ -2961,7 +3050,7 @@ const UserMessageBlock = memo(function UserMessageBlock({ text }: { text: string
   );
 
   return (
-    <div className="sticky top-0 z-10 flex justify-end">
+    <div className="flex justify-end">
       <div ref={bubbleRef} className="max-w-[85%] rounded-2xl rounded-br-md border border-primary/30 bg-card/50 px-3 py-1.5 text-foreground shadow-sm backdrop-blur-md">
         {parsed?.kind === "command-output" ? (
           <>

--- a/src/mainview/lib/event-search.test.ts
+++ b/src/mainview/lib/event-search.test.ts
@@ -1,0 +1,303 @@
+import { expect, test } from "bun:test";
+import type { RunEventStream } from "../../shared/types.ts";
+import {
+  findMatchingEventIds,
+  NO_MATCHES,
+  resolveActiveMatchIndex,
+  searchableEventText,
+  stepMatchIndex,
+} from "./event-search.ts";
+
+type Ev = { stream: RunEventStream; data: string };
+
+function ev(stream: RunEventStream, data: string): Ev {
+  return { stream, data };
+}
+
+// ---------------------------------------------------------------------------
+// searchableEventText
+// ---------------------------------------------------------------------------
+
+test("searchableEventText: passthrough streams return data verbatim", () => {
+  const passthrough: RunEventStream[] = ["user", "assistant", "thinking", "status", "stderr", "stdout"];
+  for (const stream of passthrough) {
+    expect(searchableEventText(stream, "hello world")).toBe("hello world");
+  }
+});
+
+test("searchableEventText: passthrough streams pass an empty string through unchanged", () => {
+  expect(searchableEventText("assistant", "")).toBe("");
+  expect(searchableEventText("stdout", "")).toBe("");
+});
+
+test("searchableEventText: interaction/interaction_resolved/subagent are never searchable", () => {
+  expect(searchableEventText("interaction", '{"anything":"here"}')).toBeNull();
+  expect(searchableEventText("interaction_resolved", '{"anything":"here"}')).toBeNull();
+  expect(searchableEventText("subagent", '{"anything":"here"}')).toBeNull();
+  // Even plain non-JSON text is still null — the stream itself is opaque, not the payload shape.
+  expect(searchableEventText("subagent", "plain text")).toBeNull();
+});
+
+test("searchableEventText: tool_use joins name + input text", () => {
+  const data = JSON.stringify({ id: "1", name: "Read", input: { file_path: "/a/b.ts" } });
+  const text = searchableEventText("tool_use", data);
+  expect(text).toBe(`Read ${JSON.stringify({ file_path: "/a/b.ts" })}`);
+  expect(text).toContain("Read");
+  expect(text).toContain("/a/b.ts");
+});
+
+test("searchableEventText: tool_use with a string input is used as-is (not re-stringified)", () => {
+  const data = JSON.stringify({ id: "1", name: "Bash", input: "ls -la" });
+  expect(searchableEventText("tool_use", data)).toBe("Bash ls -la");
+});
+
+test("searchableEventText: tool_use with only a name (no input) still surfaces the name", () => {
+  const data = JSON.stringify({ id: "1", name: "Read" });
+  expect(searchableEventText("tool_use", data)).toBe("Read");
+});
+
+test("searchableEventText: tool_use with empty name and input falls back to the raw payload", () => {
+  const data = JSON.stringify({ id: "1", name: "", input: "" });
+  expect(searchableEventText("tool_use", data)).toBe(data);
+});
+
+test("searchableEventText: tool_use with malformed JSON falls back to the raw string", () => {
+  const data = "{not valid json";
+  expect(searchableEventText("tool_use", data)).toBe(data);
+});
+
+test("searchableEventText: tool_use whose JSON parses to a non-object falls back to the raw string", () => {
+  expect(searchableEventText("tool_use", "42")).toBe("42");
+  expect(searchableEventText("tool_use", '"just a string"')).toBe('"just a string"');
+  expect(searchableEventText("tool_use", "null")).toBe("null");
+});
+
+test("searchableEventText: tool_use with empty data falls back to the empty raw string", () => {
+  expect(searchableEventText("tool_use", "")).toBe("");
+});
+
+test("searchableEventText: tool_result extracts string content", () => {
+  const data = JSON.stringify({ toolUseId: "1", content: "the file contents" });
+  expect(searchableEventText("tool_result", data)).toBe("the file contents");
+});
+
+test("searchableEventText: tool_result stringifies structured (non-string) content", () => {
+  const content = [{ type: "text", text: "needle in the haystack" }];
+  const data = JSON.stringify({ toolUseId: "1", content });
+  const text = searchableEventText("tool_result", data);
+  expect(text).toBe(JSON.stringify(content));
+  expect(text).toContain("needle in the haystack");
+});
+
+test("searchableEventText: tool_result with content explicitly null returns an empty string", () => {
+  const data = JSON.stringify({ toolUseId: "1", content: null });
+  expect(searchableEventText("tool_result", data)).toBe("");
+});
+
+test("searchableEventText: tool_result missing the content key falls back to the raw payload", () => {
+  const data = JSON.stringify({ toolUseId: "1" });
+  expect(searchableEventText("tool_result", data)).toBe(data);
+});
+
+test("searchableEventText: tool_result with malformed JSON falls back to the raw string", () => {
+  const data = "not json at all";
+  expect(searchableEventText("tool_result", data)).toBe(data);
+});
+
+test("searchableEventText: tool_result whose JSON parses to a non-object falls back to the raw string", () => {
+  expect(searchableEventText("tool_result", "[1,2,3]")).toBe("[1,2,3]");
+});
+
+test("searchableEventText: tool_result with empty data falls back to the empty raw string", () => {
+  expect(searchableEventText("tool_result", "")).toBe("");
+});
+
+// ---------------------------------------------------------------------------
+// findMatchingEventIds
+// ---------------------------------------------------------------------------
+
+test("findMatchingEventIds: case-insensitive substring match", () => {
+  const events = [ev("assistant", "Hello WORLD"), ev("assistant", "goodbye")];
+  expect(findMatchingEventIds(events, "world")).toEqual([0]);
+  expect(findMatchingEventIds(events, "WORLD")).toEqual([0]);
+  expect(findMatchingEventIds(events, "WoRlD")).toEqual([0]);
+});
+
+test("findMatchingEventIds: query is trimmed before matching", () => {
+  const events = [ev("assistant", "hello world")];
+  expect(findMatchingEventIds(events, "  world  ")).toEqual([0]);
+});
+
+test("findMatchingEventIds: blank query returns the NO_MATCHES sentinel", () => {
+  const events = [ev("assistant", "hello world")];
+  expect(findMatchingEventIds(events, "")).toBe(NO_MATCHES);
+});
+
+test("findMatchingEventIds: whitespace-only query returns the NO_MATCHES sentinel", () => {
+  const events = [ev("assistant", "hello world")];
+  expect(findMatchingEventIds(events, "   ")).toBe(NO_MATCHES);
+});
+
+test("findMatchingEventIds: empty events array returns the NO_MATCHES sentinel", () => {
+  expect(findMatchingEventIds([], "anything")).toBe(NO_MATCHES);
+});
+
+test("findMatchingEventIds: zero matches returns the NO_MATCHES sentinel", () => {
+  const events = [ev("assistant", "hello world"), ev("stdout", "goodbye")];
+  expect(findMatchingEventIds(events, "xyz-not-present")).toBe(NO_MATCHES);
+});
+
+test("findMatchingEventIds: returned ids are positions in the events array", () => {
+  const events = [
+    ev("assistant", "no match here"),
+    ev("assistant", "match one"),
+    ev("assistant", "no match here either"),
+    ev("assistant", "match two"),
+  ];
+  expect(findMatchingEventIds(events, "match")).toEqual([0, 1, 2, 3]);
+  expect(findMatchingEventIds(events, "one")).toEqual([1]);
+  expect(findMatchingEventIds(events, "two")).toEqual([3]);
+});
+
+test("findMatchingEventIds: non-searchable streams never match, even when the raw data contains the query", () => {
+  const events = [
+    ev("interaction", '{"question":"needle"}'),
+    ev("interaction_resolved", '{"answer":"needle"}'),
+    ev("subagent", '{"description":"needle"}'),
+  ];
+  expect(findMatchingEventIds(events, "needle")).toBe(NO_MATCHES);
+});
+
+test("findMatchingEventIds: tool_result folds into an earlier owning tool_use and matches at the tool_use index", () => {
+  const events = [
+    ev("tool_use", JSON.stringify({ id: "abc", name: "Bash", input: "ls" })),
+    ev("tool_result", JSON.stringify({ toolUseId: "abc", content: "needle output" })),
+  ];
+  // The match is on text that lives only in the folded result — the tool_use's
+  // own text ("Bash ls") does not contain "needle".
+  const matches = findMatchingEventIds(events, "needle");
+  expect(matches).toEqual([0]);
+  // The tool_result's own index must not also appear (no duplicate match).
+  expect(matches).not.toContain(1);
+});
+
+test("findMatchingEventIds: a match present in both the tool_use text and the folded result text still appears once", () => {
+  const events = [
+    ev("tool_use", JSON.stringify({ id: "abc", name: "needle-tool", input: "x" })),
+    ev("tool_result", JSON.stringify({ toolUseId: "abc", content: "needle output too" })),
+  ];
+  expect(findMatchingEventIds(events, "needle")).toEqual([0]);
+});
+
+test("findMatchingEventIds: orphan tool_result (no owning tool_use) matches at its own index", () => {
+  const events = [
+    ev("assistant", "unrelated"),
+    ev("tool_result", JSON.stringify({ toolUseId: "does-not-exist", content: "needle output" })),
+  ];
+  expect(findMatchingEventIds(events, "needle")).toEqual([1]);
+});
+
+test("findMatchingEventIds: a forward-referencing tool_result (owner appears later) is not folded and stays independently matchable at its own index", () => {
+  // Documented behavior: pass 2 only folds a tool_result into a tool_use whose
+  // index is strictly earlier (`ownerIdx >= i` is excluded). A tool_use that
+  // appears AFTER its tool_result in the array therefore never "owns" it — the
+  // result behaves exactly like an orphan and keeps its own index.
+  const events = [
+    ev("tool_result", JSON.stringify({ toolUseId: "abc", content: "needle output" })),
+    ev("tool_use", JSON.stringify({ id: "abc", name: "Bash", input: "ls" })),
+  ];
+  expect(findMatchingEventIds(events, "needle")).toEqual([0]);
+});
+
+test("findMatchingEventIds: a tool_use with an empty id never registers as an owner", () => {
+  const events = [
+    ev("tool_use", JSON.stringify({ id: "", name: "Bash", input: "ls" })),
+    // toolUseId is also empty here, so this is really an orphan by the same rule,
+    // but the point under test is that an empty-id tool_use never gets registered
+    // in the owner map in the first place.
+    ev("tool_result", JSON.stringify({ toolUseId: "", content: "needle output" })),
+  ];
+  expect(findMatchingEventIds(events, "needle")).toEqual([1]);
+});
+
+test("findMatchingEventIds: multiple tool_results folding into the same owner all contribute, none duplicate", () => {
+  const events = [
+    ev("tool_use", JSON.stringify({ id: "abc", name: "Bash", input: "ls" })),
+    ev("tool_result", JSON.stringify({ toolUseId: "abc", content: "first needle" })),
+    ev("assistant", "filler"),
+    ev("tool_result", JSON.stringify({ toolUseId: "abc", content: "second needle" })),
+  ];
+  // Both results fold into the same owner (index 0); neither result index
+  // (1 or 3) appears as its own match, and the owner appears only once.
+  expect(findMatchingEventIds(events, "needle")).toEqual([0]);
+  expect(findMatchingEventIds(events, "first")).toEqual([0]);
+  expect(findMatchingEventIds(events, "second")).toEqual([0]);
+});
+
+// ---------------------------------------------------------------------------
+// stepMatchIndex
+// ---------------------------------------------------------------------------
+
+test("stepMatchIndex: zero matches always returns -1", () => {
+  expect(stepMatchIndex(0, -1, 1)).toBe(-1);
+  expect(stepMatchIndex(0, -1, -1)).toBe(-1);
+  expect(stepMatchIndex(0, 0, 1)).toBe(-1);
+});
+
+test("stepMatchIndex: unseeded current (-1) forward lands on the first match", () => {
+  expect(stepMatchIndex(5, -1, 1)).toBe(0);
+});
+
+test("stepMatchIndex: unseeded current (-1) backward lands on the last match", () => {
+  expect(stepMatchIndex(5, -1, -1)).toBe(4);
+});
+
+test("stepMatchIndex: any negative current is treated as unseeded", () => {
+  expect(stepMatchIndex(5, -7, 1)).toBe(0);
+  expect(stepMatchIndex(5, -7, -1)).toBe(4);
+});
+
+test("stepMatchIndex: forward wraps from the last match back to the first", () => {
+  expect(stepMatchIndex(3, 2, 1)).toBe(0);
+});
+
+test("stepMatchIndex: backward wraps from the first match back to the last", () => {
+  expect(stepMatchIndex(3, 0, -1)).toBe(2);
+});
+
+test("stepMatchIndex: forward/backward step within bounds without wrapping", () => {
+  expect(stepMatchIndex(5, 1, 1)).toBe(2);
+  expect(stepMatchIndex(5, 3, -1)).toBe(2);
+});
+
+test("stepMatchIndex: single-match list always resolves back to position 0", () => {
+  expect(stepMatchIndex(1, -1, 1)).toBe(0);
+  expect(stepMatchIndex(1, -1, -1)).toBe(0);
+  expect(stepMatchIndex(1, 0, 1)).toBe(0);
+  expect(stepMatchIndex(1, 0, -1)).toBe(0);
+});
+
+// ---------------------------------------------------------------------------
+// resolveActiveMatchIndex
+// ---------------------------------------------------------------------------
+
+test("resolveActiveMatchIndex: empty matches always resolves to -1, regardless of prevActiveId", () => {
+  expect(resolveActiveMatchIndex([], null)).toBe(-1);
+  expect(resolveActiveMatchIndex([], 3)).toBe(-1);
+});
+
+test("resolveActiveMatchIndex: null prevActiveId defaults to the first match (position 0)", () => {
+  expect(resolveActiveMatchIndex([5, 8, 12], null)).toBe(0);
+});
+
+test("resolveActiveMatchIndex: prevActiveId still present keeps pointing at its (possibly shifted) position", () => {
+  expect(resolveActiveMatchIndex([5, 8, 12], 12)).toBe(2);
+  expect(resolveActiveMatchIndex([5, 8, 12], 5)).toBe(0);
+  // Position shifted from a previous recompute (12 used to be first, now last)
+  // but the same event id (12) stays selected via its new position.
+  expect(resolveActiveMatchIndex([8, 5, 12], 12)).toBe(2);
+});
+
+test("resolveActiveMatchIndex: prevActiveId no longer present defaults to the first match (position 0)", () => {
+  expect(resolveActiveMatchIndex([5, 8, 12], 999)).toBe(0);
+});

--- a/src/mainview/lib/event-search.ts
+++ b/src/mainview/lib/event-search.ts
@@ -3,10 +3,13 @@
 // the matching/navigation math can be unit-tested without a DOM harness —
 // this repo has no jsdom/testing-library, so anything that touches the log's
 // actual React tree has to be validated by testing the logic it's driven by
-// instead. RunPanel itself owns the client-assigned `id` scheme it hands to
-// `findMatchingEventIds` (an index into whatever event list is currently
-// displayed, since the server doesn't guarantee a stable id across every
-// source an event can come from — see `StreamEvent` in RunPanel.tsx).
+// instead. `findMatchingEventIds` uses each event's position in the array
+// RunPanel hands it (`displayedEvents`, in `RunEvent` order) as the match id
+// — the server doesn't guarantee a stable id across every source an event
+// can come from (live SSE vs. a JSONL rebuild splice — see `StreamEvent` in
+// RunPanel.tsx), but a positional index scoped to "whatever's currently
+// displayed" is always available, and it's exactly what the log's
+// `data-evid` DOM attribute is keyed on too.
 import type { RunEventStream } from "../../shared/types.ts";
 
 /** Best-effort JSON.parse that never throws — malformed/partial JSON (e.g. a
@@ -34,13 +37,16 @@ function textOf(value: unknown): string {
 }
 
 /**
- * Human-visible search text for one event, mirroring exactly what
- * `RunEventList` renders for that `stream` — so a match always corresponds to
- * something the user can actually see on screen. Returns `null` for streams
- * the log never renders (`interaction`/`interaction_resolved` are consumed
- * into interaction cards keyed by request id, not by event; `subagent` is a
- * tab-strip lifecycle delta, not a transcript line) — those events can never
- * match a query.
+ * Search text for one event's own JSON/string payload. This is raw event
+ * data — a superset/approximation of what `RunEventList` actually renders,
+ * not a faithful re-implementation of it (no markdown formatting, no
+ * per-tool input summarizer, no truncated-JSON repair) — good enough to
+ * decide "does this event contain the query," not a guarantee that every
+ * matched substring is visible verbatim on screen. Returns `null` for
+ * streams the log never renders as their own block (`interaction`/
+ * `interaction_resolved` are consumed into interaction cards keyed by
+ * request id, not by event; `subagent` is a tab-strip lifecycle delta, not a
+ * transcript line) — those events can never match a query.
  *
  * `tool_use`/`tool_result` carry JSON (`{ id, name, input }` /
  * `{ toolUseId, content }` per the `RunEvent` doc comment in shared/types.ts);
@@ -76,32 +82,91 @@ export function searchableEventText(stream: RunEventStream, data: string): strin
   }
 }
 
-/** Minimal shape `findMatchingEventIds` needs — RunPanel maps its
- *  `displayedEvents` (whatever shape those happen to be — live `StreamEvent`s
- *  with a client id, or `RunEvent`s replayed from a JSONL rebuild with none)
- *  into this before calling in, assigning `id` fresh each time. */
-export interface SearchableEvent {
-  id: number;
-  stream: RunEventStream;
-  data: string;
-}
+/** Frozen empty-matches sentinel, returned (rather than a fresh `[]`)
+ *  whenever there's nothing to match — a blank/whitespace query, an empty
+ *  `events` array, or a query with zero hits — so callers get a stable
+ *  identity for "no results" instead of a new array reference every call. */
+export const NO_MATCHES: readonly number[] = Object.freeze([]);
 
 /**
- * Ids (in `events` order) of every event whose searchable text contains
- * `query`, case-insensitively. `query` is trimmed first — an empty/whitespace
- * query matches nothing (search is "off", not "match everything").
+ * Ids (positions in `events`, matching the `data-evid` attribute
+ * `RunEventList` renders) of every event whose searchable text contains
+ * `query`, case-insensitively. `query` is trimmed first — an empty/
+ * whitespace query matches nothing (search is "off", not "match
+ * everything") — and an empty `events` array always matches nothing.
+ *
+ * `RunEventList` folds a `tool_result` into the `ToolUseBlock` of the
+ * `tool_use` it answers (paired by `toolUseId` ↔ `id`, matching the
+ * `ParsedToolUse`/`ParsedToolResult` shapes in RunPanel.tsx) whenever that
+ * owning call appears earlier in the stream — the standalone "orphan tool
+ * result" card only renders when no such owner exists. A search match has
+ * to land on a DOM block that's actually rendered, so this mirrors that
+ * fold: a `tool_result` with an earlier owning `tool_use` is excluded from
+ * matching at its own index, and its text is appended to the owner's
+ * searchable text instead. An orphan `tool_result` (no owner, or the
+ * "owner" only appears later / never arrives) stays independently matchable
+ * at its own index, same as every other stream.
  */
-export function findMatchingEventIds(events: ReadonlyArray<SearchableEvent>, query: string): number[] {
+export function findMatchingEventIds(
+  events: ReadonlyArray<{ stream: RunEventStream; data: string }>,
+  query: string,
+): readonly number[] {
   const trimmed = query.trim();
-  if (!trimmed) return [];
+  if (!trimmed || events.length === 0) return NO_MATCHES;
   const needle = trimmed.toLowerCase();
-  const out: number[] = [];
-  for (const e of events) {
-    const text = searchableEventText(e.stream, e.data);
-    if (text === null) continue;
-    if (text.toLowerCase().includes(needle)) out.push(e.id);
+
+  // Pass 1: each event's own searchable text, plus a toolUseId → index map
+  // for every tool_use that published a non-empty id (legacy normalized
+  // events carry `id: ""`, which is falsy and deliberately never
+  // registered as an owner — an orphan id can't own anything).
+  const ownText: (string | null)[] = new Array(events.length);
+  const toolUseIndexById = new Map<string, number>();
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i]!;
+    ownText[i] = searchableEventText(e.stream, e.data);
+    if (e.stream === "tool_use") {
+      const parsed = tryParseJson(e.data) as { id?: unknown } | null;
+      const id = parsed && typeof parsed === "object" ? parsed.id : undefined;
+      if (typeof id === "string" && id) toolUseIndexById.set(id, i);
+    }
   }
-  return out;
+
+  // Pass 2: fold each owned tool_result's text into its owner's entry, and
+  // mark the tool_result's own index as owned so pass 3 skips it as a
+  // separate match target.
+  const foldedText = new Map<number, string[]>();
+  const owned = new Array<boolean>(events.length).fill(false);
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i]!;
+    if (e.stream !== "tool_result") continue;
+    const parsed = tryParseJson(e.data) as { toolUseId?: unknown } | null;
+    const toolUseId = parsed && typeof parsed === "object" ? parsed.toolUseId : undefined;
+    if (typeof toolUseId !== "string" || !toolUseId) continue;
+    const ownerIdx = toolUseIndexById.get(toolUseId);
+    // Only an EARLIER tool_use counts as an owner — RunEventList only ever
+    // folds a result into a call it has already rendered, never one that
+    // hasn't arrived yet (or itself, which can't happen, but >= guards it).
+    if (ownerIdx === undefined || ownerIdx >= i) continue;
+    owned[i] = true;
+    const text = ownText[i];
+    if (text) {
+      const list = foldedText.get(ownerIdx);
+      if (list) list.push(text);
+      else foldedText.set(ownerIdx, [text]);
+    }
+  }
+
+  // Pass 3: match. An owned tool_result contributes no match of its own —
+  // its text was folded into the owner above instead.
+  const out: number[] = [];
+  for (let i = 0; i < events.length; i++) {
+    if (owned[i]) continue;
+    const extra = foldedText.get(i);
+    const text = extra ? `${ownText[i] ?? ""} ${extra.join(" ")}` : ownText[i];
+    if (!text) continue;
+    if (text.toLowerCase().includes(needle)) out.push(i);
+  }
+  return out.length > 0 ? out : NO_MATCHES;
 }
 
 /**
@@ -128,7 +193,7 @@ export function stepMatchIndex(matchCount: number, current: number, dir: 1 | -1)
  * previous match scrolled out of the matched set, should land on the top hit
  * rather than nothing. Returns -1 when there are no matches at all.
  */
-export function resolveActiveMatchIndex(matches: number[], prevActiveId: number | null): number {
+export function resolveActiveMatchIndex(matches: ReadonlyArray<number>, prevActiveId: number | null): number {
   if (matches.length === 0) return -1;
   if (prevActiveId !== null) {
     const idx = matches.indexOf(prevActiveId);

--- a/src/mainview/lib/event-search.ts
+++ b/src/mainview/lib/event-search.ts
@@ -1,0 +1,138 @@
+// Pure search-over-events logic for the task-details message stream
+// (RunPanel). Kept DOM-free (like subagent-tabs.ts / command-message.ts) so
+// the matching/navigation math can be unit-tested without a DOM harness —
+// this repo has no jsdom/testing-library, so anything that touches the log's
+// actual React tree has to be validated by testing the logic it's driven by
+// instead. RunPanel itself owns the client-assigned `id` scheme it hands to
+// `findMatchingEventIds` (an index into whatever event list is currently
+// displayed, since the server doesn't guarantee a stable id across every
+// source an event can come from — see `StreamEvent` in RunPanel.tsx).
+import type { RunEventStream } from "../../shared/types.ts";
+
+/** Best-effort JSON.parse that never throws — malformed/partial JSON (e.g. a
+ *  tool input truncated by an older agetor mapper) falls back to `null`
+ *  rather than blowing up the search. */
+function tryParseJson(data: string): unknown {
+  try {
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
+}
+
+/** Render a JSON value as search-friendly text: pass strings through as-is,
+ *  stringify anything else (objects/arrays/numbers) so nested tool input/
+ *  result text is still searchable. */
+function textOf(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined || value === null) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Human-visible search text for one event, mirroring exactly what
+ * `RunEventList` renders for that `stream` — so a match always corresponds to
+ * something the user can actually see on screen. Returns `null` for streams
+ * the log never renders (`interaction`/`interaction_resolved` are consumed
+ * into interaction cards keyed by request id, not by event; `subagent` is a
+ * tab-strip lifecycle delta, not a transcript line) — those events can never
+ * match a query.
+ *
+ * `tool_use`/`tool_result` carry JSON (`{ id, name, input }` /
+ * `{ toolUseId, content }` per the `RunEvent` doc comment in shared/types.ts);
+ * malformed JSON (legacy truncated payloads, corrupt persisted rows) falls
+ * back to the raw string rather than throwing, same as every other
+ * best-effort JSON.parse over transcript data in this codebase.
+ */
+export function searchableEventText(stream: RunEventStream, data: string): string | null {
+  switch (stream) {
+    case "interaction":
+    case "interaction_resolved":
+    case "subagent":
+      return null;
+    case "tool_use": {
+      const parsed = tryParseJson(data) as { name?: unknown; input?: unknown } | null;
+      if (!parsed || typeof parsed !== "object") return data;
+      const parts = [textOf(parsed.name), textOf(parsed.input)].filter((s) => s !== "");
+      return parts.length > 0 ? parts.join(" ") : data;
+    }
+    case "tool_result": {
+      const parsed = tryParseJson(data) as { content?: unknown } | null;
+      if (!parsed || typeof parsed !== "object" || !("content" in parsed)) return data;
+      return textOf(parsed.content);
+    }
+    case "user":
+    case "assistant":
+    case "thinking":
+    case "status":
+    case "stderr":
+    case "stdout":
+    default:
+      return data;
+  }
+}
+
+/** Minimal shape `findMatchingEventIds` needs — RunPanel maps its
+ *  `displayedEvents` (whatever shape those happen to be — live `StreamEvent`s
+ *  with a client id, or `RunEvent`s replayed from a JSONL rebuild with none)
+ *  into this before calling in, assigning `id` fresh each time. */
+export interface SearchableEvent {
+  id: number;
+  stream: RunEventStream;
+  data: string;
+}
+
+/**
+ * Ids (in `events` order) of every event whose searchable text contains
+ * `query`, case-insensitively. `query` is trimmed first — an empty/whitespace
+ * query matches nothing (search is "off", not "match everything").
+ */
+export function findMatchingEventIds(events: ReadonlyArray<SearchableEvent>, query: string): number[] {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+  const needle = trimmed.toLowerCase();
+  const out: number[] = [];
+  for (const e of events) {
+    const text = searchableEventText(e.stream, e.data);
+    if (text === null) continue;
+    if (text.toLowerCase().includes(needle)) out.push(e.id);
+  }
+  return out;
+}
+
+/**
+ * Step the active-match *position* (an index into the `matches` array — not
+ * an event id) by one, wrapping around both ends. Pass `current = -1` for
+ * "nothing selected yet": stepping forward lands on the first match, backward
+ * lands on the last. Returns -1 when there's nothing to select.
+ */
+export function stepMatchIndex(matchCount: number, current: number, dir: 1 | -1): number {
+  if (matchCount === 0) return -1;
+  if (current < 0) return dir === 1 ? 0 : matchCount - 1;
+  return (current + dir + matchCount) % matchCount;
+}
+
+/**
+ * Recompute the active-match *position* (matching `stepMatchIndex`'s
+ * index-into-`matches` convention) after `matches` is recomputed — e.g. on
+ * every keystroke, or when the underlying event list shifts under an open
+ * search. If `prevActiveId` (the event id that was active before this
+ * recompute) is still present in the new `matches`, keep pointing at it —
+ * its position may have shifted, but the same event stays selected instead
+ * of navigation progress silently resetting on every keystroke. Otherwise
+ * default to the first match (position 0): a fresh query, or one whose
+ * previous match scrolled out of the matched set, should land on the top hit
+ * rather than nothing. Returns -1 when there are no matches at all.
+ */
+export function resolveActiveMatchIndex(matches: number[], prevActiveId: number | null): number {
+  if (matches.length === 0) return -1;
+  if (prevActiveId !== null) {
+    const idx = matches.indexOf(prevActiveId);
+    if (idx !== -1) return idx;
+  }
+  return 0;
+}


### PR DESCRIPTION
## What

Adds in-panel search over the task details modal's unified message stream (RunPanel):

- **Search toggle** in the panel header, plus **Cmd+F** (Ctrl+F off-mac) while the panel is open — guarded against open dialogs/popovers, embedded xterm terminals (`Ctrl+F` is a PTY/emacs binding), and the panel's closing animation.
- **Search bar** with case-insensitive matching, `n/N` match counter, prev/next buttons, Enter / Shift+Enter navigation, and Escape that closes the bar *before* the panel (one layer per press, coordinated via a `[data-search-open]` DOM marker since `stopPropagation` doesn't work across same-document listeners).
- Navigating scrolls the matched event block to center and highlights it with a ring. Works on subagent tabs and archived tasks (search is read-only, so it isn't gated on `activeStream === "main"`).

## How

- Pure matching logic lives in a new **`src/mainview/lib/event-search.ts`** (no React imports, per repo convention): searchable-text extraction per stream type, match filtering, and wraparound navigation math. Covered by 43 tests in `event-search.test.ts`.
- **Tool-result folding**: well-formed `tool_result` events render *inside* their owning `ToolUseBlock`, so they have no DOM block of their own. The matcher pairs results to their tool_use by `toolUseId` and surfaces the match at the tool_use's index — matches always land on a real element. Orphan results stay independently matchable.
- **Perf-safe highlighting**: the active match is applied imperatively (classList on the `data-evid` wrapper) instead of threading state through the perf-critical `sections` useMemo — a memo dep there re-renders every tool card per keystroke because `safeParse` produces fresh props each rebuild. No intra-markdown `<mark>` in v1 for the same reason (hoisted `ReactMarkdown` components must keep stable identity).
- Match ids are **positional indices** into `displayedEvents` (JSONL-rebuilt splice events carry no client id); active-match state resets when the scope changes (task, stream tab, or rebuilt-snapshot identity).
- Sticky user-message headers keep pinning: the sticky classes moved onto the new outermost per-event wrapper for `user` events.

## Verification

- `bun run typecheck` green.
- `bun test` → 1765 pass / 1 skip / 2 fail — both failures are pre-existing daemon integration tests (`daemon-boot`, `daemon-handoff`) that can't find `bun` on the sandbox `$PATH`; unrelated to this branch.
- Opus code-review pass surfaced 15 findings (5 major); all fixed in `d4fb36a`.

Plan doc: `docs/plans/task-details-messages-search.md` (built via the `/implement` workflow in autonomous mode — assumptions logged in §8: active-tab-only scope, event-level matches, ephemeral search state).