### PR TITLE
feature: move new-task helper messages into (i) info popovers

### DIFF
--- a/docs/plans/move-helper-messages-to-info-icons.md
+++ b/docs/plans/move-helper-messages-to-info-icons.md
@@ -1,0 +1,117 @@
+# Plan — Move New-Task-Panel Helper Messages to (i) Info Icons
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-31 |
+| Source | /implement invocation (agetor task prompt) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/move-helper-message-to-i-icon-button |
+| Base SHA | 5953e190c262b598ad36a10c449b984517bd19a1 |
+| Mode | Autonomous — grill + plan-approval gates bypassed (no owner reachable mid-run); assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+Declutter the New Task form by moving two always-visible helper paragraphs into
+click-triggered (i) info popovers, and enrich the Mode dropdown so each option
+shows its name **and** its helper hint:
+
+1. **Files / Folders** — helper text moves into a popover opened by a new (i)
+   icon button placed to the right of the "Files / Folders" label.
+2. **Mode** — the selected-mode hint paragraph under the dropdown is replaced
+   by an (i) icon button to the right of the mode selector; clicking it shows
+   the current mode's hint.
+3. **Mode dropdown options** — the native `<select>` is replaced with the
+   existing popover combobox (`SearchSelect`) in a new non-searchable variant,
+   so each option renders `label` + `hint` (data already present in
+   `AGENT_OPTIONS[kind].modes` in `src/shared/types.ts`).
+
+Success: form renders without the two inline helper paragraphs; (i) buttons
+toggle popovers on click (outside-click + Escape close); mode dropdown shows
+name + hint per option; `bun run typecheck` and `bun test` green.
+
+## 2. Context & constraints
+
+- `src/mainview/components/kanban/NewTaskForm.tsx:739-741` — inline
+  `selectedModeHint` paragraph (source: `modes.find(m => m.id === mode)?.hint`).
+- `src/mainview/components/kanban/NewTaskForm.tsx:730-738` — Mode `Select`
+  (native, `ui/select.tsx`) — native `<option>` cannot render two lines.
+- `src/mainview/components/kanban/ReferencesPicker.tsx:222` — Files/Folders
+  empty-state helper: "No files attached yet — use the buttons or drag from
+  Finder. Absolute paths are inlined into the prompt as text."
+- `src/mainview/components/ui/search-select.tsx` — hand-rolled popover combobox
+  that already renders `label` + `hint` per item; has outside-click/Escape
+  handling and a `data-popover-open` marker. Model for popover conventions.
+- No tooltip primitive exists in `ui/`; native `title=` attrs are used
+  elsewhere but the request is an explicit click-triggered tooltip.
+- ReferencesPicker's label lives inside a `<details><summary>` — clicks inside
+  the summary toggle the section, so the (i) button must `stopPropagation`
+  (same trick as the Files/Folder buttons at ReferencesPicker.tsx:146).
+- Frontend has no DOM test harness (no jsdom/testing-library); React behavior
+  is tested only via pure logic extracted to `src/mainview/lib/*.ts`.
+- Dark mode only; Tailwind v3 + shadcn HSL variables; form column is `w-80`.
+
+## 3. Approach & key decisions
+
+- **New `InfoTip` primitive** (`src/mainview/components/ui/info-tip.tsx`):
+  lucide `Info` icon button + absolutely-positioned popover, click-toggled,
+  closed on outside click / Escape, `data-popover-open` marker, right-aligned
+  by default (both usage sites sit near the right edge of a w-80 column).
+  Chosen over per-site inline popovers (two call sites already) and over
+  pulling in a library (repo hand-rolls all primitives).
+- **Extend `SearchSelect` with `searchable?: boolean` (default `true`)**
+  rather than writing a parallel `OptionSelect`: when `false`, hide the search
+  header and skip filtering/autofocus. Reuses existing trigger, item rendering
+  (label + hint), and dismissal logic. Alternative (new component) rejected as
+  duplication.
+- Mode select keeps its 2-col Code/Plan pills untouched; only the dropdown
+  row changes to `SearchSelect (searchable=false)` with the (i) button beside it.
+- Model/Effort selects stay native — out of scope.
+
+## 4. Work breakdown — implementation tasks
+
+Single wave, single agent (files are small and interdependent enough that
+splitting would cost more than it saves):
+
+- **T1** (owns all four files):
+  - `src/mainview/components/ui/info-tip.tsx` (new) — InfoTip primitive.
+  - `src/mainview/components/ui/search-select.tsx` — add `searchable` prop.
+  - `src/mainview/components/kanban/ReferencesPicker.tsx` — (i) + popover on
+    the expandable variant's summary label; drop the long empty-state helper
+    (keep a minimal "No files attached yet."); inline error `hint` unchanged.
+  - `src/mainview/components/kanban/NewTaskForm.tsx` — Mode dropdown →
+    `SearchSelect searchable={false}` with hints; (i) button to its right
+    showing the selected mode's hint; remove the `selectedModeHint` paragraph.
+  - Acceptance: §1 criteria; no behavior change to mode state logic
+    (`setMode`, fallback effects, Code/Plan pills).
+
+## 5. Work breakdown — test tasks
+
+- No DOM harness exists, and this change introduces no new pure logic worth
+  extracting (all JSX/positioning). **No new test files.** Verification =
+  `bun run typecheck` + full `bun test` (existing suite must stay green).
+
+## 6. Execution waves
+
+- Wave 1: T1 (one sonnet agent). Then review (opus), then typecheck + tests.
+
+## 7. Blast radius & risks
+
+- `SearchSelect` is shared by ProjectPicker/BranchPicker/dialogs — the
+  `searchable` prop must default to `true` so existing call sites are
+  untouched.
+- ReferencesPicker `inline` variant (RunPanel composer) must be unchanged.
+- Popover overflow: the form column scrolls (`overflow-y-auto`) — popovers are
+  absolutely positioned inside it, same as existing pickers, so clipping
+  behavior matches the accepted status quo.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+- "Tooltip on click" = click-toggled popover (not hover), dismissed by
+  outside click / Escape / second click.
+- The "Files / Folders helper message" = the empty-state paragraph at
+  ReferencesPicker.tsx:222. Its text moves to the popover (rephrased to not be
+  empty-state-specific); a minimal "No files attached yet." remains as the
+  empty state so an open empty section doesn't look broken.
+- The Mode (i) shows the *currently selected* mode's hint — kept even though
+  hints now also appear per-option, per the explicit "additionally" in the ask.
+- Model/Effort dropdowns intentionally left native (not requested).

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -4,6 +4,8 @@ import { api, type AgentModelMap, type AvailableCommand, type AvailableExtension
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
+import { SearchSelect } from "@/components/ui/search-select";
+import { InfoTip } from "@/components/ui/info-tip";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { taskTypeIcon } from "@/lib/task-type-icon";
@@ -727,18 +729,19 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
               Plan
             </Button>
           </div>
-          <Select
-            value={mode}
-            onChange={(e) => setMode(e.target.value)}
-            className="h-8"
-          >
-            {modes.map((m) => (
-              <option key={m.id} value={m.id}>{m.label}</option>
-            ))}
-          </Select>
-          {selectedModeHint && (
-            <p className="text-[11px] leading-snug text-muted-foreground">{selectedModeHint}</p>
-          )}
+          <div className="flex items-center gap-1.5">
+            <SearchSelect
+              value={mode}
+              onChange={setMode}
+              items={modes.map((m) => ({ value: m.id, label: m.label, hint: m.hint }))}
+              searchable={false}
+              wrapHints
+              placement="bottom"
+              className="min-w-0 flex-1"
+              triggerClassName="h-8 text-xs"
+            />
+            {selectedModeHint && <InfoTip text={selectedModeHint} label="About this mode" />}
+          </div>
         </div>
 
         <div className="grid grid-cols-2 gap-2">

--- a/src/mainview/components/kanban/ReferencesPicker.tsx
+++ b/src/mainview/components/kanban/ReferencesPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { FilePlus, FolderPlus, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { InfoTip } from "@/components/ui/info-tip";
 import { cn } from "@/lib/utils";
 import { iconForRef, refBasename } from "@/lib/file-icons";
 import { captureDroppedOrPastedItems } from "@/lib/capture-refs";
@@ -210,16 +211,21 @@ export function ReferencesPicker({
       onDrop={onDrop}
     >
       <summary className="flex cursor-pointer items-center justify-between gap-2 text-[11px] text-muted-foreground">
-        <span>
+        <span className="inline-flex items-center gap-1">
           {label}{" "}
           {refs.length > 0 && <span className="font-mono">({refs.length})</span>}
+          <InfoTip
+            text="Attach files or folders with the buttons or drag from Finder. Absolute paths are inlined into the prompt as text."
+            label="About files and folders"
+            align="left"
+          />
         </span>
         {buttons}
       </summary>
       <div className="mt-1.5 space-y-1">
         {refs.length > 0
           ? chips
-          : <p className="text-[10px] text-muted-foreground">No files attached yet — use the buttons or drag from Finder. Absolute paths are inlined into the prompt as text.</p>}
+          : <p className="text-[10px] text-muted-foreground">No files attached yet.</p>}
         {hint && <p className="text-[10px] text-muted-foreground">{hint}</p>}
       </div>
       {dropOverlay}

--- a/src/mainview/components/ui/info-tip.tsx
+++ b/src/mainview/components/ui/info-tip.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import { Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  text: ReactNode;
+  className?: string;
+  /** Accessible label on the trigger button. */
+  label?: string;
+  /** Which side of the icon the popover opens toward. */
+  side?: "top" | "bottom";
+  /** Which side of the icon the popover aligns to horizontally. */
+  align?: "left" | "right";
+}
+
+/**
+ * Click-toggled (i) info popover. Used to move always-visible helper copy
+ * out of the layout and behind an icon the user opts into reading.
+ */
+export function InfoTip({ text, className, label = "More info", side = "bottom", align = "right" }: Props) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const panelId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className={cn("relative inline-flex", className)}>
+      <button
+        type="button"
+        aria-label={label}
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        className="text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <Info className="size-3.5" aria-hidden />
+      </button>
+
+      {open && (
+        <div
+          id={panelId}
+          role="note"
+          // Marker for enclosing Esc handlers to bail and let this popover
+          // consume Escape first (mirrors search-select.tsx).
+          data-popover-open=""
+          // The panel sits inside a <details><summary> at one call site —
+          // an unstopped click/mousedown inside it bubbles up and toggles
+          // the section, same reason the trigger button stops propagation.
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+          className={cn(
+            "absolute z-50 max-w-[min(16rem,calc(100vw-2rem))] w-64 rounded-md border border-border bg-card p-2 text-left text-[11px] leading-snug text-muted-foreground shadow-xl",
+            side === "top" ? "bottom-full mb-1" : "top-full mt-1",
+            align === "left" ? "left-0" : "right-0",
+          )}
+        >
+          {text}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/mainview/components/ui/search-select.tsx
+++ b/src/mainview/components/ui/search-select.tsx
@@ -24,6 +24,8 @@ interface Props {
   /** Override the trigger label for an arbitrary value (e.g. show basename for a path). */
   displayValue?: (value: string) => string;
   className?: string;
+  /** Extra classes on the trigger button itself (className applies to the root wrapper). */
+  triggerClassName?: string;
   /** Left-side icon in the trigger. */
   leadingIcon?: ReactNode;
   disabled?: boolean;
@@ -35,6 +37,11 @@ interface Props {
    * picker near the top of a modal should pass "bottom".
    */
   placement?: "top" | "bottom";
+  /** Show the search box and filter items as the user types. Default true;
+   *  pass false for short enumerated lists where search adds no value. */
+  searchable?: boolean;
+  /** Let the item hint wrap across lines instead of truncating to one. */
+  wrapHints?: boolean;
 }
 
 /**
@@ -51,10 +58,13 @@ export function SearchSelect({
   footer,
   displayValue,
   className,
+  triggerClassName,
   leadingIcon,
   disabled,
   title,
   placement = "top",
+  searchable = true,
+  wrapHints = false,
 }: Props) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -72,12 +82,12 @@ export function SearchSelect({
     document.addEventListener("mousedown", onDown);
     document.addEventListener("keydown", onKey);
     // Focus the search box once the panel is mounted.
-    queueMicrotask(() => searchRef.current?.focus());
+    if (searchable) queueMicrotask(() => searchRef.current?.focus());
     return () => {
       document.removeEventListener("mousedown", onDown);
       document.removeEventListener("keydown", onKey);
     };
-  }, [open]);
+  }, [open, searchable]);
 
   // Reset the query each time the panel closes so the next open starts clean.
   useEffect(() => {
@@ -85,13 +95,14 @@ export function SearchSelect({
   }, [open]);
 
   const filtered = useMemo(() => {
+    if (!searchable) return items;
     const q = query.trim().toLowerCase();
     if (!q) return items;
     return items.filter((i) =>
       i.label.toLowerCase().includes(q)
       || i.value.toLowerCase().includes(q)
       || (i.hint?.toLowerCase().includes(q) ?? false));
-  }, [items, query]);
+  }, [items, query, searchable]);
 
   // Show pinned matches at the top of the filtered view.
   const ordered = useMemo(() => {
@@ -100,8 +111,9 @@ export function SearchSelect({
     return [...pinned, ...rest];
   }, [filtered]);
 
+  const selected = items.find((i) => i.value === value);
   const triggerLabel = value
-    ? (displayValue ? displayValue(value) : value)
+    ? (displayValue ? displayValue(value) : selected?.label ?? value)
     : (emptyLabel ?? placeholder);
 
   return (
@@ -114,6 +126,7 @@ export function SearchSelect({
         className={cn(
           "flex h-9 w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-1 text-left text-sm shadow-sm transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
           disabled && "cursor-not-allowed opacity-50",
+          triggerClassName,
         )}
       >
         {leadingIcon && <span className="shrink-0 text-muted-foreground">{leadingIcon}</span>}
@@ -133,16 +146,18 @@ export function SearchSelect({
             placement === "top" ? "bottom-full mb-1" : "top-full mt-1",
           )}
         >
-          <div className="flex items-center gap-2 border-b border-border/60 px-2 py-1.5">
-            <Search className="size-3.5 shrink-0 opacity-60" aria-hidden />
-            <Input
-              ref={searchRef}
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder={placeholder}
-              className="h-7 border-0 px-0 shadow-none focus-visible:ring-0"
-            />
-          </div>
+          {searchable && (
+            <div className="flex items-center gap-2 border-b border-border/60 px-2 py-1.5">
+              <Search className="size-3.5 shrink-0 opacity-60" aria-hidden />
+              <Input
+                ref={searchRef}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={placeholder}
+                className="h-7 border-0 px-0 shadow-none focus-visible:ring-0"
+              />
+            </div>
+          )}
           <div className="max-h-64 overflow-y-auto py-1">
             {ordered.length === 0 ? (
               <div className="px-3 py-2 text-xs text-muted-foreground">No matches.</div>
@@ -172,7 +187,12 @@ export function SearchSelect({
                     <span className="min-w-0 flex-1">
                       <span className="block truncate">{item.label}</span>
                       {item.hint && (
-                        <span className="block truncate text-[11px] text-muted-foreground">
+                        <span
+                          className={cn(
+                            "block text-[11px] text-muted-foreground",
+                            wrapHints ? "whitespace-normal break-words" : "truncate",
+                          )}
+                        >
                           {item.hint}
                         </span>
                       )}


### PR DESCRIPTION
## What changed

Declutters the New Task panel by moving its two always-visible helper paragraphs behind click-triggered (i) info icons, and makes the Mode dropdown self-explanatory.

- **New `InfoTip` primitive** (`src/mainview/components/ui/info-tip.tsx`) — an (i) icon button that click-toggles a helper popover. Follows the repo's popover conventions (`data-popover-open` marker, outside-click + Escape dismissal), with `side`/`align` placement props and aria wiring (`aria-expanded`, `aria-controls`, `role="note"`). Clicks inside the panel are neutralized so it can live inside a `<details><summary>` without toggling the section.
- **Files / Folders** — the helper sentence moved from the section body into an (i) popover next to the label (`align="left"` so it doesn't clip past the narrow form's edge); the empty state is now just "No files attached yet." The RunPanel's inline variant is untouched.
- **Mode** — the inline hint paragraph under the dropdown is replaced by an (i) icon to the right of the selector showing the selected mode's hint, and the dropdown itself now shows **each option's name and helper message**: the native `<select>` (which can't render two-line options) was replaced with the existing `SearchSelect` popover combobox.
- **`SearchSelect`** gained additive props, all defaulting to prior behavior: `searchable` (false hides the search header for short fixed lists), `wrapHints` (full-sentence hints wrap instead of truncating), `triggerClassName` (size the trigger, e.g. `h-8`), plus a trigger-label fallback to the selected item's `label` so call sites without `displayValue` no longer surface raw ids (e.g. `acceptEdits`).

## Why

The two helper paragraphs took permanent vertical space in the w-80 form for text you read once; and mode descriptions were only visible for the *currently selected* mode, so comparing modes meant selecting each one. Now the hints live where you choose (in the dropdown options) with an (i) for the current pick.

## Verification

- `bun run typecheck` green; `bun test` 1967 pass / 2 skip / 0 fail.
- Reviewed (must-fix trigger-label bug, popover click-bubbling, and left-edge clipping caught and fixed pre-merge).
- Existing `SearchSelect` call sites (Project/Branch pickers) and the RunPanel inline references picker are behaviorally unchanged.

## Known trade-off

The Mode dropdown loses native `<select>` arrow-key traversal, matching how the Project/Branch pickers already behave. Follow-up idea: real listbox keyboard semantics in `SearchSelect`, which would upgrade all three pickers at once.