### PR TITLE
fix: end the run when a background agent hits an API error

### DIFF
--- a/docs/plans/bg-agent-api-error-ends-run.md
+++ b/docs/plans/bg-agent-api-error-ends-run.md
@@ -1,0 +1,171 @@
+# Plan — Background-agent API errors end the run
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-30 |
+| Source | /implement task: "we must consider the following error and similars as ending of the agent running" + screenshot of a subagent tab showing `API Error: 529 Overloaded` / "API ERROR: HTTP 529 — TURN ABORTED; BLOCKED FOR MANUAL RETRY" with the heartbeat stuck on "Agent is working…" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/fix-bg-agent-api-error-catch |
+| Base SHA | 25fb711b5bd8eb892acc034fccf5031a0cba168e (tree clean) |
+| Mode | **Autonomous** — the two human gates (grill, plan approval) were bypassed; all decisions logged in §8. |
+
+## 1. Objective & success criteria
+
+When a claude-code **background agent / subagent** stream emits an API-error line
+(`isApiErrorMessage: true` in its `agent-<id>.jsonl` — 529 Overloaded, 400, any status),
+the run must end instead of hanging forever:
+
+- The subagent's own row settles immediately (`failed`) — the subagent tab's
+  "Agent is working…" heartbeat stops.
+- If the parent task's main turn is **in flight**, the run settles exactly like a
+  main-stream API error: task column → `blocked` (reason `api-error`), run status →
+  `failed`, tmux session left alive for manual retry/follow-up.
+- If the main run already **succeeded** and the task is only held open by background
+  agents, the errored agent stops holding it — the task releases to `review` once no
+  running subagents remain (existing `maybeReleaseHeldTask` machinery).
+- No re-fire on boot reattach (JSONL replayed from offset 0 must not re-block a task).
+
+## 2. Context & constraints (Phase-1 findings)
+
+- Subagent transcripts are separate files tailed by `src/bun/claude-subagents.ts`
+  (`tailFile`, ~:505-553); chunks are written straight to DB+SSE, **bypassing the
+  orchestrator's `makeChunkHandler`** — so `handle.apiError` is never set and nothing
+  settles the main turn. That is the bug's mechanism.
+- The shared mapper already emits the sentinel for subagent streams too:
+  `claude-tmux.ts:887-893` emits `status` = `CLAUDE_API_ERROR_STATUS_PREFIX` +
+  `"HTTP <n> — turn aborted; blocked for manual retry"` and returns `endOfTurn: true`.
+- The main-stream consumer is `orchestrator.ts:900-915` (`makeChunkHandler`): prefix
+  match → `handle.apiError = true` + `updateColumn(taskId, runId, "blocked", "api-error")`;
+  `attachDoneHandler` (~:966-990) folds `wasApiError` into run `failed`.
+- The template for cross-stream settlement is `signalSessionDeath`
+  (`claude-tmux.ts:~3604-3660`): two branches — `turnInFlight(state)` → emit sentinel via
+  `slot.onChunk` + resolve the slot; else `heldProbeSafe(taskId)` → plain status +
+  `orphanRunningSubagents`. Our fix mirrors this shape but **does not tear down** the
+  session/tailers (the tmux session is alive; only the turn aborted).
+- The `#81` reattach pre-seed guard (`orchestrator.ts:584-590`, `subagent_id IS NULL`)
+  stays as-is (§8, A4).
+- `SubagentStatus` already includes `"failed"` (`shared/types.ts:1808-1813`).
+- The watcher is attached at a single choke point: `attachTailer` →
+  `attachSubagentWatcher({ taskId, jsonlPath })` (`claude-tmux.ts:~3850`).
+- Reattach replay safety: `tailFile` dedups lines via the `seen` uuid set (seeded from
+  `run_events.line_uuid` on rehydrate), so a replayed API-error line is skipped before
+  our new detection point — no re-fire by construction.
+- Idle reaper can't save us: `reapIdleSessions` skips runs in the `active` map.
+
+## 3. Approach & key decisions
+
+Detect the API error **inside the subagent tailer** (it's the only thing reading that
+file), settle the subagent row immediately, and notify claude-tmux via a new optional
+callback on `attachSubagentWatcher`. claude-tmux then runs a `signalSessionDeath`-shaped
+two-branch settle that reuses the existing sentinel so the orchestrator needs **zero
+changes** (the sentinel flows through `slot.onChunk` = `makeChunkHandler`, which already
+does blocked/api-error + failed).
+
+Alternative considered — a new orchestrator hook (like `setSubagentSettleHook`) that
+directly mutates the handle: rejected; it would duplicate blocked/failed logic the
+sentinel path already owns and diverge from the session-died precedent.
+
+## 4. Work breakdown — implementation (Wave 1, one agent — files are interface-coupled)
+
+**T1 — detection + propagation** (owns `src/bun/claude-subagents.ts` and
+`src/bun/claude-tmux.ts` only):
+
+a) `claude-subagents.ts`:
+   - Add `onApiError?: (info: { subagentId: string; detail: string }) => void` to
+     `attachSubagentWatcher` opts.
+   - In `tailFile`'s per-line mapping (`mapJsonlEventToChunks` callback), flag when a
+     chunk is `stream === "status" && data.startsWith(CLAUDE_API_ERROR_STATUS_PREFIX)`
+     (import the constant — it's already exported from claude-tmux; if that import
+     would create a cycle, move/re-export the constant via `shared/types.ts`-style or
+     import type-free constant — check existing import direction first: claude-subagents
+     already imports `mapJsonlEventToChunks` from claude-tmux, so importing the constant
+     is fine).
+   - After the line is processed (post `seen.add`): settle the row immediately —
+     `fs.status = "failed"; fs.endedAt = now; subagentsDb.setStatus(id, "failed", now);
+     emitLifecycle(fs, "finished"); fireSettle(taskId);` then invoke
+     `opts.onApiError?.({ subagentId, detail })` where `detail` is the sentinel payload
+     after the prefix. Mirror `checkDone`'s completed block ordering (DB write before
+     `fireSettle`). Do not wait for `DONE_IDLE_MS`.
+   - The existing "resumed subagent flips back to running" block (~:529) must keep
+     working: a retry that appends new lines flips the `failed` row back to `running`.
+
+b) `claude-tmux.ts`:
+   - New `function signalSubagentApiError(state: SessionState, info): void`, next to
+     `signalSessionDeath`, mirroring its settle shape but **without** any
+     watcher/session teardown and **without** `orphanRunningSubagents`:
+     - If `turnInFlight(state)`: clear `state.pendingSlashToken`; emit via
+       `slot.onChunk ?? state.lastChunk`:
+       `${CLAUDE_API_ERROR_STATUS_PREFIX}background agent aborted: ${detail}`;
+       then settle the slot exactly like signalSessionDeath (shift queue, set
+       `state.lastChunk`, `resolve(0)`; else fall back to `state.onEndOfTurn`).
+       Also `clearContinuationWatchdog(state)` (nothing will end this turn now).
+     - Else: no-op (the watcher already settled the row; `fireSettle` handles the held
+       release; an idle session needs nothing).
+   - Wire it at the attach site: `attachSubagentWatcher({ taskId, jsonlPath,
+     onApiError: (info) => signalSubagentApiError(state, info) })`.
+   - Doc-comment cross-references on `signalSessionDeath` and the sentinel constant.
+
+Acceptance: typecheck green; behavior per §1; no orchestrator/webview changes.
+
+## 5. Work breakdown — tests (Wave 2, two agents, disjoint new files)
+
+**T2 — `src/bun/claude-subagents-apierror.test.ts`** (new file; owns it alone).
+Follow `claude-subagents.test.ts` conventions (temp `AGETOR_DATA_DIR` via mkdtemp before
+db import, `attachSubagentWatcher({ manual: true })` + `pump()`, fixture
+`agent-<id>.jsonl` written with `writeFileSync`/`appendFileSync`, save/restore
+`setSubagentEmitter`/`setSubagentSettleHook`, delete created tasks in afterEach):
+1. A subagent jsonl gaining an `isApiErrorMessage: true` line (with `apiErrorStatus:
+   529`) → row flips to `failed` immediately on the same pump (no `DONE_IDLE_MS` wait),
+   lifecycle `finished` emitted, settle hook fired, `onApiError` called with the
+   subagent id and a detail containing `HTTP 529`.
+2. Reattach replay: seed `run_events.line_uuid` for the API-error line (or pre-populate
+   via a first watcher pass), attach a fresh watcher → `onApiError` NOT called again.
+3. A normal end_turn subagent still completes via the idle path (regression guard).
+
+**T3 — `src/bun/claude-tmux-subagent-apierror.test.ts`** (new file; owns it alone).
+Exercise `signalSubagentApiError` (export it, or drive via the watcher callback seam)
+following `claude-turn-routing.test.ts` fake-session state-building idiom:
+1. In-flight turn: chunk recorded with `CLAUDE_API_ERROR_STATUS_PREFIX` and the HTTP
+   detail; slot resolved with 0; queue empty afterwards.
+2. No turn in flight: no chunk emitted, nothing settled (no-op branch).
+3. End-to-end settlement contract: feed the emitted sentinel through
+   `orchestrator`'s existing machinery only if cheap via existing fake-driver test
+   (`orchestrator-blocked.test.ts` already proves sentinel→blocked; do NOT duplicate).
+
+## 6. Execution waves
+
+- Wave 1: T1 (single agent, sonnet).
+- Barrier (typecheck).
+- Phase 5 review (opus) on the diff.
+- Wave 2: T2 ∥ T3 (two sonnet agents, disjoint files).
+- Phase 7: full `bun test` + `bun run typecheck` (haiku).
+
+## 7. Blast radius & risks
+
+- `makeChunkHandler`'s api-error branch now also fires for subagent-originated
+  sentinels — intended; text differs ("background agent aborted: …") but prefix match
+  is unchanged. Reattach pre-seed picks up the new main-stream row naturally
+  (`subagent_id IS NULL` holds — it's emitted via the run's own chunk handler).
+- If claude's TUI would have recovered (Task tool returns an error tool_result and the
+  main turn continues), we now settle the run `failed`/`blocked` anyway; later JSONL
+  lines still append via `lastChunk` routing, and a stray later `end_turn` finds an
+  empty queue (no-op). Accepted per the user's explicit directive (§8, A1).
+- Held tasks with *other* live background agents keep holding — only the errored row
+  settles. Correct per #92 semantics.
+- Codex untouched (no subagent tracking).
+
+## 8. Assumptions (autonomous mode — audit these)
+
+- **A1**: "consider … as ending of the agent running" = settle the run immediately and
+  terminally on any subagent API error while a turn is in flight (blocked/api-error,
+  run failed) — no grace period waiting for the TUI to self-recover. Screenshot shows
+  non-recovery; interactive claude waits for manual retry.
+- **A2**: "and similars" = any `isApiErrorMessage: true` line (all HTTP statuses), the
+  same criterion the main stream already uses. No allowlist of status codes.
+- **A3**: Held-after-success case releases to `review` (not `blocked`) — main work
+  already succeeded; mirrors the session-died held branch.
+- **A4**: The `#81` reattach pre-seed guard stays main-stream-only. New-style blocks
+  write their own main-stream sentinel row, which the existing query already counts;
+  historical transient subagent api-error rows in old DBs must not retro-block runs.
+- **A5**: Subagent row settles as `failed` (not `orphaned` — reserved for
+  reconciliation/teardown paths).

--- a/src/bun/claude-subagents-apierror.test.ts
+++ b/src/bun/claude-subagents-apierror.test.ts
@@ -1,0 +1,397 @@
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Background-agent API errors end the run (docs/plans/bg-agent-api-error-ends-run.md).
+ *
+ * Covers the subagent-tailer side only (T2 in the plan): `claude-subagents.ts`'s
+ * `tailFile` peeking `isApiErrorMessage`/`apiErrorStatus` straight off a
+ * subagent's own `agent-<id>.jsonl` line, settling that row `failed`
+ * immediately (no `DONE_IDLE_MS` wait), and firing the injected `onApiError`
+ * callback so `claude-tmux.ts`'s `signalSubagentApiError` can abort the main
+ * turn. This file does NOT touch `signalSubagentApiError` itself (that's T3,
+ * a disjoint file) — only the watcher's detection + settle + callback wiring.
+ *
+ * Conventions mirrored from `claude-subagents.test.ts` (read first): temp
+ * `AGETOR_DATA_DIR` via `mkdtempSync` before any `./db.ts`-importing import;
+ * `attachSubagentWatcher({ manual: true })` + `pump()` driving; fixture jsonl
+ * written with `writeFileSync`/`appendFileSync` under
+ * `<dir>/<sessionId>/subagents/agent-<id>.jsonl`; save/restore
+ * `setSubagentEmitter`/`setSubagentSettleHook` in beforeEach/afterEach (bun
+ * test shares one process/DB across files — leaked hooks strand sibling
+ * files); track created task ids and hard-delete in afterEach.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+import { test, expect, beforeAll, afterEach } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { RunEvent } from "../shared/types.ts";
+
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-subagents-apierror-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+
+// Whatever the orchestrator registered at its module load (or `null` if this
+// file runs before it). `bun test` shares one process across every file, so
+// hard-resetting these to `null` in `afterEach` would leave every later file
+// with no SSE sink and no release path. Capture by read-modify-restore and
+// put the originals back — same posture as claude-subagents.test.ts.
+let originalEmitter: ((e: RunEvent) => void) | null = null;
+let originalSettleHook: ((taskId: string) => void) | null = null;
+
+beforeAll(async () => {
+  await import("./db.ts");
+  const { setSubagentEmitter, setSubagentSettleHook } = await import("./claude-subagents.ts");
+  originalEmitter = setSubagentEmitter(null);
+  setSubagentEmitter(originalEmitter);
+  originalSettleHook = setSubagentSettleHook(null);
+  setSubagentSettleHook(originalSettleHook);
+});
+
+const createdTaskIds: string[] = [];
+
+afterEach(async () => {
+  const { detachWatcherFor, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  setSubagentEmitter(originalEmitter);
+  setSubagentSettleHook(originalSettleHook);
+  if (createdTaskIds.length === 0) return;
+  const { tasks } = await import("./db.ts");
+  for (const id of createdTaskIds) {
+    try {
+      detachWatcherFor(id);
+    } catch {
+      /* best-effort */
+    }
+    try {
+      tasks.delete(id);
+    } catch {
+      /* best-effort */
+    }
+  }
+  createdTaskIds.length = 0;
+});
+
+/** Build a temp `<sessionId>/subagents/` layout + a seeded task/run, returning
+ *  the jsonlPath the watcher derives the subagents dir from. Mirrors
+ *  claude-subagents.test.ts's `seed()` exactly (same task/run shape, same
+ *  reconcileOrphans trap avoidance rationale). */
+async function seed() {
+  const { tasks, runs } = await import("./db.ts");
+  const taskId = `task-sub-apierr-${randomUUID()}`;
+  const runId = `run-sub-apierr-${randomUUID()}`;
+  createdTaskIds.push(taskId);
+  const now = Date.now();
+  tasks.insert({
+    id: taskId, title: "t", prompt: "p", column: "running", agent: "claude-code",
+    workdir: "/tmp", isolation: "none", taskType: "task", branch: null, branchSource: "created", worktreePath: null,
+    baseRef: null, mode: null, model: null, effort: null, references: [], backlog: [], draft: null, runId,
+    prUrl: null,
+    hasOpenableRun: false, pendingInteractionCount: 0, openTerminalCount: 0,
+    archivedAt: null, createdAt: now, updatedAt: now,
+  });
+  runs.insert({
+    id: runId, taskId, agent: "claude-code", status: "succeeded", startedAt: now,
+    endedAt: now, exitCode: 0, tmuxSession: null, claudeSessionId: null, codexSessionId: null,
+  });
+
+  const sessionId = randomUUID();
+  const proj = path.join(DATA_DIR, "projects", "encoded");
+  const subagentsDir = path.join(proj, sessionId, "subagents");
+  mkdirSync(subagentsDir, { recursive: true });
+  const jsonlPath = path.join(proj, `${sessionId}.jsonl`);
+  return { taskId, runId, jsonlPath, subagentsDir };
+}
+
+/** A normal (non-error) sidechain opener: a user turn + a tool_use reply.
+ *  Same shape claude-subagents.test.ts uses to get past discovery. */
+function sidechainLines(): string {
+  return [
+    JSON.stringify({ type: "user", isSidechain: true, uuid: "u1", message: { role: "user", content: "do the thing" } }),
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: "a1", message: { role: "assistant", stop_reason: "tool_use", content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "ls" } }] } }),
+  ].join("\n") + "\n";
+}
+
+/** A synthetic `isApiErrorMessage: true` line, matching the shape claude code
+ *  actually writes (mirrors claude-tmux.test.ts's own fixture for the
+ *  main-stream mapper test). `uuid` is a caller-supplied param (not baked in)
+ *  so the uuid-less-line test (case 2) can omit it entirely. */
+function apiErrorLine(opts: { uuid?: string; status?: number }): string {
+  const body: Record<string, unknown> = {
+    type: "assistant",
+    isSidechain: true,
+    isApiErrorMessage: true,
+    apiErrorStatus: opts.status ?? 529,
+    message: {
+      role: "assistant",
+      stop_reason: "stop_sequence",
+      content: [{ type: "text", text: `API Error: ${opts.status ?? 529} Overloaded. This is a server-side issue, usually temporary — try again in a moment.` }],
+    },
+  };
+  if (opts.uuid !== undefined) body.uuid = opts.uuid;
+  return JSON.stringify(body);
+}
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 1. Immediate settle + callback
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("an isApiErrorMessage line settles the subagent row failed on the same pump, no DONE_IDLE_MS wait, and fires onApiError once", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, runId, jsonlPath, subagentsDir } = await seed();
+
+  const captured: RunEvent[] = [];
+  setSubagentEmitter((e) => captured.push(e));
+  const settleCalls: string[] = [];
+  setSubagentSettleHook((tid) => settleCalls.push(tid));
+  const apiErrorCalls: { subagentId: string; detail: string; runId: string }[] = [];
+
+  const agentId = `apierr1-${randomUUID()}`;
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "Explore", description: "errors out", spawnDepth: 1 }));
+  // The whole file — normal opener + the terminal api-error line — is present
+  // BEFORE the first pump, so discovery, tailing, and the settle all happen
+  // inside that single pump() call. No idle wait is involved anywhere.
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`),
+    sidechainLines() + apiErrorLine({ uuid: "err1", status: 529 }) + "\n");
+
+  const w = attachSubagentWatcher({
+    taskId, jsonlPath, manual: true,
+    onApiError: (info) => apiErrorCalls.push(info),
+  });
+  w.pump(Date.now());
+
+  const row = subagents.get(agentId)!;
+  expect(row.status).toBe("failed");
+  expect(row.endedAt).not.toBeNull();
+
+  const finished = captured.filter((e) => e.stream === "subagent" && JSON.parse(e.data).phase === "finished");
+  expect(finished.length).toBe(1);
+  expect(finished[0]!.subagentId).toBe(agentId);
+
+  expect(settleCalls).toEqual([taskId]);
+
+  expect(apiErrorCalls.length).toBe(1);
+  expect(apiErrorCalls[0]!.subagentId).toBe(agentId);
+  expect(apiErrorCalls[0]!.runId).toBe(runId);
+  expect(apiErrorCalls[0]!.detail).toContain("HTTP 529");
+
+  w.detach();
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 2. uuid-less line does not fire
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("an isApiErrorMessage line with no uuid does not settle the row or fire onApiError", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+
+  setSubagentEmitter(() => { /* drain */ });
+  const apiErrorCalls: unknown[] = [];
+
+  const agentId = `apierr2-${randomUUID()}`;
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "Explore", description: "no uuid", spawnDepth: 1 }));
+  // Same error payload as case 1, but the line carries no `uuid` field —
+  // the detection gate in tailFile requires a durable dedup key before it
+  // will fire the settle (a uuid-less line can't be seeded into `seen` /
+  // `run_events.line_uuid`, so replaying it on a future reattach would look
+  // brand-new every time and could re-fire the abort forever).
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`),
+    sidechainLines() + apiErrorLine({ status: 529 }) + "\n");
+
+  const w = attachSubagentWatcher({
+    taskId, jsonlPath, manual: true,
+    onApiError: (info) => apiErrorCalls.push(info),
+  });
+  w.pump(Date.now());
+
+  const row = subagents.get(agentId)!;
+  expect(row.status).toBe("running");
+  expect(apiErrorCalls.length).toBe(0);
+
+  w.detach();
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 3. Replay does not re-fire
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("reattaching a fresh watcher over an already-settled api-error transcript does not re-fire onApiError or re-flip the row", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+
+  setSubagentEmitter(() => { /* drain */ });
+  setSubagentSettleHook(() => { /* drain */ });
+
+  const agentId = `apierr3-${randomUUID()}`;
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "Explore", description: "replay", spawnDepth: 1 }));
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`),
+    sidechainLines() + apiErrorLine({ uuid: "err3", status: 500 }) + "\n");
+
+  const firstCalls: unknown[] = [];
+  const w = attachSubagentWatcher({
+    taskId, jsonlPath, manual: true,
+    onApiError: (info) => firstCalls.push(info),
+  });
+  w.pump(Date.now());
+  expect(subagents.get(agentId)!.status).toBe("failed");
+  expect(firstCalls.length).toBe(1);
+  w.detach();
+
+  // Fresh watcher over the SAME files — the reattach path. Rehydration seeds
+  // `seen` from `run_events.line_uuid` (persisted for the api-error line
+  // because `tailFile` asks the mapper to carry the line's uuid on its own
+  // status chunk too), so the dedup check must skip the line before the
+  // api-error peek ever runs again.
+  const secondCalls: unknown[] = [];
+  const w2 = attachSubagentWatcher({
+    taskId, jsonlPath, manual: true,
+    onApiError: (info) => secondCalls.push(info),
+  });
+  w2.pump(Date.now());
+
+  expect(secondCalls.length).toBe(0);
+  const row = subagents.get(agentId)!;
+  expect(row.status).toBe("failed");
+
+  w2.detach();
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 4. Retry flips back without losing toolUseId
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("a retry after an api-error settle flips the row back to running and preserves toolUseId for the tool_result fallback", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+
+  setSubagentEmitter(() => { /* drain */ });
+  setSubagentSettleHook(() => { /* drain */ });
+
+  const agentId = `apierr4-${randomUUID()}`;
+  const toolUseId = "toolu_retry_x";
+  const file = path.join(subagentsDir, `agent-${agentId}.jsonl`);
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "Explore", description: "retry", spawnDepth: 1, toolUseId }));
+  writeFileSync(file, sidechainLines() + apiErrorLine({ uuid: "err4", status: 529 }) + "\n");
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0);
+  expect(subagents.get(agentId)!.status).toBe("failed");
+
+  // Retry: a resumed background agent appends a fresh (non-terminal) turn.
+  // Steady-state polling only re-reads `running` files (a real dir-watcher
+  // append event is what re-opens a non-running one in production — see
+  // `armDirWatcher`'s doc comment); the deterministic way to force a full
+  // re-tail in a `manual: true` test, exactly like claude-subagents.test.ts's
+  // own "resumed subagent" test, is to detach and attach a fresh watcher
+  // (its first cycle always tails every file, regardless of status).
+  appendFileSync(file,
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: "retryA", message: { role: "assistant", stop_reason: "tool_use", content: [{ type: "tool_use", id: "t2", name: "Bash", input: { command: "pwd" } }] } }) + "\n");
+  w.detach();
+  const w2 = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  w2.pump(t0 + 1);
+  expect(subagents.get(agentId)!.status).toBe("running");
+
+  // Prove `toolUseId` survived the flip-back (the `apiErrored` latch's whole
+  // reason for existing) by exercising the tool_result fallback settle path
+  // (`scanMainForToolResults`), which only considers `running` rows with a
+  // non-null `toolUseId`. If the flip-back block had nulled it (as it does
+  // for an ordinary `completed`-row flip), this tool_result would never be
+  // matched and the row would stay stuck `running` forever.
+  writeFileSync(jsonlPath,
+    JSON.stringify({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: toolUseId, content: "ok" }] } }) + "\n");
+  w2.pump(t0 + 2);
+
+  expect(subagents.get(agentId)!.status).toBe("completed");
+
+  w2.detach();
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 5. Regression: ordinary end_turn idle-completion path is untouched
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("an ordinary subagent (no api error) still completes via the end_turn + DONE_IDLE_MS idle path", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+
+  setSubagentEmitter(() => { /* drain */ });
+
+  const agentId = `apierr5-${randomUUID()}`;
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "general-purpose", description: "normal", spawnDepth: 1 }));
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`), sidechainLines());
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0);
+  expect(subagents.get(agentId)!.status).toBe("running");
+
+  appendFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`),
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: "a2", message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "done" }] } }) + "\n");
+  w.pump(t0 + 1); // sawEndOfTurn=true, but not idle yet
+  expect(subagents.get(agentId)!.status).toBe("running");
+
+  w.pump(t0 + 10_000); // idle past DONE_IDLE_MS -> completed
+  const row = subagents.get(agentId)!;
+  expect(row.status).toBe("completed");
+  expect(row.endedAt).not.toBeNull();
+
+  w.detach();
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 6. onApiError throwing does not break the tick
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("a throwing onApiError callback does not crash the pump, and the row still settles failed", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+
+  setSubagentEmitter(() => { /* drain */ });
+  let settleFired = 0;
+  setSubagentSettleHook(() => { settleFired++; });
+
+  const agentId = `apierr6-${randomUUID()}`;
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "Explore", description: "throws", spawnDepth: 1 }));
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.jsonl`),
+    sidechainLines() + apiErrorLine({ uuid: "err6", status: 400 }) + "\n");
+
+  let hookCalls = 0;
+  const w = attachSubagentWatcher({
+    taskId, jsonlPath, manual: true,
+    onApiError: () => {
+      hookCalls++;
+      throw new Error("onApiError boom");
+    },
+  });
+
+  expect(() => w.pump(Date.now())).not.toThrow();
+  expect(hookCalls).toBe(1);
+  // The settle hook (a DIFFERENT injected callback, fired before onApiError)
+  // still ran, and the DB write landed before onApiError was even invoked —
+  // a throwing onApiError must not roll any of that back.
+  expect(settleFired).toBe(1);
+  expect(subagents.get(agentId)!.status).toBe("failed");
+
+  w.detach();
+});

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -56,7 +56,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { runs, subagents as subagentsDb, tasks } from "./db.ts";
-import { mapJsonlEventToChunks } from "./claude-tmux.ts";
+import { formatApiErrorDetail, mapJsonlEventToChunks } from "./claude-tmux.ts";
 import type { RunEvent, Subagent, SubagentEvent, SubagentStatus } from "../shared/types.ts";
 
 /** Off only when explicitly disabled. The watcher is cheap when idle, but the
@@ -244,6 +244,13 @@ interface FileState {
    *  matches against `tool_result` blocks in the main session JSONL. Null until
    *  discovery (or rehydration backfill) finds one in the meta sidecar. */
   toolUseId: string | null;
+  /** Set when `status` was flipped to `failed` via the api-error path (below),
+   *  cleared the next time this row flips back to `running` (a resumed
+   *  background agent appending after the abort). Distinguishes an
+   *  api-errored row from an ordinary `completed` one in the "flip back to
+   *  running" block, which otherwise retires `toolUseId` unconditionally —
+   *  see that block for why an api-errored row must NOT lose it. */
+  apiErrored: boolean;
 }
 
 export interface SubagentWatcherHandle {
@@ -360,6 +367,18 @@ export function attachSubagentWatcher(opts: {
   /** Test-only: suppress the self-scheduling poll timer so a test drives the
    *  watcher via `pump()` instead of real timers. */
   manual?: boolean;
+  /** Fired the moment a subagent's own transcript emits an API-error line
+   *  (`isApiErrorMessage: true`), right after this module has already
+   *  settled that subagent's row `failed`. This module has no visibility
+   *  into the parent claude-tmux `SessionState` (see the module header —
+   *  read-only w.r.t. the agent), so it cannot itself abort the main turn;
+   *  claude-tmux wires this to `signalSubagentApiError` to do that part.
+   *  `runId` (the subagent's OWN parent run — `FileState.runId`, captured at
+   *  discovery time and stable thereafter) lets the claude-tmux side detect
+   *  a stale async subagent from an OLDER run erroring while a NEWER run is
+   *  in flight on the same session, and no-op instead of wrongly aborting
+   *  the new run. */
+  onApiError?: (info: { subagentId: string; detail: string; runId: string }) => void;
 }): SubagentWatcherHandle {
   const { taskId } = opts;
   // Make double-attach for the same task structurally impossible: whatever
@@ -432,6 +451,14 @@ export function attachSubagentWatcher(opts: {
         startedAt: row.startedAt,
         endedAt: row.endedAt,
         toolUseId,
+        // `"failed"` has exactly one writer in this codebase — the api-error
+        // settle block below — so a rehydrated row already in that status
+        // was necessarily api-errored pre-restart. Reconstructing the latch
+        // here (not just at the live settle site) is what keeps the finding
+        // #5 fix correct across a restart: an agetor restart right after an
+        // api-error, followed by the same background agent resuming, must
+        // still preserve `toolUseId` in the flip-back block below.
+        apiErrored: row.status === "failed",
       });
     }
   } catch (e) {
@@ -450,6 +477,20 @@ export function attachSubagentWatcher(opts: {
       ts: Date.now(),
       subagentId: fs.subagentId,
     });
+  }
+
+  /** Call the per-attach `onApiError` hook, never letting a throwing hook
+   *  reach `tailFile`/`cycle` — mirrors `fireSettle`/`fireParkedDiscovery`'s
+   *  posture exactly: this hook runs orchestrator logic (claude-tmux's
+   *  `signalSubagentApiError`, which does DB-adjacent session-state work) we
+   *  don't control, and a bad handler must not take the tail (or the poll
+   *  timer driving it) down. */
+  function fireApiError(info: { subagentId: string; detail: string; runId: string }): void {
+    try {
+      opts.onApiError?.(info);
+    } catch (e) {
+      console.error(`[claude-subagents] api-error hook threw for subagent ${info.subagentId}:`, e);
+    }
   }
 
   /** Pick up newly-created `agent-*.jsonl` files. */
@@ -483,6 +524,7 @@ export function attachSubagentWatcher(opts: {
         startedAt,
         endedAt: null,
         toolUseId: meta.toolUseId,
+        apiErrored: false,
       };
       files.set(id, fs);
       lastChangeAt = Date.now();
@@ -511,10 +553,38 @@ export function attachSubagentWatcher(opts: {
       // the line, not per onChunk call). Peek the uuid + end_turn first.
       let uuid: string | undefined;
       let endTurnHint = false;
+      // Detected here (parsed-flag peek), NOT by string-matching the
+      // rendered `CLAUDE_API_ERROR_STATUS_PREFIX` status chunk after the
+      // mapper runs: the mapper's `isMeta` path forwards transcript text
+      // verbatim on the `status` stream, so a transcript-controlled string
+      // could otherwise spoof the sentinel, and a future wording change to
+      // `formatApiErrorDetail` would silently break detection. Reading
+      // `isApiErrorMessage`/`apiErrorStatus` straight off the JSONL line
+      // sidesteps both.
+      let apiErrorInfo: { detail: string } | null = null;
       try {
-        const o = JSON.parse(line) as { uuid?: unknown; type?: unknown; message?: { stop_reason?: unknown } };
+        const o = JSON.parse(line) as {
+          uuid?: unknown;
+          type?: unknown;
+          message?: { stop_reason?: unknown };
+          isApiErrorMessage?: unknown;
+          apiErrorStatus?: unknown;
+        };
         uuid = typeof o.uuid === "string" ? o.uuid : undefined;
         endTurnHint = o.type === "assistant" && o.message?.stop_reason === "end_turn";
+        // Gate the WHOLE api-error settle on `uuid` being a string: a
+        // uuid-less line has no durable dedup key (`fs.seen` and
+        // `run_events.line_uuid` both key off it), so a replayed uuid-less
+        // line on a boot reattach would look brand-new every time and could
+        // re-fire the settle (and `onApiError` → an abort of whatever run
+        // happens to be in flight at that point) on every restart. Real
+        // claude JSONL lines always carry a uuid in practice, so this only
+        // ever excludes a malformed/synthetic line — never a genuine error.
+        if (uuid !== undefined && o.isApiErrorMessage === true) {
+          apiErrorInfo = {
+            detail: formatApiErrorDetail(typeof o.apiErrorStatus === "number" ? o.apiErrorStatus : undefined),
+          };
+        }
       } catch { /* fall through; mapper will surface the parse error */ }
 
       if (uuid && fs.seen.has(uuid)) {
@@ -538,18 +608,65 @@ export function attachSubagentWatcher(opts: {
         // re-settle a resumed agent, but the next append flips it right
         // back (dir watcher) and its real completion arrives via
         // task-notification / its own end_turn.
-        fs.toolUseId = null;
+        //
+        // EXCEPT when the row being flipped was settled `failed` via an
+        // API error (`fs.apiErrored`): for a SYNCHRONOUS subagent,
+        // `toolUseId` is the ONLY remaining fallback settle signal
+        // (`scanMainForToolResults`) — the agent's own transcript may never
+        // produce another terminal end_turn (that is the exact hang class
+        // this feature exists to fix) and there is no task-notification for
+        // a synchronous agent either. Retiring the id here would stop that
+        // fallback from ever firing again, stranding the row `running`
+        // forever after this trailing append — reintroducing the bug.
+        // Keeping it means trailing garbage appended after the abort can
+        // still be reconciled via the tool_result scan. The asymmetry with
+        // the `completed`-row case above is deliberate: a completed row's
+        // stale tool_result genuinely predates the resume and retiring it
+        // there only prevents a MIS-settle, never a stuck one — so that
+        // case still retires unconditionally.
+        if (!fs.apiErrored) fs.toolUseId = null;
+        fs.apiErrored = false;
         subagentsDb.setStatus(fs.subagentId, "running", null);
         emitLifecycle(fs, "started");
         fireParkedDiscovery(taskId);
       }
-      const { endOfTurn } = mapJsonlEventToChunks(line, (stream, data, lineUuid) => {
-        runs.appendEvent(fs.runId, stream, data, lineUuid ?? null, fs.subagentId);
-        emitFn?.({ runId: fs.runId, taskId, stream, data, ts: Date.now(), subagentId: fs.subagentId });
-      });
+      const { endOfTurn } = mapJsonlEventToChunks(
+        line,
+        (stream, data, lineUuid) => {
+          runs.appendEvent(fs.runId, stream, data, lineUuid ?? null, fs.subagentId);
+          emitFn?.({ runId: fs.runId, taskId, stream, data, ts: Date.now(), subagentId: fs.subagentId });
+        },
+        // Ask the mapper to carry this line's uuid on its own api-error
+        // `status` chunk too (unlike the MAIN stream's `dispatchLine`,
+        // which never opts in — see `mapParsedEventToChunks`'s doc): gives
+        // the row a durable `line_uuid` even in the edge case where the
+        // line has no text content block to carry it instead, so reattach
+        // seeding (`seenLineUuidsForSubagent`, below) reliably covers this
+        // line. A harmless no-op write when a text block IS present (the
+        // common case) — INSERT OR IGNORE just keeps that first row.
+        true,
+      );
       if (uuid) fs.seen.add(uuid);
       if (endOfTurn) fs.sawEndOfTurn = true;
       fs.lastAppendAt = Date.now();
+      // A reattach replay never reaches here for a HISTORICAL error line:
+      // `fs.seen` is seeded from `run_events.line_uuid` on rehydrate, so the
+      // dedup check above (`if (uuid && fs.seen.has(uuid))`) skips the line
+      // — and this whole per-line block — before we ever get here again.
+      if (apiErrorInfo !== null) {
+        // Settle immediately — do NOT wait for `DONE_IDLE_MS`. Mirrors
+        // `checkDone`'s completed block, but `failed` instead of
+        // `completed`; DB write must land before `fireSettle` for the same
+        // reason noted there (the orchestrator's release predicate reads
+        // `subagentsDb.hasRunning`).
+        fs.status = "failed";
+        fs.endedAt = fs.lastAppendAt;
+        fs.apiErrored = true;
+        subagentsDb.setStatus(fs.subagentId, "failed", fs.endedAt);
+        emitLifecycle(fs, "finished");
+        fireSettle(taskId);
+        fireApiError({ subagentId: fs.subagentId, detail: apiErrorInfo.detail, runId: fs.runId });
+      }
     }
   }
 

--- a/src/bun/claude-tmux-subagent-apierror.test.ts
+++ b/src/bun/claude-tmux-subagent-apierror.test.ts
@@ -1,0 +1,311 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+// Pre-set AGETOR_DATA_DIR before claude-tmux.ts's transitive db.ts import —
+// same convention as claude-tmux-death.test.ts / claude-turn-routing.test.ts.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-tmux-subagent-apierror-"));
+
+const {
+  __forTest,
+  CLAUDE_API_ERROR_STATUS_PREFIX,
+  formatApiErrorDetail,
+  setActiveRunProbe,
+  setHeldSessionProbe,
+} = await import("./claude-tmux.ts");
+
+interface Recorded { stream: string; data: string }
+function recorder() {
+  const out: Recorded[] = [];
+  return {
+    out,
+    onChunk: (stream: string, data: string) => out.push({ stream, data }),
+  };
+}
+
+/** Fresh synthetic session, same shape as claude-tmux-death.test.ts's
+ *  `freshSession` — `installSession` builds a full `SessionState` via
+ *  `makeSessionState` with no live tmux/timers, so `signalSubagentApiError`
+ *  can be driven directly against it. */
+function freshSession() {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-subagent-apierror-"));
+  const jsonlPath = path.join(dir, `${randomUUID()}.jsonl`);
+  writeFileSync(jsonlPath, "");
+  const taskId = randomUUID();
+  const state = __forTest.installSession(taskId, jsonlPath);
+  return { taskId, jsonlPath, state };
+}
+
+/** Minimal `info` argument `signalSubagentApiError` expects. */
+function apiErrorInfo(overrides: Partial<{ subagentId: string; detail: string; runId: string }> = {}) {
+  return {
+    subagentId: overrides.subagentId ?? "agent-1",
+    detail: overrides.detail ?? formatApiErrorDetail(529),
+    runId: overrides.runId ?? "run-1",
+  };
+}
+
+test(
+  "signalSubagentApiError: in-flight turn settles — sentinel emitted once, slot resolved 0, "
+  + "queue drained, staged-turn latches cleared, continuation watchdog cleared",
+  async () => {
+    const { taskId, state } = freshSession();
+    const rec = recorder();
+    // Stage everything an in-flight turn could plausibly be carrying so the
+    // settle path's clearing behavior is actually exercised, not vacuously
+    // true because these fields were already null/false.
+    state.pendingSlashToken = "/some-command";
+    state.pendingEndTurn = { messageId: "m1", uuid: "u1", emitBanner: true, stagedAt: Date.now() };
+    state.holdUntilIdle = true;
+    const watchdogTimer = setTimeout(() => {}, 60_000);
+    state.continuationWatchdog = { timer: watchdogTimer, slot: { onChunk: () => {}, resolve: null, reject: null } };
+    // Run association is exercised here too — don't rely on the probe being
+    // unset (a leaked orchestrator-installed probe from another test file in
+    // the shared `bun test` process would otherwise report "no active run"
+    // for this synthetic taskId and make the gate no-op forever). Install an
+    // explicit matching probe, same as the "matching activeRunProbe" test
+    // below, and restore whatever was there before.
+    const prevProbe = setActiveRunProbe((id) => (id === taskId ? "run-1" : null));
+    try {
+      const done = __forTest.pushTurnSlot(state, rec.onChunk);
+      expect(__forTest.turnInFlight(state)).toBe(true);
+
+      const info = apiErrorInfo({ detail: "HTTP 529 — turn aborted; blocked for manual retry" });
+      __forTest.signalSubagentApiError(state, info);
+
+      const code = await done;
+      expect(code).toBe(0);
+
+      // Exactly one status chunk, carrying the shared sentinel prefix and the
+      // background-agent-specific wording + detail.
+      const sentinels = rec.out.filter(
+        (c) => c.stream === "status" && c.data.startsWith(CLAUDE_API_ERROR_STATUS_PREFIX),
+      );
+      expect(sentinels.length).toBe(1);
+      expect(sentinels[0]!.data).toContain("background agent aborted:");
+      expect(sentinels[0]!.data).toContain(info.detail);
+      expect(rec.out.length).toBe(1);
+
+      // Queue drained, slot resolved — no longer in flight.
+      expect(state.turnQueue.length).toBe(0);
+      expect(__forTest.turnInFlight(state)).toBe(false);
+
+      // Staged-turn / follow-up latches all cleared so nothing stale can
+      // mis-resolve a later, unrelated turn.
+      expect(state.pendingEndTurn).toBeNull();
+      expect(state.pendingSlashToken).toBeNull();
+      expect(state.holdUntilIdle).toBe(false);
+
+      // The continuation watchdog (if armed) is cancelled — nothing will end
+      // this turn naturally anymore, so a stale timer must not fire later.
+      expect(state.continuationWatchdog).toBeNull();
+    } finally {
+      setActiveRunProbe(prevProbe);
+      clearTimeout(watchdogTimer);
+      __forTest.uninstallSession(taskId);
+    }
+  },
+);
+
+test(
+  "signalSubagentApiError: matching activeRunProbe runId also settles the in-flight turn",
+  async () => {
+    const { taskId, state } = freshSession();
+    const rec = recorder();
+    const prevProbe = setActiveRunProbe((id) => (id === taskId ? "run-42" : null));
+    try {
+      const done = __forTest.pushTurnSlot(state, rec.onChunk);
+
+      __forTest.signalSubagentApiError(state, apiErrorInfo({ runId: "run-42" }));
+
+      const code = await done;
+      expect(code).toBe(0);
+      expect(
+        rec.out.some((c) => c.stream === "status" && c.data.startsWith(CLAUDE_API_ERROR_STATUS_PREFIX)),
+      ).toBe(true);
+      expect(__forTest.turnInFlight(state)).toBe(false);
+    } finally {
+      setActiveRunProbe(prevProbe);
+      __forTest.uninstallSession(taskId);
+    }
+  },
+);
+
+test(
+  "signalSubagentApiError: onEndOfTurn fallback fires when there's no queued slot (reattach shape)",
+  async () => {
+    const { taskId, state } = freshSession();
+    const rec = recorder();
+    // Same run-association gate as above — install an explicit matching
+    // probe rather than relying on "unset" (see comment on the first test).
+    const prevProbe = setActiveRunProbe((id) => (id === taskId ? "run-1" : null));
+    try {
+      // Reattached in-flight run: no in-process turn slot, but an
+      // onEndOfTurn hook the orchestrator installed so it can flip the run
+      // row on completion. lastChunk stands in for the slot's onChunk.
+      state.lastChunk = rec.onChunk;
+      let fired = false;
+      state.onEndOfTurn = () => { fired = true; };
+      expect(__forTest.turnInFlight(state)).toBe(true);
+
+      __forTest.signalSubagentApiError(state, apiErrorInfo());
+
+      expect(fired).toBe(true);
+      // Fire-once: cleared so a stray later call can't double-fire it.
+      expect(state.onEndOfTurn).toBeNull();
+      expect(__forTest.turnInFlight(state)).toBe(false);
+
+      const sentinel = rec.out.find(
+        (c) => c.stream === "status" && c.data.startsWith(CLAUDE_API_ERROR_STATUS_PREFIX),
+      );
+      expect(sentinel).toBeDefined();
+    } finally {
+      setActiveRunProbe(prevProbe);
+      __forTest.uninstallSession(taskId);
+    }
+  },
+);
+
+test(
+  "signalSubagentApiError: runId mismatch is a no-op — a stale subagent from an OLDER run "
+  + "can't abort a NEWER in-flight run on the same session",
+  async () => {
+    const { taskId, state } = freshSession();
+    const rec = recorder();
+    const prevProbe = setActiveRunProbe((id) => (id === taskId ? "run-new" : null));
+    try {
+      const donePromise = __forTest.pushTurnSlot(state, rec.onChunk);
+      let settled = false;
+      void donePromise.then(() => { settled = true; });
+
+      __forTest.signalSubagentApiError(state, apiErrorInfo({ runId: "run-old" }));
+
+      // Give any (incorrect) resolution a tick to land before asserting.
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(rec.out.length).toBe(0);
+      expect(settled).toBe(false);
+      expect(state.turnQueue.length).toBe(1);
+      expect(__forTest.turnInFlight(state)).toBe(true);
+    } finally {
+      setActiveRunProbe(prevProbe);
+      __forTest.uninstallSession(taskId);
+      // Resolve the still-pending slot so the leftover promise doesn't
+      // linger unresolved past the test.
+      const slot = state.turnQueue[0];
+      slot?.resolve?.(0);
+    }
+  },
+);
+
+test(
+  "signalSubagentApiError: held branch (no turn in flight, task held for background agents) "
+  + "emits a plain, non-sentinel status — nothing resolved",
+  async () => {
+    const { taskId, state } = freshSession();
+    const rec = recorder();
+    state.lastChunk = rec.onChunk;
+    const prevProbe = setHeldSessionProbe((id) => id === taskId);
+    try {
+      expect(__forTest.turnInFlight(state)).toBe(false);
+
+      __forTest.signalSubagentApiError(state, apiErrorInfo({ detail: "HTTP 529 — turn aborted; blocked for manual retry" }));
+
+      expect(rec.out.length).toBe(1);
+      expect(rec.out[0]!.stream).toBe("status");
+      // Must NOT carry the sentinel prefix — there's no in-flight handle for
+      // the orchestrator to flip to `blocked`; a sentinel here would lie.
+      expect(rec.out[0]!.data.startsWith(CLAUDE_API_ERROR_STATUS_PREFIX)).toBe(false);
+      expect(rec.out[0]!.data).toContain("background agent hit an API error");
+
+      // Nothing to resolve — no slot existed and onEndOfTurn was never set.
+      expect(state.turnQueue.length).toBe(0);
+      expect(state.onEndOfTurn).toBeNull();
+    } finally {
+      setHeldSessionProbe(prevProbe);
+      __forTest.uninstallSession(taskId);
+    }
+  },
+);
+
+test(
+  "signalSubagentApiError: neither in flight nor held — silent no-op",
+  async () => {
+    const { taskId, state } = freshSession();
+    const rec = recorder();
+    state.lastChunk = rec.onChunk;
+    // heldSessionProbe left at whatever the module default is (unset/null
+    // unless a leaked probe from a prior file — restore-in-afterEach
+    // discipline elsewhere is what keeps this true); force it explicitly so
+    // this test can't pass by accident of ordering.
+    const prevProbe = setHeldSessionProbe(() => false);
+    try {
+      expect(__forTest.turnInFlight(state)).toBe(false);
+
+      __forTest.signalSubagentApiError(state, apiErrorInfo());
+
+      expect(rec.out.length).toBe(0);
+      expect(state.turnQueue.length).toBe(0);
+      expect(state.onEndOfTurn).toBeNull();
+      expect(state.lastChunk).toBe(rec.onChunk); // untouched
+    } finally {
+      setHeldSessionProbe(prevProbe);
+      __forTest.uninstallSession(taskId);
+    }
+  },
+);
+
+test(
+  "signalSubagentApiError: no session teardown — unlike signalSessionDeath, the JSONL "
+  + "watcher/timers and subagent watcher are left completely alone (tmux session is alive; "
+  + "only the turn aborted)",
+  async () => {
+    const { taskId, state } = freshSession();
+    const rec = recorder();
+    let detachCalls = 0;
+    const fakeSubagentWatcher = {
+      detach: () => { detachCalls += 1; },
+      pump: () => {},
+      reflectExternalSettle: () => {},
+    };
+    // Sentinel (non-null, distinguishable) stand-ins for the fields
+    // `signalSessionDeath` nulls out on teardown, so we can assert they're
+    // byte-for-byte untouched here.
+    const fakeWatcher = {} as unknown as typeof state.watcher;
+    const fakePollTimer = setTimeout(() => {}, 60_000);
+    const fakeScrapeTimer = setInterval(() => {}, 60_000);
+    state.watcher = fakeWatcher;
+    state.pollTimer = fakePollTimer;
+    state.scrapeTimer = fakeScrapeTimer;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    state.subagentWatcher = fakeSubagentWatcher as any;
+    // Same run-association gate as the other in-flight-turn tests above —
+    // install an explicit matching probe rather than relying on "unset".
+    const prevProbe = setActiveRunProbe((id) => (id === taskId ? "run-1" : null));
+    try {
+      const done = __forTest.pushTurnSlot(state, rec.onChunk);
+
+      __forTest.signalSubagentApiError(state, apiErrorInfo());
+
+      await done;
+
+      expect(detachCalls).toBe(0);
+      expect(state.subagentWatcher).toBe(fakeSubagentWatcher as unknown as typeof state.subagentWatcher);
+      expect(state.watcher).toBe(fakeWatcher);
+      expect(state.pollTimer).toBe(fakePollTimer);
+      expect(state.scrapeTimer).toBe(fakeScrapeTimer);
+    } finally {
+      setActiveRunProbe(prevProbe);
+      clearTimeout(fakePollTimer);
+      clearInterval(fakeScrapeTimer);
+      __forTest.uninstallSession(taskId);
+    }
+  },
+);
+
+test("formatApiErrorDetail: known HTTP status vs. unknown status wording", () => {
+  expect(formatApiErrorDetail(529)).toBe("HTTP 529 — turn aborted; blocked for manual retry");
+  expect(formatApiErrorDetail(undefined)).toBe("turn aborted; blocked for manual retry");
+});

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -161,6 +161,50 @@ function heldProbeSafe(taskId: string): boolean {
 }
 
 /**
+ * Predicate the orchestrator injects to answer "what run id is currently
+ * in flight (i.e. tracked in the orchestrator's own `active` map) for this
+ * task?" — `null` when none. `signalSubagentApiError` uses this to guard
+ * against a STALE async subagent (spawned by an OLDER run) erroring while a
+ * NEWER run is in flight on the same tmux session: `TurnSlot` carries no
+ * run id of its own (it's just `{ onChunk, resolve, reject }`), so there is
+ * no way to answer "which run does the live turn belong to" from
+ * `SessionState` alone — the orchestrator's `active` map (keyed by run id)
+ * is the only place that association lives. Mirrors `heldSessionProbe`
+ * exactly: installed as a *module-level* side effect of importing
+ * `orchestrator.ts` (not lazily on first use), `null` until then. In
+ * production that import always happens (`index.ts` pulls it in at boot), so
+ * "unset" is not a reachable production state — it only shows up when a unit
+ * test drives `signalSubagentApiError` directly without ever importing
+ * `orchestrator.ts`. Because `bun test` shares one module cache across every
+ * file in a run, importing `orchestrator.ts` from *any* test file installs
+ * this probe for the rest of the process — so a test that wants "no probe"
+ * semantics can only get that reliably when run in isolation. Tests that
+ * exercise this gate should install an explicit matching (or mismatching)
+ * probe via `setActiveRunProbe` and restore the previous value afterward,
+ * rather than assuming the ambient value is `null`. */
+let activeRunProbe: ((taskId: string) => string | null) | null = null;
+export function setActiveRunProbe(
+  fn: ((taskId: string) => string | null) | null,
+): ((taskId: string) => string | null) | null {
+  const prev = activeRunProbe;
+  activeRunProbe = fn;
+  return prev;
+}
+
+/** Call `activeRunProbe`, never letting a throwing probe reach the tailer's
+ *  api-error callback — same rationale as `heldProbeSafe`. Only meaningful
+ *  to call once the caller has confirmed `activeRunProbe` is non-null (a
+ *  throw mid-call still degrades to "no active run", not "unset"). */
+function activeRunProbeSafe(taskId: string): string | null {
+  try {
+    return activeRunProbe?.(taskId) ?? null;
+  } catch (e) {
+    console.error(`[claude-tmux] activeRunProbe threw for task ${taskId}:`, e);
+    return null;
+  }
+}
+
+/**
  * Handler the orchestrator installs to learn that a background task/agent
  * named in a task-notification JSONL line has settled, so it can flip the
  * matching `subagents` row and re-check the hold predicate above. Fired
@@ -477,6 +521,19 @@ interface ParsedJsonlEvent {
  *  consumer (orchestrator) can't drift. */
 export const CLAUDE_API_ERROR_STATUS_PREFIX = "api error: ";
 
+/** Human-readable detail appended after `CLAUDE_API_ERROR_STATUS_PREFIX`.
+ *  Single source of truth for both the mapper's own emit site (main-stream
+ *  api errors, below) and `claude-subagents.ts`'s tailer peek (subagent api
+ *  errors) — factored out so the two can't drift in wording, and so
+ *  detection never has to string-match this rendered text (see
+ *  `signalSubagentApiError` / the subagent tailer's peek, which key off the
+ *  raw `isApiErrorMessage`/`apiErrorStatus` JSONL fields instead). */
+export function formatApiErrorDetail(status: number | undefined): string {
+  return typeof status === "number"
+    ? `HTTP ${status} — turn aborted; blocked for manual retry`
+    : "turn aborted; blocked for manual retry";
+}
+
 /** Status-chunk prefix for the "claude's TUI rejected the message as an
  *  unknown slash command" sentinel — mirrors `CLAUDE_API_ERROR_STATUS_PREFIX`
  *  exactly (producer here, consumer in orchestrator.ts's `makeChunkHandler`).
@@ -695,9 +752,18 @@ function formatTurnDuration(ms: number): string {
   return s === 0 ? `${m}m` : `${m}m ${s}s`;
 }
 
+/**
+ * @param includeUuidForApiError See `mapParsedEventToChunks`'s param of the
+ * same name. Defaults `false` (unchanged behavior for every existing
+ * caller/test that doesn't pass it). `claude-subagents.ts`'s tailer — the
+ * ONLY external caller of this raw-line entry point (`dispatchLine`, the
+ * main stream, parses up front and calls `mapParsedEventToChunks` directly)
+ * — passes `true`.
+ */
 export function mapJsonlEventToChunks(
   line: string,
   onChunk: ChunkHandler,
+  includeUuidForApiError = false,
 ): { endOfTurn: boolean; lineUuid?: string } {
   let evt: ParsedJsonlEvent;
   try {
@@ -706,15 +772,36 @@ export function mapJsonlEventToChunks(
     onChunk("stderr", `jsonl parse error: ${(e as Error).message}`);
     return { endOfTurn: false };
   }
-  return mapParsedEventToChunks(evt, onChunk);
+  return mapParsedEventToChunks(evt, onChunk, includeUuidForApiError);
 }
 
 /** String-variant entry point delegates to this once the JSON has been
  *  parsed. `dispatchLine` parses up front (to peek the uuid for dedup) and
- *  calls this directly — saves a second JSON.parse per JSONL line. */
+ *  calls this directly — saves a second JSON.parse per JSONL line.
+ *
+ * @param includeUuidForApiError Whether the `isApiErrorMessage` sentinel
+ * `status` chunk should carry the line's own uuid as its `line_uuid` dedup
+ * key. `dispatchLine`'s direct call (main stream) never passes this, so it
+ * defaults `false`: a main-stream api-error line's assistant TEXT block is
+ * emitted first with that SAME uuid, so reusing it here would collide on
+ * the `(run_id, IFNULL(subagent_id,''), line_uuid)` partial unique index
+ * and the status row would be silently dropped via INSERT OR IGNORE (see
+ * the dedicated test in claude-tmux.test.ts). `mapJsonlEventToChunks`
+ * passes `true` for its one real caller, the subagent tailer: a subagent's
+ * own api-error line needs a durable `line_uuid` so reattach seeding
+ * (`seenLineUuidsForSubagent`) reliably recognizes a replayed api-error
+ * line even in the edge case where the line carries no text content block
+ * (so no assistant chunk exists to carry the uuid instead) — without that,
+ * a replayed error line on a boot reattach could re-fire
+ * `signalSubagentApiError` against whatever run happens to be in flight at
+ * that point. When a text block IS present (the common case), the
+ * duplicate write is a harmless no-op — INSERT OR IGNORE silently keeps
+ * the first (assistant) row, which already carries the same uuid.
+ */
 function mapParsedEventToChunks(
   evt: ParsedJsonlEvent,
   onChunk: ChunkHandler,
+  includeUuidForApiError = false,
 ): { endOfTurn: boolean; lineUuid?: string } {
   // Claude stamps a uuid on every event line. Forward it as the third arg
   // to onChunk so the orchestrator can persist it as the run_events row's
@@ -878,17 +965,23 @@ function mapParsedEventToChunks(
       // to flip the task into the `blocked` column, and signal endOfTurn so
       // the run row resolves instead of sitting in `running` forever.
       //
-      // Emitted with `uuid: undefined` (not the JSONL line uuid) on purpose:
-      // the assistant text block above was just appended to run_events with
-      // that uuid, and the partial unique index on `(run_id, line_uuid)`
-      // would silently drop this status via INSERT OR IGNORE if we reused
-      // it. The NULL key path inserts unconditionally, so the breadcrumb
-      // also shows up on panel reload — not just live SSE.
+      // Emitted with `uuid: undefined` on the MAIN stream (the default here
+      // — see `includeUuidForApiError`'s doc) on purpose: the assistant text
+      // block above was just appended to run_events with that SAME uuid (a
+      // typical api-error line has both), and the `(run_id,
+      // IFNULL(subagent_id,''), line_uuid)` partial unique index would
+      // silently drop this status row via INSERT OR IGNORE if we reused it
+      // — verified against `claude-tmux.test.ts`'s
+      // "synthetic isApiErrorMessage line" test, which asserts exactly this.
+      // The NULL key path inserts unconditionally, so the breadcrumb still
+      // shows up on panel reload, just under a different (non-deduped) row.
       if (evt.isApiErrorMessage === true) {
-        const detail = typeof evt.apiErrorStatus === "number"
-          ? `HTTP ${evt.apiErrorStatus} — turn aborted; blocked for manual retry`
-          : "turn aborted; blocked for manual retry";
-        onChunk("status", `${CLAUDE_API_ERROR_STATUS_PREFIX}${detail}`);
+        const detail = formatApiErrorDetail(evt.apiErrorStatus);
+        onChunk(
+          "status",
+          `${CLAUDE_API_ERROR_STATUS_PREFIX}${detail}`,
+          includeUuidForApiError ? uuid : undefined,
+        );
         return { endOfTurn: true, lineUuid: uuid };
       }
       // Signal a candidate turn-end. `dispatchLine` stages this and confirms
@@ -3659,6 +3752,110 @@ function signalSessionDeath(state: SessionState): void {
 }
 
 /**
+ * Settle an in-flight turn because a BACKGROUND agent's own transcript
+ * emitted an API-error line (`isApiErrorMessage: true` — 529 Overloaded,
+ * 400, any status; see `mapJsonlEventToChunks`). `claude-subagents.ts`'s
+ * tailer has already settled that subagent's own row `failed` by the time
+ * this fires (see `attachSubagentWatcher`'s `onApiError` — wired below in
+ * `attachTailer`); this module-side half propagates that failure to the
+ * PARENT turn, which the subagent tailer cannot do itself — it is read-only
+ * w.r.t. the agent and has no `SessionState` to act on.
+ *
+ * Reuses `CLAUDE_API_ERROR_STATUS_PREFIX`, the same sentinel the main
+ * stream's own API errors emit, so the orchestrator's chunk handler needs
+ * zero changes: prefix match → `handle.apiError = true` +
+ * `updateColumn(taskId, runId, "blocked", "api-error")`; the done handler
+ * folds that into run `failed` — identical to a main-stream API error.
+ *
+ * Mirrors `signalSessionDeath`'s in-flight settle mechanics exactly (emit
+ * the sentinel via the head slot's `onChunk`, resolve the slot / fire
+ * `onEndOfTurn`) but performs NONE of its teardown: the tmux session is
+ * provably alive — a background agent errored, not the session itself — so
+ * the JSONL watcher, poll/scrape timers, and the subagent watcher all stay
+ * attached, and `orphanRunningSubagents` is deliberately NOT called. Other
+ * background agents may legitimately still be running and must keep being
+ * tailed (#92 semantics: only the errored subagent's own row settles).
+ *
+ * Won't-fix, by design: after this settle, a GENUINELY recovering main
+ * agent's next assistant line can trigger `maybeAdoptContinuation`,
+ * resurrecting the card from `blocked` to a fresh continuation run. That's
+ * intentional self-healing, not a bug — the aborted run stays `failed`; a
+ * real recovery lands as its own adopted run. The truly-stuck case (no more
+ * assistant lines ever arrive) simply stays `blocked`, which is the whole
+ * point of this feature.
+ */
+function signalSubagentApiError(
+  state: SessionState,
+  info: { subagentId: string; detail: string; runId: string },
+): void {
+  if (!turnInFlight(state)) {
+    // No active turn to abort — the tailer already settled the subagent's
+    // own row and already called `fireSettle`, which is what lets a held
+    // task (main run already succeeded, only background agents keep it
+    // open) release to `review` on its own. There is no main-turn handle
+    // here to flip to `blocked`. If the task IS held, still leave a
+    // breadcrumb on the main stream so the failure isn't silent — mirrors
+    // `signalSessionDeath`'s held branch ("say so honestly instead of
+    // reusing the sentinel": there's no handle for the orchestrator to flip
+    // to `blocked`, so a sentinel here would just lie). Neither in flight
+    // nor held: truly nothing to do.
+    if (heldProbeSafe(state.taskId)) {
+      const onChunk = state.lastChunk ?? (() => {});
+      onChunk(
+        "status",
+        `background agent hit an API error (${info.detail}) — it stopped; task releases when `
+          + `remaining agents finish`,
+      );
+    }
+    return;
+  }
+  // Run association: a STALE async subagent spawned by an OLDER run can
+  // error while a NEWER run is in flight on this same session — settling
+  // here would wrongly abort the new run over an old failure. `TurnSlot`
+  // carries no run id (verified: `interface TurnSlot` above is just
+  // `{ onChunk, resolve, reject }`), so this can't be checked locally;
+  // resolved via the same orchestrator-injected-probe seam as
+  // `heldSessionProbe` (`setActiveRunProbe`, wired in orchestrator.ts next
+  // to `setHeldSessionProbe`). Unset `activeRunProbe` (unit tests that
+  // drive this function directly, with no orchestrator wiring) allows
+  // through unconditionally — same posture as every other probe in this
+  // file when unregistered.
+  if (activeRunProbe !== null && info.runId !== activeRunProbeSafe(state.taskId)) return;
+  // The turn is being settled by a different sentinel below — an armed
+  // slash token / staged end_turn / hold-until-idle latch all have nothing
+  // left to watch for. Mirrors `signalUnknownCommand`'s "queue popped ⇒
+  // nothing staged" invariant: without clearing `pendingEndTurn`, a stale
+  // staged end_turn from BEFORE this abort could pop the user's *retry*
+  // slot via the poll's empty-text flush and instantly mis-resolve the new
+  // run as succeeded. `holdUntilIdle` likewise has no folded turn left to
+  // wait out once the slot underneath it is gone.
+  state.pendingSlashToken = null;
+  state.pendingEndTurn = null;
+  state.holdUntilIdle = false;
+  const slot = state.turnQueue[0];
+  const onChunk = slot?.onChunk ?? state.lastChunk ?? (() => {});
+  onChunk(
+    "status",
+    `${CLAUDE_API_ERROR_STATUS_PREFIX}background agent aborted: ${info.detail}`,
+  );
+  if (slot && slot.resolve) {
+    state.turnQueue.shift();
+    state.lastChunk = slot.onChunk;
+    const resolve = slot.resolve;
+    slot.resolve = null;
+    slot.reject = null;
+    resolve(0);
+  } else if (state.onEndOfTurn) {
+    const handler = state.onEndOfTurn;
+    state.onEndOfTurn = null;
+    handler();
+  }
+  // Nothing will end this turn naturally now — cancel any watchdog waiting
+  // on it so it can't fire redundantly against an already-settled slot.
+  clearContinuationWatchdog(state);
+}
+
+/**
  * Settle an in-flight turn because claude's Ink TUI rejected the last-pasted
  * message as an unknown slash command (`Unknown command: /<token>`). No
  * JSONL line is ever written for this — the message was never delivered as
@@ -3847,7 +4044,11 @@ function attachTailer(state: SessionState): void {
   // dispose a prior handle first so a re-attach (reconcileOrphans defensive
   // overwrite) can't leave two watchers polling the same dir.
   state.subagentWatcher?.detach();
-  state.subagentWatcher = attachSubagentWatcher({ taskId: state.taskId, jsonlPath: state.jsonlPath });
+  state.subagentWatcher = attachSubagentWatcher({
+    taskId: state.taskId,
+    jsonlPath: state.jsonlPath,
+    onApiError: (info) => signalSubagentApiError(state, info),
+  });
 }
 
 /* ────────────────────────────────────────────────────────────────────────── *
@@ -4942,6 +5143,10 @@ export const __forTest = {
   /** Death-watch settlement — exposed so the death test can drive it against a
    *  synthetic session without a real tmux server. */
   signalSessionDeath,
+  /** Background-agent API-error settlement — exposed so the subagent
+   *  API-error test can drive it against a synthetic session without a real
+   *  tmux server or a live `attachSubagentWatcher`. */
+  signalSubagentApiError,
   /** Unknown-slash-command settlement — exposed so the matcher/signal test
    *  can drive it against a synthetic session without a real tmux server. */
   signalUnknownCommand,

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -64,6 +64,7 @@ import {
   interruptTaskSession,
   setContinuationRunFactory,
   setHeldSessionProbe,
+  setActiveRunProbe,
   setBackgroundTaskSettledHandler,
 } from "./claude-tmux.ts";
 import {
@@ -266,6 +267,21 @@ setContinuationRunFactory(startContinuationRun);
 // silently stranding the card in `running` until the next boot. Reuses the
 // existing DB-derived hold predicate — no new state to track.
 setHeldSessionProbe(isHeldByBackgroundAgents);
+
+// Run association for `signalSubagentApiError` (#93): answers "what run id
+// is currently in flight for this task, per the orchestrator's OWN `active`
+// map?" so a stale async subagent from an older run can't abort a newer
+// run's turn. `task.runId` alone isn't enough — it's set the instant
+// `startTask` inserts the run row, before `spawnAgent` returns and
+// `registerActiveRun` populates `active`, and it's also left stale after a
+// run resolves — so the extra `active.has` check (the exact idiom used
+// throughout this file, e.g. the busy/idle branch in `sendInput`) is what
+// actually answers "in flight right now."
+setActiveRunProbe((taskId) => {
+  const task = tasks.get(taskId);
+  if (!task?.runId) return null;
+  return active.has(task.runId) ? task.runId : null;
+});
 
 // Background-task settle signal: a parent task-notification JSONL line named
 // the finishing agent/background-task id — settle that subagent row the same
@@ -2356,6 +2372,17 @@ export async function reapIdleSessions(): Promise<{ reaped: string[] }> {
     const isReapable = (task: Task): boolean => {
       if (task.runId && active.has(task.runId)) return false;
       if (isTaskHeldByBackgroundAgents(task)) return false;
+      // `isTaskHeldByBackgroundAgents` only covers the `running`-column
+      // #92 hold (main run succeeded, subagents still finishing) — it
+      // requires `task.column === "running"`. Since #93
+      // (`signalSubagentApiError`), a task can leave the `active` map via
+      // `blocked` instead: one subagent's API error aborts the main turn
+      // while SIBLING subagents are still legitimately running and tailed.
+      // That case slips past the check above (column is `blocked`, not
+      // `running`), so re-check independently of column/hold state — a
+      // task with any running subagent row must never have its tmux
+      // session reaped out from under agents still writing to it.
+      if (subagents.hasRunning(task.id)) return false;
       if (countPendingForTask(task.id) > 0) return false;
       return true;
     };


### PR DESCRIPTION
## Problem

When a **background agent (subagent)** hit an API error (e.g. `API Error: 529 Overloaded`), the error was rendered in the subagent's tab — including the "TURN ABORTED; BLOCKED FOR MANUAL RETRY" divider — but the run never ended. The heartbeat stayed on "Agent is working…" forever.

Root cause: subagent JSONL streams are tailed by `claude-subagents.ts`, which writes events straight to DB + SSE, **bypassing the orchestrator's `makeChunkHandler`**. So a subagent's `isApiErrorMessage` line never set `handle.apiError`, never settled the turn, and the run stayed in the in-memory `active` map — which `reapIdleSessions` explicitly skips, making the hang permanent.

## What changed

- **Detection (`claude-subagents.ts`)**: `tailFile` now detects API-error lines from the *parsed* event (`isApiErrorMessage` / `apiErrorStatus` — any HTTP status, not just 529; never by matching rendered status text, which transcript content could spoof). Detection is gated on the line carrying a `uuid`, so a boot-reattach replay (seen-set seeded from `run_events.line_uuid`) can never re-fire it. The subagent row settles `failed` immediately (no `DONE_IDLE_MS` wait), stopping the tab's heartbeat, and a new `onApiError` watcher callback (try/catch-wrapped, mirroring `fireSettle`) notifies claude-tmux with `{ subagentId, runId, detail }`.
- **Settlement (`claude-tmux.ts`)**: new `signalSubagentApiError`, mirroring `signalSessionDeath`'s two-branch shape:
  - **Turn in flight** → emits the existing `api error:` sentinel through the turn's chunk handler (so the orchestrator's existing path flips the task to **`blocked`**, reason `api-error`, and the run settles **`failed`**), resolves the turn slot, and clears `pendingEndTurn` / `pendingSlashToken` / `holdUntilIdle` + the continuation watchdog. **No session/watcher teardown** — the tmux session stays alive for retry/follow-up, and sibling background agents keep running.
  - **Task held by background agents** (main run already succeeded) → plain non-sentinel breadcrumb on the main stream; the errored agent stops holding the task, which releases normally once no running agents remain.
- **Run association**: an orchestrator-injected `activeRunProbe` (mirrors `setHeldSessionProbe`) ensures a stale subagent left over from run A can't block a newer in-flight run B on the same session.
- **Hardening from review**: an `apiErrored` latch keeps `toolUseId` when a post-error append flips the row back to `running` (preserving the `tool_result` settle fallback); the mapper can attach the line uuid to subagent api-error status rows (opt-in param — main-stream behavior unchanged); `reapIdleSessions` skips tasks with running subagent rows so a blocked task's session isn't reaped from under surviving siblings.
- **Deliberate non-behavior**: if the main agent genuinely recovers and keeps talking after the block, continuation-adoption resurrects the card as a fresh run — intentional self-heal; the aborted run stays `failed`. The stuck case emits no further assistant lines, so it stays `blocked`.

## Tests

- `claude-subagents-apierror.test.ts` (6): immediate settle + callback payload, uuid-less lines don't fire, reattach replay doesn't re-fire, retry flips back to `running` with `toolUseId` preserved (tool_result fallback still settles), normal idle-path completion regression, throwing hook doesn't break the tick.
- `claude-tmux-subagent-apierror.test.ts` (8): in-flight settle (sentinel once, slot resolved, latches cleared), `onEndOfTurn` reattach fallback, runId-mismatch no-op, held-branch plain breadcrumb, silent no-op, no-teardown contract, `formatApiErrorDetail` wording.

`bun run typecheck` green; full `bun test`: **1968 pass / 1 skip / 0 fail**.

Plan with logged design assumptions: `docs/plans/bg-agent-api-error-ends-run.md`.