### PR TITLE
fix: reduce idle CPU and memory — 30min idle-session reaper, timer hygiene, capped event replay, memoized board

### DIFF
--- a/docs/plans/reduce-cpu-and-memory.md
+++ b/docs/plans/reduce-cpu-and-memory.md
@@ -1,0 +1,97 @@
+# Plan — Reduce Agetor CPU and Memory
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-29 |
+| Source | /implement "Agetor is using a bunch of memory and CPU… a bunch of `node` processes" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/reduce-agetor-cpu-and-memory |
+| Base SHA | ce9177b34816982f2aeebbba15fefb8dde8bd827 |
+
+## 1. Objective & success criteria
+
+Make Agetor stop accumulating idle agent processes and stop doing unbounded/continuous background work.
+
+Success criteria:
+- No claude REPL (the "node" processes, ~300–500MB each) survives more than ~30min past its last activity when no turn is in flight and no prompt is pending. Follow-ups on reaped tasks still work via `claude --resume`.
+- The Bun main process's idle CPU drops materially (target: from ~3.7% toward <1% with no running tasks) — per-session timers stop multiplying with lingering sessions, hot routes stop doing per-row scans.
+- Opening a task with thousands of events replays a bounded recent window (~800 events) instead of full history; "Load earlier" pages backward on demand.
+- The webview stops re-rendering the full board every 2s when nothing changed, and pauses polling while the window is hidden.
+- `bun run typecheck` and `bun test` green.
+
+Owner decisions (recorded 2026-07-29): reap after ~30min idle; history cap **with** "Load earlier" button; disk/worktree/DB retention **out of scope** (peer task owns the Worktrees stale-modal surface).
+
+## 2. Context & constraints (grounded findings)
+
+**Root cause A — sessions and their timers only die on delete/archive/agent-switch.**
+- `attachDoneHandler` (`orchestrator.ts:956-1022`) never drops the session on run finish; app quit (`index.ts:323`) never touches tmux. Idle REPLs live forever (observed: two ~23h-old sessions, 6 total, 280–520MB RSS each).
+- Each lingering claude session keeps running: `scrapeTimer` — sync `Bun.spawnSync(tmux capture-pane)` every 2–10s (`claude-tmux.ts:3407,3236,972`); `pollTimer` — 400ms JSONL stat backstop (`claude-tmux.ts:3634`); `deathTimer` — 400ms (idle-gated, cheap; `claude-tmux.ts:3591-3620`); subagent watcher — `readdirSync` every 4s (`claude-subagents.ts:69-73,636-641`). All disposed only via `disposeSessionState` from `dropSession`.
+- The scraper must NEVER be fully stopped while a session lives: native AskUserQuestion writes no JSONL — a prior bug (knowledge entry 6e8074e3) was caused by hard-stopping the idle scraper. Bounding session lifetime via the reaper is the fix, not stopping the scraper.
+- Resume path already exists: `sendClaudeTurn` (`orchestrator.ts:1504`) falls back to `spawnResumedSession` (`orchestrator.ts:1681`) using persisted `runs.claude_session_id` → `claude --resume <id>` (`agents.ts:305-306`). Kill must go through `dropSession` (dispose-then-kill) so `hasSessionState` turns false and the death-watch can't misfire.
+- HARD RULE: never enumerate-and-kill `agetor-*` sessions (shared tmux socket; commits 3204c4f, b9fcd68). Every kill keyed to a task id from THIS instance's DB.
+- Codex needs no reaping — sessions are one-shot per turn and self-dispose (`codex-tmux.ts:329-342`).
+
+**Root cause B — hot routes do full-history synchronous work.**
+- `GET /tasks` every 2s: `tasks.list()` (`db.ts:195-201`) joins all tasks × all runs (2,131), and `toTask` (`db.ts:153-182`) calls `countPendingForTask` + `countTerminals` per row (two linear map scans × 289 tasks per poll).
+- SSE replay `runs.eventsForTask` (`db.ts:738-749`) has no LIMIT (worst task: 4,764 events; 134k rows / 201MB total) and `runs.task_id` has no index (only `idx_run_events_run` exists).
+
+**Root cause C — webview renders everything, always.**
+- `App.tsx:122-128,168`: unconditional 2s `setTasks(list)` with fresh identities, no equality guard; `setSelected(fresh)` force-renders the open RunPanel every tick (`App.tsx:178-182`). No `React.memo` on `Column`/`TaskCard`; handlers (`App.tsx:463-562`) re-created every render. `/harnesses` poll every 15s (`App.tsx:129-135,169`). No visibility gating anywhere.
+- RunPanel: 2s `/runs` poll (`RunPanel.tsx:362-374`) and 2s `/subagents` poll (`RunPanel.tsx:380-400`) run even for finished tasks / hidden window. `events` state unbounded (`RunPanel.tsx:258,436`). June fixes (memoized blocks, section useMemo, rAF-batched buffer with visibility flush — `lib/event-buffer.ts`) are present; keep them intact.
+- Prior bug constraint: WKWebView suspends rAF when occluded (knowledge entry 2955efba) — any visibility gating MUST refresh immediately on `visibilitychange`→visible/focus, mirroring the existing `flushNow` wiring (`RunPanel.tsx:474-477`).
+
+## 3. Approach & key decisions
+
+1. **Idle-session reaper** (solves RAM + most idle CPU at once): a periodic orchestrator sweep, candidates strictly from own DB, killed via `dropSession`. Covers both in-memory sessions (live `SessionState`) and orphan-alive sessions with no in-memory state (post-restart done/review tasks — the 23h-old case) by probing `sessionLiveness(sessionNameFor(task.id))` per own-DB task id (allowed: keyed probe, not an enumerate sweep).
+   - Idle source: new `lastActivityAtFor(taskId)` on `SessionState` (bumped on JSONL bytes, scrape change, turn start/end, user paste); fallback `task.updatedAt` when no in-memory state.
+   - Guards (all must pass): agent is claude-code; task not archived-pending; `!active.has(task.runId)`; not held by background agents; zero pending interactions for the task; idle ≥ `IDLE_SESSION_REAP_MS` (30min). Re-check guards immediately before the kill.
+   - Emits a `status` event on the task's latest run ("session hibernated after idle — next message resumes it") for visibility.
+   - Cadence: sweep every 5min (`index.ts` interval, after `reconcileOrphans` at boot). Never touches codex sessions.
+2. **Session timer hygiene** (for the ≤30min window a session is alive but idle): back the 400ms `pollTimer` off to 5s after 30s of JSONL quiet (fs.watch stays primary; any watch event or turn start resets to 400ms). Slow the subagent watcher to 10s when idle with no subagents ever discovered. Scraper ladder unchanged (AskUserQuestion constraint). Death watch unchanged.
+3. **Route/db work**: compute pending-interaction and terminal counts as grouped maps once per `/tasks` request instead of per-row scans; add migration `026_runs_task_id_index.sql` (`CREATE INDEX idx_runs_task ON runs(task_id)`); `eventsForTask` gains `{ beforeId?, limit? }` — SSE replay sends only the most recent `EVENTS_REPLAY_LIMIT` (800) events plus a `replay_meta` frame (earliest replayed event id + hasMore); new route `GET /tasks/:id/events/page?beforeId=&limit=` returns older pages (raw JSON array, newest-last).
+4. **Webview**: equality-guard `setTasks`/`setSelected` (per-task shallow compare on `updatedAt`+identity fields, keep previous object identities for unchanged tasks); `React.memo` on `Column`+`TaskCard` with `useCallback` handlers; pause all polls when `document.hidden`, immediate refresh on visible/focus; RunPanel stops `/runs`+`/subagents` polls when the latest run is terminal and no subagent is running (SSE + visibility-return re-arm); consume `replay_meta` → "Load earlier" button prepends pages; cap live `events` growth at `EVENTS_WINDOW_MAX` (3000) by trimming oldest and marking hasMore.
+5. Shared constants/types (`IDLE_SESSION_REAP_MS`, `EVENTS_REPLAY_LIMIT`, `EVENTS_WINDOW_MAX`, `replay_meta` type) land in `src/shared/types.ts` in a pre-wave commit by the orchestrator so no two agents touch that file.
+
+Alternatives considered: replacing 2s polling with pure SSE push (bigger blast radius, App.tsx already keeps `selected` in sync from polls — deferred); stopping the idle scraper entirely (rejected — regresses the post-review AskUserQuestion bug); keep-N-warm LRU sessions (unneeded complexity at 30min threshold).
+
+## 4. Work breakdown — implementation tasks
+
+**Wave 0 (orchestrator inline):**
+- **T0** — shared constants/types. Owns: `src/shared/types.ts` only. Add `IDLE_SESSION_REAP_MS`, `SESSION_REAP_SWEEP_MS`, `EVENTS_REPLAY_LIMIT`, `EVENTS_WINDOW_MAX`, `TASK_EVENTS_REPLAY_META` type/marker. Acceptance: typecheck green.
+
+**Wave 1 (3 agents, disjoint):**
+- **T1 — session timer hygiene + idle metadata.** Owns: `src/bun/claude-tmux.ts`, `src/bun/claude-subagents.ts`. Add `lastActivityAt` tracking on `SessionState` + export `sessionIdleInfo(taskId): { idleMs: number } | null`; pollTimer idle backoff (400ms→5s after 30s quiet, reset on watch event/turn); subagent watcher idle backoff (→10s). Must NOT change scraper ladder, death watch, or any kill path. Acceptance: exports exactly `sessionIdleInfo` as specified; existing tests pass.
+- **T2 — routes + db paging.** Owns: `src/bun/server.ts`, `src/bun/db.ts`, `src/bun/interactions.ts`, `src/bun/terminals.ts`, `src/bun/migrations/026_runs_task_id_index.sql`, `src/bun/migrations/index.ts`. Grouped `pendingCountsByTask()` / `terminalCountsByTask()` consumed by the `/tasks` route via `tasks.list()` (thread maps into `toTask` or map after); migration for `idx_runs_task`; `eventsForTask(taskId, { beforeId, limit })`; SSE replay capped at `EVENTS_REPLAY_LIMIT` + `replay_meta` first frame; new route `GET /tasks/:id/events/page`. Do not touch orchestrator.ts.
+- **T3 — webview board.** Owns: `src/mainview/App.tsx`, `src/mainview/components/kanban/Column.tsx`, `src/mainview/components/kanban/TaskCard.tsx`. Equality guard preserving object identity for unchanged tasks; memo + useCallback; visibility gating of `/tasks` + `/harnesses` polls with immediate-refresh-on-visible. Do not touch RunPanel.
+
+**Wave 2 (2 agents, disjoint; depends on Wave 1):**
+- **T4 — idle-session reaper.** Owns: `src/bun/orchestrator.ts`, `src/bun/index.ts`. `reapIdleSessions()` per §3.1 (uses T1's `sessionIdleInfo`, existing `dropSession`, `sessionLiveness`, `sessionNameFor`, `interactions.countPendingForTask`, `subagents.hasRunning`); wire 5min interval + post-boot sweep in `index.ts`; status event on reap. Never enumerate tmux; never touch codex.
+- **T5 — RunPanel history window + poll gating.** Owns: `src/mainview/components/kanban/RunPanel.tsx`, `src/mainview/lib/api.ts`. Consume `replay_meta`; "Load earlier" button → `GET /tasks/:id/events/page` prepend (keep dedup + section memo correctness); cap live `events` at `EVENTS_WINDOW_MAX`; stop `/runs` + `/subagents` polls when latest run terminal & no running subagents (re-arm on SSE run-status/subagent events and on visibility return); visibility-gate both polls.
+
+## 5. Work breakdown — test tasks
+
+- **TT1** (covers T4): `src/bun/session-reaper.test.ts` — reaper guards: skips in-flight run, pending interaction, held-by-subagents, young session; reaps stale one (fake driver `AGETOR_CLAUDE_DRIVER=fake`, temp `AGETOR_DATA_DIR`, no real tmux); reap → `hasSessionState` false → follow-up routes to resume path.
+- **TT2** (covers T2): `src/bun/db-events-paging.test.ts` — `eventsForTask` limit/beforeId semantics, replay meta boundary (exactly-limit, fewer-than-limit, paging to exhaustion), migration applies idempotently.
+- Webview has no test harness in-repo — T3/T5 verified by typecheck + `bunx vite build` + manual smoke.
+
+## 6. Execution waves
+
+- Wave 0: T0 (orchestrator, inline) → commit.
+- Wave 1: T1 ∥ T2 ∥ T3 → typecheck + test → commit.
+- Wave 2: T4 ∥ T5 → typecheck + test → commit.
+- Then: review (opus) → tests creation (TT1 ∥ TT2, sonnet) → run (haiku) → fixes.
+
+## 7. Blast radius & risks
+
+- Reaper kills a session the user was about to reply to → mitigated by 30min threshold + pending-interaction/in-flight guards + status event + working `--resume` fallback; worst case is a few seconds' cold start.
+- Legacy tasks with no `claude_session_id` on any run degrade to a fresh context-less session after reap (`orchestrator.ts:1674-1676` already tolerates) — reaper logs a warning status in that case.
+- Replay cap: DiffDialog/compose flows read live state, not replay — unaffected. Dedup keys (`event-dedup.ts` caps) remain valid with windowed events.
+- Poll gating on hidden window: must not regress the "freezes until nudge" fix — every gate pairs with an immediate visible/focus refresh.
+- `bun test` on shared tmux socket: reaper tests must use the fake driver / test socket (`AGETOR_TMUX_SOCKET`), temp data dir — never the user's real socket/repo.
+- Peer overlap: a peer task is fixing the Worktrees stale-modal delete button — this plan does not touch `worktrees/*` UI or `archiveTask`/`deleteTask` semantics.
+
+## 8. Open questions / assumptions
+
+- Assumed 800 as the replay window and 3000 as the live cap (owner approved "cap + load earlier" without exact numbers; constants centralized in T0, trivial to tune).
+- Assumed reap sweep every 5min is fine (not asked; bounded staleness 30–35min).
+- Assumed emitting a status event on reap is desirable visibility (investigation recommendation; harmless).

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -71,6 +71,18 @@ const FAST_POLL_MS = 600;
  *  completed-but-undeleted tasks shouldn't burn CPU; mirrors the main scraper's
  *  idle-throttle lesson. */
 const SLOW_POLL_MS = 4000;
+/** Deeper idle tier: once this watcher has discovered zero subagents for the
+ *  task AND seen no discovery / dir-watcher event for `DEEP_IDLE_AFTER_MS`,
+ *  back off further to this cadence. Covers the common case of a task whose
+ *  agent never spawns a sub-agent at all — most tasks — which otherwise pays
+ *  `SLOW_POLL_MS` (a `readdirSync`) forever. Any discovery or dir-watcher
+ *  event drops the task back to `FAST_POLL_MS` via the normal `tick` path (a
+ *  discovery makes `files.size > 0`, which permanently disqualifies this
+ *  tier for the watcher's lifetime). */
+const DEEP_IDLE_POLL_MS = 10_000;
+/** How long with zero discovered subagents and no dir/discovery activity
+ *  before backing off to `DEEP_IDLE_POLL_MS`. */
+const DEEP_IDLE_AFTER_MS = 60_000;
 /** After a subagent's transcript shows an end_turn and then goes quiet for this
  *  long, treat it as finished. A later append (a resumed background agent)
  *  flips it back to running. */
@@ -375,6 +387,13 @@ export function attachSubagentWatcher(opts: {
   // history on its first scan, the same "offset 0 on attach" idiom the
   // per-subagent rehydration above relies on.
   let mainOffset = 0;
+  // `Date.now()` of the last discovery or dir-watcher event — the idle clock
+  // for the deep-idle tier (`DEEP_IDLE_POLL_MS`). Only consulted while
+  // `files.size === 0` (see `tick`): once any subagent is ever discovered,
+  // `files.size` never goes back to 0 for this watcher's lifetime, so the
+  // deep-idle tier is permanently disqualified from then on — exactly the
+  // "zero subagents ever discovered for the task" gate the plan calls for.
+  let lastChangeAt = Date.now();
 
   // Reattach: rehydrate subagents this task already had so we resume their
   // tails from offset 0 (the DB-seeded `seen` set suppresses re-emission of
@@ -466,6 +485,7 @@ export function attachSubagentWatcher(opts: {
         toolUseId: meta.toolUseId,
       };
       files.set(id, fs);
+      lastChangeAt = Date.now();
       subagentsDb.insertIfAbsent(toSubagentShape(fs, taskId));
       // A new correlation key may have a tool_result the scan already read
       // past (its lines were consumed while only siblings were pending) —
@@ -607,6 +627,9 @@ export function attachSubagentWatcher(opts: {
     try {
       dirWatcher = fsWatch(subagentsDir, { persistent: false }, () => {
         if (detached) return;
+        // Any dir-watcher event is a life signal for the deep-idle tier,
+        // independent of whether it turns out to be a new subagent file.
+        lastChangeAt = Date.now();
         try { discover(); for (const fs of files.values()) tailFile(fs); } catch { /* never crash the watcher */ }
       });
     } catch { /* fs.watch unsupported on this FS — the poll backstop covers it */ }
@@ -635,9 +658,20 @@ export function attachSubagentWatcher(opts: {
 
   function tick(): void {
     if (detached) return;
-    cycle(Date.now());
+    const now = Date.now();
+    cycle(now);
     const anyRunning = [...files.values()].some((f) => f.status === "running");
-    timer = setTimeout(tick, anyRunning ? FAST_POLL_MS : SLOW_POLL_MS);
+    let delay: number;
+    if (anyRunning) {
+      delay = FAST_POLL_MS;
+    } else if (files.size === 0 && now - lastChangeAt >= DEEP_IDLE_AFTER_MS) {
+      // Never discovered a subagent and nothing's happened for a while —
+      // back off further than the ordinary idle cadence.
+      delay = DEEP_IDLE_POLL_MS;
+    } else {
+      delay = SLOW_POLL_MS;
+    }
+    timer = setTimeout(tick, delay);
   }
 
   // Kick off on the next tick (give the spawn path a beat to settle). Tests

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -1005,6 +1005,20 @@ export function hasSessionState(taskId: string): boolean {
   return sessions.has(taskId);
 }
 
+/**
+ * Idle metadata for the reaper (T4, orchestrator.ts imports this by exact
+ * name/signature). Returns `null` when we hold no in-memory `SessionState`
+ * for the task — the reaper falls back to `task.updatedAt` in that case (a
+ * post-restart done/review task has no live driver state to ask). Otherwise
+ * returns how long it's been since the session last showed life — see the
+ * `lastActivityAt` field doc on `SessionState` for the full list of triggers.
+ */
+export function sessionIdleInfo(taskId: string): { idleMs: number } | null {
+  const state = sessions.get(taskId);
+  if (!state) return null;
+  return { idleMs: Date.now() - state.lastActivityAt };
+}
+
 /** Name-keyed variant for callers that hold a persisted session name (e.g.
  *  `runs.tmux_session`) and don't want to recompute it from a task id.
  *  Exact-match `=` prefix — see `sessionExists`. */
@@ -1469,8 +1483,30 @@ interface SessionState {
   watcher: FSWatcher | null;
   /** Periodic poll timer that flushes appended JSONL bytes — backstop for
    *  fs.watch on macOS, which silently drops notifications on slow append
-   *  streams. Without this, after the first event we'd never see the rest. */
-  pollTimer: ReturnType<typeof setInterval> | null;
+   *  streams. Without this, after the first event we'd never see the rest.
+   *  Self-rescheduling `setTimeout` (see `armPollTimer`) rather than a fixed
+   *  `setInterval` — the cadence backs off from `POLL_FAST_MS` to
+   *  `POLL_SLOW_MS` once `lastActivityAt` has been quiet for
+   *  `POLL_IDLE_AFTER_MS`, and snaps back on the next activity. */
+  pollTimer: ReturnType<typeof setTimeout> | null;
+  /** `Date.now()` stamp of the last time this session "showed life": JSONL
+   *  bytes appended (`flush`), a scraped tmux pane change (`scrapeOnce`), a
+   *  turn starting (`sendTurn` / the deferred-prompt paste in
+   *  `spawnClaudeViaTmux`), a turn settling (`popEndOfTurn`), or a folded-in
+   *  follow-up paste (`pasteFollowUp`). Initialized to the construction time
+   *  in `makeSessionState`, so a freshly spawned or reattached session starts
+   *  its idle clock at "now" rather than epoch 0. Two consumers: the exported
+   *  `sessionIdleInfo` (the reaper's idle signal, T4/orchestrator.ts) and the
+   *  `pollTimer`'s own self-throttle just above. */
+  lastActivityAt: number;
+  /** Last full tmux pane capture `scrapeOnce` took (the same trimmed tail
+   *  text used for modal matching), kept purely to detect "the pane changed
+   *  since last capture" as an activity signal independent of JSONL writes —
+   *  covers a native AskUserQuestion modal or a user driving the session via
+   *  `tmux attach`, neither of which necessarily appends to the JSONL. Null
+   *  until the first capture (so the very first tick never counts as a
+   *  "change"). */
+  scrapeLastPaneText: string | null;
   /** FIFO of turns waiting for end_turn. The head is the active turn —
    *  events flowing through the JSONL belong to it until end_turn fires,
    *  at which point we shift it off and the next turn becomes active.
@@ -1740,6 +1776,11 @@ function makeSessionState(o: MakeSessionStateOpts): SessionState {
     pollTimer: null,
     scrapeTimer: null,
     deathTimer: null,
+    // "Initialize at spawn/reattach" — every construction site (fresh spawn,
+    // reattach, rebuild, the test helper) routes through here, so stamping
+    // "now" here covers all of them uniformly.
+    lastActivityAt: Date.now(),
+    scrapeLastPaneText: null,
     scrapeLastFingerprint: null,
     lastJsonlAppendAt: 0,
     lastIdleScrapeAt: 0,
@@ -1753,6 +1794,15 @@ function makeSessionState(o: MakeSessionStateOpts): SessionState {
     subagentWatcher: null,
     continuationWatchdog: null,
   };
+}
+
+/** Stamp `lastActivityAt` to "now" — the single write site for the idle
+ *  clock, called from every place a session "shows life" (see the field's
+ *  doc comment on `SessionState`). Kept as a named helper (rather than
+ *  inlining `Date.now()` at each call site) so the exact set of triggers is
+ *  grep-able and can't silently drift out of sync with the doc comment. */
+function bumpActivity(state: SessionState): void {
+  state.lastActivityAt = Date.now();
 }
 
 /* ────────────────────────────────────────────────────────────────────────── *
@@ -1856,6 +1906,11 @@ const END_TURN_IDLE_FIRE_MS = 800;
  *  one-shot `onEndOfTurn` listener (reattach path, where there's no slot
  *  but the orchestrator still needs to know the run completed). */
 function popEndOfTurn(state: SessionState): void {
+  // A turn settling is itself a life signal — reset the idle clock even
+  // though `flush`'s JSONL-append bump already fired for the line that
+  // triggered this (the reattach path fires `onEndOfTurn` with no fresh
+  // append behind it, so this can't be dropped as redundant).
+  bumpActivity(state);
   // The busy period (the active turn plus any folded follow-ups) is ending —
   // clear the hold so the next genuinely-sequential turn resolves normally.
   state.holdUntilIdle = false;
@@ -2774,6 +2829,10 @@ async function flush(state: SessionState): Promise<void> {
   // turn (and that one-tick-stable list-printing wouldn't normally
   // beat the two-tick stability requirement).
   state.lastJsonlAppendAt = Date.now();
+  // JSONL bytes appended is the primary "session is alive" signal — feeds
+  // the reaper's idle clock (`sessionIdleInfo`) and the pollTimer's own
+  // idle backoff below.
+  bumpActivity(state);
   for (const line of lines) {
     if (!line) continue;
     dispatchLine(state, line);
@@ -3243,6 +3302,15 @@ function scrapeOnce(state: SessionState): void {
   const tailLines = lines.slice(Math.max(0, lines.length - SCRAPE_TAIL_LINES));
   const tail = tailLines.join("\n");
 
+  // The pane changing is a life signal independent of the JSONL — a native
+  // AskUserQuestion modal, or the user driving the session directly via
+  // `tmux attach`, can both change what's on screen without ever writing to
+  // the JSONL. Skip the very first capture (nothing to compare against yet).
+  if (state.scrapeLastPaneText !== null && state.scrapeLastPaneText !== tail) {
+    bumpActivity(state);
+  }
+  state.scrapeLastPaneText = tail;
+
   // Armed, token-matched lookout for claude's TUI rejecting the last-pasted
   // message as an unknown slash command. Cheap and early-guarded — only
   // evaluated while a token is armed AND a turn is genuinely in flight — so
@@ -3497,7 +3565,7 @@ function signalSessionDeath(state: SessionState): void {
   // killed" rejection would double-settle the run.
   state.watcher?.close();
   state.watcher = null;
-  if (state.pollTimer) { clearInterval(state.pollTimer); state.pollTimer = null; }
+  if (state.pollTimer) { clearTimeout(state.pollTimer); state.pollTimer = null; }
   if (state.scrapeTimer) { clearInterval(state.scrapeTimer); state.scrapeTimer = null; }
   // The session is gone, so a notification-triggered watchdog waiting on it
   // will never see content or a normal end-turn either way — cancel rather
@@ -3619,19 +3687,73 @@ function startDeathWatch(state: SessionState): void {
   }, DEATH_POLL_MS);
 }
 
+/** Backstop poll cadence while the session has shown life within the last
+ *  `POLL_IDLE_AFTER_MS` — matches the original fixed `setInterval` rate. */
+const POLL_FAST_MS = 400;
+/** Backstop poll cadence once `lastActivityAt` has been quiet for
+ *  `POLL_IDLE_AFTER_MS` or longer. fs.watch stays the primary signal (its own
+ *  callback flushes immediately, independent of this timer) — this only
+ *  changes how often the cheap "did fs.watch miss anything" stat-and-read
+ *  backstop runs for a session nobody is doing anything with. Never fully
+ *  stops (see the scraper's own idle-throttle comment for why a hard stop
+ *  would be wrong here too: a native AskUserQuestion modal writes no JSONL,
+ *  so something must keep noticing when the session goes busy again). */
+const POLL_SLOW_MS = 5_000;
+/** How long the session must be quiet before the backstop poll backs off
+ *  from `POLL_FAST_MS` to `POLL_SLOW_MS`. */
+const POLL_IDLE_AFTER_MS = 30_000;
+
+/**
+ * Arm (or re-arm) the JSONL backstop poll. Self-rescheduling `setTimeout`
+ * rather than a fixed `setInterval`: each tick decides the NEXT tick's delay
+ * from how long the session has been quiet, so the cadence backs off to
+ * `POLL_SLOW_MS` on its own once idle, and — because `rearmPollTimerFast`
+ * below cancels and reschedules on any fresh activity — snaps back to
+ * `POLL_FAST_MS` immediately rather than waiting out a stale long wait.
+ * Chained after `flush` settles (not fire-and-forget) so a slow flush can't
+ * pile up overlapping poll ticks against the same session.
+ */
+function armPollTimer(state: SessionState, delayMs: number = POLL_FAST_MS): void {
+  state.pollTimer = setTimeout(() => {
+    void flush(state).finally(() => {
+      // `disposeSessionState` clears `pollTimer` to null synchronously (even
+      // though the already-fired timer this callback belongs to can't be
+      // cancelled retroactively) — treat that as "don't reschedule."
+      if (!state.pollTimer) return;
+      const idleMs = Date.now() - state.lastActivityAt;
+      armPollTimer(state, idleMs >= POLL_IDLE_AFTER_MS ? POLL_SLOW_MS : POLL_FAST_MS);
+    });
+  }, delayMs);
+}
+
+/** Cancel whatever poll tick is pending and re-arm at `POLL_FAST_MS`
+ *  immediately. Called from every place that counts as "fresh activity" for
+ *  the poll cadence specifically (fs.watch events, a turn starting, a folded
+ *  follow-up paste) so a session that's been backed off to `POLL_SLOW_MS`
+ *  doesn't wait out a stale long tick before resuming full-rate backstop
+ *  polling. No-op when no poll timer is armed yet (pre-`attachTailer`, or an
+ *  already-disposed session) — nothing to snap back to. */
+function rearmPollTimerFast(state: SessionState): void {
+  if (!state.pollTimer) return;
+  clearTimeout(state.pollTimer);
+  armPollTimer(state, POLL_FAST_MS);
+}
+
 function attachTailer(state: SessionState): void {
   // Drain whatever's already in the file (claude may have written events
   // before our watcher attached).
   void flush(state);
   state.watcher = fsWatch(state.jsonlPath, { persistent: false }, () => {
     void flush(state);
+    rearmPollTimerFast(state);
   });
   // Backstop poll. macOS fs.watch (FSEvents/kqueue) coalesces rapid appends
   // and drops notifications on slow append-only streams — we saw a real run
   // where the first event came through fine and then 16 more events silently
   // accumulated in the JSONL without firing the watcher. A 400ms tick is
-  // cheap (one stat + read-if-grew) and bulletproof.
-  state.pollTimer = setInterval(() => { void flush(state); }, 400);
+  // cheap (one stat + read-if-grew) and bulletproof; it backs off to
+  // `POLL_SLOW_MS` after `POLL_IDLE_AFTER_MS` of quiet (see `armPollTimer`).
+  armPollTimer(state);
   startScraper(state);
   startDeathWatch(state);
   // Track any background/sub agents this session spawns. Idempotent re-arm:
@@ -3869,6 +3991,13 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
         // "paste" already happened via the launch argv before this function
         // even returned.)
         state.pendingSlashToken = slashTokenOf(deferredPrompt);
+        // Prompt paste is a life signal — matters here specifically because
+        // boot (and the readiness wait above) can take up to
+        // DEFERRED_PROMPT_TIMEOUT_MS, well past the construction-time stamp
+        // `makeSessionState` set. `attachTailer` (and its pollTimer) hasn't
+        // run yet at this point — `rearmPollTimerFast` would no-op — so only
+        // the idle-clock bump applies here.
+        bumpActivity(state);
         void queuePaste(opts.taskId, sessionName, deferredPrompt, 0, state, {
           bracketed: true,
           onPasteFailure: () => {
@@ -4182,6 +4311,11 @@ export function sendTurn(taskId: string, prompt: string, onChunk: ChunkHandler):
     onChunk("stderr", err.message);
     return rejectedAgent(taskId, err);
   }
+  // A turn starting is a life signal — reset the idle clock and snap the
+  // backstop poll back to full rate immediately (relevant when this session
+  // had backed off to POLL_SLOW_MS while idle).
+  bumpActivity(state);
+  rearmPollTimerFast(state);
   // Drain any unprocessed JSONL content under whatever turn is currently
   // active BEFORE pushing the new slot — otherwise a trailing end_turn
   // already in the file would be dispatched against the new slot and
@@ -4262,6 +4396,10 @@ export function sendTurn(taskId: string, prompt: string, onChunk: ChunkHandler):
 export function pasteFollowUp(taskId: string, prompt: string): boolean {
   const state = sessions.get(taskId);
   if (!state) return false;
+  // A folded-in follow-up paste is a life signal — reset the idle clock and
+  // snap the backstop poll back to full rate immediately.
+  bumpActivity(state);
+  rearmPollTimerFast(state);
   state.holdUntilIdle = true;
   // Arm (or disarm) the unknown-command lookout for the folded-in prompt —
   // same rule as `sendTurn`: only a first line starting with "/" arms it.
@@ -4629,7 +4767,7 @@ function disposeSessionState(state: SessionState | undefined, orphanSubagents = 
   if (!state) return;
   state.watcher?.close();
   state.watcher = null;
-  if (state.pollTimer) clearInterval(state.pollTimer);
+  if (state.pollTimer) clearTimeout(state.pollTimer);
   state.pollTimer = null;
   if (state.scrapeTimer) clearInterval(state.scrapeTimer);
   state.scrapeTimer = null;

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -1026,6 +1026,38 @@ export function sessionExistsByName(name: string): boolean {
   return tmux(["has-session", "-t", "=" + name]).ok;
 }
 
+/**
+ * Keyed, single-round-trip liveness + activity probe for a task's tmux
+ * session, with no dependency on in-memory `SessionState`. This is what the
+ * reaper falls back to for a task it holds no `SessionState` for (e.g. after
+ * a restart, before boot reconciliation reattaches it) instead of a bare
+ * `has-session` check that can't tell whether the session is still doing
+ * anything. One `tmux display-message` round-trip pulls both
+ * `#{session_attached}` (nonzero while a real `tmux attach` is live) and
+ * `#{session_activity}` (tmux's own last-activity timestamp for the session —
+ * updated on any pane output, independent of whether we're the ones tailing
+ * it) in a single call. `-t '=<name>'` forces an exact-match target, matching
+ * every other tmux() call in this file — see `sessionExists`'s comment for
+ * why an unanchored name prefix-matches a sibling `agetor-<id>` session and
+ * would misreport a live, unrelated session as this task's. Returns null
+ * when the command fails or the session doesn't exist; the caller treats
+ * that as "can't tell," not "definitely dead."
+ */
+export function probeSessionActivity(taskId: string): { attached: boolean; activityAt: number } | null {
+  const r = tmux([
+    "display-message", "-p", "-t", "=" + sessionNameFor(taskId),
+    "#{session_attached}:#{session_activity}",
+  ]);
+  if (!r.ok) return null;
+  const [attachedRaw, activityRaw] = r.stdout.trim().split(":");
+  const attachedNum = Number(attachedRaw);
+  const activitySec = Number(activityRaw);
+  if (!Number.isFinite(attachedNum) || !Number.isFinite(activitySec)) return null;
+  // tmux reports session_activity in epoch SECONDS; callers (idle-clock math
+  // against `Date.now()`) expect milliseconds.
+  return { attached: attachedNum > 0, activityAt: activitySec * 1000 };
+}
+
 /** Tri-state liveness of a tmux session — the safe signal for the death watch. */
 export type SessionLiveness = "alive" | "gone" | "unreachable";
 
@@ -3273,6 +3305,33 @@ function decideScrapeTick(p: {
   return { run: true, stampIdle: true };
 }
 
+/** Pane chrome that repaints on a fixed cadence independent of anything
+ *  meaningful happening — claude's "esc to interrupt" spinner/status footer
+ *  (its elapsed-time-and-token-count portion ticks every render) and its
+ *  rotating "Tip: …" hint banner. Matched against a line AFTER trailing
+ *  whitespace has already been trimmed off (see `normalizePaneForActivity`). */
+const VOLATILE_PANE_LINE_RE = /esc to interrupt|^\s*Tip:/i;
+
+/**
+ * Normalize a captured pane tail into the form used for the "did the pane
+ * meaningfully change" activity signal in `scrapeOnce`. Mirrors the
+ * normalization the modal matchers (`matchNumberedModal`, `detectAskModal`)
+ * already apply when fingerprinting a pane — right-trim each line, since
+ * `tmux capture-pane` pads rows with trailing spaces that vary run to run —
+ * and additionally drops lines that are pure volatile chrome (see
+ * `VOLATILE_PANE_LINE_RE`). Without this, a session idling at the REPL can
+ * keep resetting the reaper's 30-minute idle clock (`lastActivityAt`)
+ * forever purely from chrome redraws that never touch real transcript
+ * content, neutering the reaper. Only affects the activity-diff comparison —
+ * modal matching still runs against the raw, unnormalized tail. */
+function normalizePaneForActivity(tail: string): string {
+  return tail
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => !VOLATILE_PANE_LINE_RE.test(line))
+    .join("\n");
+}
+
 /** Run a single scrape tick. Idempotent: registers at most one new
  *  TmuxPromptRequest per call, auto-cancels any pending one whose
  *  fingerprint no longer matches the pane. */
@@ -3305,11 +3364,17 @@ function scrapeOnce(state: SessionState): void {
   // The pane changing is a life signal independent of the JSONL — a native
   // AskUserQuestion modal, or the user driving the session directly via
   // `tmux attach`, can both change what's on screen without ever writing to
-  // the JSONL. Skip the very first capture (nothing to compare against yet).
-  if (state.scrapeLastPaneText !== null && state.scrapeLastPaneText !== tail) {
+  // the JSONL. Compare the NORMALIZED tail (see `normalizePaneForActivity`),
+  // not the raw capture — volatile chrome (the "esc to interrupt" spinner's
+  // elapsed-time/token counter, a rotating "Tip: …" line, trailing
+  // whitespace) would otherwise diff on nearly every tick and pin
+  // `lastActivityAt` at "now" forever, neutering the reaper's idle clock.
+  // Skip the very first capture (nothing to compare against yet).
+  const normalizedTail = normalizePaneForActivity(tail);
+  if (state.scrapeLastPaneText !== null && state.scrapeLastPaneText !== normalizedTail) {
     bumpActivity(state);
   }
-  state.scrapeLastPaneText = tail;
+  state.scrapeLastPaneText = normalizedTail;
 
   // Armed, token-matched lookout for claude's TUI rejecting the last-pasted
   // message as an unknown slash command. Cheap and early-guarded — only
@@ -3714,16 +3779,28 @@ const POLL_IDLE_AFTER_MS = 30_000;
  * pile up overlapping poll ticks against the same session.
  */
 function armPollTimer(state: SessionState, delayMs: number = POLL_FAST_MS): void {
-  state.pollTimer = setTimeout(() => {
+  // Capture the handle by identity rather than relying on `state.pollTimer`'s
+  // truthiness: `rearmPollTimerFast` (fs.watch callback) can fire *while*
+  // this tick's `flush` is still awaiting, clear+replace `state.pollTimer`
+  // with a brand-new chain, and then this tick's `.finally` would see a
+  // truthy-but-different pollTimer and reschedule anyway — spawning a second
+  // independent self-rescheduling chain that multiplies every time that
+  // race repeats. Comparing against the exact handle this closure owns means
+  // only the chain `state.pollTimer` still actually points at may continue.
+  const handle: ReturnType<typeof setTimeout> = setTimeout(() => {
+    // `disposeSessionState` / `signalSessionDeath` null `pollTimer`
+    // synchronously on teardown; a superseding `armPollTimer` call (via
+    // `rearmPollTimerFast`) overwrites it with a different handle. Either
+    // way, if `state.pollTimer` isn't this handle anymore, this chain is
+    // stale — don't run its flush.
+    if (state.pollTimer !== handle) return;
     void flush(state).finally(() => {
-      // `disposeSessionState` clears `pollTimer` to null synchronously (even
-      // though the already-fired timer this callback belongs to can't be
-      // cancelled retroactively) — treat that as "don't reschedule."
-      if (!state.pollTimer) return;
+      if (state.pollTimer !== handle) return;
       const idleMs = Date.now() - state.lastActivityAt;
       armPollTimer(state, idleMs >= POLL_IDLE_AFTER_MS ? POLL_SLOW_MS : POLL_FAST_MS);
     });
   }, delayMs);
+  state.pollTimer = handle;
 }
 
 /** Cancel whatever poll tick is pending and re-arm at `POLL_FAST_MS`

--- a/src/bun/db-events-paging.test.ts
+++ b/src/bun/db-events-paging.test.ts
@@ -1,0 +1,390 @@
+import { test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import type { Task } from "../shared/types.ts";
+
+// db.ts captures AGETOR_DATA_DIR at first import — `bun test` runs every
+// *.test.ts file in one process, so whichever file imports db.ts first wins
+// the race (see db.ts's own comment on this). Set it at the TOP LEVEL
+// (mirrors task-events.test.ts / server-auth.test.ts), not inside beforeAll,
+// so this file behaves whether it happens to import first or not.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-events-paging-"));
+// Unique port, distinct from every other *.test.ts file's AGETOR_API_PORT.
+process.env.AGETOR_API_PORT = "4485";
+
+let tasks: typeof import("./db.ts").tasks;
+let runs: typeof import("./db.ts").runs;
+let db: typeof import("./db.ts").db;
+let server: { stop: () => void; port: number };
+let token: string;
+let EVENTS_REPLAY_LIMIT: number;
+let TASK_EVENTS_REPLAY_META_EVENT: string;
+
+beforeAll(async () => {
+  ({ tasks, runs, db } = await import("./db.ts"));
+  const shared = await import("../shared/types.ts");
+  EVENTS_REPLAY_LIMIT = shared.EVENTS_REPLAY_LIMIT;
+  TASK_EVENTS_REPLAY_META_EVENT = shared.TASK_EVENTS_REPLAY_META_EVENT;
+  const { startApiServer, API_TOKEN } = await import("./server.ts");
+  server = startApiServer() as unknown as { stop: () => void; port: number };
+  token = API_TOKEN;
+});
+
+afterAll(() => {
+  server?.stop?.();
+});
+
+// The SQLite db is process-wide (see the comment above). Sibling test files
+// that count rows across the shared `tasks`/`runs`/`run_events` tables rely
+// on a clean slate between suites, so wipe everything we inserted after
+// every test — same pattern as task-events.test.ts.
+afterEach(async () => {
+  db.run(`DELETE FROM run_events`);
+  db.run(`DELETE FROM runs`);
+  db.run(`DELETE FROM tasks`);
+});
+
+const BASE = () => `http://127.0.0.1:${server.port}`;
+const authedFetch = (p: string, init: RequestInit = {}) =>
+  fetch(`${BASE()}${p}`, {
+    ...init,
+    headers: { authorization: `Bearer ${token}`, ...(init.headers ?? {}) },
+  });
+
+function makeTaskRow(taskId: string): Task {
+  return {
+    id: taskId,
+    title: "t",
+    prompt: "p",
+    agent: "claude-code",
+    workdir: "/tmp",
+    isolation: "none",
+    taskType: "task",
+    branch: null,
+    branchSource: "created",
+    worktreePath: null,
+    baseRef: null,
+    mode: null,
+    model: null,
+    effort: null,
+    references: [],
+    backlog: [],
+    draft: null,
+    column: "ready",
+    runId: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    hasOpenableRun: false,
+    pendingInteractionCount: 0,
+    openTerminalCount: 0,
+    archivedAt: null,
+  };
+}
+
+/** Seeds a task + single terminal run, then appends `count` events to it
+ *  (data payloads `"e0"`, `"e1"`, … in insertion order) wrapped in a single
+ *  sqlite transaction so seeding hundreds/thousands of rows stays fast.
+ *  Returns the task id and the full ascending list of persisted event ids. */
+function seedTaskWithEvents(count: number): { taskId: string; runId: string; ids: number[] } {
+  const taskId = randomUUID();
+  const runId = randomUUID();
+  tasks.insert(makeTaskRow(taskId));
+  const now = Date.now();
+  runs.insert({
+    id: runId, taskId, agent: "claude-code", status: "succeeded",
+    startedAt: now, endedAt: now + 1, exitCode: 0,
+    tmuxSession: null, claudeSessionId: null, codexSessionId: null,
+  });
+  const insertMany = db.transaction((n: number) => {
+    for (let i = 0; i < n; i++) {
+      runs.appendEvent(runId, "assistant", `e${i}`);
+    }
+  });
+  insertMany(count);
+  const ids = runs.eventsForTask(taskId).map((e) => e.id);
+  return { taskId, runId, ids };
+}
+
+/** Reads an SSE endpoint until `minFrames` frames have been parsed (or
+ *  `timeoutMs` elapses), returning each frame's named event (defaulting to
+ *  "message" when no `event:` line is present, matching browser EventSource
+ *  semantics) and parsed `data:` payload. Mirrors the frame-splitting used
+ *  by claude-subagents.integration.test.ts's `readSse`, extended to also
+ *  capture the event name so the `replay_meta` named frame is distinguishable
+ *  from ordinary data frames. */
+async function readSseFrames(
+  url: string,
+  minFrames: number,
+  timeoutMs: number,
+): Promise<Array<{ event: string; data: any }>> {
+  const ctrl = new AbortController();
+  const res = await fetch(url, { signal: ctrl.signal });
+  const reader = res.body!.getReader();
+  const dec = new TextDecoder();
+  const frames: Array<{ event: string; data: any }> = [];
+  let buf = "";
+  const deadline = Date.now() + timeoutMs;
+  try {
+    while (frames.length < minFrames && Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      const r = await Promise.race([
+        reader.read(),
+        new Promise<{ value: undefined; done: true }>((res2) =>
+          setTimeout(() => res2({ value: undefined, done: true }), Math.max(1, remaining))),
+      ]);
+      if (r.done) break;
+      buf += dec.decode(r.value, { stream: true });
+      let i: number;
+      while ((i = buf.indexOf("\n\n")) >= 0) {
+        const frame = buf.slice(0, i);
+        buf = buf.slice(i + 2);
+        const eventLine = frame.split("\n").find((l) => l.startsWith("event:"));
+        const dataLine = frame.split("\n").find((l) => l.startsWith("data:"));
+        if (!dataLine) continue;
+        try {
+          frames.push({
+            event: eventLine ? eventLine.slice(6).trim() : "message",
+            data: JSON.parse(dataLine.slice(5).trim()),
+          });
+        } catch {
+          // partial/ping frame — ignore.
+        }
+      }
+    }
+  } finally {
+    ctrl.abort();
+  }
+  return frames;
+}
+
+// ---------------------------------------------------------------------------
+// runs.eventsForTask
+// ---------------------------------------------------------------------------
+
+test("eventsForTask with no opts returns the full ascending history unchanged", () => {
+  const { taskId, ids } = seedTaskWithEvents(10);
+  const all = runs.eventsForTask(taskId);
+  expect(all.map((e) => e.id)).toEqual(ids);
+  expect(all.map((e) => e.data)).toEqual(Array.from({ length: 10 }, (_, i) => `e${i}`));
+  // Ascending.
+  for (let i = 1; i < all.length; i++) expect(all[i]!.id).toBeGreaterThan(all[i - 1]!.id);
+});
+
+test("eventsForTask is empty for a task with no events", () => {
+  const taskId = randomUUID();
+  tasks.insert(makeTaskRow(taskId));
+  expect(runs.eventsForTask(taskId)).toEqual([]);
+  expect(runs.eventsForTask(taskId, { limit: 50 })).toEqual([]);
+});
+
+test("eventsForTask with only `limit` returns the MOST RECENT `limit` events, ascending", () => {
+  const { taskId, ids } = seedTaskWithEvents(20);
+  const page = runs.eventsForTask(taskId, { limit: 5 });
+  expect(page.map((e) => e.id)).toEqual(ids.slice(-5));
+  expect(page.map((e) => e.data)).toEqual(["e15", "e16", "e17", "e18", "e19"]);
+  // Ascending, not descending.
+  for (let i = 1; i < page.length; i++) expect(page[i]!.id).toBeGreaterThan(page[i - 1]!.id);
+});
+
+test("eventsForTask combined beforeId+limit returns only events with id < beforeId", () => {
+  // NB: `beforeId` alone (no `limit`) is a no-op in the current implementation
+  // — the filter only applies inside the `opts.limit` branch. This test pins
+  // the combined-usage path, which is what both the SSE replay and the
+  // paging route actually exercise.
+  const { taskId, ids } = seedTaskWithEvents(30);
+  const cutoff = ids[20]!; // id of the 21st event (index 20)
+  const page = runs.eventsForTask(taskId, { beforeId: cutoff, limit: 1000 });
+  expect(page.every((e) => e.id < cutoff)).toBe(true);
+  expect(page.map((e) => e.id)).toEqual(ids.slice(0, 20));
+});
+
+test("eventsForTask combined beforeId+small-limit returns the newest slice strictly before the cutoff", () => {
+  const { taskId, ids } = seedTaskWithEvents(30);
+  const cutoff = ids[20]!;
+  const page = runs.eventsForTask(taskId, { beforeId: cutoff, limit: 5 });
+  // The 5 events immediately preceding the cutoff, ascending.
+  expect(page.map((e) => e.id)).toEqual(ids.slice(15, 20));
+});
+
+test("eventsForTask limit larger than available events returns all of them", () => {
+  const { taskId, ids } = seedTaskWithEvents(3);
+  const page = runs.eventsForTask(taskId, { limit: 1000 });
+  expect(page.map((e) => e.id)).toEqual(ids);
+});
+
+// ---------------------------------------------------------------------------
+// runs.hasEventsBefore
+// ---------------------------------------------------------------------------
+
+test("hasEventsBefore is false at the exact earliest id and true just past it", () => {
+  const { taskId, ids } = seedTaskWithEvents(5);
+  const earliest = ids[0]!;
+  expect(runs.hasEventsBefore(taskId, earliest)).toBe(false);
+  expect(runs.hasEventsBefore(taskId, earliest + 1)).toBe(true);
+  // Comfortably below anything ever inserted for this task.
+  expect(runs.hasEventsBefore(taskId, -1)).toBe(false);
+});
+
+test("hasEventsBefore is false for a task with no events regardless of cursor", () => {
+  const taskId = randomUUID();
+  tasks.insert(makeTaskRow(taskId));
+  expect(runs.hasEventsBefore(taskId, 0)).toBe(false);
+  expect(runs.hasEventsBefore(taskId, Number.MAX_SAFE_INTEGER)).toBe(false);
+});
+
+// ---------------------------------------------------------------------------
+// GET /tasks/:id/events/page
+// ---------------------------------------------------------------------------
+
+test("paging route walks the full history via beforeId with no gaps or duplicates, hasMore flips false on the last page", async () => {
+  const { taskId, ids } = seedTaskWithEvents(25); // more than one page at limit=10
+  const collected: number[] = [];
+  let cursor = Number.MAX_SAFE_INTEGER;
+  let hasMoreFlags: boolean[] = [];
+  for (let guard = 0; guard < 10; guard++) {
+    const res = await authedFetch(`/tasks/${taskId}/events/page?beforeId=${cursor}&limit=10`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { events: Array<{ id: number }>; earliestId: number | null; hasMore: boolean };
+    collected.unshift(...body.events.map((e) => e.id));
+    hasMoreFlags.push(body.hasMore);
+    if (!body.hasMore) break;
+    expect(body.earliestId).not.toBeNull();
+    cursor = body.earliestId!;
+  }
+  expect(collected).toEqual(ids); // no gaps, no duplicates, full coverage
+  expect(new Set(collected).size).toBe(collected.length); // no duplicates, restated
+  expect(hasMoreFlags[hasMoreFlags.length - 1]).toBe(false); // exhausted
+  expect(hasMoreFlags.slice(0, -1).every(Boolean)).toBe(true); // true on every page but the last
+  expect(hasMoreFlags.length).toBe(3); // 25 events / limit 10 -> pages of 10, 10, 5
+});
+
+test("paging route 400s on a missing beforeId", async () => {
+  const { taskId } = seedTaskWithEvents(3);
+  const res = await authedFetch(`/tasks/${taskId}/events/page`);
+  expect(res.status).toBe(400);
+  const body = await res.json();
+  expect(body.error).toBeTruthy();
+});
+
+test("paging route 400s on a non-numeric beforeId", async () => {
+  const { taskId } = seedTaskWithEvents(3);
+  const res = await authedFetch(`/tasks/${taskId}/events/page?beforeId=not-a-number`);
+  expect(res.status).toBe(400);
+});
+
+test("paging route 404s for an unknown task", async () => {
+  const res = await authedFetch(`/tasks/${randomUUID()}/events/page?beforeId=999999999`);
+  expect(res.status).toBe(404);
+});
+
+test("paging route caps `limit` at 2000 and defaults to EVENTS_REPLAY_LIMIT when omitted", async () => {
+  const { taskId, ids } = seedTaskWithEvents(2005);
+
+  const capped = await authedFetch(`/tasks/${taskId}/events/page?beforeId=${Number.MAX_SAFE_INTEGER}&limit=999999`);
+  expect(capped.status).toBe(200);
+  const cappedBody = await capped.json() as { events: unknown[]; hasMore: boolean };
+  expect(cappedBody.events.length).toBe(2000); // capped, not 2005 and not 999999
+  expect(cappedBody.hasMore).toBe(true); // 5 older events remain
+
+  const defaulted = await authedFetch(`/tasks/${taskId}/events/page?beforeId=${Number.MAX_SAFE_INTEGER}`);
+  expect(defaulted.status).toBe(200);
+  const defaultedBody = await defaulted.json() as { events: Array<{ id: number }> };
+  expect(defaultedBody.events.length).toBe(EVENTS_REPLAY_LIMIT);
+  expect(defaultedBody.events.map((e) => e.id)).toEqual(ids.slice(-EVENTS_REPLAY_LIMIT));
+});
+
+test("paging route requires auth", async () => {
+  const { taskId } = seedTaskWithEvents(3);
+  const res = await fetch(`${BASE()}/tasks/${taskId}/events/page?beforeId=999999999`);
+  expect(res.status).toBe(401);
+});
+
+// ---------------------------------------------------------------------------
+// SSE replay cap on GET /tasks/:id/events
+// ---------------------------------------------------------------------------
+
+test("SSE replay caps at EVENTS_REPLAY_LIMIT: a leading named replay_meta frame followed by exactly the newest window, ascending", async () => {
+  const seedCount = EVENTS_REPLAY_LIMIT + 50; // comfortably over the cap, still fast to seed
+  const { taskId, ids } = seedTaskWithEvents(seedCount);
+  expect(ids.length).toBe(seedCount);
+
+  const expectedWindow = ids.slice(-EVENTS_REPLAY_LIMIT);
+  const expectedEarliestId = expectedWindow[0]!;
+  expect(runs.hasEventsBefore(taskId, expectedEarliestId)).toBe(true);
+  // The SSE `RunEvent` payload (unlike the paging route's) carries no `id` —
+  // just runId/taskId/stream/data/ts/subagentId — so identify the window by
+  // the seeded `data` payload ("e{i}") instead of a numeric id.
+  const expectedPayloads = Array.from(
+    { length: EVENTS_REPLAY_LIMIT },
+    (_, i) => `e${seedCount - EVENTS_REPLAY_LIMIT + i}`,
+  );
+
+  const url = `${BASE()}/tasks/${taskId}/events?token=${encodeURIComponent(token)}`;
+  const frames = await readSseFrames(url, EVENTS_REPLAY_LIMIT + 1, 10_000);
+
+  expect(frames.length).toBe(EVENTS_REPLAY_LIMIT + 1);
+
+  const [metaFrame, ...dataFrames] = frames;
+  expect(metaFrame!.event).toBe(TASK_EVENTS_REPLAY_META_EVENT);
+  expect(metaFrame!.data.earliestId).toBe(expectedEarliestId);
+  expect(metaFrame!.data.hasMore).toBe(true);
+
+  expect(dataFrames.length).toBe(EVENTS_REPLAY_LIMIT);
+  expect(dataFrames.every((f) => f.event === "message")).toBe(true);
+  const dataPayloads = dataFrames.map((f) => f.data.data);
+  expect(dataPayloads).toEqual(expectedPayloads); // ascending, matches the newest-window slice exactly
+  expect(dataPayloads[dataPayloads.length - 1]).toBe(`e${seedCount - 1}`); // ends at the newest event
+  expect(dataFrames.every((f) => f.data.taskId === taskId)).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// Migration 030: idx_runs_task
+// ---------------------------------------------------------------------------
+
+test("migration 030 creates idx_runs_task and is idempotent across two runner passes", async () => {
+  const { migrate } = await import("./migrate.ts");
+  const { migrations } = await import("./migrations/index.ts");
+
+  const fresh = new Database(":memory:");
+  const firstPass = migrate(fresh, migrations);
+  expect(firstPass).toEqual(migrations.map((m) => m.id)); // every migration applied, in order, on a blank db
+  expect(firstPass).toContain("030_runs_task_id_index");
+
+  const indexRow = fresh.query<{ name: string }, []>(
+    `SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_runs_task'`,
+  ).get();
+  expect(indexRow?.name).toBe("idx_runs_task");
+
+  // Re-running the full migration list against the same db is a no-op —
+  // every id is already recorded in `_migrations`.
+  const secondPass = migrate(fresh, migrations);
+  expect(secondPass).toEqual([]);
+
+  // The index still exists exactly once (no duplicate-index error, no drop).
+  const indexRowsAfter = fresh.query<{ name: string }, []>(
+    `SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_runs_task'`,
+  ).all();
+  expect(indexRowsAfter.length).toBe(1);
+});
+
+test("migration 030 (CREATE INDEX IF NOT EXISTS) tolerates a pre-existing index of the same name", () => {
+  // Simulates re-applying just the 030 SQL directly (not through the
+  // `_migrations` bookkeeping) against a db that already has the index —
+  // this is what makes the migration itself idempotent, independent of the
+  // runner's own already-applied tracking exercised above.
+  const fresh = new Database(":memory:");
+  fresh.exec(`CREATE TABLE runs (id TEXT PRIMARY KEY, task_id TEXT NOT NULL);`);
+  const sql = readFileSync(
+    path.join(import.meta.dir, "migrations", "030_runs_task_id_index.sql"),
+    "utf8",
+  );
+  expect(() => fresh.exec(sql)).not.toThrow();
+  expect(() => fresh.exec(sql)).not.toThrow(); // second apply, same connection
+  const rows = fresh.query<{ name: string }, []>(
+    `SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_runs_task'`,
+  ).all();
+  expect(rows.length).toBe(1);
+});

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -15,11 +15,11 @@ import { coreCredsPath } from "./core-creds.ts";
 // tasks.get(...)` at module scope in interactions.ts) — under ESM live
 // bindings the unresolved cycle becomes an undefined-binding crash at
 // import time. Keep both sides lazy.
-import { countPendingForTask } from "./interactions.ts";
+import { countPendingForTask, pendingCountsByTask } from "./interactions.ts";
 // Same lazy-cycle contract as interactions.ts above: terminals.ts imports
 // `tasks` from this module, and we call `countTerminals` only inside `toTask`
 // (a function body), never at top level. Do not hoist this call site.
-import { countTerminals } from "./terminals.ts";
+import { countTerminals, terminalCountsByTask } from "./terminals.ts";
 
 // Hard guard against test fixtures silently leaking into the user's real
 // SQLite db. `bun test` runs every *.test.ts file in one process, so the
@@ -150,7 +150,18 @@ const parseDraft = (raw: unknown): TaskDraft | null => {
   } catch { return null; }
 };
 
-const toTask = (r: TaskRow): Task => ({
+/** Optional pre-computed grouped counts, threaded in by `tasks.list()` so a
+ *  multi-row query does one pass over each in-memory registry instead of a
+ *  per-row `countPendingForTask`/`countTerminals` scan (289 tasks × 2 linear
+ *  scans on every 2s `/tasks` poll, before this). Single-task reads
+ *  (`tasks.get`, `insert`, `update`) omit this and fall back to the
+ *  per-task counters — called far less often than the poll. */
+interface TaskCounts {
+  pending?: Map<string, number>;
+  terminals?: Map<string, number>;
+}
+
+const toTask = (r: TaskRow, counts?: TaskCounts): Task => ({
   id: r.id,
   title: r.title,
   prompt: r.prompt,
@@ -174,8 +185,8 @@ const toTask = (r: TaskRow): Task => ({
   // join (e.g. insert/update returning the freshly-written shape, where
   // no runs exist yet → false is the right default).
   hasOpenableRun: r.has_openable_run === 1,
-  pendingInteractionCount: countPendingForTask(r.id),
-  openTerminalCount: countTerminals(r.id),
+  pendingInteractionCount: counts?.pending ? (counts.pending.get(r.id) ?? 0) : countPendingForTask(r.id),
+  openTerminalCount: counts?.terminals ? (counts.terminals.get(r.id) ?? 0) : countTerminals(r.id),
   createdAt: r.created_at,
   updatedAt: r.updated_at,
   archivedAt: r.archived_at,
@@ -192,12 +203,18 @@ const TASKS_SELECT = `
 `;
 
 export const tasks = {
+  // Computes the pending-interaction and open-terminal grouped counts ONCE
+  // for the whole result set (two single-pass scans over their respective
+  // in-memory maps) instead of once per row via `toTask`'s per-task fallback
+  // — this is the hot path hit by the 2s `/tasks` poll.
   list(): Task[] {
-    return db.query<TaskRow, []>(
+    const rows = db.query<TaskRow, []>(
       `${TASKS_SELECT}
          GROUP BY tasks.id
          ORDER BY tasks.created_at DESC`,
-    ).all().map(toTask);
+    ).all();
+    const counts: TaskCounts = { pending: pendingCountsByTask(), terminals: terminalCountsByTask() };
+    return rows.map((r) => toTask(r, counts));
   },
   get(id: string): Task | null {
     const row = db.query<TaskRow, [string]>(
@@ -734,18 +751,62 @@ export const runs = {
    *  chronological — id is autoincrement, ts can collide when bursts of
    *  events land in the same Date.now() ms). Used by the unified
    *  task-level stream so the panel shows the whole conversation as one
-   *  scrollback instead of per-run silos. */
-  eventsForTask(taskId: string) {
-    return db.query<
-      { runId: string; stream: string; data: string; ts: number; subagentId: string | null },
-      [string]
-    >(
-      `SELECT run_events.run_id as runId, stream, data, ts, run_events.subagent_id as subagentId
+   *  scrollback instead of per-run silos.
+   *
+   *  With no `opts` (or no `opts.limit`), returns the full unbounded
+   *  ascending history — the original behavior, kept for existing callers
+   *  (tests, `rebuildEventsFromJsonl`-adjacent tooling) that want everything.
+   *
+   *  With `opts.limit` set, returns only the MOST RECENT `limit` events:
+   *  filters `id < opts.beforeId` when given, orders by id DESC, takes
+   *  `limit`, then reverses so the caller still sees ascending order. This
+   *  is what powers the capped SSE replay window and the `/events/page`
+   *  paging route — both want "the newest N (before some cursor)", not
+   *  "the first N". */
+  eventsForTask(
+    taskId: string,
+    opts?: { beforeId?: number; limit?: number },
+  ): Array<{ id: number; runId: string; stream: string; data: string; ts: number; subagentId: string | null }> {
+    type Row = { id: number; runId: string; stream: string; data: string; ts: number; subagentId: string | null };
+    if (opts?.limit) {
+      const conditions = ["runs.task_id = ?"];
+      const params: Array<string | number> = [taskId];
+      if (opts.beforeId != null) {
+        conditions.push("run_events.id < ?");
+        params.push(opts.beforeId);
+      }
+      params.push(opts.limit);
+      const rows = db.query<Row, Array<string | number>>(
+        `SELECT run_events.id as id, run_events.run_id as runId, stream, data, ts, run_events.subagent_id as subagentId
+         FROM run_events
+         JOIN runs ON runs.id = run_events.run_id
+         WHERE ${conditions.join(" AND ")}
+         ORDER BY run_events.id DESC
+         LIMIT ?`,
+      ).all(...params);
+      return rows.reverse();
+    }
+    return db.query<Row, [string]>(
+      `SELECT run_events.id as id, run_events.run_id as runId, stream, data, ts, run_events.subagent_id as subagentId
        FROM run_events
        JOIN runs ON runs.id = run_events.run_id
        WHERE runs.task_id = ?
        ORDER BY run_events.id ASC`,
     ).all(taskId);
+  },
+  /** Cheap existence check — is there at least one persisted event for this
+   *  task older than `beforeId`? Backs the `hasMore` flag on both the SSE
+   *  `replay_meta` frame and the `/events/page` paging route, so the client
+   *  knows whether to keep showing "Load earlier" without fetching (and
+   *  counting) the whole remaining history. */
+  hasEventsBefore(taskId: string, beforeId: number): boolean {
+    const row = db.query<{ 1: number }, [string, number]>(
+      `SELECT 1 FROM run_events
+       JOIN runs ON runs.id = run_events.run_id
+       WHERE runs.task_id = ? AND run_events.id < ?
+       LIMIT 1`,
+    ).get(taskId, beforeId);
+    return row !== null;
   },
   appendEvent(
     runId: string,

--- a/src/bun/headless.ts
+++ b/src/bun/headless.ts
@@ -1,7 +1,7 @@
 import pkg from "../../package.json" with { type: "json" };
 import { API_TOKEN } from "./api-config.ts";
 import { db, dataDir } from "./db.ts";
-import { reconcileOrphans } from "./orchestrator.ts";
+import { reconcileOrphans, reapIdleSessions } from "./orchestrator.ts";
 import { startApiServer, attachedClientCount } from "./server.ts";
 import { rehydratePath } from "./login-path.ts";
 import { refreshDiscoveredModels } from "./agent-discovery.ts";
@@ -12,6 +12,7 @@ import {
   probeLiveCore,
 } from "./core-creds.ts";
 import { daemonLog } from "./daemon-log.ts";
+import { SESSION_REAP_SWEEP_MS } from "../shared/types.ts";
 
 /**
  * Headless Agetor core — the same Bun server + orchestrator the desktop app
@@ -69,6 +70,27 @@ export async function runDaemon(): Promise<void> {
   rehydratePath();
   reconcileOrphans();
   void refreshDiscoveredModels();
+
+  // Idle-session reaper (docs/plans/reduce-cpu-and-memory.md §3.1, T4):
+  // mirrors index.ts's wiring so the headless daemon doesn't accumulate the
+  // same idle claude REPLs the desktop app now reaps. A 30s delay before the
+  // first sweep lets `reconcileOrphans` above finish reattaching live
+  // sessions first. Both timers are `.unref()`'d — like the idle-shutdown
+  // timer below, a reap timer must never be what keeps this process alive;
+  // the daemon's own idle-shutdown path (and its resulting `process.exit`)
+  // has to remain reachable regardless of these firing.
+  const reapPostBootTimer = setTimeout(() => {
+    reapIdleSessions().catch((err) => {
+      daemonLog(`idle-session reap (post-boot) failed: ${(err as Error)?.message ?? String(err)}`);
+    });
+  }, 30_000);
+  reapPostBootTimer.unref();
+  const reapIntervalTimer = setInterval(() => {
+    reapIdleSessions().catch((err) => {
+      daemonLog(`idle-session reap (interval) failed: ${(err as Error)?.message ?? String(err)}`);
+    });
+  }, SESSION_REAP_SWEEP_MS);
+  reapIntervalTimer.unref();
 
   let server: ReturnType<typeof startApiServer>;
   try {

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -3,7 +3,8 @@ import Electrobun, { ApplicationMenu, BrowserWindow, Screen, Updater, Utils } fr
 import { rehydratePath } from "./login-path.ts";
 import { startApiServer, API_PORT, API_TOKEN, type ApiNative } from "./server.ts";
 import { db, harnesses, pidFilePath, tasks, dataDir } from "./db.ts";
-import { reconcileOrphans, sweepArchivedTeardowns } from "./orchestrator.ts";
+import { reconcileOrphans, sweepArchivedTeardowns, reapIdleSessions } from "./orchestrator.ts";
+import { SESSION_REAP_SWEEP_MS } from "../shared/types.ts";
 import { broadcastAppEvent, consumeForceQuit } from "./quit-guard.ts";
 import { refreshDiscoveredModels } from "./agent-discovery.ts";
 import { startUpdaterLoop, applyUpdate, checkForUpdate, getUpdateSnapshot } from "./updater.ts";
@@ -124,6 +125,25 @@ reconcileOrphans();
 // because agetor quit or crashed before the job fired. Fire-and-forget — it
 // only enqueues jobs onto that queue, keyed to this instance's own task ids.
 sweepArchivedTeardowns();
+
+// Idle-session reaper (docs/plans/reduce-cpu-and-memory.md §3.1, T4): kills
+// claude REPL tmux sessions that have sat idle (no turn in flight, nothing
+// pending, no activity) for IDLE_SESSION_REAP_MS, reclaiming their ~300–500MB
+// "node" process and per-session timers. A 30s delay before the first sweep
+// lets `reconcileOrphans` above finish reattaching live sessions first, so a
+// task that's mid-reattach isn't mistaken for idle. Errors are swallowed —
+// this is best-effort background hygiene, never something that should crash
+// the app.
+setTimeout(() => {
+  reapIdleSessions().catch((err) => {
+    console.error("[agetor] idle-session reap (post-boot) failed:", err);
+  });
+}, 30_000);
+setInterval(() => {
+  reapIdleSessions().catch((err) => {
+    console.error("[agetor] idle-session reap (interval) failed:", err);
+  });
+}, SESSION_REAP_SWEEP_MS);
 
 installNativeMenu();
 

--- a/src/bun/interactions.ts
+++ b/src/bun/interactions.ts
@@ -394,6 +394,20 @@ export function countPendingForTask(taskId: string): number {
   return n;
 }
 
+/** Grouped counts of pending interactions across every task in one pass over
+ *  both in-memory maps — used by `tasks.list()` so the 2s `/tasks` poll does
+ *  a single scan instead of calling `countPendingForTask` per task row. */
+export function pendingCountsByTask(): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const e of askQuestions.values()) {
+    counts.set(e.req.taskId, (counts.get(e.req.taskId) ?? 0) + 1);
+  }
+  for (const e of tmuxPrompts.values()) {
+    counts.set(e.req.taskId, (counts.get(e.req.taskId) ?? 0) + 1);
+  }
+  return counts;
+}
+
 /** Test-only handle for asserting the registry state. */
 export const __testing = {
   askQuestionsSize: () => askQuestions.size,

--- a/src/bun/migrations/030_runs_task_id_index.sql
+++ b/src/bun/migrations/030_runs_task_id_index.sql
@@ -1,0 +1,5 @@
+-- `runs.task_id` had no index — every /tasks poll's LEFT JOIN and every
+-- eventsForTask/hasEventsBefore query (JOIN runs ON runs.task_id = ...) did a
+-- full table scan of `runs`. Cheap, additive, safe to apply on an existing
+-- large runs table.
+CREATE INDEX IF NOT EXISTS idx_runs_task ON runs(task_id);

--- a/src/bun/migrations/index.ts
+++ b/src/bun/migrations/index.ts
@@ -33,6 +33,7 @@ import m028 from "./028_branch_source.sql" with { type: "text" };
 // This branch originally used 028 for task_draft; renumbered to 029 on merge
 // to avoid the clash with main's 028_branch_source (same as 026 above).
 import m029 from "./029_task_draft.sql" with { type: "text" };
+import m030 from "./030_runs_task_id_index.sql" with { type: "text" };
 
 import type { Migration } from "../migrate.ts";
 
@@ -66,4 +67,5 @@ export const migrations: Migration[] = [
   { id: "027_subagent_tool_use_id", sql: m027 },
   { id: "028_branch_source", sql: m028 },
   { id: "029_task_draft", sql: m029 },
+  { id: "030_runs_task_id_index", sql: m030 },
 ];

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_EFFORT,
   DEFAULT_MODEL,
   DEFAULT_TASK_TYPE,
+  IDLE_SESSION_REAP_MS,
   MODEL_EFFORT_SUPPORT,
   SESSION_DIED_STATUS_PREFIX,
   TASK_TYPES,
@@ -34,6 +35,7 @@ function resolveHarness(harnessId: string): Harness | null {
 }
 import {
   cancelPendingForTask,
+  countPendingForTask,
   setBroadcaster,
   setResolvedBroadcaster,
   type AnyRequest,
@@ -54,6 +56,7 @@ import {
   hasSessionState,
   sessionExists,
   sessionExistsByName,
+  sessionIdleInfo,
   sessionLiveness,
   sessionNameFor,
   jsonlPathFor,
@@ -144,6 +147,14 @@ interface ActiveRun {
   unknownCommand: boolean;
 }
 const active = new Map<string, ActiveRun>(); // runId -> handle
+
+// Guards `reapIdleSessions` against overlapping sweeps — the boot one-shot
+// and the recurring `setInterval` in index.ts could otherwise both be
+// in-flight if a sweep ever ran long (many candidate tasks, a slow tmux
+// probe). A simple boolean is enough: sweeps are infrequent (every
+// `SESSION_REAP_SWEEP_MS`) and idempotent, so skipping one entirely when
+// another is still running just means its candidates get picked up next tick.
+let reapInFlight = false;
 
 // Archive/delete teardown (tmux session kill, terminal teardown, worktree
 // detach/remove) is deferred onto a per-source-workdir FIFO queue so
@@ -2150,6 +2161,97 @@ export function sweepArchivedTeardowns(): number {
     enqueued++;
   }
   return enqueued;
+}
+
+/**
+ * Idle-session reaper (T4, `docs/plans/reduce-cpu-and-memory.md` §3.1). Kills
+ * the tmux session backing a claude-code task's REPL once it's sat idle —
+ * no turn in flight, nothing waiting on the user, no session activity — for
+ * `IDLE_SESSION_REAP_MS` (30min), reclaiming the ~300–500MB "node" process
+ * and every per-session timer (`disposeSessionState`, invoked via
+ * `dropSession`). A follow-up sent afterward still works: `sendClaudeTurn`
+ * falls back to `spawnResumedSession` (`claude --resume <id>`) whenever
+ * `hasSessionState` is false, so this is invisible to the user beyond a
+ * slightly slower first reply.
+ *
+ * Candidates come ONLY from this instance's own DB — this must never
+ * enumerate-and-kill tmux sessions (the shared-socket rule documented on
+ * `reconcileOrphans` above applies here identically: a blind sweep would
+ * reap a sibling agetor instance's or a `bun test` run's sessions). Probing
+ * `sessionLiveness(sessionNameFor(task.id))` for a specific candidate task id
+ * we already own is fine — that's a keyed lookup, not a sweep. Codex is never
+ * a candidate: its sessions are one-shot per turn and self-dispose
+ * (`codex-tmux.ts`), so there's nothing to reap.
+ *
+ * Every guard is re-checked against a freshly-read task row immediately
+ * before the kill, not from the snapshot the loop started with — a message
+ * that lands mid-sweep (flips `active`, clears a pending interaction) must
+ * win over a reap decision made a moment earlier.
+ *
+ * Called once ~30s after boot (letting boot reattach settle first) and then
+ * on a `SESSION_REAP_SWEEP_MS` interval from `src/bun/index.ts`.
+ */
+export async function reapIdleSessions(): Promise<{ reaped: string[] }> {
+  if (reapInFlight) return { reaped: [] };
+  reapInFlight = true;
+  try {
+    const reaped: string[] = [];
+    const candidateIds = tasks
+      .list()
+      .filter((t) => t.archivedAt == null && resolveHarness(t.agent)?.kind === "claude-code")
+      .map((t) => t.id);
+
+    const isReapable = (task: Task): boolean => {
+      if (task.runId && active.has(task.runId)) return false;
+      if (isHeldByBackgroundAgents(task.id)) return false;
+      if (countPendingForTask(task.id) > 0) return false;
+      return true;
+    };
+
+    for (const taskId of candidateIds) {
+      const task = tasks.get(taskId);
+      if (!task || !isReapable(task)) continue;
+
+      const idleInfo = sessionIdleInfo(taskId);
+      const sessionName = sessionNameFor(taskId);
+      let idleLongEnough: boolean;
+      if (idleInfo) {
+        idleLongEnough = idleInfo.idleMs >= IDLE_SESSION_REAP_MS;
+      } else {
+        // No in-memory SessionState — e.g. a done/review task whose session
+        // survived a restart (boot reconciliation only reattaches `running`
+        // rows). Fall back to `task.updatedAt`, but only when a tmux session
+        // still exists to reap; nothing to do otherwise.
+        if (sessionLiveness(sessionName) === "gone") continue;
+        idleLongEnough = Date.now() - task.updatedAt >= IDLE_SESSION_REAP_MS;
+      }
+      if (!idleLongEnough) continue;
+
+      // Re-check immediately before the kill against a fresh row — closes
+      // the window between the idle check above and the kill below.
+      const fresh = tasks.get(taskId);
+      if (!fresh || !isReapable(fresh)) continue;
+
+      dropSession(taskId);
+      reaped.push(taskId);
+
+      const recent = runs.listForTask(taskId)[0];
+      if (recent) {
+        const data = findLastClaudeSessionId(taskId)
+          ? "session hibernated after 30m idle — next message will resume it"
+          : "session hibernated after 30m idle — no saved session id, next message starts a fresh context";
+        runs.appendEvent(recent.id, "status", data);
+        emit({ runId: recent.id, taskId, stream: "status", data, ts: Date.now() });
+      }
+    }
+
+    if (reaped.length > 0) {
+      console.log(`[agetor] reaped ${reaped.length} idle claude session(s)`);
+    }
+    return { reaped };
+  } finally {
+    reapInFlight = false;
+  }
 }
 
 /**

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -59,6 +59,7 @@ import {
   sessionIdleInfo,
   sessionLiveness,
   sessionNameFor,
+  probeSessionActivity,
   jsonlPathFor,
   interruptTaskSession,
   setContinuationRunFactory,
@@ -336,12 +337,21 @@ function updateColumn(
  * `active` map) so the answer survives a restart and doesn't depend on
  * whether the subagent's settle fired before or after the run's completion
  * landed — either interleaving reads the same committed rows.
+ *
+ * Split into a pure `(task) => boolean` predicate plus a taskId-keyed
+ * wrapper so callers that already hold a freshly-fetched `Task` row (e.g.
+ * `reapIdleSessions`'s per-candidate guard) can reuse it without a second,
+ * redundant `tasks.get`.
  */
+function isTaskHeldByBackgroundAgents(task: Task): boolean {
+  if (task.column !== "running" || task.runId == null) return false;
+  if (runs.get(task.runId)?.status !== "succeeded") return false;
+  return subagents.hasRunning(task.id);
+}
+
 function isHeldByBackgroundAgents(taskId: string): boolean {
   const task = tasks.get(taskId);
-  if (!task || task.column !== "running" || task.runId == null) return false;
-  if (runs.get(task.runId)?.status !== "succeeded") return false;
-  return subagents.hasRunning(taskId);
+  return task ? isTaskHeldByBackgroundAgents(task) : false;
 }
 
 /**
@@ -2178,18 +2188,41 @@ export function sweepArchivedTeardowns(): number {
  * enumerate-and-kill tmux sessions (the shared-socket rule documented on
  * `reconcileOrphans` above applies here identically: a blind sweep would
  * reap a sibling agetor instance's or a `bun test` run's sessions). Probing
- * `sessionLiveness(sessionNameFor(task.id))` for a specific candidate task id
- * we already own is fine — that's a keyed lookup, not a sweep. Codex is never
- * a candidate: its sessions are one-shot per turn and self-dispose
+ * a specific candidate task id we already own (`probeSessionActivity`,
+ * `sessionIdleInfo`) is fine — that's a keyed lookup, not a sweep. Codex is
+ * never a candidate: its sessions are one-shot per turn and self-dispose
  * (`codex-tmux.ts`), so there's nothing to reap.
  *
+ * Two performance properties keep a sweep from becoming a synchronous burst
+ * that stalls the main process for the duration of the scan (previously: N
+ * non-archived claude tasks × ~5 DB queries + a blocking tmux probe each, all
+ * in one event-loop turn):
+ *  - **Cheap pre-filter.** `candidateIds` is derived entirely from the rows
+ *    `tasks.list()` already fetched (no per-candidate `tasks.get` yet) and
+ *    excludes any task that plainly can't own a session: archived, non-claude,
+ *    or — the key trim — neither holding in-memory `SessionState` nor ever
+ *    having started a run (`hasSessionState(t.id) || t.runId != null`). A
+ *    never-started task fails both and drops out before it costs anything
+ *    more than an array filter.
+ *  - **Per-candidate yield.** `await Bun.sleep(0)` at the top of every loop
+ *    iteration hands control back to the event loop between candidates, so
+ *    HTTP requests, SSE pushes, and session tailers keep running throughout a
+ *    sweep instead of queuing up behind it. This is what makes the pre-kill
+ *    re-check below load-bearing rather than defensive-only: with real
+ *    yields between iterations, a message that lands mid-sweep (starts a
+ *    turn, opens a pending interaction) MUST be caught by a guard re-read
+ *    immediately before the kill, not just the one the loop started with.
+ *
  * Every guard is re-checked against a freshly-read task row immediately
- * before the kill, not from the snapshot the loop started with — a message
- * that lands mid-sweep (flips `active`, clears a pending interaction) must
- * win over a reap decision made a moment earlier.
+ * before the kill, not from the snapshot the loop started with. Guard work
+ * itself is hoisted to avoid redundant reads: `isReapable` takes the already
+ * -fetched `Task` row and calls the pure `isTaskHeldByBackgroundAgents(task)`
+ * predicate directly rather than the taskId-keyed `isHeldByBackgroundAgents`
+ * wrapper, which would otherwise re-fetch the same row internally.
  *
  * Called once ~30s after boot (letting boot reattach settle first) and then
- * on a `SESSION_REAP_SWEEP_MS` interval from `src/bun/index.ts`.
+ * on a `SESSION_REAP_SWEEP_MS` interval from `src/bun/index.ts` and
+ * `src/bun/headless.ts`.
  */
 export async function reapIdleSessions(): Promise<{ reaped: string[] }> {
   if (reapInFlight) return { reaped: [] };
@@ -2198,37 +2231,62 @@ export async function reapIdleSessions(): Promise<{ reaped: string[] }> {
     const reaped: string[] = [];
     const candidateIds = tasks
       .list()
-      .filter((t) => t.archivedAt == null && resolveHarness(t.agent)?.kind === "claude-code")
+      .filter(
+        (t) =>
+          t.archivedAt == null
+          && resolveHarness(t.agent)?.kind === "claude-code"
+          && (hasSessionState(t.id) || t.runId != null),
+      )
       .map((t) => t.id);
 
     const isReapable = (task: Task): boolean => {
       if (task.runId && active.has(task.runId)) return false;
-      if (isHeldByBackgroundAgents(task.id)) return false;
+      if (isTaskHeldByBackgroundAgents(task)) return false;
       if (countPendingForTask(task.id) > 0) return false;
       return true;
     };
 
     for (const taskId of candidateIds) {
+      // Yield between candidates — see the perf-properties doc above. Safe
+      // because every guard is re-checked against a fresh row immediately
+      // before the kill below.
+      await Bun.sleep(0);
+
       const task = tasks.get(taskId);
       if (!task || !isReapable(task)) continue;
 
       const idleInfo = sessionIdleInfo(taskId);
-      const sessionName = sessionNameFor(taskId);
       let idleLongEnough: boolean;
       if (idleInfo) {
         idleLongEnough = idleInfo.idleMs >= IDLE_SESSION_REAP_MS;
       } else {
         // No in-memory SessionState — e.g. a done/review task whose session
         // survived a restart (boot reconciliation only reattaches `running`
-        // rows). Fall back to `task.updatedAt`, but only when a tmux session
-        // still exists to reap; nothing to do otherwise.
-        if (sessionLiveness(sessionName) === "gone") continue;
-        idleLongEnough = Date.now() - task.updatedAt >= IDLE_SESSION_REAP_MS;
+        // rows). Probe tmux directly for the session's own activity clock
+        // (`#{session_activity}`) instead of the previous `task.updatedAt`
+        // heuristic, which could read stale on a task nobody touched through
+        // agetor but that's still being used interactively in its terminal.
+        // `null` means the session is already gone (or unreachable) — nothing
+        // to reap. `attached === true` means a human has the pane open right
+        // now — never reap that regardless of how long it's been idle by the
+        // clock. Otherwise require BOTH tmux's activity clock AND the task
+        // row's `updatedAt` past the threshold before reaping a session we
+        // have no in-memory visibility into — the extra-conservative choice
+        // called out in the review: a session could be driven by something
+        // other than agetor (a human at the tmux client) bumping tmux's
+        // activity clock without ever updating our DB row, or vice versa.
+        const activity = probeSessionActivity(taskId);
+        if (!activity) continue;
+        if (activity.attached) continue;
+        idleLongEnough =
+          Date.now() - activity.activityAt >= IDLE_SESSION_REAP_MS
+          && Date.now() - task.updatedAt >= IDLE_SESSION_REAP_MS;
       }
       if (!idleLongEnough) continue;
 
       // Re-check immediately before the kill against a fresh row — closes
-      // the window between the idle check above and the kill below.
+      // the window between the idle check above (which may itself have
+      // awaited a yield or a tmux probe) and the kill below.
       const fresh = tasks.get(taskId);
       if (!fresh || !isReapable(fresh)) continue;
 

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -3797,9 +3797,27 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       // and WebKit's fetch rejects with the unhelpful "Load failed".
       "/runs/:id/rebuild-events": { GET: authed((req) => {
         try {
+          // Optional `?limit=` caps the response to the most recent N mapped
+          // events (ascending) plus `hasMore`, so the RunPanel's auto-rebuild
+          // on opening a finished claude task doesn't defeat the SSE replay
+          // window by pulling unbounded full JSONL history. Absent `limit`,
+          // the response keeps its pre-existing shape (bare `events` array,
+          // no `hasMore`) for any other caller — additive-only change.
+          const url = new URL(req.url);
+          const limitParam = url.searchParams.get("limit");
+          const hasLimit = limitParam !== null;
+          const limitRaw = Number(limitParam);
+          const limit = Number.isFinite(limitRaw) && limitRaw > 0
+            ? Math.max(1, Math.min(Math.floor(limitRaw), 2000))
+            : EVENTS_REPLAY_LIMIT;
           const run = runs.get(req.params.id);
           if (!run) return json({ error: "run not found" }, { status: 404, headers: corsHeaders(req) });
-          if (!run.claudeSessionId) return json({ events: [], reason: "run has no claude session id" }, { headers: corsHeaders(req) });
+          if (!run.claudeSessionId) {
+            return json(
+              { events: [], reason: "run has no claude session id", ...(hasLimit ? { hasMore: false } : {}) },
+              { headers: corsHeaders(req) },
+            );
+          }
           const task = tasks.get(run.taskId);
           if (!task) return json({ error: "task not found" }, { status: 404, headers: corsHeaders(req) });
           // Reconstruct the cwd claude was launched against. Worktree tasks
@@ -3811,7 +3829,10 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           const harness = harnesses.getByIdOrKind(task.agent);
           const jsonlPath = jsonlPathFor(cwd, run.claudeSessionId, harness?.home ?? null);
           if (!existsSync(jsonlPath)) {
-            return json({ events: [], reason: `JSONL not found at ${jsonlPath}` }, { headers: corsHeaders(req) });
+            return json(
+              { events: [], reason: `JSONL not found at ${jsonlPath}`, ...(hasLimit ? { hasMore: false } : {}) },
+              { headers: corsHeaders(req) },
+            );
           }
           // Drive the JSONL through the same staging pipeline live tailing
           // uses, so the rebuilt event stream contains "turn complete"
@@ -3834,6 +3855,11 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             });
           };
           rebuildEventsFromJsonl(readFileSync(jsonlPath, "utf8"), onChunk);
+          if (hasLimit) {
+            const hasMore = events.length > limit;
+            const windowed = hasMore ? events.slice(events.length - limit) : events;
+            return json({ events: windowed, hasMore, source: jsonlPath }, { headers: corsHeaders(req) });
+          }
           return json({ events, source: jsonlPath }, { headers: corsHeaders(req) });
         } catch (e) {
           const msg = (e as Error).message ?? String(e);
@@ -4129,15 +4155,15 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           const url = new URL(req.url);
           const beforeIdParam = url.searchParams.get("beforeId");
           const beforeIdRaw = beforeIdParam === null ? NaN : Number(beforeIdParam);
-          if (!Number.isFinite(beforeIdRaw)) {
+          if (!Number.isInteger(beforeIdRaw) || beforeIdRaw <= 0) {
             return json(
-              { error: "beforeId (integer) required" },
+              { error: "beforeId (positive integer) required" },
               { status: 400, headers: corsHeaders(req) },
             );
           }
           const limitRaw = Number(url.searchParams.get("limit"));
           const limit = Number.isFinite(limitRaw) && limitRaw > 0
-            ? Math.min(limitRaw, 2000)
+            ? Math.max(1, Math.min(Math.floor(limitRaw), 2000))
             : EVENTS_REPLAY_LIMIT;
           const rows = runs.eventsForTask(taskId, { beforeId: beforeIdRaw, limit });
           const events = rows.map((ev) => ({
@@ -4203,6 +4229,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             sendNamed(TASK_EVENTS_REPLAY_META_EVENT, { earliestId, hasMore } satisfies TaskEventsReplayMeta);
             for (const ev of window) {
               send({
+                id: ev.id,
                 runId: ev.runId,
                 taskId,
                 stream: ev.stream as RunEvent["stream"],

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -144,7 +144,14 @@ import {
   listPendingForTask,
   type AskQuestionsAnswer,
 } from "./interactions.ts";
-import { DEFAULT_BRANCH_CONFIG, MODEL_EFFORT_SUPPORT, TASK_TYPES, validateBranchConfig } from "../shared/types.ts";
+import {
+  DEFAULT_BRANCH_CONFIG,
+  EVENTS_REPLAY_LIMIT,
+  MODEL_EFFORT_SUPPORT,
+  TASK_EVENTS_REPLAY_META_EVENT,
+  TASK_TYPES,
+  validateBranchConfig,
+} from "../shared/types.ts";
 import type {
   AgentKind,
   AppEvent,
@@ -158,6 +165,7 @@ import type {
   GlobalEvent,
   RunEvent,
   Task,
+  TaskEventsReplayMeta,
   TaskReference,
 } from "../shared/types.ts";
 import { armForceQuit, broadcastAppEvent, subscribeAppEvents } from "./quit-guard.ts";
@@ -4107,6 +4115,46 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
         }),
       },
 
+      // Paged access to older events, for the "Load earlier" affordance once
+      // the SSE replay window (below) has been exhausted. `beforeId` is
+      // required — this is a backward-paging cursor, not a general listing
+      // endpoint. Ascending order, same event shape as the SSE frames (plus
+      // `id`, which is handy for chaining the next `beforeId`).
+      "/tasks/:id/events/page": {
+        GET: authed((req) => {
+          const taskId = req.params.id;
+          if (!tasks.get(taskId)) {
+            return json({ error: "not found" }, { status: 404, headers: corsHeaders(req) });
+          }
+          const url = new URL(req.url);
+          const beforeIdParam = url.searchParams.get("beforeId");
+          const beforeIdRaw = beforeIdParam === null ? NaN : Number(beforeIdParam);
+          if (!Number.isFinite(beforeIdRaw)) {
+            return json(
+              { error: "beforeId (integer) required" },
+              { status: 400, headers: corsHeaders(req) },
+            );
+          }
+          const limitRaw = Number(url.searchParams.get("limit"));
+          const limit = Number.isFinite(limitRaw) && limitRaw > 0
+            ? Math.min(limitRaw, 2000)
+            : EVENTS_REPLAY_LIMIT;
+          const rows = runs.eventsForTask(taskId, { beforeId: beforeIdRaw, limit });
+          const events = rows.map((ev) => ({
+            id: ev.id,
+            runId: ev.runId,
+            taskId,
+            stream: ev.stream as RunEvent["stream"],
+            data: ev.data,
+            ts: ev.ts,
+            subagentId: ev.subagentId,
+          }));
+          const earliestId = events.length > 0 ? events[0]!.id : null;
+          const hasMore = earliestId !== null && runs.hasEventsBefore(taskId, earliestId);
+          return json({ events, earliestId, hasMore }, { headers: corsHeaders(req) });
+        }),
+      },
+
       "/tasks/:id/events": authed((req) => {
         const taskId = req.params.id;
         const stream = new ReadableStream({
@@ -4125,6 +4173,17 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
                 // (which would then permanently block the daemon's idle-shutdown).
               }
             };
+            // Named frame — invisible to a plain `onmessage` listener (only
+            // `addEventListener(name, ...)` sees it), so old/unmodified
+            // clients keep working unchanged even though a new frame now
+            // precedes the replayed window.
+            const sendNamed = (name: string, data: unknown) => {
+              try {
+                controller.enqueue(enc.encode(`event: ${name}\ndata: ${JSON.stringify(data)}\n\n`));
+              } catch {
+                // Same rationale as `send`'s catch above.
+              }
+            };
             // Unified task-level stream: one scrollback per task, merging
             // events across every run. Subscribe before replay (same race
             // protection as the per-run endpoint).
@@ -4134,7 +4193,15 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
               if (buffer) buffer.push(e);
               else send(e);
             });
-            for (const ev of runs.eventsForTask(taskId)) {
+            // Cap replay to the most recent EVENTS_REPLAY_LIMIT events instead
+            // of the task's full history — a task with thousands of events
+            // used to replay every one of them on every SSE (re)connect.
+            // Older history is fetched on demand via /tasks/:id/events/page.
+            const window = runs.eventsForTask(taskId, { limit: EVENTS_REPLAY_LIMIT });
+            const earliestId = window.length > 0 ? window[0]!.id : null;
+            const hasMore = earliestId !== null && runs.hasEventsBefore(taskId, earliestId);
+            sendNamed(TASK_EVENTS_REPLAY_META_EVENT, { earliestId, hasMore } satisfies TaskEventsReplayMeta);
+            for (const ev of window) {
               send({
                 runId: ev.runId,
                 taskId,

--- a/src/bun/session-reaper.test.ts
+++ b/src/bun/session-reaper.test.ts
@@ -1,0 +1,323 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+// Top-level: db.ts captures AGETOR_DATA_DIR at first import — a `beforeAll`
+// hook would race with any sibling test file that already imported db.ts in
+// this process (see orchestrator.test.ts's identical comment). Every test
+// below reaches `./orchestrator.ts`/`./db.ts` only through a dynamic
+// `await import(...)` inside the test body, so this top-level assignment is
+// guaranteed to run first.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-reap-test-"));
+// Drive claude through the in-process fake driver instead of tmux + the real
+// CLI (orchestrator.test.ts's pattern). AGETOR_CLAUDE_BIN/AGETOR_TMUX_BIN are
+// also overridden to `/bin/echo` so the agent-status/tmux preflights inside
+// startTask pass without either binary installed, and so any tmux call the
+// reaper's kill path makes (`killTaskSession` → `tmux kill-session`) is a
+// harmless no-op against `/bin/echo` rather than touching the user's real
+// tmux socket.
+process.env.AGETOR_CLAUDE_DRIVER = "fake";
+process.env.AGETOR_CLAUDE_BIN = "/bin/echo";
+process.env.AGETOR_TMUX_BIN = "/bin/echo";
+process.env.AGETOR_CLAUDE_ARGS = "";
+
+/** Create a claude-code task with worktree isolation off, so no real git
+ *  branch/worktree is materialized in the repo running the test suite (see
+ *  the worktree-isolation warning in CLAUDE.md and orchestrator.test.ts's
+ *  identical convention). */
+async function createClaudeTask(title: string) {
+  const { createTask } = await import("./orchestrator.ts");
+  const created = await createTask({
+    title,
+    prompt: "hello",
+    agent: "claude-code",
+    workdir: process.cwd(),
+    isolation: "none",
+  });
+  if ("error" in created) throw new Error(created.error);
+  return created.task;
+}
+
+/** Install a synthetic in-memory `SessionState` for `taskId` (the same
+ *  `__forTest.installSession` helper orchestrator.test.ts's fold-while-busy
+ *  test uses) and back-date its activity clock so `sessionIdleInfo` reports
+ *  it idle for at least `aheadOfNowMs` beyond "now". The fake claude driver
+ *  never touches claude-tmux at all, so nothing does this automatically —
+ *  tests that want the reaper's in-memory-session branch (rather than its
+ *  no-in-memory-state `task.updatedAt` fallback) must install one by hand. */
+async function installIdleSession(taskId: string, idleMs: number) {
+  const claudeTmux = await import("./claude-tmux.ts");
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-reap-session-"));
+  const jsonlPath = path.join(dir, `${randomUUID()}.jsonl`);
+  writeFileSync(jsonlPath, "");
+  const state = claudeTmux.__forTest.installSession(taskId, jsonlPath);
+  state.lastActivityAt = Date.now() - idleMs;
+  return state;
+}
+
+test("reaps a claude task whose in-memory session has been idle past the threshold, and appends a hibernation status event", async () => {
+  const { startTask, reapIdleSessions } = await import("./orchestrator.ts");
+  const { db, runs } = await import("./db.ts");
+  const claudeTmux = await import("./claude-tmux.ts");
+  const { IDLE_SESSION_REAP_MS } = await import("../shared/types.ts");
+
+  const task = await createClaudeTask("idle reap candidate");
+  const taskId = task.id;
+
+  const started = await startTask(taskId);
+  if (!("runId" in started)) throw new Error("expected the run to start");
+
+  // Let the fake driver's ~20ms turn resolve so `active` no longer holds this
+  // run — otherwise the in-flight guard would (correctly, but uninterestingly
+  // for THIS test) block the reap regardless of idle time.
+  await new Promise((r) => setTimeout(r, 80));
+
+  await installIdleSession(taskId, IDLE_SESSION_REAP_MS + 5_000);
+
+  try {
+    expect(claudeTmux.hasSessionState(taskId)).toBe(true);
+
+    const { reaped } = await reapIdleSessions();
+
+    expect(reaped).toContain(taskId);
+    expect(claudeTmux.hasSessionState(taskId)).toBe(false);
+
+    const events = runs.eventsForTask(taskId);
+    const hibernated = events.find(
+      (e) => e.stream === "status" && e.data.includes("hibernated"),
+    );
+    expect(hibernated).toBeDefined();
+    expect(hibernated?.data).toContain("30m idle");
+  } finally {
+    claudeTmux.__forTest.uninstallSession(taskId);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("does not reap a task whose run is still active (a turn in flight)", async () => {
+  const { startTask, reapIdleSessions } = await import("./orchestrator.ts");
+  const { db } = await import("./db.ts");
+
+  const task = await createClaudeTask("in-flight guard");
+  const taskId = task.id;
+
+  const started = await startTask(taskId);
+  if (!("runId" in started)) throw new Error("expected the run to start");
+
+  try {
+    // TIMING INVARIANT (mirrors orchestrator.test.ts's fold-while-busy test):
+    // no `await` runs between `startTask` resolving and this call, so
+    // `active` is guaranteed to still hold this run's handle — the fake
+    // driver doesn't resolve the turn for ~20ms. `reapIdleSessions` itself
+    // does no internal `await` before consulting `active`, so this captures
+    // the in-flight state precisely.
+    const { reaped } = await reapIdleSessions();
+    expect(reaped).not.toContain(taskId);
+  } finally {
+    // Let the in-flight fake turn resolve before the row is deleted out from
+    // under its timer.
+    await new Promise((r) => setTimeout(r, 80));
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("does not reap a task with a pending interaction", async () => {
+  const { startTask, reapIdleSessions } = await import("./orchestrator.ts");
+  const { db } = await import("./db.ts");
+  const claudeTmux = await import("./claude-tmux.ts");
+  const { registerScrapedAskQuestions, cancelPendingForTask } = await import("./interactions.ts");
+  const { IDLE_SESSION_REAP_MS } = await import("../shared/types.ts");
+
+  const task = await createClaudeTask("pending interaction guard");
+  const taskId = task.id;
+
+  const started = await startTask(taskId);
+  if (!("runId" in started)) throw new Error("expected the run to start");
+  const runId = started.runId;
+  await new Promise((r) => setTimeout(r, 80)); // let the turn resolve, clearing `active`
+
+  await installIdleSession(taskId, IDLE_SESSION_REAP_MS + 5_000);
+
+  registerScrapedAskQuestions({
+    taskId,
+    runId,
+    questions: [{ question: "Pick one", options: [{ label: "A" }, { label: "B" }] }],
+    fingerprint: "fp-reap-guard",
+  });
+
+  try {
+    const { reaped } = await reapIdleSessions();
+    expect(reaped).not.toContain(taskId);
+    expect(claudeTmux.hasSessionState(taskId)).toBe(true);
+  } finally {
+    cancelPendingForTask(taskId, "test cleanup");
+    claudeTmux.__forTest.uninstallSession(taskId);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("does not reap a session that has been idle for less than the threshold", async () => {
+  const { startTask, reapIdleSessions } = await import("./orchestrator.ts");
+  const { db } = await import("./db.ts");
+  const claudeTmux = await import("./claude-tmux.ts");
+
+  const task = await createClaudeTask("young session guard");
+  const taskId = task.id;
+
+  const started = await startTask(taskId);
+  if (!("runId" in started)) throw new Error("expected the run to start");
+  await new Promise((r) => setTimeout(r, 80)); // let the turn resolve, clearing `active`
+
+  // Comfortably below IDLE_SESSION_REAP_MS (30min) — "just showed life".
+  await installIdleSession(taskId, 1_000);
+
+  try {
+    const { reaped } = await reapIdleSessions();
+    expect(reaped).not.toContain(taskId);
+    expect(claudeTmux.hasSessionState(taskId)).toBe(true);
+  } finally {
+    claudeTmux.__forTest.uninstallSession(taskId);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("never considers a codex task, even when its updatedAt is old enough to otherwise qualify", async () => {
+  const { createTask, reapIdleSessions } = await import("./orchestrator.ts");
+  const { db } = await import("./db.ts");
+  const { IDLE_SESSION_REAP_MS } = await import("../shared/types.ts");
+
+  const created = await createTask({
+    title: "codex is never a reap candidate",
+    prompt: "hello",
+    agent: "codex",
+    workdir: process.cwd(),
+    isolation: "none",
+  });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  // `tasks.update` always stamps `updatedAt` to "now", so the only way to
+  // simulate an old row is a raw UPDATE — mirroring how these tests already
+  // reach into `db` directly for cleanup. If the reaper didn't filter on
+  // agent kind up front, this alone would make the task eligible via the
+  // no-in-memory-state `task.updatedAt` fallback (there's no live tmux
+  // session to make `sessionLiveness` say "gone", and `/bin/echo` standing in
+  // for tmux always reports "alive").
+  db.run(`UPDATE tasks SET updated_at = ? WHERE id = ?`, [
+    Date.now() - IDLE_SESSION_REAP_MS - 60_000,
+    taskId,
+  ]);
+
+  try {
+    const { reaped } = await reapIdleSessions();
+    expect(reaped).not.toContain(taskId);
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("after a reap, a follow-up routes through the resume path (new run, not a live-session paste)", async () => {
+  const { startTask, sendInput, reapIdleSessions } = await import("./orchestrator.ts");
+  const { db, runs } = await import("./db.ts");
+  const claudeTmux = await import("./claude-tmux.ts");
+  const { IDLE_SESSION_REAP_MS } = await import("../shared/types.ts");
+
+  const task = await createClaudeTask("reap then resume");
+  const taskId = task.id;
+
+  const started = await startTask(taskId);
+  if (!("runId" in started)) throw new Error("expected the run to start");
+  const originalRunId = started.runId;
+  await new Promise((r) => setTimeout(r, 80)); // let the turn resolve, clearing `active`
+
+  await installIdleSession(taskId, IDLE_SESSION_REAP_MS + 5_000);
+
+  try {
+    const { reaped } = await reapIdleSessions();
+    expect(reaped).toContain(taskId);
+    // This is the exact signal `sendClaudeTurn` branches on: with no
+    // in-memory session state, it must take `spawnResumedSession` instead of
+    // `sendTurnInExistingSession`'s live-session paste path.
+    expect(claudeTmux.hasSessionState(taskId)).toBe(false);
+
+    const sent = await sendInput(originalRunId, "are you still there?");
+    expect(sent.delivered).toBe(true);
+    if (!sent.delivered) return;
+
+    // `spawnResumedSession` always creates a brand-new run row (unlike the
+    // fold-while-busy path, which reuses the active run) — this is the
+    // observable proof the resume branch, not the paste branch, ran.
+    expect(sent.runId).not.toBe(originalRunId);
+
+    const rows = runs.listForTask(taskId);
+    expect(rows.map((r) => r.id).sort()).toEqual([originalRunId, sent.runId].sort());
+
+    // `spawnResumedSession` emits one of these two status lines unconditionally
+    // right after spawning — the fake driver never stamps a claudeSessionId,
+    // so this run takes the "no prior session" branch, but either phrasing
+    // proves the resume path (not the paste path, which never emits either).
+    const resumeStatus = runs
+      .eventsForTask(taskId)
+      .find(
+        (e) =>
+          e.runId === sent.runId
+          && e.stream === "status"
+          && (e.data.includes("resuming claude session") || e.data.includes("no prior claude session")),
+      );
+    expect(resumeStatus).toBeDefined();
+
+    // Let the resumed fake turn resolve before cleanup deletes the row out
+    // from under its ~20ms timer.
+    await new Promise((r) => setTimeout(r, 80));
+  } finally {
+    claudeTmux.__forTest.uninstallSession(taskId);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("back-to-back reap sweeps never reap the same task twice", async () => {
+  const { startTask, reapIdleSessions } = await import("./orchestrator.ts");
+  const { db, runs } = await import("./db.ts");
+  const claudeTmux = await import("./claude-tmux.ts");
+  const { IDLE_SESSION_REAP_MS } = await import("../shared/types.ts");
+
+  const task = await createClaudeTask("no double reap");
+  const taskId = task.id;
+
+  const started = await startTask(taskId);
+  if (!("runId" in started)) throw new Error("expected the run to start");
+  await new Promise((r) => setTimeout(r, 80)); // let the turn resolve, clearing `active`
+
+  await installIdleSession(taskId, IDLE_SESSION_REAP_MS + 5_000);
+
+  try {
+    // Honest caveat: `reapIdleSessions` has no internal `await` in its body
+    // (confirmed by reading orchestrator.ts) — every await it might hit
+    // (tasks.get, dropSession, runs.appendEvent) is actually synchronous
+    // (sqlite + in-memory work), so calling it twice back-to-back can never
+    // produce TRUE interleaving in this single-threaded runtime: the first
+    // call runs to completion (including resetting the `reapInFlight` mutex)
+    // before the second call's body even starts. Exercising a genuine race
+    // would require monkeypatching an internal export mid-sweep, which no
+    // existing test in this codebase does and which the task brief asked not
+    // to invent. What IS testable — and still a real regression guard for the
+    // documented invariant — is that neither call double-reaps: the second
+    // sweep must see the session already gone and the task's `updatedAt`
+    // freshly bumped (recent, not idle), so its `task.updatedAt` fallback
+    // correctly declines a second time.
+    const [first, second] = await Promise.all([reapIdleSessions(), reapIdleSessions()]);
+
+    const hits = (first.reaped.includes(taskId) ? 1 : 0) + (second.reaped.includes(taskId) ? 1 : 0);
+    expect(hits).toBe(1);
+
+    const hibernatedEvents = runs
+      .eventsForTask(taskId)
+      .filter((e) => e.stream === "status" && e.data.includes("hibernated"));
+    expect(hibernatedEvents.length).toBe(1);
+  } finally {
+    claudeTmux.__forTest.uninstallSession(taskId);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});

--- a/src/bun/terminals.ts
+++ b/src/bun/terminals.ts
@@ -226,6 +226,17 @@ export function countTerminals(taskId: string): number {
   return n;
 }
 
+/** Grouped counts of open terminals across every task in one pass over the
+ *  in-memory map — used by `tasks.list()` so the 2s `/tasks` poll does a
+ *  single scan instead of calling `countTerminals` per task row. */
+export function terminalCountsByTask(): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const e of terminals.values()) {
+    counts.set(e.taskId, (counts.get(e.taskId) ?? 0) + 1);
+  }
+  return counts;
+}
+
 export function getTerminal(id: string): TerminalTab | null {
   const e = terminals.get(id);
   return e ? toTab(e) : null;

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -85,16 +85,49 @@ function ErrorToast({ error, onDismiss }: { error: string | null; onDismiss: () 
  * `runningSubagents`, `openTerminalCount` are all computed server-side per
  * request and aren't reflected in `updatedAt`).
  *
+ * `cache`, when passed, memoizes each entry's serialized form by id so a
+ * poll where nothing changed only has to `JSON.stringify` the freshly
+ * fetched (`next`) side — the `prev` side is a cache hit as long as the
+ * cached entry's object reference still matches what's actually in `prev`
+ * (it can legitimately not: several call sites patch `tasks` state directly
+ * for optimistic updates, bypassing this function, so a stale/mismatched
+ * cache entry falls back to recomputing rather than trusting a stringified
+ * form for a different object). Entries whose id no longer appears in
+ * `next` are evicted so the cache doesn't grow unboundedly across a
+ * session's worth of deleted/archived tasks.
+ *
  * Returns `prev` itself (same array reference) when every entry, in the
  * same order, is unchanged — letting the caller's `setState` bail out
  * entirely instead of triggering a render.
  */
-function reconcileById<T>(prev: T[], next: T[], keyOf: (item: T) => string): T[] {
+function reconcileById<T>(
+  prev: T[],
+  next: T[],
+  keyOf: (item: T) => string,
+  cache?: Map<string, { obj: T; json: string }>,
+): T[] {
   const prevByKey = new Map(prev.map((item) => [keyOf(item), item] as const));
+  const seen = new Set<string>();
   const merged = next.map((item) => {
-    const old = prevByKey.get(keyOf(item));
-    return old && JSON.stringify(old) === JSON.stringify(item) ? old : item;
+    const key = keyOf(item);
+    seen.add(key);
+    const old = prevByKey.get(key);
+    const nextJson = JSON.stringify(item);
+    let unchanged = false;
+    if (old !== undefined) {
+      const cached = cache?.get(key);
+      const oldJson = cached && cached.obj === old ? cached.json : JSON.stringify(old);
+      unchanged = oldJson === nextJson;
+    }
+    const finalItem = unchanged ? old! : item;
+    if (cache) cache.set(key, { obj: finalItem, json: nextJson });
+    return finalItem;
   });
+  if (cache) {
+    for (const key of cache.keys()) {
+      if (!seen.has(key)) cache.delete(key);
+    }
+  }
   if (merged.length === prev.length && merged.every((item, i) => item === prev[i])) {
     return prev;
   }
@@ -145,6 +178,11 @@ export default function App() {
     return () => { clearTimeout(hideTimer); clearTimeout(removeTimer); };
   }, []);
 
+  // Per-task serialized-form cache for `reconcileById` below — see that
+  // function's doc comment. A ref (not state) since it's pure bookkeeping
+  // that must survive across polls without itself triggering a render.
+  const taskReconcileCacheRef = useRef(new Map<string, { obj: Task; json: string }>());
+
   /** Re-list tasks. Returns the fetched list so callers that need to inspect a
    *  task right after a mutation don't have to issue a second GET. `null` on
    *  failure — the last good snapshot stays rendered and the poll retries. */
@@ -154,7 +192,7 @@ export default function App() {
       // `list` (unreconciled) is what callers get back for immediate reads
       // (e.g. re-checking a just-created task's branch); the reconciled,
       // identity-preserving version is what actually lands in state.
-      setTasks((prev) => reconcileById(prev, list, (t) => t.id));
+      setTasks((prev) => reconcileById(prev, list, (t) => t.id, taskReconcileCacheRef.current));
       return list;
     } catch { return null; /* keep last good snapshot; retry next tick */ }
   }, []);

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { AlertTriangle, FolderGit2, GitPullRequest, Settings, X } from "lucide-react";
 import { api, type AgentModelMap } from "@/lib/api";
@@ -72,6 +72,35 @@ function ErrorToast({ error, onDismiss }: { error: string | null; onDismiss: () 
   );
 }
 
+/**
+ * Reconcile a freshly-fetched list against the previously-rendered one,
+ * preserving object identity for entries that haven't actually changed.
+ * Poll-driven fetches (`/tasks` every 2s, `/harnesses` every 15s) otherwise
+ * hand back brand-new object graphs every tick even when nothing changed
+ * server-side — that defeats `React.memo` on every downstream card/column
+ * and force-renders the selected-task sync effect. Deep-equality here is a
+ * plain `JSON.stringify` compare: cheap at this scale (hundreds of small
+ * objects, once per poll) and robust against any field changing without a
+ * corresponding `updatedAt` bump (e.g. `pendingInteractionCount`,
+ * `runningSubagents`, `openTerminalCount` are all computed server-side per
+ * request and aren't reflected in `updatedAt`).
+ *
+ * Returns `prev` itself (same array reference) when every entry, in the
+ * same order, is unchanged — letting the caller's `setState` bail out
+ * entirely instead of triggering a render.
+ */
+function reconcileById<T>(prev: T[], next: T[], keyOf: (item: T) => string): T[] {
+  const prevByKey = new Map(prev.map((item) => [keyOf(item), item] as const));
+  const merged = next.map((item) => {
+    const old = prevByKey.get(keyOf(item));
+    return old && JSON.stringify(old) === JSON.stringify(item) ? old : item;
+  });
+  if (merged.length === prev.length && merged.every((item, i) => item === prev[i])) {
+    return prev;
+  }
+  return merged;
+}
+
 export default function App() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [agents, setAgents] = useState<AgentStatus[]>([]);
@@ -119,23 +148,26 @@ export default function App() {
   /** Re-list tasks. Returns the fetched list so callers that need to inspect a
    *  task right after a mutation don't have to issue a second GET. `null` on
    *  failure — the last good snapshot stays rendered and the poll retries. */
-  const refresh = async (): Promise<Task[] | null> => {
+  const refresh = useCallback(async (): Promise<Task[] | null> => {
     try {
       const list = await api.listTasks();
-      setTasks(list);
+      // `list` (unreconciled) is what callers get back for immediate reads
+      // (e.g. re-checking a just-created task's branch); the reconciled,
+      // identity-preserving version is what actually lands in state.
+      setTasks((prev) => reconcileById(prev, list, (t) => t.id));
       return list;
     } catch { return null; /* keep last good snapshot; retry next tick */ }
-  };
-  const refreshAgents = async () => {
+  }, []);
+  const refreshAgents = useCallback(async () => {
     try {
       const payload = await api.listHarnesses();
-      setHarnesses(payload.harnesses);
-      setAgents(payload.statuses);
+      setHarnesses((prev) => reconcileById(prev, payload.harnesses, (h) => h.id));
+      setAgents((prev) => reconcileById(prev, payload.statuses, (a) => a.harnessId));
     } catch { /* leave previous state */ }
-  };
-  const refreshAgentModels = async () => {
+  }, []);
+  const refreshAgentModels = useCallback(async () => {
     try { setAgentModels(await api.listAgentModels()); } catch { /* leave previous state */ }
-  };
+  }, []);
   useEffect(() => {
     void refresh();
     void refreshAgents();
@@ -165,14 +197,34 @@ export default function App() {
     // freshly-opened webview wouldn't know about an update that was already
     // downloaded by the previous main-process tick.
     api.getUpdateStatus().then(setUpdateSnapshot).catch(() => { /* fine */ });
-    const t = setInterval(refresh, 2000);
-    const a = setInterval(refreshAgents, 15_000);
+    // Skip poll ticks while the window is hidden — a backgrounded kanban
+    // board has no reason to keep re-fetching + re-rendering every 2s/15s.
+    // The intervals themselves keep running (cheap — it's just the fetch +
+    // setState that's skipped) so there's nothing to re-arm; `visible`
+    // fires an immediate refresh so returning to the window doesn't wait
+    // out a stale tick. This mirrors the existing `flushNow`-on-visible
+    // wiring in RunPanel and is mandatory, not an optimization: WKWebView
+    // suspends rAF (not setInterval) while occluded, but a naive "just
+    // gate the poll" change without an immediate on-return refresh would
+    // reintroduce the same class of "frozen until you nudge the window"
+    // bug previously fixed there.
+    const t = setInterval(() => { if (!document.hidden) void refresh(); }, 2000);
+    const a = setInterval(() => { if (!document.hidden) void refreshAgents(); }, 15_000);
+    const onVisible = () => {
+      if (document.hidden) return;
+      void refresh();
+      void refreshAgents();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
     return () => {
       clearInterval(t);
       clearInterval(a);
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
       if (defaultsTimer) clearTimeout(defaultsTimer);
     };
-  }, []);
+  }, [refresh, refreshAgents, refreshAgentModels]);
 
   // Keep the selected task in sync as the list refreshes.
   useEffect(() => {
@@ -425,14 +477,26 @@ export default function App() {
     [tasks],
   );
 
-  const surfaceError = (e: unknown) =>
+  // Every handler below is wrapped in `useCallback` so it keeps a stable
+  // identity across App re-renders (poll ticks, unrelated state changes,
+  // etc.) — they're passed straight down to `Column`/`TaskCard`, both
+  // `React.memo`'d, and an unstable function prop would force every card in
+  // every column to re-render on every tick regardless of the task-list
+  // equality guard above. None of these actually need to read the current
+  // `tasks`/`selected` state (they operate on the `t` argument the caller
+  // already has), except `del`'s "is the deleted task the open one" check —
+  // that reads `selectedIdRef` (already kept in sync by the effect above)
+  // instead of `selected` directly, so `del` doesn't have to change identity
+  // every time the user opens a different task.
+  const surfaceError = useCallback((e: unknown) => {
     setError(e instanceof Error ? e.message : String(e));
+  }, []);
 
-  const onDragEnd = async (e: DragEndEvent) => {
+  const onDragEnd = useCallback(async (e: DragEndEvent) => {
     const id = String(e.active.id);
     const col = e.over?.id as ColumnId | undefined;
     if (!col) return;
-    const t = tasks.find((x) => x.id === id);
+    const t = tasksRef.current.find((x) => x.id === id);
     if (!t || t.column === col) return;
     setTasks((cur) => cur.map((x) => (x.id === id ? { ...x, column: col } : x)));
     try {
@@ -443,14 +507,14 @@ export default function App() {
       // Server didn't accept the move — re-sync the optimistic UI.
       await refresh();
     }
-  };
+  }, [refresh, surfaceError]);
 
   // `startTask` materializes the worktree, which can re-pin the branch when a
   // create-time uniqueness race is only detectable once the branch actually
   // exists. Surface the change so the user isn't left believing the name they
   // saw. Reads the new branch out of the refresh we already do — no extra GET.
   // Best-effort: if the refresh failed, the 2s poll still shows the real branch.
-  const startAndNotifyBranch = async (taskId: string, branchBefore: string | null) => {
+  const startAndNotifyBranch = useCallback(async (taskId: string, branchBefore: string | null) => {
     await api.startTask(taskId);
     const list = await refresh();
     if (!branchBefore || !list) return;
@@ -458,9 +522,9 @@ export default function App() {
     if (after?.branch && after.branch !== branchBefore) {
       toast(`Branch changed to “${after.branch}” — “${branchBefore}” was already taken.`);
     }
-  };
+  }, [refresh]);
 
-  const start = async (t: Task) => {
+  const start = useCallback(async (t: Task) => {
     try {
       setError(null);
       await startAndNotifyBranch(t.id, t.branch);
@@ -475,8 +539,8 @@ export default function App() {
       }
       void refreshAgents();
     }
-  };
-  const cancel = async (t: Task) => {
+  }, [startAndNotifyBranch, surfaceError, refreshAgents]);
+  const cancel = useCallback(async (t: Task) => {
     if (!t.runId) return;
     try {
       setError(null);
@@ -484,8 +548,8 @@ export default function App() {
     } catch (e) {
       surfaceError(e);
     }
-  };
-  const markDone = async (t: Task) => {
+  }, [surfaceError]);
+  const markDone = useCallback(async (t: Task) => {
     setTasks((cur) => cur.map((x) => (x.id === t.id ? { ...x, column: "done" } : x)));
     try {
       setError(null);
@@ -495,8 +559,8 @@ export default function App() {
       surfaceError(e);
       await refresh();
     }
-  };
-  const archive = async (t: Task) => {
+  }, [refresh, surfaceError]);
+  const archive = useCallback(async (t: Task) => {
     const active = t.column === "running" || t.column === "blocked";
     if (active) {
       const ok = await confirm({
@@ -518,8 +582,8 @@ export default function App() {
       surfaceError(e);
       await refresh();
     }
-  };
-  const unarchive = async (t: Task) => {
+  }, [confirm, refresh, surfaceError]);
+  const unarchive = useCallback(async (t: Task) => {
     setTasks((cur) => cur.map((x) => (x.id === t.id ? { ...x, archivedAt: null } : x)));
     try {
       setError(null);
@@ -529,8 +593,8 @@ export default function App() {
       surfaceError(e);
       await refresh();
     }
-  };
-  const del = async (t: Task) => {
+  }, [refresh, surfaceError]);
+  const del = useCallback(async (t: Task) => {
     const ok = await confirm({
       title: `Delete "${t.title}"?`,
       description: (
@@ -552,14 +616,14 @@ export default function App() {
     try {
       setError(null);
       await api.deleteTask(t.id);
-      if (selected?.id === t.id) setSelected(null);
+      if (selectedIdRef.current === t.id) setSelected(null);
       await refresh();
     } catch (e) {
       surfaceError(e);
       // Refresh anyway so the UI matches the server.
       await refresh();
     }
-  };
+  }, [confirm, refresh, surfaceError]);
 
   return (
     <div className="flex h-screen w-screen flex-col bg-background text-foreground">

--- a/src/mainview/components/kanban/Column.tsx
+++ b/src/mainview/components/kanban/Column.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -19,7 +20,19 @@ interface Props {
   onUnarchive: (t: Task) => void;
 }
 
-export function Column({ id, label, tasks, homeDir, onStart, onCancel, onDelete, onOpen, onDiff, onMarkDone, onArchive, onUnarchive }: Props) {
+/** Array is considered unchanged when same length and every element is the
+ *  same object reference at the same index. Relies on the caller (App.tsx's
+ *  `reconcileById`) preserving task identity across polls for tasks that
+ *  didn't actually change — that's what lets an unaffected column bail out
+ *  below even though `visibleTasks.filter(...)` in App.tsx produces a new
+ *  array reference on every render. */
+function sameTasks(a: Task[], b: Task[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  return a.every((t, i) => t === b[i]);
+}
+
+function ColumnImpl({ id, label, tasks, homeDir, onStart, onCancel, onDelete, onOpen, onDiff, onMarkDone, onArchive, onUnarchive }: Props) {
   const { setNodeRef, isOver } = useDroppable({ id });
   return (
     <div
@@ -55,3 +68,27 @@ export function Column({ id, label, tasks, homeDir, onStart, onCancel, onDelete,
     </div>
   );
 }
+
+/** Custom comparator instead of the default shallow-props compare: `tasks`
+ *  is an array, so the default `Object.is` per-prop check would see a new
+ *  reference on every render (App.tsx's `visibleTasks.filter(...)` always
+ *  allocates a fresh array) and re-render every column on every tick. With
+ *  `sameTasks` doing an element-wise identity check instead, a column whose
+ *  member tasks are all reference-unchanged bails out — so a single task
+ *  update (which only changes that one task's object identity, per
+ *  App.tsx's `reconcileById`) only re-renders the column(s) that actually
+ *  contain the changed task. */
+export const Column = memo(ColumnImpl, (prev, next) => (
+  prev.id === next.id &&
+  prev.label === next.label &&
+  prev.homeDir === next.homeDir &&
+  prev.onStart === next.onStart &&
+  prev.onCancel === next.onCancel &&
+  prev.onDelete === next.onDelete &&
+  prev.onOpen === next.onOpen &&
+  prev.onDiff === next.onDiff &&
+  prev.onMarkDone === next.onMarkDone &&
+  prev.onArchive === next.onArchive &&
+  prev.onUnarchive === next.onUnarchive &&
+  sameTasks(prev.tasks, next.tasks)
+));

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -69,22 +69,27 @@ function harnessKindOf(harnessId: string, harnesses: Harness[]): AgentKind {
 
 /**
  * `RunEvent` as held in the panel's local `events` state, tagged with a
- * client-assigned monotonic id. The server doesn't expose a stable event id
- * over SSE (`run_events.id` never leaves the DB layer) — `id` here is
- * assigned by `nextEventIdRef` the moment an event is accepted into the
+ * client-assigned monotonic id. `id` here is always assigned by
+ * `nextEventIdRef`/`prevEventIdRef` the moment an event is accepted into the
  * unified stream, purely so `rebuilt-mask.ts` can tell a genuinely NEW live
  * event apart from one the server re-delivers on SSE reconnect (full-history
- * replay) when deciding whether the JSONL rebuild snapshot has gone stale.
+ * replay) when deciding whether the JSONL rebuild snapshot has gone stale —
+ * it is NEVER the server's own event id, even when one is available (see
+ * `dbId` below), since `rebuilt-mask.ts`'s ordering depends on this id space
+ * being contiguous and monotonic per-connection.
  *
- * `dbId`, when present, is the REAL `run_events.id` row id — only known for
- * events fetched via `GET /tasks/:id/events/page` ("Load earlier"), since
- * that's the one route that returns it (the SSE replay/live paths never do —
- * see above). It's what lets the live-window trim (`EVENTS_WINDOW_MAX`) figure
- * out a fresh `beforeId` cursor after eating into previously-loaded earlier
- * history: if the new front-of-window event carries a `dbId`, that becomes
- * the new `earliestId`; if it doesn't (an ordinary replay/live event with no
- * known DB id), "Load earlier" has nothing reliable to page from and hides
- * until the next SSE (re)connect re-seeds `earliestId` from `replay_meta`.
+ * `dbId`, when present, is the REAL `run_events.id` row id. Historically this
+ * was only known for events fetched via `GET /tasks/:id/events/page` ("Load
+ * earlier"), but SSE replayed frames (the burst sent on connect/reconnect,
+ * before `replay_meta`'s window) now carry it too — only a genuinely NEW
+ * live event delivered after the connection has settled lacks one. It's what
+ * lets the live-window trim (`EVENTS_WINDOW_MAX`) figure out a fresh
+ * `beforeId` cursor after eating into previously-loaded earlier history: if
+ * the new front-of-window event carries a `dbId`, that becomes the new
+ * `earliestId`; if it doesn't (the rare case of a brand-new live event
+ * pushing the window over the cap before any replay/page fetch has run),
+ * "Load earlier" has nothing reliable to page from and hides until the next
+ * SSE (re)connect re-seeds `earliestId` from `replay_meta`.
  */
 type StreamEvent = RunEvent & { id: number; dbId?: number };
 
@@ -321,6 +326,16 @@ function RunPanelBody({
   // doing the window-cap trim (see EVENTS_WINDOW_MAX below) inside a
   // setState updater would run twice under StrictMode's dev double-invoke.
   const eventsRef = useRef<StreamEvent[]>([]);
+  /** Every real `run_events.id` (`StreamEvent.dbId`) currently represented in
+   *  `eventsRef.current`, whether it arrived via SSE replay, a live push, or
+   *  a "Load earlier" page fetch. Populated as events are accepted (see the
+   *  SSE subscription effect and `loadEarlierEvents` below); reset on task
+   *  switch. Lets `loadEarlierEvents` defensively drop rows it's already
+   *  holding — e.g. after an SSE reconnect moves `earliestId` backward (see
+   *  the `replay_meta` handler below) a subsequent page fetch can legitimately
+   *  overlap the tail of what a previous page fetch (or the live window)
+   *  already loaded. */
+  const loadedDbIdsRef = useRef<Set<number>>(new Set());
   /** DB id of the earliest event currently anchoring the "Load earlier"
    *  cursor, or null when unknown (hides the button — see `StreamEvent.dbId`
    *  and the window-trim comment in the SSE effect below). Seeded from the
@@ -341,6 +356,7 @@ function RunPanelBody({
     setEvents([]);
     eventsRef.current = [];
     prevEventIdRef.current = -1;
+    loadedDbIdsRef.current = new Set();
     setEarliestId(null);
     setHasMoreEarlier(false);
     setLoadingEarlier(false);
@@ -448,17 +464,23 @@ function RunPanelBody({
       if (timer) return;
       timer = setInterval(() => { if (!document.hidden) void load(); }, 2000);
     };
+    // Mirrors whether the timer is currently (supposed to be) running.
+    // `evaluate()` is called on every SSE frame during a mid-turn flood (see
+    // the subscription effect's `runsPollEvaluateRef.current()` calls) — the
+    // early return below skips the `document.hidden`/ref reads and the
+    // start/stop call entirely once the desired state already matches,
+    // rather than re-deriving and re-applying the same state on every event.
+    let armed = false;
     // Paused while the window is hidden (nothing to repaint) or once the task
     // has gone fully idle (terminal run, no subagent running, no pending
     // interaction) — resumed by `kick()` below on visible/focus or a live-sign
     // SSE event, so a change on the server side is never missed for long.
     const evaluate = () => {
-      if (document.hidden) { stopTimer(); return; }
-      if (!runActiveRef.current && !subagentActiveRef.current && !interactionPendingRef.current) {
-        stopTimer();
-        return;
-      }
-      startTimer();
+      const shouldRun = !document.hidden
+        && (runActiveRef.current || subagentActiveRef.current || interactionPendingRef.current);
+      if (shouldRun === armed) return;
+      armed = shouldRun;
+      if (shouldRun) startTimer(); else stopTimer();
     };
     const kick = () => {
       if (!document.hidden) void load();
@@ -508,13 +530,15 @@ function RunPanelBody({
       if (timer) return;
       timer = setInterval(() => { if (!document.hidden) void load(); }, 2000);
     };
+    // See the runs-poll effect above for why this early-returns on a no-op
+    // state transition instead of re-deriving/re-applying on every call.
+    let armed = false;
     const evaluate = () => {
-      if (document.hidden) { stopTimer(); return; }
-      if (!runActiveRef.current && !subagentActiveRef.current && !interactionPendingRef.current) {
-        stopTimer();
-        return;
-      }
-      startTimer();
+      const shouldRun = !document.hidden
+        && (runActiveRef.current || subagentActiveRef.current || interactionPendingRef.current);
+      if (shouldRun === armed) return;
+      armed = shouldRun;
+      if (shouldRun) startTimer(); else stopTimer();
     };
     const kick = () => {
       if (!document.hidden) void load();
@@ -568,18 +592,43 @@ function RunPanelBody({
     // arm/flush bookkeeping (and the re-arm-after-flush invariant that fixes
     // the freeze) lives in `createEventBuffer` so it can be unit-tested.
     const FLUSH_FALLBACK_MS = 250;
-    // Flips true the moment the first batch flushes. All of the SSE replay
-    // burst's `onmessage` calls land synchronously, well before the first
-    // rAF/timeout-scheduled flush can fire (see the buffer's own doc comment)
-    // — so gating the "any onmessage is a life sign" poll-kick (below) on
-    // this flag means the replay burst itself can only ever trigger cheap
-    // `evaluate()` calls, never a fetch storm at panel-open time. Once the
-    // first flush has happened, subsequent `status`/`user` events are almost
-    // certainly genuinely live, and DO warrant an immediate poll kick.
-    const initialSettledRef = { current: false };
+    // Wall-clock connect time, used below to suppress poll kicks for the
+    // first ~1s of a (re)connect. The SSE replay burst can contain many
+    // historical `status`/`user` events (a big backlog dumps its whole
+    // recent window in one go), and each used to fire an immediate
+    // `runsPollKickRef`/`subagentsPollKickRef` call — a fetch storm at
+    // panel-open time. Wall-clock time (rather than "has the first batch
+    // flushed yet") is the right gate: a slow flush doesn't shrink the
+    // window, and a burst that keeps arriving past 1s still degrades
+    // gracefully into the debounce below rather than firing on every event.
+    const CONNECT_SETTLE_MS = 1000;
+    const connectedAtRef = { current: Date.now() };
+    // Debounce for kicks that land after the settle window: at most one
+    // poll-kick per second, trailing-edge, so a burst of live `status`/`user`
+    // events (e.g. several follow-ups folding into a turn in quick
+    // succession) can't each trigger their own fetch.
+    const KICK_DEBOUNCE_MS = 1000;
+    const lastKickAtRef = { current: 0 };
+    let kickTimer: ReturnType<typeof setTimeout> | null = null;
+    const debouncedKick = () => {
+      const now = Date.now();
+      const elapsed = now - lastKickAtRef.current;
+      if (elapsed >= KICK_DEBOUNCE_MS) {
+        lastKickAtRef.current = now;
+        runsPollKickRef.current();
+        subagentsPollKickRef.current();
+        return;
+      }
+      if (kickTimer) return;
+      kickTimer = setTimeout(() => {
+        kickTimer = null;
+        lastKickAtRef.current = Date.now();
+        runsPollKickRef.current();
+        subagentsPollKickRef.current();
+      }, KICK_DEBOUNCE_MS - elapsed);
+    };
     const buffer = createEventBuffer<StreamEvent>(
       (batch) => {
-        initialSettledRef.current = true;
         // Trim from the front once the live window exceeds EVENTS_WINDOW_MAX
         // (see StreamEvent's `dbId` doc comment for how the new earliestId is
         // derived — or why it sometimes can't be). `eventsRef` mirrors
@@ -685,30 +734,63 @@ function RunPanelBody({
         // ended, or a follow-up was sent) — worth an immediate poll kick.
         // Every other stream (assistant/thinking/tool_use/tool_result/stdout/
         // stderr) can arrive at high frequency mid-turn, so those only get the
-        // cheap no-fetch `evaluate()`. Gated on `initialSettledRef` so the
-        // open-time replay burst (which can contain many historical status/
-        // user events) never turns into a fetch storm — see that ref's doc
-        // comment above.
-        if (initialSettledRef.current && (e.stream === "status" || e.stream === "user")) {
-          runsPollKickRef.current();
-          subagentsPollKickRef.current();
+        // cheap no-fetch `evaluate()`. Gated on wall-clock time since connect
+        // so the open-time replay burst (which can contain many historical
+        // status/user events) never turns into a fetch storm, and further
+        // debounced to at most one kick/second so a rapid live burst past the
+        // settle window can't do the same — see `CONNECT_SETTLE_MS`/
+        // `debouncedKick` above.
+        if (e.stream === "status" || e.stream === "user") {
+          if (Date.now() - connectedAtRef.current < CONNECT_SETTLE_MS) {
+            runsPollEvaluateRef.current();
+            subagentsPollEvaluateRef.current();
+          } else {
+            debouncedKick();
+          }
         } else {
           runsPollEvaluateRef.current();
           subagentsPollEvaluateRef.current();
         }
-        // Tag with the next client-assigned id (see `StreamEvent`) — the
-        // server doesn't send one over SSE, and the invalidation check above
-        // needs a monotonic ordering to distinguish a genuinely new event from
-        // one the replay burst re-delivers on reconnect.
-        buffer.push({ ...e, id: nextEventIdRef.current++ });
+        // Tag with the next client-assigned id (see `StreamEvent`) — this
+        // client id space is distinct from the server's own `RunEvent.id`
+        // (only present on replayed/paged frames, see its doc comment), and
+        // the invalidation check above needs a monotonic ordering to
+        // distinguish a genuinely new event from one the replay burst
+        // re-delivers on reconnect. Capture the server id as `dbId` when
+        // present so the window-cap trim above can derive an exact
+        // `earliestId` cursor from replay alone, without waiting on a
+        // "Load earlier" page fetch.
+        const dbId = e.id;
+        if (typeof dbId === "number") loadedDbIdsRef.current.add(dbId);
+        buffer.push({ ...e, id: nextEventIdRef.current++, dbId });
       },
       (meta) => {
-        setEarliestId(meta.earliestId);
-        setHasMoreEarlier(meta.hasMore);
+        // The server sends `replay_meta` as the FIRST frame of every (re)connect
+        // — including an EventSource-internal reconnect after a network blip,
+        // which reuses this same subscription/effect instance rather than
+        // re-running it. Re-arming the settle window here (not just at effect
+        // setup) is what makes the kick-storm suppression above cover BOTH the
+        // initial open and every later reconnect's replay burst.
+        connectedAtRef.current = Date.now();
+        // Never move the cursor FORWARD on a reconnect: a fresh `replay_meta`
+        // reflects only the just-replayed window, which is capped at
+        // EVENTS_REPLAY_LIMIT and so always starts later than whatever
+        // earlier history "Load earlier" may have already paged in before
+        // the reconnect. Losing that progress would silently re-show a
+        // narrower "Load earlier" cursor (or hide it) after every SSE drop —
+        // taking the min (treating null as "no bound yet") keeps whichever
+        // cursor reaches furthest back. `hasMore` only ever grows for the
+        // same reason: once we know older history exists, a later replay
+        // that (re)confirms a narrower window can't un-know that.
+        setEarliestId((prev) =>
+          prev == null ? meta.earliestId : meta.earliestId == null ? prev : Math.min(prev, meta.earliestId),
+        );
+        setHasMoreEarlier((prev) => prev || meta.hasMore);
       },
     );
     return () => {
       buffer.dispose();
+      if (kickTimer) clearTimeout(kickTimer);
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("focus", onFocus);
       unsub();
@@ -736,12 +818,26 @@ function RunPanelBody({
     setLoadingEarlier(true);
     void api.fetchTaskEventsPage(task.id, earliestId)
       .then((page) => {
-        if (page.events.length > 0) {
-          const mapped: StreamEvent[] = page.events.map((ev) => ({
-            ...ev,
-            id: prevEventIdRef.current--,
-            dbId: ev.id,
-          }));
+        // Defensive dedupe: `earliestId` can point past events this panel
+        // already holds — e.g. an SSE reconnect moved it backward (see the
+        // `replay_meta` handler's "never move forward" comment above), so a
+        // page fetched from that cursor can legitimately overlap the tail of
+        // what a previous fetch (or the live/replayed window) already loaded.
+        const fresh = page.events.filter((ev) => !loadedDbIdsRef.current.has(ev.id));
+        if (fresh.length > 0) {
+          // Set BEFORE the prepend's setState, not after: the pin-to-bottom
+          // effect below reads `nearBottomRef` on every `events` change, and
+          // runs as a passive effect AFTER this component's commit — if this
+          // flag flipped after `setEvents`, that effect could still see the
+          // pre-prepend (stale) `true` and yank the viewport back to the
+          // bottom, fighting the `useLayoutEffect` scroll restore just below
+          // (which always wins the ordering race, but only for scrollTop —
+          // the pin effect would then immediately override it again).
+          nearBottomRef.current = false;
+          const mapped: StreamEvent[] = fresh.map((ev) => {
+            loadedDbIdsRef.current.add(ev.id);
+            return { ...ev, id: prevEventIdRef.current--, dbId: ev.id };
+          });
           if (el) {
             scrollRestoreRef.current = { prevScrollHeight: el.scrollHeight, prevScrollTop: el.scrollTop };
           }
@@ -844,7 +940,12 @@ function RunPanelBody({
     if (!latestRun.claudeSessionId) return;
     const sessionId = latestRun.claudeSessionId;
     let cancelled = false;
-    void api.rebuildRunEvents(latestRun.id).then((res) => {
+    // Bounded to EVENTS_WINDOW_MAX — the same cap the live stream itself is
+    // held to (see the SSE batch-flush trim above). Without a limit here, the
+    // auto-rebuild silently replaced the panel's bounded window with an
+    // unbounded full-session dump on every run completion, defeating the
+    // whole point of capping live/replayed history (code review finding).
+    void api.rebuildRunEvents(latestRun.id, EVENTS_WINDOW_MAX).then((res) => {
       if (cancelled) return;
       if (res.events.length > 0) {
         setRebuilt({
@@ -854,6 +955,11 @@ function RunPanelBody({
           maxLiveEventIdAtSnapshot: nextEventIdRef.current - 1,
         });
         setRebuildNote(`Loaded ${res.events.length} events from session JSONL.`);
+        // The rebuild itself has no DB row ids to page from (JSONL events are
+        // synthesized, not persisted `run_events` rows), so this only ever
+        // grows the affordance's visibility — it never clobbers an
+        // `earliestId` cursor the live/replayed stream already established.
+        if (res.hasMore) setHasMoreEarlier(true);
       } else if (res.reason) {
         setRebuildNote(res.reason);
       }
@@ -908,12 +1014,22 @@ function RunPanelBody({
   /** Events for whichever stream the tab strip has selected. For "main", splice
    *  `rebuilt` in by dropping events from runs that share its sessionId and
    *  appending the rebuilt set (earlier sessions stay visible). A subagent tab
-   *  shows that subagent's transcript directly (no rebuild path applies). */
+   *  shows that subagent's transcript directly (no rebuild path applies).
+   *
+   *  `status` events are the one exception to "drop the rebuilt run's live
+   *  events": they're synthesized by the orchestrator (e.g. "session
+   *  hibernated after idle…"), never appear in the JSONL transcript, and so
+   *  can never duplicate against `rebuilt.events` — dropping them would just
+   *  hide legitimate lifecycle notices for as long as the rebuild snapshot is
+   *  active. Kept in original arrival order, then re-sorted by `ts` against
+   *  the appended rebuild set (whose synthetic timestamps are anchored at the
+   *  run's start, not real wall-clock time) so a status event doesn't jump to
+   *  the wrong end of the transcript. */
   const displayedEvents = useMemo(() => {
     if (activeStream !== "main") return subagentEventsById.get(activeStream) ?? [];
     if (!rebuilt || !rebuiltRunIds) return mainEvents;
-    const others = mainEvents.filter((e) => !rebuiltRunIds.has(e.runId));
-    return [...others, ...rebuilt.events];
+    const others = mainEvents.filter((e) => !rebuiltRunIds.has(e.runId) || e.stream === "status");
+    return [...others, ...rebuilt.events].sort((a, b) => a.ts - b.ts);
   }, [activeStream, subagentEventsById, mainEvents, rebuilt, rebuiltRunIds]);
 
   /** The current to-do list for whichever stream is selected. Claude re-emits

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -20,6 +20,7 @@ import {
   AGENT_OPTIONS,
   DEFAULT_EFFORT,
   DEFAULT_MODEL,
+  EVENTS_WINDOW_MAX,
   supportedEfforts,
   supportedModes,
   type AgentKind,
@@ -32,6 +33,7 @@ import {
   type SubagentEvent,
   type Task,
   type TaskDraft,
+  type TaskEventsReplayMeta,
   type TaskReference,
 } from "../../../shared/types.ts";
 import { appendReferences } from "../../../shared/refs.ts";
@@ -73,8 +75,18 @@ function harnessKindOf(harnessId: string, harnesses: Harness[]): AgentKind {
  * unified stream, purely so `rebuilt-mask.ts` can tell a genuinely NEW live
  * event apart from one the server re-delivers on SSE reconnect (full-history
  * replay) when deciding whether the JSONL rebuild snapshot has gone stale.
+ *
+ * `dbId`, when present, is the REAL `run_events.id` row id — only known for
+ * events fetched via `GET /tasks/:id/events/page` ("Load earlier"), since
+ * that's the one route that returns it (the SSE replay/live paths never do —
+ * see above). It's what lets the live-window trim (`EVENTS_WINDOW_MAX`) figure
+ * out a fresh `beforeId` cursor after eating into previously-loaded earlier
+ * history: if the new front-of-window event carries a `dbId`, that becomes
+ * the new `earliestId`; if it doesn't (an ordinary replay/live event with no
+ * known DB id), "Load earlier" has nothing reliable to page from and hides
+ * until the next SSE (re)connect re-seeds `earliestId` from `replay_meta`.
  */
-type StreamEvent = RunEvent & { id: number };
+type StreamEvent = RunEvent & { id: number; dbId?: number };
 
 interface Props {
   /** When null, the panel slides off-screen and unmounts after the exit animation. */
@@ -296,6 +308,30 @@ function RunPanelBody({
   // the rebuild-snapshot-invalidation check needs to be race-free. Reset to
   // 0 on task switch alongside the rest of the stream state.
   const nextEventIdRef = useRef(0);
+  // Descending id source for events PREPENDED via "Load earlier" (see
+  // `loadEarlierEvents`). Always negative and always decreasing, so a
+  // page-fetched historical event's client `id` sorts before every live/replay
+  // `StreamEvent.id` (which start at 0 and only increase) — this keeps it
+  // outside `rebuilt-mask.ts`'s "genuinely newer than the snapshot" check
+  // without needing any special-casing there. Reset to -1 on task switch.
+  const prevEventIdRef = useRef(-1);
+  // Mirrors `events` synchronously (state updates land a render later) so the
+  // SSE batch-flush callback and `loadEarlierEvents` can read/trim the
+  // "current" array without relying on React's functional-setState form —
+  // doing the window-cap trim (see EVENTS_WINDOW_MAX below) inside a
+  // setState updater would run twice under StrictMode's dev double-invoke.
+  const eventsRef = useRef<StreamEvent[]>([]);
+  /** DB id of the earliest event currently anchoring the "Load earlier"
+   *  cursor, or null when unknown (hides the button — see `StreamEvent.dbId`
+   *  and the window-trim comment in the SSE effect below). Seeded from the
+   *  SSE `replay_meta` frame on (re)connect; advanced by each successful
+   *  "Load earlier" page fetch; recomputed (possibly to null) when live
+   *  growth trims the window's front past a known anchor. */
+  const [earliestId, setEarliestId] = useState<number | null>(null);
+  /** Whether older history exists before `earliestId` — gates the "Load
+   *  earlier" button together with `earliestId !== null`. */
+  const [hasMoreEarlier, setHasMoreEarlier] = useState(false);
+  const [loadingEarlier, setLoadingEarlier] = useState(false);
 
   // Reset on task switch (no remount because we no longer key on task.id).
   // Re-arm the auto-scroll heuristic so opening a different task pins the
@@ -303,6 +339,11 @@ function RunPanelBody({
   // task's scrolled-up position.
   useEffect(() => {
     setEvents([]);
+    eventsRef.current = [];
+    prevEventIdRef.current = -1;
+    setEarliestId(null);
+    setHasMoreEarlier(false);
+    setLoadingEarlier(false);
     setRebuilt(null);
     setRebuildNote(null);
     setInteractions([]);
@@ -359,8 +400,42 @@ function RunPanelBody({
     [],
   );
 
+  // ── Poll gating (runs + subagents) ────────────────────────────────────────
+  // Both 2s polls below share the same "is there any reason to keep looking"
+  // condition: a run in flight, a subagent running, or an interaction waiting
+  // on the user. These booleans are read by each poll's own `evaluate()`
+  // (defined inside the effect so it can start/stop that effect's own timer)
+  // — refs, not plain closures, because `latestRun`/`subagentList`/
+  // `interactions` change on every render without re-running the poll effects
+  // (whose deps are just `[task.id, task.runId]` / `[task.id]`, deliberately,
+  // so an interaction resolving doesn't reset an in-flight interval). The
+  // kick/evaluate refs let the activity-change effect and the SSE handler
+  // below reach into a poll effect that was set up earlier without needing it
+  // in their own dependency arrays.
+  const runActiveRef = useRef(false);
+  const subagentActiveRef = useRef(false);
+  const interactionPendingRef = useRef(false);
+  const runsPollKickRef = useRef<() => void>(() => {});
+  const subagentsPollKickRef = useRef<() => void>(() => {});
+  const runsPollEvaluateRef = useRef<() => void>(() => {});
+  const subagentsPollEvaluateRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    runActiveRef.current = latestRun?.status === "running";
+    subagentActiveRef.current = subagentList.some((s) => s.status === "running");
+    interactionPendingRef.current = interactions.length > 0;
+    // Re-arm (or re-suspend) both polls now that the activity picture changed
+    // — e.g. the latest run just resolved (stop) or a subagent just finished
+    // while the run was already idle (also stop; the reverse case, a run/
+    // subagent starting, is normally already covered by `task.runId`/mount
+    // effects below, but this keeps both polls honest either way).
+    runsPollEvaluateRef.current();
+    subagentsPollEvaluateRef.current();
+  }, [latestRun?.status, subagentList, interactions.length]);
+
   useEffect(() => {
     let cancelled = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
     const load = async () => {
       try {
         const list = await api.listRuns(task.id);
@@ -368,17 +443,51 @@ function RunPanelBody({
         setRuns(list);
       } catch { /* task may have been deleted */ }
     };
-    void load();
-    const t = setInterval(load, 2000);
-    return () => { cancelled = true; clearInterval(t); };
+    const stopTimer = () => { if (timer) { clearInterval(timer); timer = null; } };
+    const startTimer = () => {
+      if (timer) return;
+      timer = setInterval(() => { if (!document.hidden) void load(); }, 2000);
+    };
+    // Paused while the window is hidden (nothing to repaint) or once the task
+    // has gone fully idle (terminal run, no subagent running, no pending
+    // interaction) — resumed by `kick()` below on visible/focus or a live-sign
+    // SSE event, so a change on the server side is never missed for long.
+    const evaluate = () => {
+      if (document.hidden) { stopTimer(); return; }
+      if (!runActiveRef.current && !subagentActiveRef.current && !interactionPendingRef.current) {
+        stopTimer();
+        return;
+      }
+      startTimer();
+    };
+    const kick = () => {
+      if (!document.hidden) void load();
+      evaluate();
+    };
+    runsPollKickRef.current = kick;
+    runsPollEvaluateRef.current = evaluate;
+    void load(); // initial load on mount always happens, regardless of gating
+    evaluate();
+    const onVisible = () => { if (document.visibilityState === "visible") kick(); };
+    const onFocus = () => kick();
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onFocus);
+    return () => {
+      cancelled = true;
+      stopTimer();
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onFocus);
+    };
   }, [task.id, task.runId]);
 
   // Snapshot + poll the task's background/sub agents. The SSE `subagent` deltas
   // keep this fresh live; the poll is a reopen/reconnect backstop (mirrors the
   // runs poll). Merge rather than replace so an in-flight SSE delta isn't
-  // clobbered by a slightly-stale poll.
+  // clobbered by a slightly-stale poll. Same visibility/idle gating as the
+  // runs poll above (own timer, shared activity refs).
   useEffect(() => {
     let cancelled = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
     const load = async () => {
       try {
         const list = await api.listSubagents(task.id);
@@ -394,9 +503,37 @@ function RunPanelBody({
         });
       } catch { /* task may have been deleted */ }
     };
+    const stopTimer = () => { if (timer) { clearInterval(timer); timer = null; } };
+    const startTimer = () => {
+      if (timer) return;
+      timer = setInterval(() => { if (!document.hidden) void load(); }, 2000);
+    };
+    const evaluate = () => {
+      if (document.hidden) { stopTimer(); return; }
+      if (!runActiveRef.current && !subagentActiveRef.current && !interactionPendingRef.current) {
+        stopTimer();
+        return;
+      }
+      startTimer();
+    };
+    const kick = () => {
+      if (!document.hidden) void load();
+      evaluate();
+    };
+    subagentsPollKickRef.current = kick;
+    subagentsPollEvaluateRef.current = evaluate;
     void load();
-    const t = setInterval(load, 2000);
-    return () => { cancelled = true; clearInterval(t); };
+    evaluate();
+    const onVisible = () => { if (document.visibilityState === "visible") kick(); };
+    const onFocus = () => kick();
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onFocus);
+    return () => {
+      cancelled = true;
+      stopTimer();
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onFocus);
+    };
   }, [task.id]);
 
   // One unified task-level stream: every event from every run, merged in
@@ -431,9 +568,36 @@ function RunPanelBody({
     // arm/flush bookkeeping (and the re-arm-after-flush invariant that fixes
     // the freeze) lives in `createEventBuffer` so it can be unit-tested.
     const FLUSH_FALLBACK_MS = 250;
+    // Flips true the moment the first batch flushes. All of the SSE replay
+    // burst's `onmessage` calls land synchronously, well before the first
+    // rAF/timeout-scheduled flush can fire (see the buffer's own doc comment)
+    // — so gating the "any onmessage is a life sign" poll-kick (below) on
+    // this flag means the replay burst itself can only ever trigger cheap
+    // `evaluate()` calls, never a fetch storm at panel-open time. Once the
+    // first flush has happened, subsequent `status`/`user` events are almost
+    // certainly genuinely live, and DO warrant an immediate poll kick.
+    const initialSettledRef = { current: false };
     const buffer = createEventBuffer<StreamEvent>(
       (batch) => {
-        setEvents((cur) => [...cur, ...batch]);
+        initialSettledRef.current = true;
+        // Trim from the front once the live window exceeds EVENTS_WINDOW_MAX
+        // (see StreamEvent's `dbId` doc comment for how the new earliestId is
+        // derived — or why it sometimes can't be). `eventsRef` mirrors
+        // `events` synchronously so this math doesn't need React's
+        // functional-setState form (which would run twice under StrictMode's
+        // dev double-invoke and could double-decrement counters/side effects
+        // if this logic lived inside it).
+        const merged = [...eventsRef.current, ...batch];
+        let next = merged;
+        if (merged.length > EVENTS_WINDOW_MAX) {
+          next = merged.slice(merged.length - EVENTS_WINDOW_MAX);
+          const front = next[0];
+          const newEarliestId = front?.dbId ?? null;
+          setEarliestId(newEarliestId);
+          setHasMoreEarlier(newEarliestId != null);
+        }
+        eventsRef.current = next;
+        setEvents(next);
         // A newer live MAIN-stream event landing for a run the rebuilt-from-
         // JSONL snapshot is currently masking means the snapshot is stale —
         // clear it so `displayedEvents` falls back to the live stream. This
@@ -475,50 +639,74 @@ function RunPanelBody({
     const onFocus = () => buffer.flushNow();
     document.addEventListener("visibilitychange", onVisible);
     window.addEventListener("focus", onFocus);
-    const unsub = api.subscribeTask(task.id, (e) => {
-      if (!dedupe.accept(e)) return;
-      if (e.stream === "interaction") {
-        try {
-          const req = JSON.parse(e.data) as PendingInteraction;
-          setInteractions((cur) => cur.some((x) => x.id === req.id) ? cur : [...cur, req]);
-        } catch { /* ignore malformed */ }
-        return;
-      }
-      if (e.stream === "subagent") {
-        // Live lifecycle delta for a background/sub agent — upsert into the tab
-        // list instead of pushing to the log buffer. The agent's actual
-        // transcript rides the normal user/assistant/tool_* streams (tagged
-        // via `subagentId`) and flows through to `buffer.push` below.
-        try {
-          const { subagent } = JSON.parse(e.data) as SubagentEvent;
-          setSubagentList((cur) => {
-            const i = cur.findIndex((s) => s.id === subagent.id);
-            if (i === -1) return [...cur, subagent];
-            const next = cur.slice();
-            next[i] = subagent;
-            return next;
-          });
-        } catch { /* ignore malformed */ }
-        return;
-      }
-      if (e.stream === "interaction_resolved") {
-        // Server-side resolution (scraper auto-cancel, run cancellation,
-        // delete) — drop the matching card so the UI doesn't keep
-        // showing a stale prompt. The card's own submit handler also
-        // calls `dismissInteraction(id)` directly; both paths are
-        // idempotent under `id`-based filtering.
-        try {
-          const { id } = JSON.parse(e.data) as { id: string };
-          setInteractions((cur) => cur.filter((x) => x.id !== id));
-        } catch { /* ignore malformed */ }
-        return;
-      }
-      // Tag with the next client-assigned id (see `StreamEvent`) — the
-      // server doesn't send one over SSE, and the invalidation check above
-      // needs a monotonic ordering to distinguish a genuinely new event from
-      // one the replay burst re-delivers on reconnect.
-      buffer.push({ ...e, id: nextEventIdRef.current++ });
-    });
+    const unsub = api.subscribeTask(
+      task.id,
+      (e) => {
+        if (!dedupe.accept(e)) return;
+        if (e.stream === "interaction") {
+          try {
+            const req = JSON.parse(e.data) as PendingInteraction;
+            setInteractions((cur) => cur.some((x) => x.id === req.id) ? cur : [...cur, req]);
+          } catch { /* ignore malformed */ }
+          return;
+        }
+        if (e.stream === "subagent") {
+          // Live lifecycle delta for a background/sub agent — upsert into the tab
+          // list instead of pushing to the log buffer. The agent's actual
+          // transcript rides the normal user/assistant/tool_* streams (tagged
+          // via `subagentId`) and flows through to `buffer.push` below.
+          try {
+            const { subagent } = JSON.parse(e.data) as SubagentEvent;
+            setSubagentList((cur) => {
+              const i = cur.findIndex((s) => s.id === subagent.id);
+              if (i === -1) return [...cur, subagent];
+              const next = cur.slice();
+              next[i] = subagent;
+              return next;
+            });
+          } catch { /* ignore malformed */ }
+          return;
+        }
+        if (e.stream === "interaction_resolved") {
+          // Server-side resolution (scraper auto-cancel, run cancellation,
+          // delete) — drop the matching card so the UI doesn't keep
+          // showing a stale prompt. The card's own submit handler also
+          // calls `dismissInteraction(id)` directly; both paths are
+          // idempotent under `id`-based filtering.
+          try {
+            const { id } = JSON.parse(e.data) as { id: string };
+            setInteractions((cur) => cur.filter((x) => x.id !== id));
+          } catch { /* ignore malformed */ }
+          return;
+        }
+        // "Life sign" re-arm for the runs/subagents polls (see the poll-gating
+        // block above): a `status` or `user` event is the rare, low-volume
+        // signal that a run's lifecycle actually moved (started/hibernated/
+        // ended, or a follow-up was sent) — worth an immediate poll kick.
+        // Every other stream (assistant/thinking/tool_use/tool_result/stdout/
+        // stderr) can arrive at high frequency mid-turn, so those only get the
+        // cheap no-fetch `evaluate()`. Gated on `initialSettledRef` so the
+        // open-time replay burst (which can contain many historical status/
+        // user events) never turns into a fetch storm — see that ref's doc
+        // comment above.
+        if (initialSettledRef.current && (e.stream === "status" || e.stream === "user")) {
+          runsPollKickRef.current();
+          subagentsPollKickRef.current();
+        } else {
+          runsPollEvaluateRef.current();
+          subagentsPollEvaluateRef.current();
+        }
+        // Tag with the next client-assigned id (see `StreamEvent`) — the
+        // server doesn't send one over SSE, and the invalidation check above
+        // needs a monotonic ordering to distinguish a genuinely new event from
+        // one the replay burst re-delivers on reconnect.
+        buffer.push({ ...e, id: nextEventIdRef.current++ });
+      },
+      (meta) => {
+        setEarliestId(meta.earliestId);
+        setHasMoreEarlier(meta.hasMore);
+      },
+    );
     return () => {
       buffer.dispose();
       document.removeEventListener("visibilitychange", onVisible);
@@ -526,6 +714,64 @@ function RunPanelBody({
       unsub();
     };
   }, [task.id]);
+
+  // Holds a pre-prepend `{scrollHeight, scrollTop}` snapshot for the layout
+  // effect just below to restore from — see that effect's doc comment.
+  const scrollRestoreRef = useRef<{ prevScrollHeight: number; prevScrollTop: number } | null>(null);
+
+  /**
+   * "Load earlier messages" — fetches one older page (`beforeId = earliestId`)
+   * and prepends it to `events`. Prepended events get a descending client id
+   * from `prevEventIdRef` (see `StreamEvent`'s doc comment) and carry the
+   * real server `dbId`, which is what lets a later window-cap trim re-derive
+   * `earliestId` after eating into this history. Scroll position is
+   * preserved by capturing the log's `scrollHeight`/`scrollTop` before the
+   * prepend and restoring `scrollTop` by the height delta once the DOM has
+   * grown (see the layout effect below) — the "simple approach" from the
+   * plan rather than anchoring to a specific DOM node.
+   */
+  const loadEarlierEvents = useCallback(() => {
+    if (earliestId == null || !hasMoreEarlier || loadingEarlier) return;
+    const el = logRef.current;
+    setLoadingEarlier(true);
+    void api.fetchTaskEventsPage(task.id, earliestId)
+      .then((page) => {
+        if (page.events.length > 0) {
+          const mapped: StreamEvent[] = page.events.map((ev) => ({
+            ...ev,
+            id: prevEventIdRef.current--,
+            dbId: ev.id,
+          }));
+          if (el) {
+            scrollRestoreRef.current = { prevScrollHeight: el.scrollHeight, prevScrollTop: el.scrollTop };
+          }
+          const next = [...mapped, ...eventsRef.current];
+          eventsRef.current = next;
+          setEvents(next);
+        }
+        setEarliestId(page.earliestId);
+        setHasMoreEarlier(page.hasMore);
+      })
+      .catch(() => { /* transient failure — button stays enabled to retry */ })
+      .finally(() => setLoadingEarlier(false));
+  }, [task.id, earliestId, hasMoreEarlier, loadingEarlier]);
+
+  // Restores scroll position after "Load earlier" prepends older events above
+  // the current viewport — without this the browser leaves `scrollTop`
+  // unchanged, which visually yanks the previously-visible content down by
+  // however tall the newly-inserted history is. Runs after every commit (the
+  // ref-guarded early return keeps that cheap) rather than being keyed to a
+  // dependency, since the meaningful trigger is "did `loadEarlierEvents` just
+  // prepend", not any particular prop.
+  useLayoutEffect(() => {
+    const pending = scrollRestoreRef.current;
+    if (!pending) return;
+    scrollRestoreRef.current = null;
+    const el = logRef.current;
+    if (!el) return;
+    const delta = el.scrollHeight - pending.prevScrollHeight;
+    el.scrollTop = pending.prevScrollTop + delta;
+  });
 
   // Two complementary pin-to-bottom paths, both gated on `nearBottomRef` so
   // a user who scrolled up to read history is never yanked back down:
@@ -1470,6 +1716,23 @@ function RunPanelBody({
         // problematic spots instead.
         className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden p-3 text-xs leading-relaxed"
       >
+        {/* "Load earlier messages" — only meaningful once we have a real DB
+            cursor to page from (see StreamEvent's `dbId` doc comment for why
+            `earliestId` can go null). Sits above everything else in the
+            scrollback, including the rebuild-from-JSONL row below. */}
+        {hasMoreEarlier && earliestId != null && (
+          <div className="mb-2 flex justify-center">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={loadEarlierEvents}
+              disabled={loadingEarlier}
+              className="h-6 px-2 text-[10px] uppercase tracking-wide text-muted-foreground"
+            >
+              {loadingEarlier ? "Loading…" : "Load earlier messages"}
+            </Button>
+          </div>
+        )}
         {runs.length === 0 ? (
           <div className="text-muted-foreground">(no runs yet — press Run to start the agent)</div>
         ) : displayedEvents.length === 0 ? (

--- a/src/mainview/components/kanban/TaskCard.tsx
+++ b/src/mainview/components/kanban/TaskCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { Archive, ArchiveRestore, ArrowRight, Bot, CheckCircle2, FolderOpen, GitBranch, GitCompare, MessageCircleQuestion, Play, Square, Terminal, Trash2 } from "lucide-react";
@@ -22,7 +23,7 @@ interface Props {
   onUnarchive: (t: Task) => void;
 }
 
-export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDiff, onMarkDone, onArchive, onUnarchive }: Props) {
+function TaskCardImpl({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDiff, onMarkDone, onArchive, onUnarchive }: Props) {
   const archived = task.archivedAt != null;
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: task.id,
@@ -205,3 +206,12 @@ export function TaskCard({ task, homeDir, onStart, onCancel, onDelete, onOpen, o
     </Card>
   );
 }
+
+// Default shallow-props comparator is correct here (unlike Column, which
+// needs a custom comparator for its array prop): `task` is a single object
+// whose identity App.tsx's `reconcileById` preserves across polls when
+// unchanged, and every other prop is either a primitive (`homeDir`) or a
+// `useCallback`-stabilized handler. dnd-kit's `useDraggable` lives inside
+// the component body, so memoizing the outer function doesn't interfere
+// with drag state — that's driven by dnd-kit's own context, not props.
+export const TaskCard = memo(TaskCardImpl);

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -1232,10 +1232,17 @@ export const api = {
    *  structured-event refactor (the legacy mapper truncated tool inputs
    *  at 500 chars, so the in-DB copy is missing the tail bytes). Returns
    *  an empty list + `reason` when the JSONL is gone or the run had no
-   *  claude session id (e.g. codex runs). */
-  rebuildRunEvents: (runId: string) =>
-    j<{ events: RunEvent[]; source?: string; reason?: string }>(
-      `/runs/${runId}/rebuild-events`,
+   *  claude session id (e.g. codex runs).
+   *
+   *  `limit`, when passed, bounds the rebuild to the most recent `limit`
+   *  mapped events (ascending) and the response carries `hasMore` — so an
+   *  automatic/background rebuild doesn't silently replace the panel's
+   *  bounded live window with an unbounded full-history dump. Omitted
+   *  (the manual "Rebuild from session JSONL" button's case), the server
+   *  returns the legacy full array with no `hasMore` field. */
+  rebuildRunEvents: (runId: string, limit?: number) =>
+    j<{ events: RunEvent[]; hasMore?: boolean; source?: string; reason?: string }>(
+      `/runs/${runId}/rebuild-events${limit ? `?limit=${limit}` : ""}`,
     ),
 
   /** Fire a native macOS notification via the Bun process. Fire-and-forget

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -70,6 +70,7 @@ import type {
   Subagent,
   Task,
   TaskDiff,
+  TaskEventsReplayMeta,
   TaskReference,
   TaskType,
   TerminalTab,
@@ -77,6 +78,7 @@ import type {
   WorktreeGitStatus,
   WorktreeInfo,
 } from "../../shared/types.ts";
+import { TASK_EVENTS_REPLAY_META_EVENT } from "../../shared/types.ts";
 import { fetchWithRecovery } from "./net-retry.ts";
 
 export interface UpdateSnapshot {
@@ -295,6 +297,18 @@ async function j<T>(
 }
 
 export interface AppDefaults { home: string; cwd: string; dataDir: string }
+
+/** One page of older task events, as returned by `GET /tasks/:id/events/page`
+ *  (the "Load earlier" backward-paging cursor). Ascending order (oldest
+ *  first), same shape as the SSE stream's events plus `id` — the real
+ *  `run_events` row id, which the SSE stream never carries (see
+ *  `TaskEventsReplayMeta`) but this paging route does, since it's exactly
+ *  what the next `beforeId` needs. */
+export interface TaskEventsPage {
+  events: (RunEvent & { id: number })[];
+  earliestId: number | null;
+  hasMore: boolean;
+}
 
 export interface HarnessesPayload { harnesses: Harness[]; statuses: HarnessStatus[] }
 export interface HarnessInput {
@@ -1078,6 +1092,16 @@ export const api = {
   terminalSocketUrl: (id: string) =>
     `ws://127.0.0.1:${API_PORT}/terminals/${encodeURIComponent(id)}/ws?token=${encodeURIComponent(API_TOKEN)}`,
   listRuns: (taskId: string) => j<Run[]>(`/tasks/${taskId}/runs`),
+  /** Backward page of a task's persisted events, older than `beforeId`
+   *  (exclusive) — drives the run panel's "Load earlier" affordance once the
+   *  bounded SSE replay window (`EVENTS_REPLAY_LIMIT`) has been exhausted.
+   *  `beforeId` is required by the route; `limit` defaults server-side to
+   *  `EVENTS_REPLAY_LIMIT` when omitted. */
+  fetchTaskEventsPage: (taskId: string, beforeId: number, limit?: number) => {
+    const q = new URLSearchParams({ beforeId: String(beforeId) });
+    if (limit) q.set("limit", String(limit));
+    return j<TaskEventsPage>(`/tasks/${taskId}/events/page?${q.toString()}`);
+  },
   /** Background/sub agents tracked for a task — drives the run panel's
    *  read-only per-subagent tab strip. Polled like `listRuns`; live deltas
    *  also arrive on the task SSE as `stream: "subagent"` events. */
@@ -1286,9 +1310,28 @@ export const api = {
   },
   /** Unified task-level event stream: every run's events, merged in id
    *  order. Replaces per-run subscriptions for the run panel so the user
-   *  sees the whole conversation as one scrollback. */
-  subscribeTask(taskId: string, onEvent: (e: RunEvent) => void): () => void {
+   *  sees the whole conversation as one scrollback.
+   *
+   *  `onReplayMeta`, when supplied, receives the named `replay_meta` frame the
+   *  server sends as the FIRST frame of every (re)connect — the bounded
+   *  replay window's earliest event id and whether older history exists
+   *  (drives the run panel's "Load earlier" button). It's a *named* SSE
+   *  event (`event: replay_meta`), invisible to `onmessage`, so registering
+   *  the listener only when a caller asks for it costs nothing for callers
+   *  that don't care. */
+  subscribeTask(
+    taskId: string,
+    onEvent: (e: RunEvent) => void,
+    onReplayMeta?: (meta: TaskEventsReplayMeta) => void,
+  ): () => void {
     const es = new EventSource(`${BASE}/tasks/${taskId}/events?token=${encodeURIComponent(API_TOKEN)}`);
+    if (onReplayMeta) {
+      es.addEventListener(TASK_EVENTS_REPLAY_META_EVENT, (m: MessageEvent) => {
+        try {
+          onReplayMeta(JSON.parse(m.data) as TaskEventsReplayMeta);
+        } catch { /* ignore malformed */ }
+      });
+    }
     es.onmessage = (m) => {
       try {
         const parsed = JSON.parse(m.data);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1728,6 +1728,12 @@ export interface RunEvent {
    * per-subagent tabs. Threaded from `run_events.subagent_id`.
    */
   subagentId?: string | null;
+  /**
+   * `run_events.id`, present on replayed/paged persisted events (SSE replay
+   * window, `/tasks/:id/events/page`); absent on live-broadcast frames, which
+   * have no row yet at broadcast time.
+   */
+  id?: number;
 }
 
 /** Lifecycle state of a tracked background/sub agent. Mirrors `RunStatus` plus

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -665,6 +665,15 @@ export type WorktreeStaleReason = "orphaned" | "archived" | "inactive";
  *  `"inactive"` — 7 days. */
 export const WORKTREE_STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
+/** How long a claude session must sit idle (no in-flight turn, no pending
+ *  interaction, no session activity) before the idle-session reaper kills its
+ *  tmux session to reclaim the REPL's memory. Follow-ups after a reap resume
+ *  via `claude --resume` (spawnResumedSession) instead of a live paste. */
+export const IDLE_SESSION_REAP_MS = 30 * 60 * 1000; // 30 minutes
+
+/** Cadence of the orchestrator's idle-session reap sweep. */
+export const SESSION_REAP_SWEEP_MS = 5 * 60 * 1000; // 5 minutes
+
 /**
  * A git worktree materialized on disk under `dataDir/worktrees/`, as surfaced
  * by `GET /worktrees`. One row per directory found on disk — computed live by
@@ -1681,6 +1690,30 @@ export type RunEventStream =
   | "tool_use"
   | "tool_result"
   | "subagent";
+
+/** Max number of persisted events `GET /tasks/:id/events` replays on SSE
+ *  (re)connect — the most recent window; older history is fetched on demand
+ *  via `GET /tasks/:id/events/page`. */
+export const EVENTS_REPLAY_LIMIT = 800;
+
+/** Max number of events the run panel keeps in webview memory for one task.
+ *  When live streaming pushes past this, the oldest events are trimmed and the
+ *  "Load earlier" affordance re-appears. */
+export const EVENTS_WINDOW_MAX = 3000;
+
+/** Named SSE event (`event: replay_meta`) sent as the FIRST frame of
+ *  `GET /tasks/:id/events`, before the replayed window. Unnamed `message`
+ *  listeners ignore it, so old clients are unaffected. */
+export const TASK_EVENTS_REPLAY_META_EVENT = "replay_meta";
+
+/** Payload of the {@link TASK_EVENTS_REPLAY_META_EVENT} frame. */
+export interface TaskEventsReplayMeta {
+  /** DB id of the earliest event included in the replayed window, or null when
+   *  the task has no persisted events. */
+  earliestId: number | null;
+  /** True when older events exist before `earliestId` (drives "Load earlier"). */
+  hasMore: boolean;
+}
 
 export interface RunEvent {
   runId: string;


### PR DESCRIPTION
## Why

Agetor was accumulating idle `claude` REPL processes (280–520MB RSS each — the "bunch of node processes") and burning a constant ~3.7% CPU in the main Bun process while nominally idle. Root causes:

- **Sessions never died on run finish.** A task's tmux session (hosting the interactive claude REPL) was only killed on delete/archive/agent-switch, so finished tasks kept ~300MB REPLs alive for days — and each lingering session kept 3–4 main-process timers running forever (sync `tmux capture-pane` every 2–10s, 400ms JSONL poll backstop, 400ms death watch, 4s subagent `readdirSync`).
- **Hot routes did full-history work.** The 2s `GET /tasks` poll ran a full tasks×runs join plus two per-row map scans; opening a task replayed its *entire* event history over SSE (worst task: 4,764 events); `runs.task_id` had no index.
- **The webview re-rendered everything.** No equality guard before `setTasks`, no memo on Column/TaskCard, polls ran while the window was hidden, and RunPanel kept an unbounded event array.

## What changed

### Idle-session reaper (RAM + most of the idle CPU)
- `reapIdleSessions()` sweeps every 5min (plus ~30s after boot, wired in both `index.ts` and the headless daemon with `unref()`'d timers): claude sessions idle ≥ `IDLE_SESSION_REAP_MS` (30min) are killed via `dropSession` (dispose-then-kill, so the death watch can't misfire and `hasSessionState` flips false).
- Candidates come **only from this instance's DB** (never enumerates `agetor-*` sessions), pre-filtered to tasks that could own a session, with `Bun.sleep(0)` yields between candidates and all guards (in-flight run, held-by-subagents, pending interaction) re-checked immediately before the kill.
- Sessions with no in-memory state (post-restart) use a keyed `tmux display-message` probe: **attached sessions are never reaped**, and idleness requires both `#{session_activity}` and `task.updatedAt` past the threshold.
- Follow-ups on a reaped task transparently respawn via the existing `claude --resume` path; a status event on the task explains the hibernation. Codex is untouched (its sessions are one-shot per turn already).

### Session timer hygiene (for the ≤30min window a session idles)
- 400ms JSONL poll backs off to 5s after 30s of quiet (fs.watch stays primary; instant re-arm on activity), with identity-checked self-rescheduling so re-arms can't spawn parallel timer chains.
- Subagent watcher backs off to 10s when no subagents were ever discovered.
- The pane-activity signal compares a normalized pane tail (trailing-whitespace trim + volatile TUI chrome dropped) so spinners/tip lines can't reset the idle clock. The scrape ladder itself is untouched (the post-`review` native-AskUserQuestion path depends on it).

### Route/DB work
- `GET /tasks`: pending-interaction and terminal counts computed as grouped maps once per request instead of per-row scans.
- Migration `030_runs_task_id_index.sql`: `idx_runs_task` on `runs(task_id)`.
- SSE replay capped at `EVENTS_REPLAY_LIMIT` (800) with a named `replay_meta` first frame (`{earliestId, hasMore}`); replayed frames now carry `run_events.id`. Old clients ignore named frames.
- New `GET /tasks/:id/events/page?beforeId=&limit=` pages older history (strict integer validation, limit capped at 2000).
- `GET /runs/:id/rebuild-events` accepts `?limit=` (same cap semantics, `{events, hasMore}` shape) — legacy no-param shape unchanged.

### Webview
- Board: identity-preserving reconcile before `setTasks`/`setSelected` (with a serialized-form cache), `React.memo` on `Column`/`TaskCard`, `useCallback` handlers — a no-change poll tick renders zero cards.
- All polls (`/tasks`, `/harnesses`, RunPanel `/runs` + `/subagents`) skip ticks while `document.hidden` and refresh immediately on visible/focus (preserving the WKWebView rAF-suspension fix).
- RunPanel: stops its 2s polls once the latest run is terminal (SSE/visibility re-arm), keeps at most `EVENTS_WINDOW_MAX` (3000) events in memory, and gains a **"Load earlier messages"** button with scroll-anchored prepends, reconnect-safe cursors (never move forward), and dbId dedupe. `status` events are exempt from the rebuilt-run mask so the hibernation notice is visible.

## Review & tests

- Opus code review: 2 must-fix, 8 should-fix, 4 nits — all addressed except one deliberate deferral (polls stay alive while an interaction is pending). Safety invariants verified: no tmux enumeration, dispose-then-kill ordering, codex excluded, scrape ladder unchanged.
- 24 new tests: `session-reaper.test.ts` (guards, resume routing, no double-reap) and `db-events-paging.test.ts` (paging semantics, SSE replay cap + `replay_meta`, migration idempotency).
- `bun test`: **1748 pass / 0 fail** · `tsc --noEmit` clean · `bunx vite build` green.

## Out of scope / follow-ups

- Disk retention (58GB of worktrees, 259MB DB, `run_events` never pruned) — deliberately left to the Worktrees page / a follow-up task.
- Legacy tasks with no persisted `claude_session_id` resume with a fresh context after a reap (warned in the status event).
- Plan document: `docs/plans/reduce-cpu-and-memory.md`.