### PR TITLE
feature: New PR composes as a Git Integration subpage; task Open/View PR open the modal on that page

### DIFF
--- a/docs/plans/new-pr-git-integration-page.md
+++ b/docs/plans/new-pr-git-integration-page.md
@@ -1,0 +1,93 @@
+# Plan — New PR as a Git Integration page + task Open/View PR routes into the modal
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-30 |
+| Source | /implement invocation: "New PR should be a page in the Git Integration, just like when opening a PR. And the Open or View PR from the Task should open the Git Integration modal and on that page" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/new-pr |
+| Base SHA | 5953e190c262b598ad36a10c449b984517bd19a1 (tree clean) |
+| Mode | **Autonomous** — grill + plan-approval gates bypassed (headless run, no owner present); all assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+1. The New-PR composer in the Git Integration modal (`GitHubDialog`) becomes a **dedicated subpage** of the modal — same navigation pattern as the PR/issue detail subpage (back-chevron header, Escape pops to list, filter bar/panels/list hidden while on the page).
+2. The task's **"Open PR"** chip (RunPanel, post commit-&-push) opens the modal directly **on that New-PR page**, prefilled as today.
+3. The task's **"View PR"** header link opens the modal **on that PR's detail subpage** instead of jumping straight to the browser (browser access remains via the detail page's open-on-GitHub affordance; external open remains the fallback if the PR can't be fetched).
+
+Done = typecheck green, `bun test` green, behaviors verified in code review.
+
+## 2. Context & constraints (verified findings)
+
+- Subpage navigation is the `GitHubDialogView` union in `src/mainview/lib/github-dialog-view.ts:26-29` — `{kind:"list"} | {kind:"detail"; item: GitHubListItem} | {kind:"panel"; panel}` with helpers `openDetail/openPanel/backToList/togglePanel/resolveEscape`. `GitHubDialog.tsx` holds `view` state (line 554), header 3-way ternary (2845-2913), body ternary (3207), `Dialog onClose` pops via `resolveEscape` (2834-2840). **No exhaustive switch on `view.kind` anywhere** — every consumer is an ad-hoc boolean (`showDetail` 2823, `isPanelView` 2824); a new member must be manually threaded through header, toolbar (2926), filter bar (3038), body.
+- The composer is currently **inline, boolean-gated**: `pullComposerOpen` (648) / `issueComposerOpen` (640); `PullComposer` (3646-3806) / `IssueComposer` (3808-3922) render inside the list body at 3522/3549, gated `kind==="pulls"|"issues" && !isAggregate`. The "New PR"/"New issue" trigger button is embedded *inside* each composer component when closed (3693-3701 / 3843-3851). Escape while composing **closes the whole dialog** today (view is still `"list"`).
+- Submit: `createPull` (2675-2706) / `createIssue` (2626-2657) → `POST /github/pull-create` / `issue-create` → `upsertListItem(result.item, true)` (prepend), closes composer, success banner — **no navigation to detail**.
+- Reset asymmetry (**known bug**): `[projectPath, kind]` effect (938-960) resets both composers; `[open]` close-reset (987-997) resets **only** the pull composer — issue-composer state leaks across opens of the always-mounted singleton (`App.tsx:864-873`).
+- `pullPrefill` one-shot (from PR #133): producer `RunPanel.tsx:2405-2423` ("Open PR" chip, gated `!task.prUrl && task.branch != null && shouldOfferOpenPr(gitStatus) && !sending`) → `App.tsx:846-849` sets `githubPullPrefill` + opens; consumption is a two-effect dance (`GitHubDialog.tsx:685-696` sets projectPath/kind; 969-979, declared *after* the `[projectPath,kind]` reset, opens + seeds) with `lastPullPrefillRef`/`pendingPullPrefillRef` dedupe.
+- "View PR": `RunPanel.tsx:2011-2019`, an `ExternalLink` (file-private, 3856-3879, `^(https?|mailto):` whitelist, `api.openExternal`) on `task.prUrl` — full provider `html_url`, set server-side only by `pull-create` (`server.ts:1657-1664`), never patchable. **No PR-URL parser exists anywhere; no fetch-single-PR/issue route exists** (`/github/discussion?path=&number=` proves the single-item-GET pattern for discussions only). Detail views need a **full `GitHubListItem`** (`openDetail(item)`; `expandedItem` memo 1020-1027 re-resolves against `result.items` by `itemKey` with snapshot fallback).
+- Server side resolves owner/repo fresh from the directory's git remote (`providerRepoForDir`, `git-provider.ts`) — `projectPath` is a filesystem path; RunPanel deliberately passes `task.workdir` (not `worktreePath`).
+- `git-host.ts` is the multi-provider dispatch layer (github/gitlab/bitbucket adapters, `withSourcePath(item, dir)` stamping). Mutation routes (e.g. `pullReopen` 527) already return fresh mapped items per provider.
+- Tests: pure-logic only (no jsdom/RTL). `github-dialog-view.test.ts` (helpers), `pr-proposal.test.ts`, `commit-push.test.ts`, `pull-create-task-url.test.ts` (server route w/ network-test utils `github-test-util.ts` etc.). Test cmd: `bun test`; typecheck: `bun run typecheck`.
+- RunPanel is the **only** PR entry point in the webview (TaskCard/Column/DiffDialog have zero PR code).
+
+## 3. Approach & key decisions
+
+- **Compose = 4th view-union member** `{ kind: "compose" }` (no payload: which composer shows follows the dialog's existing pulls/issues `kind` state, mirroring how the list body already switches). Alternative considered — `{kind:"compose"; itemKind}` payload — rejected: duplicates existing `kind` state and invites drift.
+- **Both composers** ride the new view (PR *and* issue): same mechanics, keeps the union coherent, and unifying the `[open]` reset fixes the issue-composer leak. (Assumption A1.)
+- **Post-create navigation**: success now navigates to the created item's **detail subpage** (`setView(openDetail(result.item))`) after `upsertListItem(result.item, true)` — "a page, just like when opening a PR" end-to-end. (A2.)
+- **View PR** routes through a new one-shot `pullDetailPrefill` prop (mirroring `pullPrefill`'s dance): App passes `{ projectPath, number, prUrl }`; the dialog sets projectPath/kind, fetches the item via a **new `GET /github/pull-detail?path=&number=` route**, then `setView(openDetail(item))`. On fetch failure: toast + fall back to `api.openExternal(prUrl)` (old behavior preserved). (A3.)
+- **New server route** implemented in `git-host.ts` (`pullDetail({dir, number})`) dispatching per provider, reusing each adapter's existing single-item fetch/mappers (the same ones mutation responses use). GitHub support is mandatory; GitLab/Bitbucket best-effort — a friendly `{ok:false,error}` triggers the UI fallback. (A4.)
+- **PR number parsing** from `task.prUrl` in a new pure module `src/mainview/lib/pr-url.ts` (handles `/pull/N`, `/merge_requests/N`, `/pull-requests/N` tails; returns `number | null`; null → keep old external-link behavior).
+- Escape/back semantics: compose **pops to list** via `resolveEscape` (behavior change from close-dialog — consistent with detail/panel). Draft fields keep their current lifecycle (survive a pop; wiped on project/kind change and on dialog close).
+- Filter-change effect (865-931) pops `compose` like `detail` (stale draft under changed scope is confusing; also the filter bar is hidden in compose anyway).
+
+## 4. Work breakdown — implementation tasks
+
+**T1 — backend single-PR fetch + API client** (Wave 1)
+- Owns: `src/bun/git-host.ts`, `src/bun/github.ts`, `src/bun/gitlab.ts`, `src/bun/bitbucket.ts` (only if needed), `src/bun/server.ts`, `src/mainview/lib/api.ts`.
+- Goal: `pullDetail({dir, number}) → {ok:true; item: GitHubListItem} | {ok:false; error}` in git-host (provider dispatch, `withSourcePath`); route `GET /github/pull-detail?path=&number=` in server.ts following the object-style `routes` shape + existing param validation idioms; client fn `getGitHubPullDetail(path, number)` in api.ts following its fetch/auth idioms.
+- Acceptance: typecheck green; route returns a mapped item for GitHub repos; non-numeric/missing params → 400-style error like sibling routes.
+
+**T2 — compose view-union refactor** (Wave 1)
+- Owns: `src/mainview/lib/github-dialog-view.ts`, `src/mainview/components/kanban/GitHubDialog.tsx`.
+- Goal: add `{kind:"compose"}` + `openCompose()`; `resolveEscape` returns `"pop"` for compose; delete `pullComposerOpen`/`issueComposerOpen`; move trigger buttons out of the composer components into the list toolbar area (`setView(openCompose())`, still gated `!isAggregate` + matching `kind`); compose header branch (back chevron + "New pull request"/"New issue" per `kind`); hide filter bar, panels, and list in compose view; composer Cancel → `setView(backToList())`; `pullPrefill` part-2 sets `setView(openCompose())` instead of the boolean; success handler navigates `setView(openDetail(result.item))`; unify `[open]` reset (both composers' fields + `setView(backToList())` on close); filter-change effect pops compose.
+- Acceptance: typecheck green; no references to the deleted booleans remain; aggregate mode shows no compose trigger.
+
+**T3 — View PR routing + detailPrefill wiring** (Wave 2 — depends on T1's api fn and T2's view refactor)
+- Owns: `src/mainview/lib/pr-url.ts` (new), `src/mainview/components/kanban/GitHubDialog.tsx`, `src/mainview/components/kanban/RunPanel.tsx`, `src/mainview/App.tsx`.
+- Goal: `parsePullNumber(url): number | null` pure helper; `pullDetailPrefill?: { projectPath: string; number: number; prUrl: string } | null` prop on GitHubDialog with two-effect + pending/last-ref consumption (set projectPath + kind "pulls"; once landed, await `getGitHubPullDetail`; success → `setView(openDetail(item))`; failure → sonner toast + `api.openExternal(prUrl)` + close nothing); RunPanel "View PR" becomes a button invoking new prop `onViewPullRequest({projectPath: task.workdir, prUrl: task.prUrl})` (falls back to ExternalLink behavior when `parsePullNumber` returns null); App holds `githubPullDetailPrefill` state (set by callback + parse, cleared in dialog `onClose`), passes prop, and includes it in the `initialProjectPath` fallback chain.
+- Acceptance: typecheck green; prefill consumed exactly once; close clears state in App like `githubPullPrefill`.
+
+## 5. Work breakdown — test tasks
+
+**U1 — mainview pure-logic tests** (covers T2, T3 frontend)
+- Owns: `src/mainview/lib/github-dialog-view.test.ts`, `src/mainview/lib/pr-url.test.ts` (new).
+- compose member: openCompose, resolveEscape pop, togglePanel from compose, backToList; pr-url: github/gitlab/bitbucket shapes, trailing slashes/query/fragment, garbage, non-PR urls → null.
+
+**U2 — bun server/git-host tests** (covers T1)
+- Owns: one new test file in `src/bun/` (e.g. `pull-detail.test.ts`), following `github-network.test.ts`/`github-test-util.ts` mock conventions and the `AGETOR_DATA_DIR` mkdtemp rule.
+- Route param validation, GitHub happy path returns mapped item with sourcePath, provider/remote-missing error shape.
+
+## 6. Execution waves
+
+- Wave 1: T1 ∥ T2 (file-disjoint). Barrier: typecheck + commit.
+- Wave 2: T3. Then typecheck + commit.
+- Phase 5 review (opus) → Phase 6: U1 ∥ U2 (file-disjoint) → Phase 7 `bun test` (haiku) → Phase 8 fixes if needed.
+
+## 7. Blast radius & risks
+
+- `GitHubDialog.tsx` is ~8.9k lines with zero component-test coverage — regressions ride on typecheck + review + pure-logic tests. Mitigate: T2 keeps the flat field state as-is (only the open/closed mechanism moves into `view`).
+- No exhaustive `view.kind` switch: T2 must audit every `showDetail`/`isPanelView`/`!showDetail` site (header 2845-2913, toolbar 2926, filter bar 3038, body 3207).
+- Escape-while-composing changes from "close dialog" to "pop to list" — intentional, called out here.
+- `pullPrefill` sequencing (declaration order vs the `[projectPath,kind]` reset effect) must be preserved when part 2 switches to `setView`.
+- Aggregate mode must never enter compose (no valid target repo).
+- Peer coordination: active peer silver-ridge-6ad2 works `fix/fix-bg-agent-api-error-catch` (background-agent streams) — no file overlap expected except possibly `RunPanel.tsx`; their branch is separate, merge-time only.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+- **A1**: Issue composer is folded into the same compose page (uniformity; fixes the `[open]`-reset leak). User only asked about New PR.
+- **A2**: Successful create navigates to the new item's detail subpage instead of list + banner.
+- **A3**: "View PR" is modal-first; browser open remains reachable from the detail page and as the automatic fallback when the item can't be fetched/parsed.
+- **A4**: GitLab/Bitbucket single-PR fetch is best-effort; errors degrade to external open.
+- **A5**: Kanban cards / other surfaces stay untouched (RunPanel is the only PR entry point today).
+- **A6**: Draft fields persist across a back-pop within one open (matching current cancel semantics); wiped on close/project change as today.

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -874,6 +874,23 @@ export async function getBitbucketPullChecks(repo: ProviderRepoInfo, number: num
   return { ok: true, repo: `${repo.owner}/${repo.name}`, pullNumber: number, sha, checkRuns };
 }
 
+/** Matches `getGitHubPullDetail`'s shape — a single pull request by number,
+ *  normalized through the same `normalizeBitbucketPull` mapper
+ *  `closeBitbucketPull` uses. `sourcePath` is left `null` here, same as every
+ *  other adapter function — the facade (`git-host.ts`) stitches it on via
+ *  `withSourcePath`. */
+export async function getBitbucketPullDetail(repo: ProviderRepoInfo, number: number): Promise<BitbucketIssueResponse> {
+  const creds = await bitbucketCreds(repo.remoteHost);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
+  const res = await fetchBitbucket(`${repoBasePath(repo)}/pullrequests/${number}`, creds, "application/json");
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  const item = normalizeBitbucketPull(json, null);
+  if (!item) return { ok: false, error: "Bitbucket returned an unexpected pull request response" };
+  return { ok: true, item };
+}
+
 /** The shared `GitHubPullMergeMethod` enum ("merge"|"squash"|"rebase") maps to
  *  Bitbucket's three `merge_strategy` values. There is no fast-forward entry
  *  in the shared enum, so Bitbucket's `fast_forward` (a linear, no-merge-

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -880,8 +880,8 @@ export async function getBitbucketPullChecks(repo: ProviderRepoInfo, number: num
  *  other adapter function — the facade (`git-host.ts`) stitches it on via
  *  `withSourcePath`. */
 export async function getBitbucketPullDetail(repo: ProviderRepoInfo, number: number): Promise<BitbucketIssueResponse> {
-  const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
+  const creds = await bitbucketCreds(repo.remoteHost);
   const res = await fetchBitbucket(`${repoBasePath(repo)}/pullrequests/${number}`, creds, "application/json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);

--- a/src/bun/git-host.ts
+++ b/src/bun/git-host.ts
@@ -25,6 +25,7 @@ import {
   createGitHubPullLineComment,
   getGitHubPullChecks,
   getGitHubPullDefaults,
+  getGitHubPullDetail,
   getGitHubPullDiff,
   getGitHubViewer,
   listGitHubComments,
@@ -48,6 +49,7 @@ import {
   createGitLabPullLineComment,
   getGitLabPullChecks,
   getGitLabPullDefaults,
+  getGitLabPullDetail,
   getGitLabPullDiff,
   getGitLabViewer,
   listGitLabComments,
@@ -68,6 +70,7 @@ import {
   createBitbucketPullLineComment,
   getBitbucketPullChecks,
   getBitbucketPullDefaults,
+  getBitbucketPullDetail,
   getBitbucketPullDiff,
   getBitbucketViewer,
   listBitbucketComments,
@@ -376,6 +379,25 @@ export async function pullDiff(input: { dir: string; number: number }): Promise<
   if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
   if (repoInfo.provider === "github") return getGitHubPullDiff(input);
   return repoInfo.provider === "gitlab" ? getGitLabPullDiff(repoInfo, input.number) : getBitbucketPullDiff(repoInfo, input.number);
+}
+
+/**
+ * Fetches a single pull request by number — powers the Git Integration
+ * modal's future PR detail subpage (opening directly on a task's stored PR
+ * URL instead of landing on the list). All three providers are fully wired:
+ * GitHub via `getGitHubPullDetail`, GitLab via `getGitLabPullDetail`,
+ * Bitbucket via `getBitbucketPullDetail` — each a plain single-item GET
+ * normalized through the same mapper its provider's list/mutation paths use.
+ */
+export async function pullDetail(input: { dir: string; number: number }): Promise<IssueResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return getGitHubPullDetail(input);
+  const res = repoInfo.provider === "gitlab"
+    ? await getGitLabPullDetail(repoInfo, input.number)
+    : await getBitbucketPullDetail(repoInfo, input.number);
+  if (!res.ok) return res;
+  return { ...res, item: withSourcePath(res.item, input.dir) };
 }
 
 export interface ListCommentsInput {

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -1719,6 +1719,30 @@ export async function getGitHubPullDiff(input: GetGitHubPullDiffInput): Promise<
   };
 }
 
+/** `GET /repos/:o/:r/pulls/:number` — a single pull request by number,
+ *  normalized through the same `normalizeItem` mapper `reopenGitHubPull` and
+ *  `listGitHubItems` use, so the UI's PR detail subpage renders an item
+ *  shaped identically to one that arrived via a list fetch. Unlike the
+ *  mutation endpoints above, this is a plain read — no token is required for
+ *  a public repo (`fetchGitHub` already treats `token: null` as anonymous). */
+export async function getGitHubPullDetail(input: GitHubItemNumberInput): Promise<GitHubIssueResponse> {
+  const repo = await repoForDir(input.dir);
+  if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
+  if (!Number.isInteger(input.number) || input.number <= 0) {
+    return { ok: false, error: "pull request number must be positive" };
+  }
+
+  const token = await githubToken(repo.remoteHost ?? null);
+  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+  const res = await fetchGitHub(url, token, "application/vnd.github+json");
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiError(json, res.status, res.statusText) };
+  const item = normalizeItem("pulls", json, input.dir);
+  if (!item) return { ok: false, error: "GitHub returned an unexpected pull request response" };
+  return { ok: true, item };
+}
+
 export async function listGitHubComments(input: GitHubItemNumberInput): Promise<GitHubCommentsResponse> {
   const repo = await repoForDir(input.dir);
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };

--- a/src/bun/gitlab.ts
+++ b/src/bun/gitlab.ts
@@ -874,6 +874,22 @@ export async function getGitLabPullChecks(repo: ProviderRepoInfo, number: number
   return { ok: true, repo: `${repo.owner}/${repo.name}`, pullNumber: number, sha, checkRuns };
 }
 
+/** Matches `getGitHubPullDetail`'s shape — a single merge request by number,
+ *  normalized through the same `normalizeItem` mapper `closeGitLabPull` /
+ *  `reopenGitLabPull` use. */
+export async function getGitLabPullDetail(repo: ProviderRepoInfo, number: number): Promise<GitLabIssueResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
+  const token = await gitlabToken(repo.remoteHost);
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`, token);
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!token) };
+  const item = normalizeItem("pulls", json);
+  if (!item) return { ok: false, error: "GitLab returned an unexpected merge request response" };
+  return { ok: true, item };
+}
+
 /** Matches `mergeGitHubPull`'s shape. GitLab's `merge_strategy`/merge-method
  *  vocabulary is squash-or-not (`squash: boolean`) rather than GitHub's
  *  named strategies — `PROVIDER_CAPS.gitlab.mergeMethods` only ever offers

--- a/src/bun/pull-detail.test.ts
+++ b/src/bun/pull-detail.test.ts
@@ -1,0 +1,353 @@
+// Tests for the new backend single-PR fetch: the three provider fetchers
+// (getGitHubPullDetail in github.ts, getGitLabPullDetail in gitlab.ts,
+// getBitbucketPullDetail in bitbucket.ts), the git-host `pullDetail` facade
+// dispatch, and the `GET /github/pull-detail` server route.
+//
+// Layering follows the sibling test files' own split:
+//  - Fetcher-level tests call each provider's `get*PullDetail` directly
+//    against a mocked `globalThis.fetch` (mockGitHubFetch, github-test-util.ts
+//    — host-agnostic, reused as-is for GitLab/Bitbucket too, same convention
+//    as git-host.test.ts and gitlab/bitbucket-test-util.ts's own re-exports).
+//  - Facade-level tests call `pullDetail` from git-host.ts, mirroring
+//    git-host.test.ts's existing dispatch tests (which cover every other
+//    facade function except pullDetail — this file closes that gap).
+//  - Route-level tests hit the real `GET /github/pull-detail` endpoint
+//    through a live server, following pull-create-task-url.test.ts's
+//    pattern: AGETOR_DATA_DIR + a unique AGETOR_API_PORT are set at module
+//    scope BEFORE db.ts/server.ts are dynamically imported in beforeAll
+//    (both capture their config at import time), and a `realFetch` captured
+//    before any mock is installed is used for requests to our own server
+//    (mockGitHubFetch replaces globalThis.fetch wholesale and can't tell our
+//    own server apart from the GitHub/GitLab/Bitbucket API it's meant to
+//    intercept).
+import { test, expect, beforeAll, beforeEach, afterEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { makeGitHubRepo, mockGitHubFetch, type FetchMock } from "./github-test-util.ts";
+import { sampleRepo, gitlabMergeRequest } from "./gitlab-test-util.ts";
+import { makeBitbucketRepo } from "./bitbucket-test-util.ts";
+import { getGitHubPullDetail } from "./github.ts";
+import { getGitLabPullDetail } from "./gitlab.ts";
+import { getBitbucketPullDetail } from "./bitbucket.ts";
+import { pullDetail } from "./git-host.ts";
+
+// Route-level fixtures: AGETOR_DATA_DIR + a port unique among every other
+// *.test.ts file's AGETOR_API_PORT (see the convention comment in
+// draft-endpoint.test.ts / db-events-paging.test.ts / pull-create-task-url.test.ts).
+const ROUTE_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-pull-detail-route-"));
+process.env.AGETOR_DATA_DIR = ROUTE_DATA_DIR;
+process.env.AGETOR_API_PORT = "4497";
+
+let server: { stop: () => void } | null = null;
+let apiToken = "";
+const routeUrl = (p: string) => `http://127.0.0.1:4497${p}`;
+const realFetch = fetch.bind(globalThis);
+
+// Fetcher/facade-level tests go through github-tokens.ts / GitLab token env /
+// bitbucketCreds (git-provider.ts), which read AGETOR_DATA_DIR lazily at call
+// time (see git-host.test.ts's own comment on this) — reset it to a fresh
+// mkdtemp dir per test so a real stored token on the machine running these
+// tests can never leak in, and force GITHUB_TOKEN/GITLAB_TOKEN so
+// githubToken()/gitlabToken() never fall through to a real `gh`/`glab` CLI
+// shellout.
+const ENV_KEYS = ["GITHUB_TOKEN", "GH_TOKEN", "GITLAB_TOKEN", "BITBUCKET_TOKEN", "BITBUCKET_EMAIL"] as const;
+let savedEnv: Record<string, string | undefined> = {};
+let perTestDataDir = "";
+let fetchMock: FetchMock | null = null;
+let createdDirs: string[] = [];
+
+beforeAll(async () => {
+  await import("./db.ts");
+  const { startApiServer, API_TOKEN } = await import("./server.ts");
+  server = startApiServer() as unknown as { stop: () => void };
+  apiToken = API_TOKEN;
+});
+
+beforeEach(() => {
+  perTestDataDir = mkdtempSync(path.join(tmpdir(), "agetor-pull-detail-"));
+  process.env.AGETOR_DATA_DIR = perTestDataDir;
+  savedEnv = {};
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.GITHUB_TOKEN = "gh-test-token";
+  process.env.GITLAB_TOKEN = "glab-test-token";
+});
+
+afterEach(() => {
+  fetchMock?.restore();
+  fetchMock = null;
+  rmSync(perTestDataDir, { recursive: true, force: true });
+  process.env.AGETOR_DATA_DIR = ROUTE_DATA_DIR;
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  for (const dir of createdDirs) rmSync(dir, { recursive: true, force: true });
+  createdDirs = [];
+});
+
+afterAll(() => {
+  server?.stop?.();
+  rmSync(ROUTE_DATA_DIR, { recursive: true, force: true });
+});
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+}
+
+/** A throwaway git repo whose remote is NOT github/gitlab/bitbucket — used to
+ *  exercise `pullDetail`'s NO_REMOTE_ERROR path, mirroring git-host.test.ts's
+ *  own "providerInfoForDir errors on an unsupported git remote" test. */
+async function makeUnsupportedRepo(): Promise<string> {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-pull-detail-repo-"));
+  createdDirs.push(dir);
+  await git(["init", "-b", "main"], dir);
+  await git(["remote", "add", "origin", "git@example.com:acme/app.git"], dir);
+  return dir;
+}
+
+async function makeGitLabRepoDir(): Promise<string> {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-pull-detail-repo-"));
+  createdDirs.push(dir);
+  await git(["init", "-b", "main"], dir);
+  await git(["remote", "add", "origin", "https://gitlab.com/acme/app.git"], dir);
+  return dir;
+}
+
+function bitbucketPull(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 4,
+    title: "Add widget",
+    state: "OPEN",
+    draft: false,
+    links: { html: { href: "https://bitbucket.org/acme/app/pull-requests/4" } },
+    author: { nickname: "alice", links: {} },
+    description: "body text",
+    comment_count: 1,
+    created_on: "2026-01-01T00:00:00Z",
+    updated_on: "2026-01-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function githubPull(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    number: 7,
+    title: "Add feature",
+    state: "open",
+    html_url: "https://github.com/acme/widgets/pull/7",
+    draft: false,
+    user: { login: "octocat" },
+    assignees: [],
+    milestone: null,
+    body: "body text",
+    labels: [],
+    comments: 2,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: null,
+    merged_at: null,
+    locked: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GitHub fetcher: getGitHubPullDetail
+// ---------------------------------------------------------------------------
+
+test("getGitHubPullDetail happy path normalizes the item and stamps sourcePath with dir", async () => {
+  const dir = await makeGitHubRepo("acme", "widgets");
+  createdDirs.push(dir);
+  fetchMock = mockGitHubFetch([
+    { match: "https://api.github.com/repos/acme/widgets/pulls/7", json: githubPull() },
+  ]);
+
+  const res = await getGitHubPullDetail({ dir, number: 7 });
+  expect(res.ok).toBe(true);
+  if (!res.ok) return;
+  expect(res.item.number).toBe(7);
+  expect(res.item.kind).toBe("pulls");
+  expect(res.item.htmlUrl).toBe("https://github.com/acme/widgets/pull/7");
+  expect(res.item.sourcePath).toBe(dir);
+  expect(fetchMock.calls).toHaveLength(1);
+  expect(fetchMock.calls[0]!.method).toBe("GET");
+});
+
+test("getGitHubPullDetail maps a non-2xx GitHub response to {ok:false, error}", async () => {
+  const dir = await makeGitHubRepo("acme", "widgets2");
+  createdDirs.push(dir);
+  fetchMock = mockGitHubFetch([
+    { match: "/repos/acme/widgets2/pulls/9", status: 404, json: { message: "Not Found" } },
+  ]);
+
+  const res = await getGitHubPullDetail({ dir, number: 9 });
+  expect(res).toEqual({ ok: false, error: "Not Found" });
+});
+
+test("getGitHubPullDetail rejects a non-positive/non-integer number before any fetch", async () => {
+  const dir = await makeGitHubRepo("acme", "widgets3");
+  createdDirs.push(dir);
+  fetchMock = mockGitHubFetch([]); // any fetch call would throw — proves none happens
+
+  for (const bad of [0, -1, 1.5]) {
+    const res = await getGitHubPullDetail({ dir, number: bad });
+    expect(res).toEqual({ ok: false, error: "pull request number must be positive" });
+  }
+  expect(fetchMock.calls).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// GitLab fetcher: getGitLabPullDetail
+// ---------------------------------------------------------------------------
+
+test("getGitLabPullDetail happy path normalizes the merge request", async () => {
+  const repo = sampleRepo();
+  fetchMock = mockGitHubFetch([
+    {
+      match: /gitlab\.com\/api\/v4\/projects\/acme%2Fapp\/merge_requests\/12$/,
+      json: gitlabMergeRequest({
+        iid: 12,
+        title: "Fix bug",
+        web_url: "https://gitlab.com/acme/app/-/merge_requests/12",
+      }),
+    },
+  ]);
+
+  const res = await getGitLabPullDetail(repo, 12);
+  expect(res.ok).toBe(true);
+  if (!res.ok) return;
+  expect(res.item.number).toBe(12);
+  expect(res.item.kind).toBe("pulls");
+  expect(res.item.htmlUrl).toBe("https://gitlab.com/acme/app/-/merge_requests/12");
+  // The adapter never resolves a working directory (see gitlab.ts's module
+  // doc comment) — sourcePath is always null here; the facade stitches it on.
+  expect(res.item.sourcePath).toBeNull();
+});
+
+test("getGitLabPullDetail rejects an invalid merge request number before any fetch", async () => {
+  const repo = sampleRepo();
+  fetchMock = mockGitHubFetch([]);
+
+  for (const bad of [0, -3, 2.5]) {
+    const res = await getGitLabPullDetail(repo, bad);
+    expect(res).toEqual({ ok: false, error: "merge request number must be positive" });
+  }
+  expect(fetchMock.calls).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// Bitbucket fetcher: getBitbucketPullDetail
+// ---------------------------------------------------------------------------
+
+test("getBitbucketPullDetail happy path normalizes the pull request", async () => {
+  const repo = makeBitbucketRepo("acme", "app");
+  fetchMock = mockGitHubFetch([
+    { match: /api\.bitbucket\.org\/2\.0\/repositories\/acme\/app\/pullrequests\/4$/, json: bitbucketPull() },
+  ]);
+
+  const res = await getBitbucketPullDetail(repo, 4);
+  expect(res.ok).toBe(true);
+  if (!res.ok) return;
+  expect(res.item.number).toBe(4);
+  expect(res.item.kind).toBe("pulls");
+  expect(res.item.htmlUrl).toBe("https://bitbucket.org/acme/app/pull-requests/4");
+  expect(res.item.sourcePath).toBeNull();
+});
+
+test("getBitbucketPullDetail rejects an invalid pull request number before the creds lookup (no fetch)", async () => {
+  const repo = makeBitbucketRepo("acme", "app2");
+  fetchMock = mockGitHubFetch([]); // proves bitbucketCreds() is never reached, let alone a fetch
+
+  for (const bad of [0, -2, 3.5]) {
+    const res = await getBitbucketPullDetail(repo, bad);
+    expect(res).toEqual({ ok: false, error: "pull request number must be positive" });
+  }
+  expect(fetchMock.calls).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// git-host facade: pullDetail dispatch
+// ---------------------------------------------------------------------------
+
+test("pullDetail on a dir with no supported git remote returns the facade's NO_REMOTE_ERROR", async () => {
+  const dir = await makeUnsupportedRepo();
+  const res = await pullDetail({ dir, number: 1 });
+  expect(res).toEqual({
+    ok: false,
+    error: "project does not have a supported git remote (GitHub, GitLab, or Bitbucket)",
+  });
+});
+
+test("pullDetail dispatches a gitlab repo to the GitLab API and stitches sourcePath onto the item", async () => {
+  const dir = await makeGitLabRepoDir();
+  fetchMock = mockGitHubFetch([
+    {
+      match: /gitlab\.com\/api\/v4\/projects\/acme%2Fapp\/merge_requests\/3$/,
+      json: gitlabMergeRequest({ iid: 3 }),
+    },
+  ]);
+
+  const res = await pullDetail({ dir, number: 3 });
+  expect(res.ok).toBe(true);
+  if (!res.ok) return;
+  expect(res.item.number).toBe(3);
+  expect(res.item.sourcePath).toBe(dir);
+});
+
+// ---------------------------------------------------------------------------
+// Route: GET /github/pull-detail
+// ---------------------------------------------------------------------------
+
+test("GET /github/pull-detail without a path returns 400 'path required'", async () => {
+  const res = await realFetch(routeUrl("/github/pull-detail?number=1"), {
+    headers: { authorization: `Bearer ${apiToken}` },
+  });
+  expect(res.status).toBe(400);
+  expect(await res.json()).toEqual({ error: "path required" });
+});
+
+test("GET /github/pull-detail with a missing/non-numeric number returns 400", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-pull-detail-route-num-"));
+  createdDirs.push(dir);
+
+  // number omitted entirely
+  const missing = await realFetch(routeUrl(`/github/pull-detail?path=${encodeURIComponent(dir)}`), {
+    headers: { authorization: `Bearer ${apiToken}` },
+  });
+  expect(missing.status).toBe(400);
+  expect(await missing.json()).toEqual({ error: "valid pull request number required" });
+
+  // number non-numeric
+  const nonNumeric = await realFetch(
+    routeUrl(`/github/pull-detail?path=${encodeURIComponent(dir)}&number=abc`),
+    { headers: { authorization: `Bearer ${apiToken}` } },
+  );
+  expect(nonNumeric.status).toBe(400);
+  expect(await nonNumeric.json()).toEqual({ error: "valid pull request number required" });
+});
+
+test("GET /github/pull-detail happy path passes through the fetcher's normalized item", async () => {
+  const dir = await makeGitHubRepo("acme", "routewidgets");
+  createdDirs.push(dir);
+  fetchMock = mockGitHubFetch([
+    {
+      match: "https://api.github.com/repos/acme/routewidgets/pulls/11",
+      json: githubPull({ number: 11, html_url: "https://github.com/acme/routewidgets/pull/11" }),
+    },
+  ]);
+
+  const res = await realFetch(
+    routeUrl(`/github/pull-detail?path=${encodeURIComponent(dir)}&number=11`),
+    { headers: { authorization: `Bearer ${apiToken}` } },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.ok).toBe(true);
+  expect(body.item.number).toBe(11);
+  expect(body.item.htmlUrl).toBe("https://github.com/acme/routewidgets/pull/11");
+});

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -791,6 +791,23 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
         }),
       },
 
+      "/github/pull-detail": {
+        GET: authed(async (req) => {
+          const url = new URL(req.url);
+          const dir = url.searchParams.get("path");
+          const number = Number(url.searchParams.get("number"));
+          if (!dir) return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
+          if (typeof number !== "number" || !Number.isInteger(number) || number <= 0) {
+            return json({ error: "valid pull request number required" }, { status: 400, headers: corsHeaders(req) });
+          }
+          const result = await gitHost.pullDetail({ dir, number });
+          if (!result.ok) {
+            return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
+          }
+          return json(result, { headers: corsHeaders(req) });
+        }),
+      },
+
       "/github/viewer": {
         GET: authed(async (req) => {
           const url = new URL(req.url);

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -7,7 +7,7 @@ import { COLUMNS, type AgentStatus, type ColumnId, type GlobalEvent, type Harnes
 import { AgentIcon } from "@/components/kanban/AgentIcon";
 import { Column } from "@/components/kanban/Column";
 import { DiffDialog } from "@/components/kanban/DiffDialog";
-import { GitHubDialog, type GitHubPullPrefill } from "@/components/kanban/GitHubDialog";
+import { GitHubDialog, type GitHubPullDetailPrefill, type GitHubPullPrefill } from "@/components/kanban/GitHubDialog";
 import { KanbanFilters } from "@/components/kanban/KanbanFilters";
 import { NewTaskForm } from "@/components/kanban/NewTaskForm";
 import { EXIT_DURATION_MS as RUN_PANEL_EXIT_MS, RunPanel } from "@/components/kanban/RunPanel";
@@ -23,6 +23,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { dismissPending, notifyWaitingInput, toastApiError, toastError, toastPending, toastSessionEnded, toastSuccess, toastUnknownCommand } from "@/lib/toasts";
 import { PendingInputTracker } from "@/lib/pending-input-tracker";
 import { findTaskById } from "@/lib/notification-open";
+import { parsePullNumber } from "@/lib/pr-url";
 import { cn } from "@/lib/utils";
 import iconUrl from "../assets/agetor.iconset/icon_32x32@2x.png";
 
@@ -155,6 +156,11 @@ export default function App() {
   // specific task; cleared when the dialog closes so a later plain "GitHub"
   // open (no prefill) doesn't inherit a stale project/task.
   const [githubPullPrefill, setGithubPullPrefill] = useState<GitHubPullPrefill | null>(null);
+  // Set by RunPanel's "View PR" header affordance to open GitHubDialog
+  // straight on that PR's detail subpage; cleared alongside `githubPullPrefill`
+  // above (dialog close, or the other prefill kind winning a race) so only
+  // one prefill kind is ever live at a time.
+  const [githubPullDetailPrefill, setGithubPullDetailPrefill] = useState<GitHubPullDetailPrefill | null>(null);
   const [worktreesOpen, setWorktreesOpen] = useState(false);
   const [tmuxDialogOpen, setTmuxDialogOpen] = useState(false);
   const [updateSnapshot, setUpdateSnapshot] = useState<UpdateSnapshot | null>(null);
@@ -853,6 +859,14 @@ export default function App() {
         onUnarchive={unarchive}
         onOpenPullRequest={(prefill) => {
           setGithubPullPrefill(prefill);
+          setGithubPullDetailPrefill(null);
+          setGithubOpen(true);
+        }}
+        onViewPullRequest={({ projectPath, prUrl }) => {
+          const number = parsePullNumber(prUrl);
+          if (number == null) return;
+          setGithubPullDetailPrefill({ projectPath, number, prUrl });
+          setGithubPullPrefill(null);
           setGithubOpen(true);
         }}
       />
@@ -864,11 +878,13 @@ export default function App() {
       <GitHubDialog
         open={githubOpen}
         projects={projects}
-        initialProjectPath={githubPullPrefill?.projectPath ?? repoFilter[0] ?? selected?.workdir ?? tasks[0]?.workdir ?? null}
+        initialProjectPath={githubPullDetailPrefill?.projectPath ?? githubPullPrefill?.projectPath ?? repoFilter[0] ?? selected?.workdir ?? tasks[0]?.workdir ?? null}
         pullPrefill={githubPullPrefill}
+        pullDetailPrefill={githubPullDetailPrefill}
         onClose={() => {
           setGithubOpen(false);
           setGithubPullPrefill(null);
+          setGithubPullDetailPrefill(null);
         }}
       />
       <WorktreesDialog

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -864,7 +864,15 @@ export default function App() {
         }}
         onViewPullRequest={({ projectPath, prUrl }) => {
           const number = parsePullNumber(prUrl);
-          if (number == null) return;
+          if (number == null) {
+            // Can't drive the in-app detail subpage without a parsed PR
+            // number — fall back to the plain external link rather than
+            // silently doing nothing.
+            void api.openExternal(prUrl).catch((err: unknown) => {
+              toast.error(err instanceof Error ? err.message : "Could not open link");
+            });
+            return;
+          }
           setGithubPullDetailPrefill({ projectPath, number, prUrl });
           setGithubPullPrefill(null);
           setGithubOpen(true);

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -68,6 +68,7 @@ import { mergeabilityView, type MergeTone } from "@/lib/mergeability";
 import { ResolveConflictsDialog, type ResolveConflictsContext } from "./ResolveConflictsDialog";
 import {
   backToList,
+  openCompose,
   openDetail,
   resolveEscape,
   togglePanel,
@@ -637,7 +638,6 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   // Success banner for a completed transfer — shown at the list level since the
   // transferred item is removed from `result.items` the moment it succeeds.
   const [transferNotice, setTransferNotice] = useState<{ message: string; url: string } | null>(null);
-  const [issueComposerOpen, setIssueComposerOpen] = useState(false);
   const [newIssueTitle, setNewIssueTitle] = useState("");
   const [newIssueBody, setNewIssueBody] = useState("");
   const [newIssueLabels, setNewIssueLabels] = useState("");
@@ -645,7 +645,6 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   const [newIssueMilestone, setNewIssueMilestone] = useState("");
   const [newIssueSubmitting, setNewIssueSubmitting] = useState(false);
   const [newIssueError, setNewIssueError] = useState<string | null>(null);
-  const [pullComposerOpen, setPullComposerOpen] = useState(false);
   const [newPullTitle, setNewPullTitle] = useState("");
   const [newPullBody, setNewPullBody] = useState("");
   const [newPullHead, setNewPullHead] = useState("");
@@ -870,11 +869,11 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     commitsSeq.current += 1;
     linkedIssuesSeq.current += 1;
     reviewCommentSeq.current += 1;
-    // Only pop an open detail view back to the list — a manager panel (still
-    // showing the filter controls) should survive a filter edit. Functional
-    // update so `view` doesn't need to be a dep (popping must not re-trigger
-    // this effect on its own view-driven state changes).
-    setView((cur) => (cur.kind === "detail" ? backToList() : cur));
+    // Only pop an open detail or compose view back to the list — a manager
+    // panel (still showing the filter controls) should survive a filter
+    // edit. Functional update so `view` doesn't need to be a dep (popping
+    // must not re-trigger this effect on its own view-driven state changes).
+    setView((cur) => (cur.kind === "detail" || cur.kind === "compose" ? backToList() : cur));
     setDiffs({});
     setDiffLoading({});
     setDiffErrors({});
@@ -936,7 +935,11 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   }, [kind]);
 
   useEffect(() => {
-    setIssueComposerOpen(false);
+    // Also pops an active compose page back to the list — this is what keeps
+    // aggregate mode ("All repositories", which switches `projectPath` to the
+    // synthetic aggregate value) from ever showing the compose page: a
+    // project switch into aggregate fires this same effect.
+    setView((cur) => (cur.kind === "compose" ? backToList() : cur));
     setNewIssueTitle("");
     setNewIssueBody("");
     setNewIssueLabels("");
@@ -944,7 +947,6 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     setNewIssueMilestone("");
     setNewIssueSubmitting(false);
     setNewIssueError(null);
-    setPullComposerOpen(false);
     setNewPullTitle("");
     setNewPullBody("");
     setNewPullHead("");
@@ -970,7 +972,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     if (!open) return;
     const pending = pendingPullPrefillRef.current;
     if (!pending || projectPath !== pending.projectPath || kind !== "pulls") return;
-    setPullComposerOpen(true);
+    setView(openCompose());
     setNewPullHead(pending.head);
     setNewPullTitle(pending.title);
     setNewPullBody(pending.body);
@@ -978,15 +980,27 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     pendingPullPrefillRef.current = null;
   }, [open, projectPath, kind, pullPrefill]);
 
-  // Close wipes the pull composer + prefill bookkeeping. Without this, the
-  // dialog (which stays mounted) reopens later — often on the SAME project,
-  // since `initialProjectPath` falls back to the selected task's workdir, so
-  // the [projectPath, kind] reset above never fires — with the previous
-  // task's seeded composer and, worse, its `pullPrefillTaskId` still armed:
-  // a manual "New PR" would then stamp an unrelated PR's URL onto that task.
+  // Close wipes both composers' field state + prefill bookkeeping, and pops an
+  // active compose page back to the list. Without the pull-composer half of
+  // this, the dialog (which stays mounted) reopens later — often on the SAME
+  // project, since `initialProjectPath` falls back to the selected task's
+  // workdir, so the [projectPath, kind] reset above never fires — with the
+  // previous task's seeded composer and, worse, its `pullPrefillTaskId` still
+  // armed: a manual "New PR" would then stamp an unrelated PR's URL onto that
+  // task. The issue-composer fields are cleared here too (previously only the
+  // pull composer was — issue-composer state used to leak across opens).
+  // Detail/panel views are deliberately left untouched — they already survive
+  // close/reopen, and that's unrelated to this cleanup.
   useEffect(() => {
     if (open) return;
-    setPullComposerOpen(false);
+    setView((cur) => (cur.kind === "compose" ? backToList() : cur));
+    setNewIssueTitle("");
+    setNewIssueBody("");
+    setNewIssueLabels("");
+    setNewIssueAssignees("");
+    setNewIssueMilestone("");
+    setNewIssueSubmitting(false);
+    setNewIssueError(null);
     setNewPullTitle("");
     setNewPullBody("");
     setNewPullHead("");
@@ -2643,7 +2657,9 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
         milestone,
       });
       upsertListItem(result.item, true);
-      setIssueComposerOpen(false);
+      // Land on the created issue's detail subpage rather than just closing
+      // back to the list — mirrors clicking the row you just made.
+      setView(openDetail(result.item));
       setNewIssueTitle("");
       setNewIssueBody("");
       setNewIssueLabels("");
@@ -2691,7 +2707,9 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
         taskId: pullPrefillTaskId ?? undefined,
       });
       upsertListItem(result.item, true);
-      setPullComposerOpen(false);
+      // Land on the created pull's detail subpage rather than just closing
+      // back to the list — mirrors clicking the row you just made.
+      setView(openDetail(result.item));
       setNewPullTitle("");
       setNewPullBody("");
       setNewPullReviewers("");
@@ -2817,11 +2835,12 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     }
   };
 
-  // Detail and panel are distinct, mutually-exclusive members of the
-  // `GitHubDialogView` union, so no defensive "is anything else open" check
-  // is needed — opening either just replaces `view`.
+  // Detail, panel, and compose are distinct, mutually-exclusive members of
+  // the `GitHubDialogView` union, so no defensive "is anything else open"
+  // check is needed — opening any of them just replaces `view`.
   const showDetail = view.kind === "detail";
   const isPanelView = view.kind === "panel";
+  const isComposeView = view.kind === "compose";
 
   const openItemDetail = (item: GitHubListItem) => {
     setView(openDetail(item));
@@ -2888,6 +2907,26 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
               </div>
             </div>
           </div>
+        ) : isComposeView ? (
+          <div className="flex min-w-0 items-center gap-2">
+            <Button
+              size="icon"
+              variant="ghost"
+              aria-label="Back"
+              title="Back to list"
+              onClick={closeDetail}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+            <div className="min-w-0">
+              <div id="github-dialog-title" className="text-sm font-semibold">
+                {kind === "pulls" ? `New ${caps.pullNoun.toLowerCase()}` : "New issue"}
+              </div>
+              <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                {result ? result.repo : caps.providerName}
+              </div>
+            </div>
+          </div>
         ) : (
           <div className="min-w-0">
             <div id="github-dialog-title" className="flex items-center gap-2 text-sm font-semibold">
@@ -2923,7 +2962,11 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
               <ExternalLink className="size-4" />
             </Button>
           )}
-          {!showDetail && (
+          {/* Repo-level toolbar (manager panel toggles + "open repository")
+              stays up while browsing the list or a manager panel (the toggles
+              are how panels switch and toggle off) — hidden on the detail and
+              compose subpages, which have their own back-chevron header. */}
+          {!showDetail && !isComposeView && (
           <>
           {panelsEnabled && caps.labels && (
             <Button
@@ -3035,7 +3078,10 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
         </div>
       </header>
 
-      {!showDetail && (
+      {/* Filter bar serves the item list, which stays visible below an open
+          manager panel — hidden only on the detail and compose subpages,
+          which replace the list entirely. */}
+      {!showDetail && !isComposeView && (
       <div className="grid gap-2 border-b border-border/60 p-3 md:grid-cols-[minmax(0,1.2fr)_auto_auto]">
         <Select
           value={projectPath}
@@ -3368,6 +3414,54 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
               setCommitsErrors((cur) => ({ ...cur, [itemKey(expandedItem)]: undefined }));
             }}
           />
+        ) : isComposeView ? (
+          // Compose is its own dedicated subpage — render only the composer,
+          // never the manager panels or the item list underneath it. Which
+          // composer shows follows the dialog's existing pulls/issues `kind`
+          // state, exactly like the list body below does.
+          kind === "pulls" ? (
+            <PullComposer
+              caps={caps}
+              title={newPullTitle}
+              body={newPullBody}
+              head={newPullHead}
+              base={newPullBase}
+              reviewers={newPullReviewers}
+              draft={newPullDraft}
+              submitting={newPullSubmitting}
+              error={newPullError}
+              pushing={newPullPushing}
+              pushError={newPullPushError}
+              pushMessage={newPullPushMessage}
+              onTitleChange={setNewPullTitle}
+              onBodyChange={setNewPullBody}
+              onHeadChange={setNewPullHead}
+              onBaseChange={setNewPullBase}
+              onReviewersChange={setNewPullReviewers}
+              onDraftChange={setNewPullDraft}
+              onPushHead={() => { void pushHead(); }}
+              onCancel={() => setView(backToList())}
+              onSubmit={() => { void createPull(); }}
+            />
+          ) : (
+            <IssueComposer
+              caps={caps}
+              title={newIssueTitle}
+              body={newIssueBody}
+              labels={newIssueLabels}
+              assignees={newIssueAssignees}
+              milestone={newIssueMilestone}
+              submitting={newIssueSubmitting}
+              error={newIssueError}
+              onTitleChange={setNewIssueTitle}
+              onBodyChange={setNewIssueBody}
+              onLabelsChange={setNewIssueLabels}
+              onAssigneesChange={setNewIssueAssignees}
+              onMilestoneChange={setNewIssueMilestone}
+              onCancel={() => setView(backToList())}
+              onSubmit={() => { void createIssue(); }}
+            />
+          )
         ) : (
         <>
         {labelManagerOpen && (
@@ -3519,52 +3613,25 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
             onClose={() => setView(backToList())}
           />
         )}
+        {/* Trigger buttons for the compose subpage (moved out of the composer
+            components themselves — those now always render in "open" form,
+            only ever mounted on the compose page). */}
         {kind === "pulls" && !isAggregate && (
-          <PullComposer
-            caps={caps}
-            open={pullComposerOpen}
-            title={newPullTitle}
-            body={newPullBody}
-            head={newPullHead}
-            base={newPullBase}
-            reviewers={newPullReviewers}
-            draft={newPullDraft}
-            submitting={newPullSubmitting}
-            error={newPullError}
-            pushing={newPullPushing}
-            pushError={newPullPushError}
-            pushMessage={newPullPushMessage}
-            onOpenChange={setPullComposerOpen}
-            onTitleChange={setNewPullTitle}
-            onBodyChange={setNewPullBody}
-            onHeadChange={setNewPullHead}
-            onBaseChange={setNewPullBase}
-            onReviewersChange={setNewPullReviewers}
-            onDraftChange={setNewPullDraft}
-            onPushHead={() => { void pushHead(); }}
-            onSubmit={() => { void createPull(); }}
-          />
+          <div className="mb-3 flex justify-end">
+            <Button size="sm" onClick={() => setView(openCompose())}>
+              <Plus className="mr-2 size-3.5" />
+              New {caps.pullAbbrev}
+            </Button>
+          </div>
         )}
 
         {kind === "issues" && !isAggregate && (
-          <IssueComposer
-            caps={caps}
-            open={issueComposerOpen}
-            title={newIssueTitle}
-            body={newIssueBody}
-            labels={newIssueLabels}
-            assignees={newIssueAssignees}
-            milestone={newIssueMilestone}
-            submitting={newIssueSubmitting}
-            error={newIssueError}
-            onOpenChange={setIssueComposerOpen}
-            onTitleChange={setNewIssueTitle}
-            onBodyChange={setNewIssueBody}
-            onLabelsChange={setNewIssueLabels}
-            onAssigneesChange={setNewIssueAssignees}
-            onMilestoneChange={setNewIssueMilestone}
-            onSubmit={() => { void createIssue(); }}
-          />
+          <div className="mb-3 flex justify-end">
+            <Button size="sm" onClick={() => setView(openCompose())}>
+              <Plus className="mr-2 size-3.5" />
+              New issue
+            </Button>
+          </div>
         )}
 
         {transferNotice && (
@@ -3643,9 +3710,12 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   );
 }
 
+// Always rendered in "open" form — only ever mounted on the compose subpage
+// (see the `isComposeView` branch above). The "New <pull>" trigger that used
+// to gate this component closed lives in the list view instead, since
+// opening now navigates to a dedicated page rather than toggling local state.
 function PullComposer({
   caps,
-  open,
   title,
   body,
   head,
@@ -3657,7 +3727,6 @@ function PullComposer({
   pushing,
   pushError,
   pushMessage,
-  onOpenChange,
   onTitleChange,
   onBodyChange,
   onHeadChange,
@@ -3665,10 +3734,10 @@ function PullComposer({
   onReviewersChange,
   onDraftChange,
   onPushHead,
+  onCancel,
   onSubmit,
 }: {
   caps: ProviderCaps;
-  open: boolean;
   title: string;
   body: string;
   head: string;
@@ -3680,7 +3749,6 @@ function PullComposer({
   pushing: boolean;
   pushError: string | null;
   pushMessage: string | null;
-  onOpenChange: (open: boolean) => void;
   onTitleChange: (title: string) => void;
   onBodyChange: (body: string) => void;
   onHeadChange: (head: string) => void;
@@ -3688,19 +3756,9 @@ function PullComposer({
   onReviewersChange: (reviewers: string) => void;
   onDraftChange: (draft: boolean) => void;
   onPushHead: () => void;
+  onCancel: () => void;
   onSubmit: () => void;
 }) {
-  if (!open) {
-    return (
-      <div className="mb-3 flex justify-end">
-        <Button size="sm" onClick={() => onOpenChange(true)}>
-          <Plus className="mr-2 size-3.5" />
-          New {caps.pullAbbrev}
-        </Button>
-      </div>
-    );
-  }
-
   return (
     <div className="mb-3 rounded-md border border-border/60 bg-card p-3">
       <div className="mb-2 flex items-center justify-between gap-2">
@@ -3792,7 +3850,7 @@ function PullComposer({
           Draft
         </label>
         <div className="flex justify-end gap-2">
-          <Button size="sm" variant="ghost" disabled={submitting} onClick={() => onOpenChange(false)}>
+          <Button size="sm" variant="ghost" disabled={submitting} onClick={onCancel}>
             Cancel
           </Button>
           <Button size="sm" disabled={submitting || !title.trim() || !head.trim() || !base.trim()} onClick={onSubmit}>
@@ -3805,9 +3863,12 @@ function PullComposer({
   );
 }
 
+// Always rendered in "open" form — only ever mounted on the compose subpage
+// (see the `isComposeView` branch above). The "New issue" trigger that used
+// to gate this component closed lives in the list view instead, since
+// opening now navigates to a dedicated page rather than toggling local state.
 function IssueComposer({
   caps,
-  open,
   title,
   body,
   labels,
@@ -3815,16 +3876,15 @@ function IssueComposer({
   milestone,
   submitting,
   error,
-  onOpenChange,
   onTitleChange,
   onBodyChange,
   onLabelsChange,
   onAssigneesChange,
   onMilestoneChange,
+  onCancel,
   onSubmit,
 }: {
   caps: ProviderCaps;
-  open: boolean;
   title: string;
   body: string;
   labels: string;
@@ -3832,25 +3892,14 @@ function IssueComposer({
   milestone: string;
   submitting: boolean;
   error: string | null;
-  onOpenChange: (open: boolean) => void;
   onTitleChange: (title: string) => void;
   onBodyChange: (body: string) => void;
   onLabelsChange: (labels: string) => void;
   onAssigneesChange: (assignees: string) => void;
   onMilestoneChange: (milestone: string) => void;
+  onCancel: () => void;
   onSubmit: () => void;
 }) {
-  if (!open) {
-    return (
-      <div className="mb-3 flex justify-end">
-        <Button size="sm" onClick={() => onOpenChange(true)}>
-          <Plus className="mr-2 size-3.5" />
-          New issue
-        </Button>
-      </div>
-    );
-  }
-
   return (
     <div className="mb-3 rounded-md border border-border/60 bg-card p-3">
       <div className="mb-2 flex items-center justify-between gap-2">
@@ -3909,7 +3958,7 @@ function IssueComposer({
         </div>
       </div>
       <div className="mt-3 flex justify-end gap-2">
-        <Button size="sm" variant="ghost" disabled={submitting} onClick={() => onOpenChange(false)}>
+        <Button size="sm" variant="ghost" disabled={submitting} onClick={onCancel}>
           Cancel
         </Button>
         <Button size="sm" disabled={submitting || !title.trim()} onClick={onSubmit}>

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { toast } from "sonner";
 import {
   AlertCircle,
   ArrowDownWideNarrow,
@@ -122,6 +123,18 @@ export interface GitHubPullPrefill {
   taskId: string;
 }
 
+/** One-shot prefill for the PR detail subpage (T4, "View PR" from a task's
+ *  run panel): selects the given project, switches to the pulls tab, fetches
+ *  the single PR by number, and navigates straight to `openDetail(item)` —
+ *  landing on the same in-app detail subpage a list click would, instead of
+ *  shelling out to the browser. `prUrl` is kept alongside so a fetch failure
+ *  can still fall back to the plain external link. */
+export interface GitHubPullDetailPrefill {
+  projectPath: string;
+  number: number;
+  prUrl: string;
+}
+
 interface Props {
   open: boolean;
   projects: Project[];
@@ -131,6 +144,10 @@ interface Props {
    *  single effect can't do this safely against the composer's own
    *  reset-on-project/kind-change effect. */
   pullPrefill?: GitHubPullPrefill | null;
+  /** Same one-shot-by-reference contract as `pullPrefill` above, mirrored
+   *  with its own ref pair — see the two-part effect pair around
+   *  `pendingPullDetailPrefillRef` below. */
+  pullDetailPrefill?: GitHubPullDetailPrefill | null;
   onClose: () => void;
 }
 
@@ -427,7 +444,7 @@ function RateLimitBadge({ rateLimit }: { rateLimit: GitHubRateLimit }) {
   );
 }
 
-export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, onClose }: Props) {
+export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, pullDetailPrefill, onClose }: Props) {
   const [projectPath, setProjectPath] = useState("");
   // "All repositories" (G8/F15) — see AGGREGATE_PROJECT_PATH.
   const isAggregate = projectPath === AGGREGATE_PROJECT_PATH;
@@ -666,6 +683,10 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   // Holds a prefill that part 1 (below) has pointed project/kind at but part
   // 2 (after the composer-reset effect) hasn't applied yet.
   const pendingPullPrefillRef = useRef<GitHubPullPrefill | null>(null);
+  // Same one-shot-by-reference bookkeeping as the pair above, for the PR
+  // detail subpage prefill instead of the New-PR composer prefill.
+  const lastPullDetailPrefillRef = useRef<GitHubPullDetailPrefill | null>(null);
+  const pendingPullDetailPrefillRef = useRef<GitHubPullDetailPrefill | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -689,6 +710,19 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     setProjectPath(pullPrefill.projectPath);
     setKind("pulls");
   }, [open, pullPrefill]);
+
+  // PR-detail prefill consumption, part 1 of 2 — same shape as the New-PR
+  // prefill's part 1 above: point project + kind at the target PR, but leave
+  // the actual fetch-and-navigate to part 2 (declared after the composer-
+  // reset effect) so a project switch has already landed.
+  useEffect(() => {
+    if (!open || !pullDetailPrefill) return;
+    if (lastPullDetailPrefillRef.current === pullDetailPrefill) return;
+    lastPullDetailPrefillRef.current = pullDetailPrefill;
+    pendingPullDetailPrefillRef.current = pullDetailPrefill;
+    setProjectPath(pullDetailPrefill.projectPath);
+    setKind("pulls");
+  }, [open, pullDetailPrefill]);
 
   // Stable signal of the aggregate candidate set (G8): the joined project paths
   // when "All repositories" is selected, "" otherwise. Threaded into the reload
@@ -980,6 +1014,41 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     pendingPullPrefillRef.current = null;
   }, [open, projectPath, kind, pullPrefill]);
 
+  // PR-detail prefill consumption, part 2 of 2 — declared after the reset
+  // effect for the same reason as the New-PR prefill's part 2: the reset
+  // effect's `[projectPath, kind]` deps fire in the same pass as part 1's
+  // `setProjectPath`/`setKind`, and declaration order makes reset run first,
+  // so by the time this runs the list body wouldn't have been popped back
+  // over whatever we're about to set here. Fetches the single PR by number
+  // and navigates to its detail subpage; guards against a stale in-flight
+  // fetch (dialog closed/reopened, or these deps re-firing for another
+  // reason) via the effect's own `cancelled` cleanup flag, same pattern as
+  // any other fetch-in-effect. Falls back to the plain external link on any
+  // failure — including a well-formed `{ ok: false }` body, in case a future
+  // server change starts returning one instead of a non-2xx status.
+  useEffect(() => {
+    if (!open) return;
+    const pending = pendingPullDetailPrefillRef.current;
+    if (!pending || projectPath !== pending.projectPath || kind !== "pulls") return;
+    pendingPullDetailPrefillRef.current = null;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const result = await api.getGitHubPullDetail(pending.projectPath, pending.number);
+        if (cancelled) return;
+        if (!result?.ok || !result.item) throw new Error("Pull request not found");
+        setView(openDetail(result.item));
+      } catch (err) {
+        if (cancelled) return;
+        toast.error(err instanceof Error ? err.message : "Could not load the pull request");
+        void api.openExternal(pending.prUrl);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, projectPath, kind, pullDetailPrefill]);
+
   // Close wipes both composers' field state + prefill bookkeeping, and pops an
   // active compose page back to the list. Without the pull-composer half of
   // this, the dialog (which stays mounted) reopens later — often on the SAME
@@ -1008,6 +1077,8 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     setPullPrefillTaskId(null);
     pendingPullPrefillRef.current = null;
     lastPullPrefillRef.current = null;
+    pendingPullDetailPrefillRef.current = null;
+    lastPullDetailPrefillRef.current = null;
   }, [open]);
 
   const availableLabels = useMemo(() => {

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
@@ -179,6 +179,18 @@ function sameItem(
   b: Pick<GitHubListItem, "kind" | "number" | "sourcePath">,
 ): boolean {
   return a.kind === b.kind && a.number === b.number && (a.sourcePath ?? null) === (b.sourcePath ?? null);
+}
+
+/** Normalizes a PR URL for the detail-prefill mismatch check (strips a query
+ *  string/fragment and any trailing slash) so e.g.
+ *  `https://github.com/a/b/pull/12?diff=split` and
+ *  `https://github.com/a/b/pull/12/` compare equal to
+ *  `https://github.com/a/b/pull/12`. A plain string compare of the
+ *  normalized forms is enough — this only needs to catch "the fetch returned
+ *  an unrelated PR," not validate URL well-formedness, so host casing etc.
+ *  is deliberately left alone. */
+function normalizePrUrl(url: string): string {
+  return (url.split(/[?#]/)[0] ?? "").replace(/\/+$/, "");
 }
 
 const fmtDate = (value: string) => {
@@ -570,6 +582,14 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   // itemKey (G8) so two same-numbered PRs across repos don't share a retry budget.
   const mergeabilityRetries = useRef<Record<string, number>>({});
   const [view, setView] = useState<GitHubDialogView>({ kind: "list" });
+  // Mirrors `view` for the async prefill effect below, which needs to check
+  // "has the user navigated away from the list?" from inside a promise
+  // continuation — a plain closure over `view` would see the value from the
+  // render that started the fetch, not the current one. Kept in sync by
+  // inline assignment on every render rather than an effect, since an effect
+  // would only update it a tick after the render already committed.
+  const viewRef = useRef(view);
+  viewRef.current = view;
   // Derived rather than independent booleans — the 7 manager panels are
   // mutually exclusive with each other and with the detail subpage by
   // construction of the `GitHubDialogView` union, so there's no "close the
@@ -687,6 +707,37 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   // detail subpage prefill instead of the New-PR composer prefill.
   const lastPullDetailPrefillRef = useRef<GitHubPullDetailPrefill | null>(null);
   const pendingPullDetailPrefillRef = useRef<GitHubPullDetailPrefill | null>(null);
+
+  // Wipes every pull + issue composer field, including the prefill task-id
+  // tag — the single source of truth for "reset the composers" so the
+  // project/kind-change effect, the close-reset effect, both create-success
+  // paths, and every compose-exit path (Cancel, Escape, back-chevron) can't
+  // drift out of sync with each other again. Deliberately leaves `view` and
+  // the prefill one-shot refs alone — callers differ on whether those need
+  // touching (e.g. the close-reset also clears the refs; a plain compose
+  // exit does not), so they handle it themselves. Stable identity via
+  // `useCallback` since it closes over nothing but setters.
+  const resetComposers = useCallback(() => {
+    setNewIssueTitle("");
+    setNewIssueBody("");
+    setNewIssueLabels("");
+    setNewIssueAssignees("");
+    setNewIssueMilestone("");
+    setNewIssueSubmitting(false);
+    setNewIssueError(null);
+    setNewPullTitle("");
+    setNewPullBody("");
+    setNewPullHead("");
+    setNewPullBase("");
+    setNewPullReviewers("");
+    setNewPullDraft(false);
+    setNewPullSubmitting(false);
+    setNewPullError(null);
+    setNewPullPushing(false);
+    setNewPullPushError(null);
+    setNewPullPushMessage(null);
+    setPullPrefillTaskId(null);
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -974,26 +1025,8 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     // synthetic aggregate value) from ever showing the compose page: a
     // project switch into aggregate fires this same effect.
     setView((cur) => (cur.kind === "compose" ? backToList() : cur));
-    setNewIssueTitle("");
-    setNewIssueBody("");
-    setNewIssueLabels("");
-    setNewIssueAssignees("");
-    setNewIssueMilestone("");
-    setNewIssueSubmitting(false);
-    setNewIssueError(null);
-    setNewPullTitle("");
-    setNewPullBody("");
-    setNewPullHead("");
-    setNewPullBase("");
-    setNewPullReviewers("");
-    setNewPullDraft(false);
-    setNewPullSubmitting(false);
-    setNewPullError(null);
-    setNewPullPushing(false);
-    setNewPullPushError(null);
-    setNewPullPushMessage(null);
-    setPullPrefillTaskId(null);
-  }, [projectPath, kind]);
+    resetComposers();
+  }, [projectPath, kind, resetComposers]);
 
   // Prefill consumption, part 2 of 2: declared *after* the reset effect above
   // and sharing its [projectPath, kind] deps, so in the render where part 1
@@ -1023,9 +1056,15 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   // and navigates to its detail subpage; guards against a stale in-flight
   // fetch (dialog closed/reopened, or these deps re-firing for another
   // reason) via the effect's own `cancelled` cleanup flag, same pattern as
-  // any other fetch-in-effect. Falls back to the plain external link on any
+  // any other fetch-in-effect, AND against the user having already navigated
+  // away from the list while the fetch was in flight (`viewRef` — a plain
+  // closure over `view` would only see the value from the render that
+  // started the fetch). Falls back to the plain external link on any
   // failure — including a well-formed `{ ok: false }` body, in case a future
-  // server change starts returning one instead of a non-2xx status.
+  // server change starts returning one instead of a non-2xx status, and
+  // including a fetched item whose URL doesn't match the prefill's `prUrl`
+  // (item numbers are per-repo, so a project-path mismatch upstream could
+  // otherwise land the user on an unrelated repo's PR #N).
   useEffect(() => {
     if (!open) return;
     const pending = pendingPullDetailPrefillRef.current;
@@ -1035,13 +1074,18 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     void (async () => {
       try {
         const result = await api.getGitHubPullDetail(pending.projectPath, pending.number);
-        if (cancelled) return;
+        if (cancelled || viewRef.current.kind !== "list") return;
         if (!result?.ok || !result.item) throw new Error("Pull request not found");
+        if (normalizePrUrl(result.item.htmlUrl) !== normalizePrUrl(pending.prUrl)) {
+          throw new Error("That pull request URL points at a different repository — opening in browser.");
+        }
         setView(openDetail(result.item));
       } catch (err) {
-        if (cancelled) return;
+        if (cancelled || viewRef.current.kind !== "list") return;
         toast.error(err instanceof Error ? err.message : "Could not load the pull request");
-        void api.openExternal(pending.prUrl);
+        void api.openExternal(pending.prUrl).catch((e: unknown) => {
+          toast.error(e instanceof Error ? e.message : "Could not open the browser");
+        });
       }
     })();
     return () => {
@@ -1063,23 +1107,12 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   useEffect(() => {
     if (open) return;
     setView((cur) => (cur.kind === "compose" ? backToList() : cur));
-    setNewIssueTitle("");
-    setNewIssueBody("");
-    setNewIssueLabels("");
-    setNewIssueAssignees("");
-    setNewIssueMilestone("");
-    setNewIssueSubmitting(false);
-    setNewIssueError(null);
-    setNewPullTitle("");
-    setNewPullBody("");
-    setNewPullHead("");
-    setNewPullBase("");
-    setPullPrefillTaskId(null);
+    resetComposers();
     pendingPullPrefillRef.current = null;
     lastPullPrefillRef.current = null;
     pendingPullDetailPrefillRef.current = null;
     lastPullDetailPrefillRef.current = null;
-  }, [open]);
+  }, [open, resetComposers]);
 
   const availableLabels = useMemo(() => {
     // Prefer the full repo-label list; fall back to labels seen on loaded items
@@ -2731,11 +2764,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
       // Land on the created issue's detail subpage rather than just closing
       // back to the list — mirrors clicking the row you just made.
       setView(openDetail(result.item));
-      setNewIssueTitle("");
-      setNewIssueBody("");
-      setNewIssueLabels("");
-      setNewIssueAssignees("");
-      setNewIssueMilestone("");
+      resetComposers();
     } catch (e) {
       setNewIssueError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -2781,12 +2810,11 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
       // Land on the created pull's detail subpage rather than just closing
       // back to the list — mirrors clicking the row you just made.
       setView(openDetail(result.item));
-      setNewPullTitle("");
-      setNewPullBody("");
-      setNewPullReviewers("");
-      setNewPullDraft(false);
-      setPullPrefillTaskId(null);
-      setActionMessages((cur) => ({ ...cur, [result.item.number]: result.message ?? "Pull request created." }));
+      resetComposers();
+      // Keyed by itemKey (not the bare number) to match every other
+      // actionMessages writer/reader — a bare-number key would silently miss
+      // in aggregate mode where two repos can share PR #N.
+      setActionMessages((cur) => ({ ...cur, [itemKey(result.item)]: result.message ?? "Pull request created." }));
     } catch (e) {
       setNewPullError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -2917,13 +2945,26 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     setView(openDetail(item));
   };
   const closeDetail = () => setView(backToList());
+  // Every path that can leave the compose subpage without submitting
+  // (Cancel, Escape/backdrop, the header back-chevron) must route through
+  // this instead of the plain `closeDetail` above — otherwise
+  // `pullPrefillTaskId` stays armed and a later manual "New PR" in the same
+  // dialog session stamps an unrelated PR's URL onto the prefilled task.
+  const exitCompose = () => {
+    setView(backToList());
+    resetComposers();
+  };
 
   return (
     <Dialog
       open={open}
       onClose={() => {
         if (resolveEscape(view) === "pop") {
-          closeDetail();
+          if (view.kind === "compose") {
+            exitCompose();
+          } else {
+            closeDetail();
+          }
           return;
         }
         onClose();
@@ -2985,13 +3026,17 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
               variant="ghost"
               aria-label="Back"
               title="Back to list"
-              onClick={closeDetail}
+              onClick={exitCompose}
             >
               <ChevronLeft className="size-4" />
             </Button>
             <div className="min-w-0">
+              {/* Same label source as the list's "New <abbrev>" trigger button
+                  below (`caps.pullAbbrev`) rather than `caps.pullNoun`, so the
+                  trigger and this header can never drift to different nouns
+                  for the same provider. */}
               <div id="github-dialog-title" className="text-sm font-semibold">
-                {kind === "pulls" ? `New ${caps.pullNoun.toLowerCase()}` : "New issue"}
+                {kind === "pulls" ? `New ${caps.pullAbbrev}` : "New issue"}
               </div>
               <div className="mt-0.5 truncate text-xs text-muted-foreground">
                 {result ? result.repo : caps.providerName}
@@ -3136,6 +3181,10 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
           )}
           </>
           )}
+          {/* Reloads the (hidden) list, so it has no business staying live on
+              the compose subpage — unlike the toggles above it stays visible
+              on the detail subpage, where a refresh is still meaningful. */}
+          {!isComposeView && (
           <Button
             size="icon"
             variant="ghost"
@@ -3146,6 +3195,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
           >
             {loading ? <Loader2 className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
           </Button>
+          )}
         </div>
       </header>
 
@@ -3511,7 +3561,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
               onReviewersChange={setNewPullReviewers}
               onDraftChange={setNewPullDraft}
               onPushHead={() => { void pushHead(); }}
-              onCancel={() => setView(backToList())}
+              onCancel={exitCompose}
               onSubmit={() => { void createPull(); }}
             />
           ) : (
@@ -3529,7 +3579,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
               onLabelsChange={setNewIssueLabels}
               onAssigneesChange={setNewIssueAssignees}
               onMilestoneChange={setNewIssueMilestone}
-              onCancel={() => setView(backToList())}
+              onCancel={exitCompose}
               onSubmit={() => { void createIssue(); }}
             />
           )

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -12,6 +12,7 @@ import { shouldShowSubagentTabs, resolveActiveStream, splitTabsForOverflow, sort
 import { shouldOfferCommitPush, shouldOfferOpenPr, type TaskGitStatus } from "@/lib/commit-push";
 import { findMatchingEventIds, resolveActiveMatchIndex, stepMatchIndex } from "@/lib/event-search";
 import { latestPrProposal } from "@/lib/pr-proposal";
+import { parsePullNumber } from "@/lib/pr-url";
 import type { GitHubPullPrefill } from "./GitHubDialog";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -117,6 +118,10 @@ interface Props {
    *  "Open PR" chip below. Owned by App so the dialog stays a single
    *  App-level singleton instead of one instance per task panel. */
   onOpenPullRequest: (prefill: GitHubPullPrefill) => void;
+  /** Open GitHubDialog directly on the PR detail subpage for this task's
+   *  `prUrl` — see the header "View PR" affordance below. Same App-level-
+   *  singleton ownership rationale as `onOpenPullRequest`. */
+  onViewPullRequest: (input: { projectPath: string; prUrl: string }) => void;
 }
 
 const STATUS_VARIANT: Record<Run["status"], "default" | "secondary" | "outline" | "destructive"> = {
@@ -169,7 +174,7 @@ function formatTime(ts: number): string {
  * the kanban behind it stays visible but de-emphasized. The panel keeps the
  * last task mounted during the exit animation so the slide-out doesn't snap.
  */
-export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClose, onShowDiff, onArchive, onUnarchive, onOpenPullRequest }: Props) {
+export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClose, onShowDiff, onArchive, onUnarchive, onOpenPullRequest, onViewPullRequest }: Props) {
   // `mountedTask` lags behind `task` so that when the parent sets task → null
   // we keep rendering the old contents while the exit animation plays.
   const [mountedTask, setMountedTask] = useState<Task | null>(task);
@@ -259,6 +264,7 @@ export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClos
           onArchive={onArchive}
           onUnarchive={onUnarchive}
           onOpenPullRequest={onOpenPullRequest}
+          onViewPullRequest={onViewPullRequest}
         />
       </aside>
     </>
@@ -281,6 +287,7 @@ function RunPanelBody({
   onArchive,
   onUnarchive,
   onOpenPullRequest,
+  onViewPullRequest,
 }: {
   task: Task;
   agents: AgentStatus[];
@@ -297,6 +304,7 @@ function RunPanelBody({
   onArchive: (t: Task) => void;
   onUnarchive: (t: Task) => void;
   onOpenPullRequest: (prefill: GitHubPullPrefill) => void;
+  onViewPullRequest: (input: { projectPath: string; prUrl: string }) => void;
 }) {
   const archived = task.archivedAt != null;
   const kind = harnessKindOf(task.agent, harnesses);
@@ -1990,6 +1998,12 @@ function RunPanelBody({
     applySendCaptured(result.items);
   };
 
+  // Captured as a local const (not read via `task.prUrl` inline) so its
+  // narrowing to non-null survives into the onClick closure below — TS
+  // drops narrowing on a mutable property access once it's referenced
+  // inside a nested function expression.
+  const prUrl = task.prUrl;
+
   return (
     <>
       <header className="flex items-start justify-between gap-2 border-b border-border/60 p-3">
@@ -2007,15 +2021,28 @@ function RunPanelBody({
           {/* Lives in the header (not the composer chip row) so the link stays
               reachable on archived tasks and after orphan reconciliation
               clears the resumable run — pr_url is durable, the link must be
-              too. */}
-          {task.prUrl && (
-            <ExternalLink
-              href={task.prUrl}
-              className={cn(buttonVariants({ variant: "outline", size: "sm" }), "no-underline hover:no-underline")}
-              title="Open the pull request created for this task"
-            >
-              <GitPullRequest className="mr-1 size-3" /> View PR
-            </ExternalLink>
+              too. When the URL parses to a PR number, open the in-app detail
+              subpage directly; otherwise (an unrecognized provider URL
+              shape) fall back to the plain external link, as before. */}
+          {prUrl && (
+            parsePullNumber(prUrl) != null ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => onViewPullRequest({ projectPath: task.workdir, prUrl })}
+                title="Open the pull request created for this task"
+              >
+                <GitPullRequest className="mr-1 size-3" /> View PR
+              </Button>
+            ) : (
+              <ExternalLink
+                href={prUrl}
+                className={cn(buttonVariants({ variant: "outline", size: "sm" }), "no-underline hover:no-underline")}
+                title="Open the pull request created for this task"
+              >
+                <GitPullRequest className="mr-1 size-3" /> View PR
+              </ExternalLink>
+            )
           )}
           <Button
             size="sm"

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -27,6 +27,7 @@ import type {
   GitHubRepoMilestone,
   GitHubLinkedIssue,
   GitHubLinkedIssuesResult,
+  GitHubListItem,
   GitHubListResult,
   GitHubNotification,
   GitHubNotificationsResult,
@@ -116,6 +117,7 @@ export type {
   GitHubRepoMilestone,
   GitHubLinkedIssue,
   GitHubLinkedIssuesResult,
+  GitHubListItem,
   GitHubListResult,
   GitHubNotification,
   GitHubNotificationsResult,
@@ -506,6 +508,10 @@ export const api = {
       number: String(input.number),
     });
     return j<TaskDiff>(`/github/pull-diff?${q.toString()}`);
+  },
+  getGitHubPullDetail: (path: string, number: number) => {
+    const q = new URLSearchParams({ path, number: String(number) });
+    return j<{ ok: true; item: GitHubListItem }>(`/github/pull-detail?${q.toString()}`);
   },
   getGitHubPullChecks: (input: { path: string; number: number }) => {
     const q = new URLSearchParams({

--- a/src/mainview/lib/github-dialog-view.test.ts
+++ b/src/mainview/lib/github-dialog-view.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   backToList,
+  openCompose,
   openDetail,
   openPanel,
   resolveEscape,
@@ -59,6 +60,18 @@ test("backToList returns the list view", () => {
   expect(backToList()).toEqual({ kind: "list" });
 });
 
+test("backToList returns the list view from a compose view", () => {
+  const view = openCompose();
+  expect(view).toEqual({ kind: "compose" });
+  expect(backToList()).toEqual({ kind: "list" });
+});
+
+describe("openCompose", () => {
+  test("opens the compose view", () => {
+    expect(openCompose()).toEqual({ kind: "compose" });
+  });
+});
+
 describe("openPanel", () => {
   for (const panel of PANEL_KINDS) {
     test(`opens the ${panel} panel`, () => {
@@ -86,6 +99,11 @@ describe("togglePanel", () => {
     const view = openDetail(item({ kind: "pulls", number: 3 }));
     expect(togglePanel(view, "actions")).toEqual({ kind: "panel", panel: "actions" });
   });
+
+  test("from a compose view, opens the requested panel (current implementation replaces compose; it does not restore the underlying list/compose on toggle-off)", () => {
+    const view = openCompose();
+    expect(togglePanel(view, "actions")).toEqual({ kind: "panel", panel: "actions" });
+  });
 });
 
 describe("resolveEscape", () => {
@@ -99,5 +117,9 @@ describe("resolveEscape", () => {
 
   test("pops to the list from a panel view", () => {
     expect(resolveEscape(openPanel("discussions"))).toBe("pop");
+  });
+
+  test("pops to the list from a compose view", () => {
+    expect(resolveEscape(openCompose())).toBe("pop");
   });
 });

--- a/src/mainview/lib/github-dialog-view.ts
+++ b/src/mainview/lib/github-dialog-view.ts
@@ -21,12 +21,16 @@ export type GitHubPanelKind =
  * PR/issue browser, "detail" is the full-panel subpage for a single item
  * (replaces the old inline accordion expansion), "panel" is one of the 7
  * manager panels (labels, milestones, releases, notifications, actions,
- * projects, discussions).
+ * projects, discussions), "compose" is the New-PR / New-issue subpage
+ * (replaces the old inline composer accordion) — no payload, since which
+ * composer renders follows the dialog's existing pulls/issues `kind` state,
+ * exactly like the list body already does.
  */
 export type GitHubDialogView =
   | { kind: "list" }
   | { kind: "detail"; item: GitHubListItem }
-  | { kind: "panel"; panel: GitHubPanelKind };
+  | { kind: "panel"; panel: GitHubPanelKind }
+  | { kind: "compose" };
 
 /** Navigate to the detail subpage for `item`. */
 export function openDetail(item: GitHubListItem): GitHubDialogView {
@@ -36,6 +40,11 @@ export function openDetail(item: GitHubListItem): GitHubDialogView {
 /** Navigate to a manager panel. */
 export function openPanel(panel: GitHubPanelKind): GitHubDialogView {
   return { kind: "panel", panel };
+}
+
+/** Navigate to the New-PR / New-issue compose subpage. */
+export function openCompose(): GitHubDialogView {
+  return { kind: "compose" };
 }
 
 /** Navigate back to the list view. */
@@ -56,8 +65,8 @@ export function togglePanel(view: GitHubDialogView, panel: GitHubPanelKind): Git
 /**
  * Resolve what Escape (or a backdrop click) should do given the current view:
  * pop the subpage back to the list, or close the modal outright. Only the
- * list view closes the modal — any other view (detail or panel) pops to the
- * list first.
+ * list view closes the modal — any other view (detail, panel, or compose)
+ * pops to the list first.
  */
 export function resolveEscape(view: GitHubDialogView): "pop" | "close" {
   return view.kind === "list" ? "close" : "pop";

--- a/src/mainview/lib/pr-url.test.ts
+++ b/src/mainview/lib/pr-url.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { parsePullNumber } from "./pr-url.ts";
+
+describe("parsePullNumber — GitHub", () => {
+  test("parses a plain GitHub pull URL", () => {
+    expect(parsePullNumber("https://github.com/o/r/pull/12")).toBe(12);
+  });
+
+  test("tolerates an extra tail segment (.../pull/12/files)", () => {
+    expect(parsePullNumber("https://github.com/o/r/pull/12/files")).toBe(12);
+  });
+
+  test("tolerates a trailing slash", () => {
+    expect(parsePullNumber("https://github.com/o/r/pull/12/")).toBe(12);
+  });
+
+  test("tolerates a query string", () => {
+    expect(parsePullNumber("https://github.com/o/r/pull/12?diff=split")).toBe(12);
+  });
+
+  test("tolerates a fragment", () => {
+    expect(parsePullNumber("https://github.com/o/r/pull/12#discussion_r123")).toBe(12);
+  });
+});
+
+describe("parsePullNumber — GitLab", () => {
+  test("parses a merge_requests URL", () => {
+    expect(parsePullNumber("https://gitlab.com/o/r/merge_requests/7")).toBe(7);
+  });
+
+  test("parses a merge_requests URL nested under /-/", () => {
+    expect(parsePullNumber("https://gitlab.com/o/r/-/merge_requests/7")).toBe(7);
+  });
+});
+
+describe("parsePullNumber — Bitbucket", () => {
+  test("parses a pull-requests URL", () => {
+    expect(parsePullNumber("https://bitbucket.org/o/r/pull-requests/3")).toBe(3);
+  });
+});
+
+describe("parsePullNumber — rejections", () => {
+  test("rejects a file: scheme", () => {
+    expect(parsePullNumber("file:///pull/12")).toBeNull();
+  });
+
+  test("rejects a custom (non-http/https) scheme", () => {
+    expect(parsePullNumber("myapp://host/pull/12")).toBeNull();
+  });
+
+  test("rejects a malformed URL", () => {
+    expect(parsePullNumber("not a url")).toBeNull();
+  });
+
+  test("rejects a URL with no marker segment", () => {
+    expect(parsePullNumber("https://github.com/o/r/issues/12")).toBeNull();
+  });
+
+  test("rejects a marker followed by a non-numeric segment", () => {
+    expect(parsePullNumber("https://github.com/o/r/pull/abc")).toBeNull();
+  });
+
+  test('rejects exponential notation ("1e3")', () => {
+    expect(parsePullNumber("https://github.com/o/r/pull/1e3")).toBeNull();
+  });
+
+  test('rejects hex notation ("0x10")', () => {
+    expect(parsePullNumber("https://github.com/o/r/pull/0x10")).toBeNull();
+  });
+
+  test('rejects decimal notation ("12.0")', () => {
+    expect(parsePullNumber("https://github.com/o/r/pull/12.0")).toBeNull();
+  });
+
+  test('accepts a leading-zero decimal ("0012") since it is all digits, parsing to 12', () => {
+    expect(parsePullNumber("https://github.com/o/r/pull/0012")).toBe(12);
+  });
+
+  test("rejects zero (.../pull/0)", () => {
+    expect(parsePullNumber("https://github.com/o/r/pull/0")).toBeNull();
+  });
+
+  test("rejects the marker as the last path segment (no number follows)", () => {
+    expect(parsePullNumber("https://github.com/o/r/pull")).toBeNull();
+  });
+
+  test("rejects an empty string", () => {
+    expect(parsePullNumber("")).toBeNull();
+  });
+
+  test("is case-sensitive about the marker segment", () => {
+    expect(parsePullNumber("https://github.com/o/r/Pull/12")).toBeNull();
+  });
+});

--- a/src/mainview/lib/pr-url.ts
+++ b/src/mainview/lib/pr-url.ts
@@ -15,18 +15,23 @@
  * throws — for anything else, including a malformed URL.
  */
 export function parsePullNumber(url: string): number | null {
-  let pathname: string;
+  let parsed: URL;
   try {
-    pathname = new URL(url).pathname;
+    parsed = new URL(url);
   } catch {
     return null;
   }
-  const segments = pathname.split("/").filter(Boolean);
+  // Only web URLs qualify — a non-http(s) scheme must keep taking the
+  // ExternalLink branch, where its whitelist applies.
+  if (!/^https?:$/.test(parsed.protocol)) return null;
+  const segments = parsed.pathname.split("/").filter(Boolean);
   const markers = new Set(["pull", "merge_requests", "pull-requests"]);
   for (let i = 0; i < segments.length - 1; i++) {
     const marker = segments[i];
     const next = segments[i + 1];
     if (marker === undefined || next === undefined || !markers.has(marker)) continue;
+    // Canonical decimal only — Number() would also admit "1e3"/"0x10"/"12.0".
+    if (!/^\d+$/.test(next)) continue;
     const n = Number(next);
     if (Number.isInteger(n) && n > 0) return n;
   }

--- a/src/mainview/lib/pr-url.ts
+++ b/src/mainview/lib/pr-url.ts
@@ -1,0 +1,34 @@
+/**
+ * Parses the pull/merge-request number out of a provider web URL. Lets the
+ * "View PR" affordance in RunPanel decide whether it can open the in-app
+ * detail subpage (needs a number to fetch by) or must fall back to the
+ * plain external link. Pure — no React, no network — kept DOM-free like its
+ * sibling `commit-push.ts` so it's unit-testable on its own.
+ *
+ * Supports the URL shape each provider uses for a single PR/MR:
+ *   - GitHub:    .../pull/<n>
+ *   - GitLab:    .../merge_requests/<n>      (optionally nested under /-/)
+ *   - Bitbucket: .../pull-requests/<n>
+ *
+ * Tolerates a trailing slash, query string, fragment, and extra tail
+ * segments (e.g. GitHub's ".../pull/12/files"). Returns null — never
+ * throws — for anything else, including a malformed URL.
+ */
+export function parsePullNumber(url: string): number | null {
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return null;
+  }
+  const segments = pathname.split("/").filter(Boolean);
+  const markers = new Set(["pull", "merge_requests", "pull-requests"]);
+  for (let i = 0; i < segments.length - 1; i++) {
+    const marker = segments[i];
+    const next = segments[i + 1];
+    if (marker === undefined || next === undefined || !markers.has(marker)) continue;
+    const n = Number(next);
+    if (Number.isInteger(n) && n > 0) return n;
+  }
+  return null;
+}


### PR DESCRIPTION
## What

Makes the "New PR" experience a first-class page inside the Git Integration modal, and routes a task's PR affordances into the modal instead of around it:

- **Compose subpage.** The New-PR and New-issue composers move out of the inline list body into a dedicated `{kind:"compose"}` member of the modal's `GitHubDialogView` union — same navigation pattern as the PR detail subpage: back-chevron header, Escape pops back to the list (previously it closed the whole dialog), and the filter bar / manager panels / item list are hidden while composing. Creating a PR or issue now lands directly on the new item's detail subpage.
- **Task "Open PR"** (the post commit-&-push chip in the RunPanel) opens the modal straight onto that compose page, prefilled from the agent's proposal as before — the existing `pullPrefill` one-shot flow now targets the page.
- **Task "View PR"** opens the modal on that PR's **detail subpage** instead of jumping to the browser. New pieces: `GET /github/pull-detail?path=&number=` (git-host `pullDetail` facade dispatching to GitHub/GitLab/Bitbucket fetchers that reuse the existing item mappers), a `parsePullNumber` URL helper (`src/mainview/lib/pr-url.ts`), and a one-shot `pullDetailPrefill` prop consumed with the same two-effect dance as `pullPrefill`. The browser remains the fallback whenever the URL doesn't parse, the fetch fails, or the fetched PR doesn't match the stored URL — and it's still reachable from the detail page's open-on-GitHub button.

## Why

Opening and viewing PRs previously split across three UI idioms (inline composer, detail subpage, external browser). This unifies them on the modal's canonical subpage pattern, so a task's PR lifecycle — compose → create → review — stays inside the app.

## Notable fixes folded in (from the pre-merge review)

- Wrong-repo guard: the detail fetch resolves the repo from the task workdir's git remote, so a re-pointed `workdir` on an `isolation: none` task could have silently shown a *different* repo's PR #N — the fetched item's `htmlUrl` is now verified against the stored `pr_url`.
- Navigation-clobber guard: a slow prefill fetch can no longer yank the view off a page the user opened meanwhile (and a late failure won't toast/open a browser tab under them).
- Cancelling/escaping the compose page now clears the task binding (`pullPrefillTaskId`), so a later manual "New PR" can't stamp an unrelated PR's URL onto the previously prefilled task.
- The create-success banner was keyed by bare `number` and never rendered; it's now keyed by `itemKey`. All composer-field wipes were consolidated into one `resetComposers()` helper, which also fixes a pre-existing leak where issue-composer state survived dialog reopens.

## Tests

54 new tests (view-union helpers, `parsePullNumber` matrix, pull-detail fetchers/facade/route). Full suite: **2004 pass / 2 skip / 0 fail**; `tsc --noEmit` and `vite build` green.

Plan and logged assumptions: `docs/plans/new-pr-git-integration-page.md` (built autonomously; assumptions in §8 — notably the issue composer rides the same subpage, and create-success navigates to the new item's detail page).