### PR TITLE
feature: drag-to-select diff lines in DiffDialog compose-from-diff

### DIFF
--- a/docs/plans/diff-drag-select.md
+++ b/docs/plans/diff-drag-select.md
@@ -1,0 +1,83 @@
+# Plan — Drag-to-select diff lines in DiffDialog
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-29 |
+| Source | /implement: "user needs to click each line; add click-and-drag to select multiple lines" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/drag-n-drop-selection-on-git-diff |
+| Base SHA | ce9177b34816982f2aeebbba15fefb8dde8bd827 (tree clean at start) |
+
+## 1. Objective & success criteria
+
+Add a click-and-drag gesture to the compose-from-diff feature: mouse down on a diff line, drag across adjacent lines, release → every selectable line in the dragged range is selected. Existing gestures are unchanged: plain click still toggles one line; shift-click still range-extends from `lastClicked`.
+
+Success = drag paints a contiguous range as selected (additive, never deselects), clamped to the file where the drag started, with edge auto-scroll in the diff panel; a mousedown+mouseup on the same row still behaves exactly like today's click; `bun run typecheck` green; new unit tests green.
+
+Owner decisions (confirmed 2026-07-29): drag **always selects** (additive paint); **same-file only**; **auto-scroll yes**.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- Selection state: `Map<string, Set<number>>` keyed by `file.path` → set of row indices into `toRows(f.hunks)` — `DiffDialog.tsx:57`. `lastClicked: {path, index} | null` at `:58` anchors shift-click (same-file only, `:133`).
+- Click wiring: per-row `onClick` → `handleRowClick(path, index, rows, shiftKey)` (`DiffDialog.tsx:126-152`), functional-updater style (`new Map(prev)` / `new Set`), empty per-file sets deleted from the map. Existing `onMouseDown` preventDefault for shift only (`:498`) to suppress native shift text-selection.
+- Selectable kinds `ctx|add|del` — duplicated as `SELECTABLE_KINDS` in `DiffDialog.tsx:38` and `lib/diff-selection.ts:18`.
+- Rendering: `FileBlock` → `DiffBody` (`:478-531`), row divs keyed by array index, `isSelected` computed inline (`:494`); whole file's rows re-render on any selection change → drag must not commit to `selected` per mousemove.
+- Scroll container: `overflow-y-auto` div at `DiffDialog.tsx:310` (vertical), per-file `overflow-x-auto` at `:491`.
+- Diff text span (`:525`) allows native text selection today; gutters/markers are `select-none`.
+- No DOM test harness in this repo (peer knowledge entry, confirmed by repo scan): test React behavior by extracting pure logic into `src/mainview/lib/*.ts` + bun test. Existing pure tests: `src/mainview/lib/diff-selection.test.ts`.
+- dnd-kit is kanban-only; not reusable for drag-select. Raw pointer events it is.
+
+## 3. Approach & key decisions
+
+**Gesture model** — mousedown (primary button, no shift) on a selectable row arms a *pending* drag (`{path, anchorIndex, currentIndex}` — kept in one small state value + a ref mirror for document-level listeners). The drag *activates* only when the pointer crosses onto a different row index. Until then nothing changes, so:
+
+- mousedown+mouseup on the same row → drag never activates → the native `click` fires → today's toggle path, untouched.
+- Once active: a `didDrag` ref suppresses the trailing `click` event so the anchor row isn't double-toggled (the committed range already includes it).
+
+**Native text selection** — we do *not* preventDefault on plain mousedown (within-row text drag still yields a normal copyable text selection). On drag activation (first row-boundary crossing) we clear the native selection (`window.getSelection()?.removeAllRanges()`) and set a `dragActive` flag that applies `select-none` to the diff container until mouseup. Shift-click keeps its existing preventDefault.
+
+**Tracking** — document-level `mousemove` + `mouseup` listeners installed only while a drag is armed (mirrors the document-level listener pattern in `ui/dialog.tsx`). Rows get `data-diff-path` / `data-diff-index` attributes; mousemove resolves the hovered row via `event.target.closest("[data-diff-index]")`. Same-file clamp: if the pointer is over another file or dead space, clamp by comparing `clientY` against the anchor file's `DiffBody` bounding rect (above → first selectable index, below → last). State updates only when `currentIndex` changes (row-boundary granularity), not per pixel.
+
+**Visual preview** — during the drag, rows show as selected if committed-selected OR inside the pending drag range (selectable kinds only). Commit to the real `selected` map happens once, on mouseup — cheap re-renders during drag (one small state object), one Map rebuild at the end.
+
+**Commit + pure logic extraction** — the range math (walk `rows[lo..hi]`, keep `SELECTABLE_KINDS`, union into the file's set) is exactly what shift-click already does inline. Extract it into `lib/diff-selection.ts` as pure helpers, e.g. `selectableIndicesInRange(rows, a, b): number[]` and `addRangeToSelection(map, path, rows, a, b): Map` (immutable, deletes-empty-sets convention preserved), plus `isRowInDragRange(drag, path, index)` for the preview. `handleRowClick`'s shift branch and the drag commit both call these — one source of truth, unit-testable without a DOM. On mouseup, `lastClicked` updates to the drag endpoint so a follow-up shift-click extends from there.
+
+**Auto-scroll** — while a drag is active, a rAF loop scrolls the `overflow-y-auto` container (`:310`, gets a ref) when the last known `clientY` is within an edge zone (~40px), speed proportional to proximity. After each scroll step, re-resolve the hovered row via `document.elementFromPoint(lastClientX, lastClientY)` (mousemove doesn't fire on scroll-under-pointer). Loop starts on drag activation, stops on mouseup/unmount. rAF suspension in occluded WKWebViews is irrelevant mid-drag (window is foregrounded).
+
+**Alternatives considered** — per-row `onMouseMove` (rejected: hundreds of handlers, misses fast drags); committing to `selected` on every move (rejected: full-file re-render per pixel); pixel-threshold click-vs-drag discrimination (rejected: row-boundary crossing is simpler and unambiguous); dnd-kit (rejected: wrong tool — it does element reordering, not range multi-select).
+
+## 4. Work breakdown — implementation tasks
+
+**T1 — pure selection helpers** (`src/mainview/lib/diff-selection.ts`)
+Add `selectableIndicesInRange`, `addRangeToSelection`, drag-range types + `isRowInDragRange`. Preserve existing exports untouched. Acceptance: typecheck green; helpers mirror the inline shift-click semantics exactly (inclusive lo..hi, selectable kinds only, empty-set deletion).
+
+**T2 — DiffDialog gesture wiring** (`src/mainview/components/kanban/DiffDialog.tsx`)
+Pending-drag state + refs, row `data-*` attributes, mousedown arming, document mousemove/mouseup, click suppression after drag, preview styling, `select-none` while dragging, scroll-container ref + edge auto-scroll rAF loop, refactor shift-click branch to call the T1 helpers, `lastClicked` update on drag end. Acceptance: all §1 success criteria; no changes to any other file.
+
+T1 and T2 touch different files but T2 depends on T1's exports → **one agent does both sequentially** (single wave, single agent — fan-out would add cost, not speed, at this size).
+
+## 5. Work breakdown — test tasks
+
+**TT1 — unit tests** (`src/mainview/lib/diff-selection.test.ts` only)
+Extend the existing bun-test file, matching its fixture style (`rows(...)` helper): range over mixed kinds skips `hunk`/`meta`; reversed anchor/current normalizes; additive union with pre-existing selection; single-row range equals that row; `addRangeToSelection` immutability (input map/set not mutated) + empty-set-deletion convention; `isRowInDragRange` path mismatch / bounds / inactive drag. Covers T1 directly and T2's commit/preview logic indirectly (the component itself has no DOM harness — by design).
+
+## 6. Execution waves
+
+- Wave 1 (Phase 4): one agent — T1 then T2.
+- Phase 5: review diff `<base>..HEAD` (opus).
+- Wave 2 (Phase 6): one agent — TT1.
+- Phase 7: `bun test` + `bun run typecheck` (haiku).
+
+## 7. Blast radius & risks
+
+- `handleRowClick` shift branch refactored onto shared helpers — behavior must be identical (tests + review focus).
+- Trailing-click suppression must not eat legitimate clicks (reset `didDrag` in the click handler / on next mousedown).
+- Document listeners must detach on mouseup and on unmount/dialog close (cleanup in effect return); leaked listeners would ghost-select in a reopened dialog.
+- Native text-copy by dragging *across* lines is superseded by drag-select (within one line still works). Accepted tradeoff — composing the snippet is the feature's whole point.
+- No server/API/schema impact; webview-only.
+
+## 8. Open questions / assumptions
+
+- Assumption: drag with shift held is treated as plain shift-click on mouseup (drag arming requires no-shift), so the two gestures can't interleave.
+- Assumption: no minimum drag distance — row-boundary crossing is the discriminator.
+- Assumption: horizontal `overflow-x-auto` edge auto-scroll is out of scope (vertical only).

--- a/src/mainview/components/kanban/DiffDialog.tsx
+++ b/src/mainview/components/kanban/DiffDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import {
   AlertCircle, BookmarkPlus, ChevronDown, ChevronRight, FileMinus, FilePen, FilePlus,
   FileSymlink, GitCompare, Loader2, Send, X,
@@ -9,7 +9,10 @@ import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { api, type PendingInteraction } from "@/lib/api";
 import { toRows, type DiffRow } from "@/lib/diff-rows";
-import { composeDiffMessage, groupSelectedRows, type DiffSelectionBlock } from "@/lib/diff-selection";
+import {
+  addRangeToSelection, composeDiffMessage, groupSelectedRows, isRowInDragRange,
+  type DiffDragRange, type DiffSelectionBlock,
+} from "@/lib/diff-selection";
 import type { AgentKind, DiffFile, Harness, Run, Task, TaskDiff } from "../../../shared/types.ts";
 
 interface Props {
@@ -37,6 +40,39 @@ function harnessKindOf(harnessId: string, harnesses: Harness[]): AgentKind {
 
 const SELECTABLE_KINDS = new Set<DiffRow["kind"]>(["ctx", "add", "del"]);
 
+// Edge auto-scroll tuning for the drag gesture below: start scrolling once
+// the pointer is within this many px of the scroll container's top/bottom,
+// at a speed proportional to how deep into that zone the pointer is (capped).
+const AUTOSCROLL_EDGE_PX = 40;
+const AUTOSCROLL_MAX_SPEED = 15;
+
+/** Resolve the `data-diff-path`/`data-diff-index` row a DOM node sits inside
+ *  (or is itself), via the nearest `[data-diff-index]` ancestor. Used by both
+ *  the mousemove handler (fed `event.target`) and the auto-scroll loop (fed
+ *  `document.elementFromPoint`, since mousemove doesn't fire while the
+ *  container scrolls out from under a stationary pointer). */
+function resolveRowFromElement(el: Element | null): { path: string; index: number } | null {
+  const rowEl = el?.closest<HTMLElement>("[data-diff-index]");
+  if (!rowEl) return null;
+  const path = rowEl.dataset.diffPath;
+  const indexStr = rowEl.dataset.diffIndex;
+  if (!path || indexStr === undefined) return null;
+  const index = Number(indexStr);
+  return Number.isNaN(index) ? null : { path, index };
+}
+
+function firstSelectableIndex(rows: DiffRow[]): number {
+  const idx = rows.findIndex((r) => SELECTABLE_KINDS.has(r.kind));
+  return idx === -1 ? 0 : idx;
+}
+
+function lastSelectableIndex(rows: DiffRow[]): number {
+  for (let i = rows.length - 1; i >= 0; i--) {
+    if (SELECTABLE_KINDS.has(rows[i]!.kind)) return i;
+  }
+  return rows.length - 1;
+}
+
 /**
  * Read-only viewer for everything a task's worktree changed vs its pinned base
  * ref, plus click-to-select diff lines that compose into a message you can
@@ -60,6 +96,192 @@ export function DiffDialog({ open, task, onClose }: Props) {
   const [busy, setBusy] = useState(false);
   const [hint, setHint] = useState<string | null>(null);
 
+  // Click-and-drag multi-line selection. `dragRange` is the *pending* drag's
+  // React-visible state — it stays null while a drag is armed-but-not-yet-
+  // activated (a plain mousedown+mouseup on one row must fall through to the
+  // ordinary click path below untouched) and only becomes non-null once the
+  // pointer crosses onto a different row. Refs mirror what the document-level
+  // listeners and the rAF auto-scroll loop need without waiting for a render:
+  // `dragRangeRef` is the authoritative in-flight range, `didDragRef` flags
+  // "a real drag happened" (suppresses the trailing click on the anchor row),
+  // `anchorRowsRef` holds the anchor file's rows for clamping/committing, and
+  // `bodyRefs` maps file path -> that file's row-list DOM node (for the
+  // same-file clamp's bounding-rect check).
+  const [dragRange, setDragRange] = useState<DiffDragRange | null>(null);
+  const dragRangeRef = useRef<DiffDragRange | null>(null);
+  const didDragRef = useRef(false);
+  const lastClientRef = useRef({ x: 0, y: 0 });
+  const anchorRowsRef = useRef<DiffRow[]>([]);
+  const bodyRefs = useRef(new Map<string, HTMLDivElement>());
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const registerBody = useCallback((path: string, el: HTMLDivElement | null) => {
+    if (el) bodyRefs.current.set(path, el);
+    else bodyRefs.current.delete(path);
+  }, []);
+
+  // Resolve which row index the drag should report as `currentIndex` given a
+  // hit-tested DOM element (mousemove's `event.target`, or
+  // `document.elementFromPoint` during auto-scroll). When the hit lands on a
+  // row in the anchor file, use it directly (even a non-selectable hunk/meta
+  // row — downstream range math filters to selectable kinds). Otherwise
+  // (a different file, or dead space) clamp against the anchor file's
+  // row-list bounding rect: above it -> first selectable row, below it ->
+  // last selectable row, inside its vertical span but unresolved -> `null`
+  // (hold the previous index).
+  const resolveDragIndex = useCallback(
+    (drag: DiffDragRange, clientY: number, hitTarget: Element | null): number | null => {
+      const resolved = resolveRowFromElement(hitTarget);
+      if (resolved && resolved.path === drag.path) return resolved.index;
+      const container = bodyRefs.current.get(drag.path);
+      if (!container) return null;
+      const rect = container.getBoundingClientRect();
+      if (clientY < rect.top) return firstSelectableIndex(anchorRowsRef.current);
+      if (clientY > rect.bottom) return lastSelectableIndex(anchorRowsRef.current);
+      return null;
+    },
+    [],
+  );
+
+  // Apply a newly-resolved hovered index at row-boundary granularity only
+  // (a no-op if it matches the current index, so pixel-level mousemove churn
+  // doesn't cascade into re-renders). Crossing away from the anchor row for
+  // the first time flips `didDragRef` — the drag-activation signal that the
+  // `dragActive` effect below reacts to (clearing native selection, starting
+  // auto-scroll).
+  const applyDragIndex = useCallback((newIndex: number) => {
+    const drag = dragRangeRef.current;
+    if (!drag || newIndex === drag.currentIndex) return;
+    if (newIndex !== drag.anchorIndex) didDragRef.current = true;
+    const nextRange: DiffDragRange = { ...drag, currentIndex: newIndex };
+    dragRangeRef.current = nextRange;
+    setDragRange(nextRange);
+  }, []);
+
+  const handleDocumentMouseMove = useCallback(
+    (e: MouseEvent) => {
+      lastClientRef.current = { x: e.clientX, y: e.clientY };
+      const drag = dragRangeRef.current;
+      if (!drag) return;
+      const idx = resolveDragIndex(drag, e.clientY, e.target as Element | null);
+      if (idx !== null) applyDragIndex(idx);
+    },
+    [resolveDragIndex, applyDragIndex],
+  );
+
+  const handleDocumentMouseUp = useCallback(() => {
+    document.removeEventListener("mousemove", handleDocumentMouseMove);
+    document.removeEventListener("mouseup", handleDocumentMouseUp);
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    const drag = dragRangeRef.current;
+    // Only commit if the drag actually activated (crossed a row boundary) —
+    // a same-row mousedown+mouseup never activates, so the native `click`
+    // fires and today's toggle path handles it untouched.
+    if (drag && didDragRef.current) {
+      const rows = anchorRowsRef.current;
+      setSelected((prev) => addRangeToSelection(prev, drag.path, rows, drag.anchorIndex, drag.currentIndex));
+      setLastClicked({ path: drag.path, index: drag.currentIndex });
+    }
+    dragRangeRef.current = null;
+    anchorRowsRef.current = [];
+    setDragRange(null);
+    // `didDragRef` is deliberately left as-is here — `handleRowClick` (or the
+    // next `handleRowMouseDown`) consumes and resets it, so the trailing
+    // click on the anchor row (if any) gets suppressed.
+  }, [handleDocumentMouseMove]);
+
+  // Arm a pending drag on primary-button mousedown over a selectable row.
+  // No preventDefault here (within-row native text selection must still be
+  // able to start) — the shift-click preventDefault stays put separately in
+  // the row's onMouseDown. Document-level listeners are attached only for
+  // the lifetime of this drag (removed in handleDocumentMouseUp / cancelDrag).
+  const handleRowMouseDown = useCallback(
+    (path: string, index: number, rows: DiffRow[], e: ReactMouseEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      dragRangeRef.current = { path, anchorIndex: index, currentIndex: index };
+      didDragRef.current = false;
+      anchorRowsRef.current = rows;
+      lastClientRef.current = { x: e.clientX, y: e.clientY };
+      document.addEventListener("mousemove", handleDocumentMouseMove);
+      document.addEventListener("mouseup", handleDocumentMouseUp);
+    },
+    [handleDocumentMouseMove, handleDocumentMouseUp],
+  );
+
+  // Abandon any in-flight drag without committing — used when the dialog
+  // closes/reopens or switches tasks mid-drag, and on unmount.
+  const cancelDrag = useCallback(() => {
+    document.removeEventListener("mousemove", handleDocumentMouseMove);
+    document.removeEventListener("mouseup", handleDocumentMouseUp);
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    dragRangeRef.current = null;
+    didDragRef.current = false;
+    anchorRowsRef.current = [];
+    setDragRange(null);
+  }, [handleDocumentMouseMove, handleDocumentMouseUp]);
+
+  // Derived, not stored: `dragRange` only goes non-null once a drag has
+  // activated (see applyDragIndex), so this doubles as "is a real drag in
+  // progress" for the select-none styling below.
+  const dragActive = dragRange !== null;
+
+  const autoScrollStep = useCallback(() => {
+    const container = scrollContainerRef.current;
+    const drag = dragRangeRef.current;
+    if (container && drag) {
+      const rect = container.getBoundingClientRect();
+      const { x, y } = lastClientRef.current;
+      let dy = 0;
+      if (y < rect.top + AUTOSCROLL_EDGE_PX) {
+        dy = -Math.min(AUTOSCROLL_MAX_SPEED, (rect.top + AUTOSCROLL_EDGE_PX - y) / 2);
+      } else if (y > rect.bottom - AUTOSCROLL_EDGE_PX) {
+        dy = Math.min(AUTOSCROLL_MAX_SPEED, (y - (rect.bottom - AUTOSCROLL_EDGE_PX)) / 2);
+      }
+      if (dy !== 0) {
+        container.scrollTop += dy;
+        // mousemove doesn't fire while the container scrolls under a
+        // stationary pointer, so re-resolve the hovered row from the last
+        // known pointer position after each scroll step.
+        const hit = document.elementFromPoint(x, y);
+        const idx = resolveDragIndex(drag, y, hit);
+        if (idx !== null) applyDragIndex(idx);
+      }
+    }
+    rafRef.current = requestAnimationFrame(autoScrollStep);
+  }, [resolveDragIndex, applyDragIndex]);
+
+  // Start/stop the edge auto-scroll loop exactly when a drag activates or
+  // deactivates. Effect cleanup (dragActive flipping false, or unmount) is
+  // what guarantees the rAF loop can't outlive the drag or the dialog.
+  useEffect(() => {
+    if (!dragActive) return;
+    window.getSelection()?.removeAllRanges();
+    rafRef.current = requestAnimationFrame(autoScrollStep);
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [dragActive, autoScrollStep]);
+
+  // Belt-and-suspenders: the document listeners above are attached
+  // imperatively from an event handler (not from an effect), so guarantee
+  // their removal on unmount even if a drag was somehow still in flight.
+  useEffect(() => {
+    return () => {
+      document.removeEventListener("mousemove", handleDocumentMouseMove);
+      document.removeEventListener("mouseup", handleDocumentMouseUp);
+    };
+  }, [handleDocumentMouseMove, handleDocumentMouseUp]);
+
   // Gating data — same shape RunPanel uses to decide whether Send is safe.
   // Fetched lazily (below) once the composer first becomes visible, rather
   // than on every dialog open, since most diff views never select a line.
@@ -69,11 +291,14 @@ export function DiffDialog({ open, task, onClose }: Props) {
 
   useEffect(() => {
     // Reset selection + composer state on every dialog close/reopen and on
-    // every diff refetch (this effect's deps mirror the fetch below).
+    // every diff refetch (this effect's deps mirror the fetch below), and
+    // abandon any drag that was still in flight (e.g. the dialog was closed
+    // mid-drag).
     setSelected(new Map());
     setLastClicked(null);
     setDraft("");
     setHint(null);
+    cancelDrag();
     if (!open || !taskId) return;
     let cancelled = false;
     setLoading(true);
@@ -98,7 +323,7 @@ export function DiffDialog({ open, task, onClose }: Props) {
     // Key on task?.id, not `task` itself — the parent polls /tasks every 2s,
     // so a new `task` object identity arrives constantly and would otherwise
     // refetch the diff on every poll tick.
-  }, [open, taskId]);
+  }, [open, taskId, cancelDrag]);
 
   const totals = useMemo(() => {
     const files = diff?.files ?? [];
@@ -120,32 +345,34 @@ export function DiffDialog({ open, task, onClose }: Props) {
     setOpenFiles(on && diff ? new Set(diff.files.map((f) => f.path)) : new Set());
 
   // Plain click toggles a row; shift-click extends from `lastClicked` when it
-  // sits in the same file (adding the contiguous selectable range), otherwise
+  // sits in the same file (adding the contiguous selectable range, via the
+  // same `addRangeToSelection` helper the drag-commit path uses), otherwise
   // it behaves like a plain click on the clicked row. `lastClicked` updates on
   // every selecting click (both branches).
   const handleRowClick = useCallback(
     (path: string, index: number, rows: DiffRow[], shiftKey: boolean) => {
+      // A real drag just ended on (or through) this row — suppress the
+      // trailing synthetic click so the anchor row isn't toggled back off;
+      // the drag already committed its range in handleDocumentMouseUp.
+      if (didDragRef.current) {
+        didDragRef.current = false;
+        return;
+      }
       const row = rows[index];
       if (!row || !SELECTABLE_KINDS.has(row.kind)) return;
-      setSelected((prev) => {
-        const next = new Map(prev);
-        const current = new Set(next.get(path) ?? []);
-        if (shiftKey && lastClicked && lastClicked.path === path) {
-          const lo = Math.min(lastClicked.index, index);
-          const hi = Math.max(lastClicked.index, index);
-          for (let i = lo; i <= hi; i++) {
-            const kind = rows[i]?.kind;
-            if (kind && SELECTABLE_KINDS.has(kind)) current.add(i);
-          }
-        } else if (current.has(index)) {
-          current.delete(index);
-        } else {
-          current.add(index);
-        }
-        if (current.size === 0) next.delete(path);
-        else next.set(path, current);
-        return next;
-      });
+      if (shiftKey && lastClicked && lastClicked.path === path) {
+        setSelected((prev) => addRangeToSelection(prev, path, rows, lastClicked.index, index));
+      } else {
+        setSelected((prev) => {
+          const next = new Map(prev);
+          const current = new Set(next.get(path) ?? []);
+          if (current.has(index)) current.delete(index);
+          else current.add(index);
+          if (current.size === 0) next.delete(path);
+          else next.set(path, current);
+          return next;
+        });
+      }
       setLastClicked({ path, index });
     },
     [lastClicked],
@@ -307,7 +534,10 @@ export function DiffDialog({ open, task, onClose }: Props) {
         </div>
       </header>
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+      <div
+        ref={scrollContainerRef}
+        className={cn("min-h-0 flex-1 overflow-y-auto p-3", dragActive && "select-none")}
+      >
         {loading && (
           <div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
             <Loader2 className="size-4 animate-spin" /> Loading diff…
@@ -342,6 +572,9 @@ export function DiffDialog({ open, task, onClose }: Props) {
                 onToggle={() => toggle(f.path)}
                 selectedIndices={selected.get(f.path)}
                 onRowClick={handleRowClick}
+                onRowMouseDown={handleRowMouseDown}
+                dragRange={dragRange}
+                registerBody={registerBody}
               />
             ))}
           </div>
@@ -431,12 +664,18 @@ function FileBlock({
   onToggle,
   selectedIndices,
   onRowClick,
+  onRowMouseDown,
+  dragRange,
+  registerBody,
 }: {
   file: DiffFile;
   open: boolean;
   onToggle: () => void;
   selectedIndices: Set<number> | undefined;
   onRowClick: (path: string, index: number, rows: DiffRow[], shiftKey: boolean) => void;
+  onRowMouseDown: (path: string, index: number, rows: DiffRow[], e: ReactMouseEvent<HTMLDivElement>) => void;
+  dragRange: DiffDragRange | null;
+  registerBody: (path: string, el: HTMLDivElement | null) => void;
 }) {
   const meta = STATUS_META[file.status];
   const Icon = meta.icon;
@@ -462,7 +701,15 @@ function FileBlock({
           <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file — no textual diff.</div>
         ) : (
           <>
-            <DiffBody path={file.path} hunks={file.hunks} selectedIndices={selectedIndices} onRowClick={onRowClick} />
+            <DiffBody
+              path={file.path}
+              hunks={file.hunks}
+              selectedIndices={selectedIndices}
+              onRowClick={onRowClick}
+              onRowMouseDown={onRowMouseDown}
+              dragRange={dragRange}
+              registerBody={registerBody}
+            />
             {file.truncated && (
               <div className="border-t border-border/60 px-3 py-1.5 text-[11px] italic text-muted-foreground">
                 Diff truncated — this file's changes are too large to display in full.
@@ -480,22 +727,37 @@ function DiffBody({
   hunks,
   selectedIndices,
   onRowClick,
+  onRowMouseDown,
+  dragRange,
+  registerBody,
 }: {
   path: string;
   hunks: string;
   selectedIndices: Set<number> | undefined;
   onRowClick: (path: string, index: number, rows: DiffRow[], shiftKey: boolean) => void;
+  onRowMouseDown: (path: string, index: number, rows: DiffRow[], e: ReactMouseEvent<HTMLDivElement>) => void;
+  dragRange: DiffDragRange | null;
+  registerBody: (path: string, el: HTMLDivElement | null) => void;
 }) {
   const rows = useMemo(() => toRows(hunks), [hunks]);
+  // Stable per (path, registerBody) so the ref callback doesn't detach/
+  // reattach on every unrelated re-render (e.g. a selection change elsewhere
+  // in the same file re-renders every row).
+  const setBodyRef = useCallback((el: HTMLDivElement | null) => registerBody(path, el), [path, registerBody]);
   return (
-    <div className="overflow-x-auto bg-card font-mono text-xs leading-relaxed">
+    <div ref={setBodyRef} className="overflow-x-auto bg-card font-mono text-xs leading-relaxed">
       {rows.map((r, i) => {
         const selectable = SELECTABLE_KINDS.has(r.kind);
-        const isSelected = selectable && (selectedIndices?.has(i) ?? false);
+        const isSelected = selectable && ((selectedIndices?.has(i) ?? false) || isRowInDragRange(dragRange, path, i));
         return (
           <div
             key={i}
-            onMouseDown={(e) => { if (e.shiftKey) e.preventDefault(); }}
+            data-diff-path={path}
+            data-diff-index={i}
+            onMouseDown={(e) => {
+              if (e.shiftKey) { e.preventDefault(); return; }
+              if (selectable) onRowMouseDown(path, i, rows, e);
+            }}
             onClick={selectable ? (e) => onRowClick(path, i, rows, e.shiftKey) : undefined}
             className={cn(
               "flex border-l-2 border-transparent",

--- a/src/mainview/components/kanban/DiffDialog.tsx
+++ b/src/mainview/components/kanban/DiffDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import {
   AlertCircle, BookmarkPlus, ChevronDown, ChevronRight, FileMinus, FilePen, FilePlus,
   FileSymlink, GitCompare, Loader2, Send, X,
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 import { api, type PendingInteraction } from "@/lib/api";
 import { toRows, type DiffRow } from "@/lib/diff-rows";
 import {
-  addRangeToSelection, composeDiffMessage, groupSelectedRows, isRowInDragRange,
+  addRangeToSelection, composeDiffMessage, groupSelectedRows, isRowInDragRange, isSelectableKind,
   type DiffDragRange, type DiffSelectionBlock,
 } from "@/lib/diff-selection";
 import type { AgentKind, DiffFile, Harness, Run, Task, TaskDiff } from "../../../shared/types.ts";
@@ -38,8 +38,6 @@ function harnessKindOf(harnessId: string, harnesses: Harness[]): AgentKind {
   return harnesses.find((h) => h.id === harnessId)?.kind ?? "claude-code";
 }
 
-const SELECTABLE_KINDS = new Set<DiffRow["kind"]>(["ctx", "add", "del"]);
-
 // Edge auto-scroll tuning for the drag gesture below: start scrolling once
 // the pointer is within this many px of the scroll container's top/bottom,
 // at a speed proportional to how deep into that zone the pointer is (capped).
@@ -47,10 +45,10 @@ const AUTOSCROLL_EDGE_PX = 40;
 const AUTOSCROLL_MAX_SPEED = 15;
 
 /** Resolve the `data-diff-path`/`data-diff-index` row a DOM node sits inside
- *  (or is itself), via the nearest `[data-diff-index]` ancestor. Used by both
- *  the mousemove handler (fed `event.target`) and the auto-scroll loop (fed
- *  `document.elementFromPoint`, since mousemove doesn't fire while the
- *  container scrolls out from under a stationary pointer). */
+ *  (or is itself), via the nearest `[data-diff-index]` ancestor. Fed whatever
+ *  element `resolveHitTarget` below decided to hit-test — either the native
+ *  event's `target`, or an `elementFromPoint` lookup (auto-scroll re-resolve,
+ *  or the pointer-outside-container clamp). */
 function resolveRowFromElement(el: Element | null): { path: string; index: number } | null {
   const rowEl = el?.closest<HTMLElement>("[data-diff-index]");
   if (!rowEl) return null;
@@ -62,13 +60,13 @@ function resolveRowFromElement(el: Element | null): { path: string; index: numbe
 }
 
 function firstSelectableIndex(rows: DiffRow[]): number {
-  const idx = rows.findIndex((r) => SELECTABLE_KINDS.has(r.kind));
+  const idx = rows.findIndex((r) => isSelectableKind(r.kind));
   return idx === -1 ? 0 : idx;
 }
 
 function lastSelectableIndex(rows: DiffRow[]): number {
   for (let i = rows.length - 1; i >= 0; i--) {
-    if (SELECTABLE_KINDS.has(rows[i]!.kind)) return i;
+    if (isSelectableKind(rows[i]!.kind)) return i;
   }
   return rows.length - 1;
 }
@@ -104,9 +102,12 @@ export function DiffDialog({ open, task, onClose }: Props) {
   // listeners and the rAF auto-scroll loop need without waiting for a render:
   // `dragRangeRef` is the authoritative in-flight range, `didDragRef` flags
   // "a real drag happened" (suppresses the trailing click on the anchor row),
-  // `anchorRowsRef` holds the anchor file's rows for clamping/committing, and
+  // `anchorRowsRef` holds the anchor file's rows for clamping/committing,
   // `bodyRefs` maps file path -> that file's row-list DOM node (for the
-  // same-file clamp's bounding-rect check).
+  // same-file clamp's bounding-rect check), and `containerRectRef` caches the
+  // scroll container's own bounding rect for the lifetime of one drag (it's
+  // captured once at arm time — scrolling the container doesn't move the
+  // container element itself, so there's no need to re-measure every frame).
   const [dragRange, setDragRange] = useState<DiffDragRange | null>(null);
   const dragRangeRef = useRef<DiffDragRange | null>(null);
   const didDragRef = useRef(false);
@@ -115,21 +116,71 @@ export function DiffDialog({ open, task, onClose }: Props) {
   const bodyRefs = useRef(new Map<string, HTMLDivElement>());
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const rafRef = useRef<number | null>(null);
+  const containerRectRef = useRef<DOMRect | null>(null);
+  // Latest-value ref mirroring `cancelDrag` (defined further below) so
+  // earlier-defined callbacks — and the diff-refetch effect — can invoke the
+  // cancel path without taking a dependency on it (that dependency would
+  // otherwise churn the effect's deps every time the drag-callback chain is
+  // touched, risking a refetch loop).
+  const cancelDragRef = useRef<() => void>(() => {});
+  // Latest-value ref mirroring `lastClicked` so `handleRowClick` can read the
+  // shift-click anchor without depending on the state value itself — that
+  // dependency would otherwise recreate `handleRowClick` on every click,
+  // defeating the `DiffBody` memoization below (a new `onRowClick` identity
+  // busts memo for every file, not just the one that changed).
+  const lastClickedRef = useRef<{ path: string; index: number } | null>(null);
 
   const registerBody = useCallback((path: string, el: HTMLDivElement | null) => {
     if (el) bodyRefs.current.set(path, el);
     else bodyRefs.current.delete(path);
   }, []);
 
+  const updateLastClicked = useCallback((value: { path: string; index: number } | null) => {
+    lastClickedRef.current = value;
+    setLastClicked(value);
+  }, []);
+
+  // Stable indirection to the in-flight `cancelDrag` (via the ref above) —
+  // used both as the window `blur` listener (needs a fixed identity to add
+  // once and remove later) and inline wherever a cancel is needed without
+  // creating a dependency on `cancelDrag` itself.
+  const handleDragCancelSignal = useCallback(() => {
+    cancelDragRef.current();
+  }, []);
+
+  // Resolve the DOM element to hit-test for drag row-resolution. When the
+  // pointer is vertically inside the cached scroll-container rect, prefer
+  // the already-known `target` (a native mousemove event's target) to avoid
+  // an extra `elementFromPoint` call; when there's no known target (the
+  // auto-scroll loop, which has no live event) fall back to
+  // `elementFromPoint` at the real position. When the pointer is vertically
+  // *outside* the container (dragged onto the composer below it, or above it
+  // onto the header), hit-test at the container's own clipped edge instead
+  // of the real, out-of-bounds point — that lands on whatever row is still
+  // visible right at the edge, rather than on unrelated content laid out
+  // below/above the scroll area (which would never resolve to a row at all).
+  const resolveHitTarget = useCallback(
+    (x: number, y: number, target: Element | null): Element | null => {
+      const rect = containerRectRef.current;
+      if (!rect) return target ?? document.elementFromPoint(x, y);
+      if (y < rect.top || y > rect.bottom) {
+        const clampedY = Math.min(Math.max(y, rect.top + 1), rect.bottom - 1);
+        return document.elementFromPoint(x, clampedY);
+      }
+      return target ?? document.elementFromPoint(x, y);
+    },
+    [],
+  );
+
   // Resolve which row index the drag should report as `currentIndex` given a
-  // hit-tested DOM element (mousemove's `event.target`, or
-  // `document.elementFromPoint` during auto-scroll). When the hit lands on a
-  // row in the anchor file, use it directly (even a non-selectable hunk/meta
-  // row — downstream range math filters to selectable kinds). Otherwise
-  // (a different file, or dead space) clamp against the anchor file's
-  // row-list bounding rect: above it -> first selectable row, below it ->
-  // last selectable row, inside its vertical span but unresolved -> `null`
-  // (hold the previous index).
+  // hit-tested DOM element (from `resolveHitTarget` above). When the hit
+  // lands on a row in the anchor file, use it directly (even a non-selectable
+  // hunk/meta row — downstream range math filters to selectable kinds).
+  // Otherwise (a different file, or dead space `resolveHitTarget` couldn't
+  // resolve to a row) clamp against the anchor file's row-list bounding
+  // rect: above it -> first selectable row, below it -> last selectable row,
+  // inside its vertical span but unresolved -> `null` (hold the previous
+  // index).
   const resolveDragIndex = useCallback(
     (drag: DiffDragRange, clientY: number, hitTarget: Element | null): number | null => {
       const resolved = resolveRowFromElement(hitTarget);
@@ -159,20 +210,75 @@ export function DiffDialog({ open, task, onClose }: Props) {
     setDragRange(nextRange);
   }, []);
 
+  // The rAF auto-scroll loop. Does *not* unconditionally reschedule itself —
+  // when the pointer isn't in an edge zone (`dy === 0`) this frame is the
+  // loop's last one; `maybeArmAutoScroll` (below) re-starts it from the
+  // mousemove handler once the pointer re-enters an edge zone. This keeps a
+  // drag that never nears an edge from paying for a permanent 60Hz loop.
+  const autoScrollStep = useCallback(() => {
+    rafRef.current = null;
+    const container = scrollContainerRef.current;
+    const drag = dragRangeRef.current;
+    const rect = containerRectRef.current;
+    if (!container || !drag || !rect) return;
+    const { x, y } = lastClientRef.current;
+    let dy = 0;
+    if (y < rect.top + AUTOSCROLL_EDGE_PX) {
+      dy = -Math.min(AUTOSCROLL_MAX_SPEED, (rect.top + AUTOSCROLL_EDGE_PX - y) / 2);
+    } else if (y > rect.bottom - AUTOSCROLL_EDGE_PX) {
+      dy = Math.min(AUTOSCROLL_MAX_SPEED, (y - (rect.bottom - AUTOSCROLL_EDGE_PX)) / 2);
+    }
+    if (dy === 0) return;
+    container.scrollTop += dy;
+    // mousemove doesn't fire while the container scrolls under a stationary
+    // pointer, so re-resolve the hovered row from the last known pointer
+    // position after each scroll step.
+    const hit = resolveHitTarget(x, y, null);
+    const idx = resolveDragIndex(drag, y, hit);
+    if (idx !== null) applyDragIndex(idx);
+    rafRef.current = requestAnimationFrame(autoScrollStep);
+  }, [resolveDragIndex, applyDragIndex, resolveHitTarget]);
+
+  // Re-arm the auto-scroll loop from the mousemove handler when the pointer
+  // (re-)enters an edge zone and the loop isn't already running — the
+  // counterpart to `autoScrollStep` letting itself go idle above.
+  const maybeArmAutoScroll = useCallback(
+    (y: number) => {
+      if (rafRef.current !== null) return;
+      const rect = containerRectRef.current;
+      if (!rect) return;
+      if (y < rect.top + AUTOSCROLL_EDGE_PX || y > rect.bottom - AUTOSCROLL_EDGE_PX) {
+        rafRef.current = requestAnimationFrame(autoScrollStep);
+      }
+    },
+    [autoScrollStep],
+  );
+
   const handleDocumentMouseMove = useCallback(
     (e: MouseEvent) => {
+      // A lost mouseup (release outside the WKWebView) leaves `buttons`
+      // reporting no buttons held on the next mousemove we do see — treat
+      // that as a cancel: tear down without committing, since the actual
+      // release was never observed.
+      if (e.buttons === 0) {
+        cancelDragRef.current();
+        return;
+      }
       lastClientRef.current = { x: e.clientX, y: e.clientY };
       const drag = dragRangeRef.current;
       if (!drag) return;
-      const idx = resolveDragIndex(drag, e.clientY, e.target as Element | null);
+      const hitTarget = resolveHitTarget(e.clientX, e.clientY, e.target as Element | null);
+      const idx = resolveDragIndex(drag, e.clientY, hitTarget);
       if (idx !== null) applyDragIndex(idx);
+      if (didDragRef.current) maybeArmAutoScroll(e.clientY);
     },
-    [resolveDragIndex, applyDragIndex],
+    [resolveHitTarget, resolveDragIndex, applyDragIndex, maybeArmAutoScroll],
   );
 
   const handleDocumentMouseUp = useCallback(() => {
     document.removeEventListener("mousemove", handleDocumentMouseMove);
     document.removeEventListener("mouseup", handleDocumentMouseUp);
+    window.removeEventListener("blur", handleDragCancelSignal);
     if (rafRef.current !== null) {
       cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
@@ -184,39 +290,54 @@ export function DiffDialog({ open, task, onClose }: Props) {
     if (drag && didDragRef.current) {
       const rows = anchorRowsRef.current;
       setSelected((prev) => addRangeToSelection(prev, drag.path, rows, drag.anchorIndex, drag.currentIndex));
-      setLastClicked({ path: drag.path, index: drag.currentIndex });
+      updateLastClicked({ path: drag.path, index: drag.currentIndex });
     }
     dragRangeRef.current = null;
     anchorRowsRef.current = [];
+    containerRectRef.current = null;
     setDragRange(null);
-    // `didDragRef` is deliberately left as-is here — `handleRowClick` (or the
-    // next `handleRowMouseDown`) consumes and resets it, so the trailing
-    // click on the anchor row (if any) gets suppressed.
-  }, [handleDocumentMouseMove]);
+    // `didDragRef` is deliberately left as-is here — the next row mousedown
+    // (`handleRowMouseDown`) unconditionally consumes and resets it, so the
+    // trailing click on the anchor row (if any) gets suppressed even when
+    // this mouseup didn't land on a row at all.
+  }, [handleDocumentMouseMove, handleDragCancelSignal, updateLastClicked]);
 
   // Arm a pending drag on primary-button mousedown over a selectable row.
   // No preventDefault here (within-row native text selection must still be
-  // able to start) — the shift-click preventDefault stays put separately in
-  // the row's onMouseDown. Document-level listeners are attached only for
-  // the lifetime of this drag (removed in handleDocumentMouseUp / cancelDrag).
+  // able to start) — the shift-click preventDefault stays put separately
+  // below. Document/window listeners are attached only for the lifetime of
+  // this drag (removed in handleDocumentMouseUp / cancelDrag).
   const handleRowMouseDown = useCallback(
-    (path: string, index: number, rows: DiffRow[], e: ReactMouseEvent<HTMLDivElement>) => {
-      if (e.button !== 0) return;
-      dragRangeRef.current = { path, anchorIndex: index, currentIndex: index };
+    (path: string, index: number, rows: DiffRow[], selectable: boolean, e: ReactMouseEvent<HTMLDivElement>) => {
+      // Unconditional and first: if the previous drag's mouseup didn't land
+      // on a row (released over dead space, the composer, or outside the
+      // WKWebView entirely), `didDragRef` would otherwise stay `true`
+      // forever and silently swallow the *next* click or shift-click
+      // anywhere in the dialog.
       didDragRef.current = false;
+      if (e.shiftKey) {
+        e.preventDefault();
+        return;
+      }
+      if (!selectable || e.button !== 0) return;
+      dragRangeRef.current = { path, anchorIndex: index, currentIndex: index };
       anchorRowsRef.current = rows;
       lastClientRef.current = { x: e.clientX, y: e.clientY };
+      containerRectRef.current = scrollContainerRef.current?.getBoundingClientRect() ?? null;
       document.addEventListener("mousemove", handleDocumentMouseMove);
       document.addEventListener("mouseup", handleDocumentMouseUp);
+      window.addEventListener("blur", handleDragCancelSignal);
     },
-    [handleDocumentMouseMove, handleDocumentMouseUp],
+    [handleDocumentMouseMove, handleDocumentMouseUp, handleDragCancelSignal],
   );
 
   // Abandon any in-flight drag without committing — used when the dialog
-  // closes/reopens or switches tasks mid-drag, and on unmount.
+  // closes/reopens or switches tasks mid-drag, on unmount, when a mouseup is
+  // lost (release outside the WKWebView), and on window blur.
   const cancelDrag = useCallback(() => {
     document.removeEventListener("mousemove", handleDocumentMouseMove);
     document.removeEventListener("mouseup", handleDocumentMouseUp);
+    window.removeEventListener("blur", handleDragCancelSignal);
     if (rafRef.current !== null) {
       cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
@@ -224,46 +345,27 @@ export function DiffDialog({ open, task, onClose }: Props) {
     dragRangeRef.current = null;
     didDragRef.current = false;
     anchorRowsRef.current = [];
+    containerRectRef.current = null;
     setDragRange(null);
-  }, [handleDocumentMouseMove, handleDocumentMouseUp]);
+  }, [handleDocumentMouseMove, handleDocumentMouseUp, handleDragCancelSignal]);
+
+  cancelDragRef.current = cancelDrag;
 
   // Derived, not stored: `dragRange` only goes non-null once a drag has
   // activated (see applyDragIndex), so this doubles as "is a real drag in
   // progress" for the select-none styling below.
   const dragActive = dragRange !== null;
 
-  const autoScrollStep = useCallback(() => {
-    const container = scrollContainerRef.current;
-    const drag = dragRangeRef.current;
-    if (container && drag) {
-      const rect = container.getBoundingClientRect();
-      const { x, y } = lastClientRef.current;
-      let dy = 0;
-      if (y < rect.top + AUTOSCROLL_EDGE_PX) {
-        dy = -Math.min(AUTOSCROLL_MAX_SPEED, (rect.top + AUTOSCROLL_EDGE_PX - y) / 2);
-      } else if (y > rect.bottom - AUTOSCROLL_EDGE_PX) {
-        dy = Math.min(AUTOSCROLL_MAX_SPEED, (y - (rect.bottom - AUTOSCROLL_EDGE_PX)) / 2);
-      }
-      if (dy !== 0) {
-        container.scrollTop += dy;
-        // mousemove doesn't fire while the container scrolls under a
-        // stationary pointer, so re-resolve the hovered row from the last
-        // known pointer position after each scroll step.
-        const hit = document.elementFromPoint(x, y);
-        const idx = resolveDragIndex(drag, y, hit);
-        if (idx !== null) applyDragIndex(idx);
-      }
-    }
-    rafRef.current = requestAnimationFrame(autoScrollStep);
-  }, [resolveDragIndex, applyDragIndex]);
-
-  // Start/stop the edge auto-scroll loop exactly when a drag activates or
-  // deactivates. Effect cleanup (dragActive flipping false, or unmount) is
-  // what guarantees the rAF loop can't outlive the drag or the dialog.
+  // Start the edge auto-scroll loop when a drag activates; cleanup (dragActive
+  // flipping false, or unmount) guarantees the rAF loop can't outlive the
+  // drag or the dialog — including any later iteration re-armed by
+  // `maybeArmAutoScroll` from the mousemove handler.
   useEffect(() => {
     if (!dragActive) return;
     window.getSelection()?.removeAllRanges();
-    rafRef.current = requestAnimationFrame(autoScrollStep);
+    if (rafRef.current === null) {
+      rafRef.current = requestAnimationFrame(autoScrollStep);
+    }
     return () => {
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current);
@@ -272,15 +374,16 @@ export function DiffDialog({ open, task, onClose }: Props) {
     };
   }, [dragActive, autoScrollStep]);
 
-  // Belt-and-suspenders: the document listeners above are attached
+  // Belt-and-suspenders: the document/window listeners above are attached
   // imperatively from an event handler (not from an effect), so guarantee
   // their removal on unmount even if a drag was somehow still in flight.
   useEffect(() => {
     return () => {
       document.removeEventListener("mousemove", handleDocumentMouseMove);
       document.removeEventListener("mouseup", handleDocumentMouseUp);
+      window.removeEventListener("blur", handleDragCancelSignal);
     };
-  }, [handleDocumentMouseMove, handleDocumentMouseUp]);
+  }, [handleDocumentMouseMove, handleDocumentMouseUp, handleDragCancelSignal]);
 
   // Gating data — same shape RunPanel uses to decide whether Send is safe.
   // Fetched lazily (below) once the composer first becomes visible, rather
@@ -293,12 +396,15 @@ export function DiffDialog({ open, task, onClose }: Props) {
     // Reset selection + composer state on every dialog close/reopen and on
     // every diff refetch (this effect's deps mirror the fetch below), and
     // abandon any drag that was still in flight (e.g. the dialog was closed
-    // mid-drag).
+    // mid-drag). Reads `cancelDrag` through the ref rather than depending on
+    // it directly — this effect also owns the diff fetch, so a dependency on
+    // the drag-callback chain would risk a refetch loop on future dep churn
+    // there; the ref keeps this effect's deps to just `[open, taskId]`.
     setSelected(new Map());
-    setLastClicked(null);
+    updateLastClicked(null);
     setDraft("");
     setHint(null);
-    cancelDrag();
+    cancelDragRef.current();
     if (!open || !taskId) return;
     let cancelled = false;
     setLoading(true);
@@ -323,7 +429,7 @@ export function DiffDialog({ open, task, onClose }: Props) {
     // Key on task?.id, not `task` itself — the parent polls /tasks every 2s,
     // so a new `task` object identity arrives constantly and would otherwise
     // refetch the diff on every poll tick.
-  }, [open, taskId, cancelDrag]);
+  }, [open, taskId]);
 
   const totals = useMemo(() => {
     const files = diff?.files ?? [];
@@ -348,7 +454,11 @@ export function DiffDialog({ open, task, onClose }: Props) {
   // sits in the same file (adding the contiguous selectable range, via the
   // same `addRangeToSelection` helper the drag-commit path uses), otherwise
   // it behaves like a plain click on the clicked row. `lastClicked` updates on
-  // every selecting click (both branches).
+  // every selecting click (both branches). Reads the shift-click anchor via
+  // `lastClickedRef` (kept in sync by `updateLastClicked`) instead of the
+  // `lastClicked` state directly, so this callback's identity stays stable
+  // across clicks — see the `DiffBody` memoization below, which relies on
+  // `onRowClick` not changing per-render for non-anchor files to bail out.
   const handleRowClick = useCallback(
     (path: string, index: number, rows: DiffRow[], shiftKey: boolean) => {
       // A real drag just ended on (or through) this row — suppress the
@@ -359,9 +469,10 @@ export function DiffDialog({ open, task, onClose }: Props) {
         return;
       }
       const row = rows[index];
-      if (!row || !SELECTABLE_KINDS.has(row.kind)) return;
-      if (shiftKey && lastClicked && lastClicked.path === path) {
-        setSelected((prev) => addRangeToSelection(prev, path, rows, lastClicked.index, index));
+      if (!row || !isSelectableKind(row.kind)) return;
+      const anchor = lastClickedRef.current;
+      if (shiftKey && anchor && anchor.path === path) {
+        setSelected((prev) => addRangeToSelection(prev, path, rows, anchor.index, index));
       } else {
         setSelected((prev) => {
           const next = new Map(prev);
@@ -373,9 +484,9 @@ export function DiffDialog({ open, task, onClose }: Props) {
           return next;
         });
       }
-      setLastClicked({ path, index });
+      updateLastClicked({ path, index });
     },
-    [lastClicked],
+    [updateLastClicked],
   );
 
   const totalSelected = useMemo(() => {
@@ -447,7 +558,7 @@ export function DiffDialog({ open, task, onClose }: Props) {
 
   const clearSelection = () => {
     setSelected(new Map());
-    setLastClicked(null);
+    updateLastClicked(null);
     setDraft("");
     setHint(null);
   };
@@ -573,7 +684,7 @@ export function DiffDialog({ open, task, onClose }: Props) {
                 selectedIndices={selected.get(f.path)}
                 onRowClick={handleRowClick}
                 onRowMouseDown={handleRowMouseDown}
-                dragRange={dragRange}
+                dragRange={dragRange?.path === f.path ? dragRange : null}
                 registerBody={registerBody}
               />
             ))}
@@ -658,6 +769,19 @@ export function DiffDialog({ open, task, onClose }: Props) {
   );
 }
 
+/** Fires on every row's `onMouseDown` — even non-selectable (hunk/meta) rows
+ *  and shift-held/non-primary clicks — so `didDragRef` can be reset
+ *  unconditionally before any of those early-return (see handleRowMouseDown
+ *  in DiffDialog). `selectable` is computed by the caller (DiffBody already
+ *  needs it for styling) rather than re-derived here. */
+type RowMouseDownHandler = (
+  path: string,
+  index: number,
+  rows: DiffRow[],
+  selectable: boolean,
+  e: ReactMouseEvent<HTMLDivElement>,
+) => void;
+
 function FileBlock({
   file,
   open,
@@ -673,7 +797,7 @@ function FileBlock({
   onToggle: () => void;
   selectedIndices: Set<number> | undefined;
   onRowClick: (path: string, index: number, rows: DiffRow[], shiftKey: boolean) => void;
-  onRowMouseDown: (path: string, index: number, rows: DiffRow[], e: ReactMouseEvent<HTMLDivElement>) => void;
+  onRowMouseDown: RowMouseDownHandler;
   dragRange: DiffDragRange | null;
   registerBody: (path: string, el: HTMLDivElement | null) => void;
 }) {
@@ -722,7 +846,16 @@ function FileBlock({
   );
 }
 
-function DiffBody({
+// Memoized so a drag's row-boundary crossings — which re-render the anchor
+// file's DiffBody on every index change — don't cascade into re-rendering
+// every OTHER expanded file's rows too. For this to pay off, every non-anchor
+// file must receive referentially-stable props: DiffDialog passes each file
+// a `dragRange` that's `null` (a stable primitive) unless it's the anchor
+// file, `onRowClick`/`onRowMouseDown`/`registerBody` are all stable
+// `useCallback`s, and `selectedIndices` is only a new `Set` reference for the
+// file whose selection actually changed (the `Map` clone in `setSelected`
+// keeps other files' `Set`s by reference).
+const DiffBody = memo(function DiffBody({
   path,
   hunks,
   selectedIndices,
@@ -735,7 +868,7 @@ function DiffBody({
   hunks: string;
   selectedIndices: Set<number> | undefined;
   onRowClick: (path: string, index: number, rows: DiffRow[], shiftKey: boolean) => void;
-  onRowMouseDown: (path: string, index: number, rows: DiffRow[], e: ReactMouseEvent<HTMLDivElement>) => void;
+  onRowMouseDown: RowMouseDownHandler;
   dragRange: DiffDragRange | null;
   registerBody: (path: string, el: HTMLDivElement | null) => void;
 }) {
@@ -747,17 +880,14 @@ function DiffBody({
   return (
     <div ref={setBodyRef} className="overflow-x-auto bg-card font-mono text-xs leading-relaxed">
       {rows.map((r, i) => {
-        const selectable = SELECTABLE_KINDS.has(r.kind);
+        const selectable = isSelectableKind(r.kind);
         const isSelected = selectable && ((selectedIndices?.has(i) ?? false) || isRowInDragRange(dragRange, path, i));
         return (
           <div
             key={i}
             data-diff-path={path}
             data-diff-index={i}
-            onMouseDown={(e) => {
-              if (e.shiftKey) { e.preventDefault(); return; }
-              if (selectable) onRowMouseDown(path, i, rows, e);
-            }}
+            onMouseDown={(e) => onRowMouseDown(path, i, rows, selectable, e)}
             onClick={selectable ? (e) => onRowClick(path, i, rows, e.shiftKey) : undefined}
             className={cn(
               "flex border-l-2 border-transparent",
@@ -790,4 +920,4 @@ function DiffBody({
       })}
     </div>
   );
-}
+});

--- a/src/mainview/lib/diff-selection.test.ts
+++ b/src/mainview/lib/diff-selection.test.ts
@@ -2,9 +2,13 @@ import { expect, test } from "bun:test";
 import type { DiffRow } from "./diff-rows.ts";
 import {
   DIFF_SELECTION_HEADING,
+  addRangeToSelection,
   composeDiffMessage,
   formatDiffSelection,
   groupSelectedRows,
+  isRowInDragRange,
+  selectableIndicesInRange,
+  type DiffDragRange,
   type DiffSelectionBlock,
 } from "./diff-selection.ts";
 
@@ -227,4 +231,127 @@ test("composeDiffMessage joins text and formatted block with a blank line", () =
   const blocks: DiffSelectionBlock[] = [{ path: "f.ts", lines: [{ old: 1, neu: 1, kind: "ctx", text: "hi" }] }];
   const out = composeDiffMessage("look at this", blocks);
   expect(out).toBe(`look at this\n\n${formatDiffSelection(blocks)}`);
+});
+
+// --- selectableIndicesInRange -------------------------------------------
+
+test("selectableIndicesInRange keeps ctx/add/del and skips hunk/meta rows within the range", () => {
+  const r = rows(
+    ["hunk", null, null, "@@ -1,3 +1,3 @@"],
+    ["ctx", 1, 1, "a"],
+    ["del", 2, null, "b"],
+    ["add", null, 2, "c"],
+    ["meta", null, null, "\\ No newline at end of file"],
+    ["ctx", 3, 3, "d"],
+  );
+  expect(selectableIndicesInRange(r, 0, 5)).toEqual([1, 2, 3, 5]);
+});
+
+test("selectableIndicesInRange normalizes reversed bounds (a > b) to the same result", () => {
+  const r = rows(["ctx", 1, 1, "a"], ["del", 2, null, "b"], ["add", null, 2, "c"]);
+  expect(selectableIndicesInRange(r, 2, 0)).toEqual(selectableIndicesInRange(r, 0, 2));
+  expect(selectableIndicesInRange(r, 2, 0)).toEqual([0, 1, 2]);
+});
+
+test("selectableIndicesInRange with a === b returns a single index for a selectable row", () => {
+  const r = rows(["ctx", 1, 1, "a"]);
+  expect(selectableIndicesInRange(r, 0, 0)).toEqual([0]);
+});
+
+test("selectableIndicesInRange with a === b returns [] for a non-selectable row", () => {
+  const r = rows(["hunk", null, null, "@@ -1,1 +1,1 @@"]);
+  expect(selectableIndicesInRange(r, 0, 0)).toEqual([]);
+});
+
+test("selectableIndicesInRange returns [] when the whole range is non-selectable rows", () => {
+  const r = rows(
+    ["hunk", null, null, "@@ -1,2 +1,2 @@"],
+    ["meta", null, null, "\\ No newline at end of file"],
+  );
+  expect(selectableIndicesInRange(r, 0, 1)).toEqual([]);
+});
+
+test("selectableIndicesInRange handles bounds at the array edges", () => {
+  const r = rows(["ctx", 1, 1, "a"], ["del", 2, null, "b"], ["add", null, 2, "c"]);
+  expect(selectableIndicesInRange(r, 0, 2)).toEqual([0, 1, 2]);
+});
+
+test("selectableIndicesInRange skips out-of-range indices past the array end", () => {
+  const r = rows(["ctx", 1, 1, "a"], ["ctx", 2, 2, "b"]);
+  expect(selectableIndicesInRange(r, 0, 5)).toEqual([0, 1]);
+});
+
+// --- addRangeToSelection --------------------------------------------------
+
+test("addRangeToSelection unions into an existing set for the path, preserving pre-selected indices", () => {
+  const r = rows(["ctx", 1, 1, "a"], ["del", 2, null, "b"], ["add", null, 2, "c"]);
+  const selected = new Map([["f.ts", new Set([0])]]);
+  const next = addRangeToSelection(selected, "f.ts", r, 1, 2);
+  expect([...next.get("f.ts")!].sort()).toEqual([0, 1, 2]);
+});
+
+test("addRangeToSelection creates the set when the path is absent", () => {
+  const r = rows(["ctx", 1, 1, "a"], ["del", 2, null, "b"]);
+  const next = addRangeToSelection(new Map(), "f.ts", r, 0, 1);
+  expect([...next.get("f.ts")!].sort()).toEqual([0, 1]);
+});
+
+test("addRangeToSelection does not insert an empty set when the range has zero selectable rows on an absent path", () => {
+  const r = rows(["hunk", null, null, "@@ -1,1 +1,1 @@"], ["meta", null, null, "\\ No newline at end of file"]);
+  const next = addRangeToSelection(new Map(), "f.ts", r, 0, 1);
+  expect(next.has("f.ts")).toBe(false);
+});
+
+test("addRangeToSelection does not mutate the input Map or its Sets, and returns a new Map", () => {
+  const r = rows(["ctx", 1, 1, "a"], ["del", 2, null, "b"]);
+  const originalSet = new Set([0]);
+  const selected = new Map([["f.ts", originalSet]]);
+  const next = addRangeToSelection(selected, "f.ts", r, 0, 1);
+
+  expect(next).not.toBe(selected);
+  expect(selected.get("f.ts")).toBe(originalSet);
+  expect([...originalSet]).toEqual([0]);
+  expect(next.get("f.ts")).not.toBe(originalSet);
+  expect([...next.get("f.ts")!].sort()).toEqual([0, 1]);
+});
+
+test("addRangeToSelection carries over other paths' sets unchanged", () => {
+  const r = rows(["ctx", 1, 1, "a"], ["del", 2, null, "b"]);
+  const otherSet = new Set([5]);
+  const selected = new Map([["other.ts", otherSet]]);
+  const next = addRangeToSelection(selected, "f.ts", r, 0, 1);
+
+  expect(next.get("other.ts")).toBe(otherSet);
+  expect([...next.get("f.ts")!].sort()).toEqual([0, 1]);
+});
+
+// --- isRowInDragRange ------------------------------------------------------
+
+test("isRowInDragRange returns false when there is no drag", () => {
+  expect(isRowInDragRange(null, "f.ts", 0)).toBe(false);
+});
+
+test("isRowInDragRange returns false when the drag anchors a different file", () => {
+  const drag: DiffDragRange = { path: "other.ts", anchorIndex: 0, currentIndex: 5 };
+  expect(isRowInDragRange(drag, "f.ts", 2)).toBe(false);
+});
+
+test("isRowInDragRange is inclusive at both bounds", () => {
+  const drag: DiffDragRange = { path: "f.ts", anchorIndex: 2, currentIndex: 5 };
+  expect(isRowInDragRange(drag, "f.ts", 2)).toBe(true);
+  expect(isRowInDragRange(drag, "f.ts", 5)).toBe(true);
+  expect(isRowInDragRange(drag, "f.ts", 3)).toBe(true);
+});
+
+test("isRowInDragRange is inclusive when anchor/current are reversed (currentIndex < anchorIndex)", () => {
+  const drag: DiffDragRange = { path: "f.ts", anchorIndex: 5, currentIndex: 2 };
+  expect(isRowInDragRange(drag, "f.ts", 2)).toBe(true);
+  expect(isRowInDragRange(drag, "f.ts", 5)).toBe(true);
+  expect(isRowInDragRange(drag, "f.ts", 3)).toBe(true);
+});
+
+test("isRowInDragRange returns false for an index just outside either bound", () => {
+  const drag: DiffDragRange = { path: "f.ts", anchorIndex: 2, currentIndex: 5 };
+  expect(isRowInDragRange(drag, "f.ts", 1)).toBe(false);
+  expect(isRowInDragRange(drag, "f.ts", 6)).toBe(false);
 });

--- a/src/mainview/lib/diff-selection.ts
+++ b/src/mainview/lib/diff-selection.ts
@@ -17,6 +17,15 @@ export const DIFF_SELECTION_HEADING = "Selected lines from the current diff:";
 
 const SELECTABLE_KINDS = new Set<DiffRow["kind"]>(["ctx", "add", "del"]);
 
+/** Whether a diff row's kind participates in selection — click, shift-click
+ *  range extension, and drag-to-select all filter through this. Exported so
+ *  DiffDialog.tsx doesn't keep its own duplicate `SELECTABLE_KINDS` copy
+ *  (that duplication was a drift surface once the component grew more
+ *  consumers of the same set). */
+export function isSelectableKind(kind: DiffRow["kind"]): boolean {
+  return SELECTABLE_KINDS.has(kind);
+}
+
 const KIND_PREFIX: Record<"ctx" | "add" | "del", string> = {
   ctx: " ",
   add: "+",

--- a/src/mainview/lib/diff-selection.ts
+++ b/src/mainview/lib/diff-selection.ts
@@ -119,3 +119,66 @@ export function composeDiffMessage(text: string, blocks: DiffSelectionBlock[]): 
   if (!text) return formatted;
   return `${text}\n\n${formatted}`;
 }
+
+/** A pending or active drag-to-select gesture, anchored at the row that was
+ *  mouse-downed. `currentIndex` tracks the row currently under the pointer
+ *  (or the same-file clamp when the pointer strays outside the anchor file —
+ *  see DiffDialog's clamp logic); both indices are into the anchor file's
+ *  `toRows` output. `null` means no drag is in progress. */
+export interface DiffDragRange {
+  path: string;
+  anchorIndex: number;
+  currentIndex: number;
+}
+
+/** Inclusive index range between `a` and `b` (either order), filtered to rows
+ *  whose kind is selectable ("ctx" | "add" | "del"). Shared by shift-click
+ *  range extension and drag-to-select commit so both gestures walk identical
+ *  logic. Out-of-range indices are naturally skipped since `rows[i]` is
+ *  undefined there. */
+export function selectableIndicesInRange(rows: DiffRow[], a: number, b: number): number[] {
+  const lo = Math.min(a, b);
+  const hi = Math.max(a, b);
+  const result: number[] = [];
+  for (let i = lo; i <= hi; i++) {
+    const kind = rows[i]?.kind;
+    if (kind && SELECTABLE_KINDS.has(kind)) result.push(i);
+  }
+  return result;
+}
+
+/** Union the selectable rows in `[a, b]` (inclusive, either order) into
+ *  `path`'s entry in `selected`. Immutable: returns a new Map, and — only
+ *  when the touched path's set actually changes — a new Set for that path;
+ *  `selected` and any of its Sets are never mutated in place. Mirrors the
+ *  existing convention that an empty selection isn't represented as an
+ *  empty Set: if the range contains no selectable rows and `path` had no
+ *  prior entry, no entry is inserted for it. */
+export function addRangeToSelection(
+  selected: Map<string, Set<number>>,
+  path: string,
+  rows: DiffRow[],
+  a: number,
+  b: number,
+): Map<string, Set<number>> {
+  const indices = selectableIndicesInRange(rows, a, b);
+  const next = new Map(selected);
+  if (indices.length === 0) return next;
+  const current = new Set(next.get(path) ?? []);
+  for (const i of indices) current.add(i);
+  next.set(path, current);
+  return next;
+}
+
+/** Whether row `index` of `path` falls inside the (inclusive, direction-
+ *  agnostic) bounds of an active/pending drag. `false` when there's no drag
+ *  (`drag` is `null`) or the drag anchors a different file. Pure bounds
+ *  check — callers are expected to have already filtered to selectable
+ *  rows (mirroring how `isSelected` is only meaningful for selectable rows
+ *  in DiffDialog's render). */
+export function isRowInDragRange(drag: DiffDragRange | null, path: string, index: number): boolean {
+  if (!drag || drag.path !== path) return false;
+  const lo = Math.min(drag.anchorIndex, drag.currentIndex);
+  const hi = Math.max(drag.anchorIndex, drag.currentIndex);
+  return index >= lo && index <= hi;
+}


### PR DESCRIPTION
## What

Adds a **click-and-drag gesture** to the compose-from-diff feature in `DiffDialog`: mouse down on a diff line, drag across adjacent lines, release — every selectable line in the range is selected. Existing gestures are unchanged: plain click still toggles a single line, shift-click still range-extends.

Semantics (as designed/approved in `docs/plans/diff-drag-select.md`):
- **Additive paint** — a drag always selects, never deselects; the range is unioned into the existing selection.
- **Same-file only** — the range clamps to the file where the drag started (matching shift-click); the overall selection remains cross-file via multiple gestures.
- **Edge auto-scroll** — holding the drag near the top/bottom of the diff panel scrolls it, so one gesture can select more than a viewport's worth of lines.
- Within-line native text selection (for copying) still works — the drag takes over only once the pointer crosses a line boundary.

## How

- The drag is **armed** on `mousedown` and only **activates** when the pointer crosses onto a different row — so a same-row mousedown+mouseup remains today's click, with no pixel-threshold heuristics.
- Document-level `mousemove`/`mouseup` listeners attach only while armed; rows carry `data-diff-path`/`data-diff-index` for hit-testing.
- The in-flight range is a lightweight preview state; the real `Map<path, Set<index>>` is rebuilt **once, on mouseup** — no per-pixel Map churn. `DiffBody` is memoized and non-anchor files receive `dragRange={null}`, so only the anchor file re-renders during a drag.
- The range math is extracted into pure helpers in `lib/diff-selection.ts` (`selectableIndicesInRange`, `addRangeToSelection`, `isRowInDragRange`, `isSelectableKind`), now shared by the shift-click branch and the drag commit — single source of truth, unit-testable (this repo intentionally has no DOM test harness).

## Hardening (from code review)

- Trailing-click suppression flag is reset unconditionally at the top of row `mousedown`, so a drag can't swallow the *next* click/shift-click (the post-drag `click` often targets the container, not a row).
- Auto-scroll hit-tests at the scroll container's clipped edge (`elementFromPoint` with clamped `y`), so the selection keeps extending when the pointer leaves the panel instead of freezing while the view scrolls.
- A mouseup released outside the window can't strand a phantom drag: `e.buttons === 0` in mousemove and a `window` blur listener both cancel (without committing).
- rAF auto-scroll loop caches the container rect per drag and idles when the pointer isn't in an edge zone.
- `cancelDrag` is ref-indirected out of the diff-fetch effect's deps to avoid future refetch-loop coupling.

## Tests

- 17 new unit tests in `src/mainview/lib/diff-selection.test.ts` covering range math (mixed/non-selectable kinds, reversed bounds, edges), `addRangeToSelection` immutability + empty-set convention, and `isRowInDragRange` bounds — `36/36` pass.
- `bun run typecheck` green. Full `bun test`: 1,738 pass; the only failures are pre-existing/environmental (daemon tests without `bun` on the runner's `PATH`, and a known load-sensitive timing flake in `claude-tmux-queue.test.ts` that passes in isolation).