### PR TITLE
fix: stop duplicate permission-mode and hibernate status chips in Task Details

### DIFF
--- a/docs/plans/fix-permission-mode-status-spam.md
+++ b/docs/plans/fix-permission-mode-status-spam.md
@@ -140,6 +140,44 @@ Two independent layers:
 - Client helper runs per render on the memoized event list — O(n), same cost
   class as the existing `normalizeLegacyEvent` map.
 
+## Follow-up (same branch): "session hibernated after 30m idle" chip spam
+
+Reported with a second screenshot: the idle-session reaper's hibernate
+breadcrumb repeats exactly like the permission-mode chips. Root cause chain
+(verified live against the user's running prod app + tmux 3.6a):
+
+- On tmux 3.6a, `display-message -p -t '=<name>' '#{session_attached}:#{session_activity}'`
+  does NOT resolve `=`-prefixed exact-match targets: it prints the format
+  with every variable expanded to empty (stdout `:`), exit 0 — identically
+  for live and nonexistent sessions. (`has-session`/`kill-session` honor
+  `=` correctly; only `display-message` is affected. The no-prefix form
+  works but prefix-matches sibling `agetor-*` names — not an option.)
+- `probeSessionActivity` (claude-tmux.ts:1174) parses that with
+  `Number("") === 0`, which passes `Number.isFinite` — so every probe
+  returns `{attached: false, activityAt: 0}`: "never attached, idle since
+  1970".
+- `reapIdleSessions` (orchestrator.ts:~2400) therefore re-reaps every
+  candidate task (finished run, no in-memory SessionState) on every
+  5-minute sweep, appending the hibernate breadcrumb each time — 528
+  persisted rows across 12 tasks in the user's prod DB, ~50 per run. The
+  "never reap attached" guard was also dead.
+
+Fix tasks (all on fix/permission-auto-spam):
+
+- **F1** (`src/bun/claude-tmux.ts` + `claude-tmux.test.ts`): rewrite
+  `probeSessionActivity` on `list-sessions -F ... -f '#{==:#{session_name},<name>}'`
+  (verified exact-match on 3.6a; empty stdout ⇒ null). Extract a pure,
+  exported parse helper; reject non-digit/empty fields BEFORE `Number()`.
+- **F2** (`src/bun/orchestrator.ts` + `db.ts` + `orchestrator.test.ts`):
+  idempotence guard — skip appending/emitting the hibernate breadcrumb when
+  the target run's latest persisted event is that identical status line
+  (defense-in-depth against any future re-reap regression).
+- **F3** (`src/mainview/lib/status-collapse.ts` + its test): also drop a
+  `status` event starting with `"session hibernated after "` when the
+  immediately-preceding kept event is a status with identical data
+  (adjacency semantics — a genuine later hibernate always has user/agent
+  events between). Cleans the persisted backlog at render time.
+
 ## 8. Open questions / assumptions (autonomous mode)
 
 1. **Assumed** desired UX is "announce only changes", including suppressing

--- a/docs/plans/fix-permission-mode-status-spam.md
+++ b/docs/plans/fix-permission-mode-status-spam.md
@@ -1,0 +1,150 @@
+# Plan — Stop "permission-mode: auto" status spam in Task Details
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-31 |
+| Source | /implement — "fix the spamming permission auto message in task details messages" + screenshot-2026-07-31_14-49-17-b54ec01a.png |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/permission-auto-spam |
+| Base SHA | 5953e19 |
+| Mode | **Autonomous** — grill (Phase 2) and plan-approval (Phase 3) gates self-resolved; assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+The Task Details unified event stream shows long runs of identical
+`permission-mode: auto` status chips (screenshot shows 8+ consecutive after a
+single "turn complete"). After the fix:
+
+- A `permission-mode: <mode>` chip appears **only when the mode actually
+  changes** (or differs from the launch mode) — never repeated back-to-back
+  with the same value.
+- Already-persisted spam in `run_events` renders collapsed (historical tasks
+  look clean without a DB rewrite).
+- `bun run typecheck` green, `bun test` green.
+
+## 2. Context & constraints (grounded findings)
+
+- **Emitter**: `src/bun/claude-tmux.ts:999-1012` — `mapParsedEventToChunks`
+  `case "system" | "permission-mode"` unconditionally emits
+  `onChunk("status", "permission-mode: <mode>", uuid)`. Claude journals a
+  mode-bearing JSONL event at **every turn start** (fleet knowledge entry
+  776d1222, verified against claude 2.1.170), each with a distinct `uuid`, so
+  every one persists to `run_events` (distinct `line_uuid`) and renders.
+- **Existing mode tracking**: `SessionState.permissionMode`
+  (`claude-tmux.ts:1686`) mirrors the latest mode-bearing event in
+  `dispatchLine` at `claude-tmux.ts:2702-2705` — deliberately ABOVE the
+  `seenLineUuids` dedup early-return, and pre-seeded from the launch mode in
+  `makeSessionState` (`claude-tmux.ts:4165`) and reattach
+  (`claude-tmux.ts:1907`). This is the comparison basis for emit-on-change.
+- **Callers of the mapper**: `dispatchLine` (main stream, calls
+  `mapParsedEventToChunks` directly at `claude-tmux.ts:2800`);
+  `mapJsonlEventToChunks` (`claude-tmux.ts:763`) whose only external caller is
+  the subagent tailer `src/bun/claude-subagents.ts:633`;
+  `rebuildEventsFromJsonl` (`claude-tmux.ts:2846`) drives `dispatchLine`
+  against a synthetic state, so it inherits whatever dispatchLine does.
+- **UI pipeline**: `RunPanel.tsx` ingests via `createEventDeduper`
+  (`lib/event-dedup.ts`) keyed on `ts|runId|stream|data` — same-value chips
+  from different lines have different `ts`, so the deduper can't collapse
+  them. Rendering is `RunEventList` (`RunPanel.tsx:3151`), which memoizes
+  `normalised` from its `events` prop (`RunPanel.tsx:3175`). Both main and
+  subagent tabs render through `RunEventList`.
+- **Do not break**: orchestrator pattern-matching on `status` sentinels
+  (`SESSION_DIED_STATUS_PREFIX`, API-error prefix) — untouched; the
+  `(run_id, IFNULL(subagent_id,''), line_uuid)` dedup invariants — we emit
+  *fewer* chunks, never re-key existing ones; existing tests
+  `claude-tmux.test.ts:649-661` (mapper emits status with no last-mode
+  context) and `:763-783` (state overwrite via dispatchLine).
+
+## 3. Approach & key decisions
+
+Two independent layers:
+
+1. **Server-side, emit-on-change** (root fix): thread the previously-known
+   mode into the mapper; emit the status chunk only when the event's mode
+   differs. Suppressed events still update `SessionState.permissionMode`
+   (mirror already runs in `dispatchLine` before the call). Rejected
+   alternative: emitting from the `dispatchLine` mirror block — it runs above
+   the replay-dedup early-return, so it would need awkward deferred emission;
+   the mapper-param approach keeps one emission site.
+2. **Client-side collapse** (historical data): a pure helper drops a
+   `permission-mode: X` status event when the *previous* permission-mode
+   status event in the list carried the same value (non-mode events pass
+   through and don't reset the tracker — matches "announce changes only").
+   Rejected alternative: DB migration deleting duplicate rows — destructive,
+   and the spam keeps arriving from sessions running under the old binary
+   anyway.
+
+## 4. Work breakdown — implementation tasks
+
+- **T1 — bun emit-on-change** (owns `src/bun/claude-tmux.ts`,
+  `src/bun/claude-subagents.ts`):
+  - `mapParsedEventToChunks` + `mapJsonlEventToChunks`: new optional trailing
+    param `lastPermissionMode?: string | null` (default `undefined` = always
+    emit, preserving all existing callers/tests). In the
+    `system`/`permission-mode` case, skip the `onChunk` when
+    `evt.permissionMode === lastPermissionMode`.
+  - `dispatchLine`: capture `const prevPermissionMode = state.permissionMode`
+    **before** the mirror at :2702, pass it to `mapParsedEventToChunks` at
+    :2800.
+  - Subagent tailer (`claude-subagents.ts:633`): add a
+    `lastPermissionMode: string | null` field to the follow-state, pass it to
+    `mapJsonlEventToChunks`, update it from the parsed line's
+    `permissionMode` after dispatch (tailer already parses each line).
+  - Acceptance: two consecutive same-mode lines through `dispatchLine`
+    produce exactly one status chunk; a mode *change* still produces one;
+    `rebuildEventsFromJsonl` over a spammy JSONL yields one chip per change.
+- **T2 — UI collapse** (owns new `src/mainview/lib/status-collapse.ts`,
+  `src/mainview/components/kanban/RunPanel.tsx`):
+  - `collapseRepeatedModeStatus(events: RunEvent[]): RunEvent[]` pure helper:
+    track the data of the last kept `status` event whose data starts with
+    `"permission-mode: "`; drop later status events with identical data; any
+    permission-mode status with a *different* value is kept and becomes the
+    new tracker value. All other events pass through untouched, order
+    preserved.
+  - Wire into `RunEventList` (`RunPanel.tsx:3175`): apply the helper to
+    `events` before `normalizeLegacyEvent` mapping, inside the existing
+    `useMemo`.
+  - Acceptance: a list with N identical consecutive (or content-interleaved)
+    `permission-mode: auto` chips renders one; `auto → plan → auto` renders
+    three.
+
+## 5. Work breakdown — test tasks
+
+- **TT1** (owns `src/bun/claude-tmux.test.ts`): mapper suppresses duplicate
+  mode vs `lastPermissionMode`, emits on change, default param keeps old
+  behavior; `dispatchLine` end-to-end: same-mode repeat → single status
+  chunk, changed mode → emitted; rebuild path collapse.
+- **TT2** (owns new `src/mainview/lib/status-collapse.test.ts`): helper unit
+  tests — consecutive dupes, interleaved-content dupes, mode change kept,
+  A→B→A kept, non-mode statuses untouched, empty list.
+
+## 6. Execution waves
+
+- Wave 1 (parallel): T1, T2 — disjoint files.
+- Wave 2: code review (opus) of the wave-1 diff.
+- Wave 3 (parallel): TT1, TT2 — disjoint files, after impl landed.
+- Wave 4: run `bun run typecheck` + `bun test` (haiku, background).
+- Wave 5 (conditional): fixes, re-run.
+
+## 7. Blast radius & risks
+
+- Suppressed emission = fewer `run_events` rows; nothing reads
+  permission-mode status rows programmatically (grep-verified: only the UI
+  renders them). Orchestrator sentinel matching untouched.
+- Reattach replay: mirror stays above the dedup return, so
+  `state.permissionMode` still rehydrates from replayed lines (comment at
+  :2698-2701 preserved).
+- First-launch chip disappears when the JSONL mode equals the launch-seeded
+  mode — intentional; the task's mode is already visible in the task's
+  mode selector UI.
+- Client helper runs per render on the memoized event list — O(n), same cost
+  class as the existing `normalizeLegacyEvent` map.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+1. **Assumed** desired UX is "announce only changes", including suppressing
+   the redundant first chip when it matches the launch mode.
+2. **Assumed** historical spam should be cleaned at render time, not via a
+   destructive DB migration.
+3. **Assumed** subagent (background-agent) tabs get the same suppression.
+4. Codex is out of scope — its event mapper never emits permission-mode.

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -605,14 +605,18 @@ export function attachSubagentWatcher(opts: {
       } catch { /* fall through; mapper will surface the parse error */ }
 
       // Mirror the mode into `fs.lastPermissionMode` BEFORE the dedup-skip
-      // continue below — same reasoning as `dispatchLine`'s mirror on the
-      // main stream: a boot reattach replays already-persisted lines through
-      // this loop too (dedup skips re-emission, not re-parsing), and without
-      // updating here first, a reattach would leave `lastPermissionMode`
-      // stuck at `null` and re-emit a redundant chip on this subagent's next
-      // genuinely-new mode-bearing line. `prevPermissionMode` is captured
-      // first so the mapper call below (for lines that ARE new) compares
-      // against what we knew before this line, not this line's own value.
+      // continue below. Defensive ordering rather than a currently-exercised
+      // path: real permission-mode JSONL lines carry no uuid, so they never
+      // hit the `fs.seen` continue in the first place — they re-emit once
+      // per reattach (the offset-0 replay has no dedup key for them), and
+      // the UI's render-time collapse (`collapseRepeatedModeStatus`) is what
+      // masks that residual repeat today. Keeping the mirror above the
+      // continue means that if claude ever ships a uuid-bearing variant of
+      // this line, it still rehydrates `fs.lastPermissionMode` correctly on
+      // replay without re-emitting a chip, with no code change needed here.
+      // `prevPermissionMode` is captured first so the mapper call below (for
+      // lines that ARE new) compares against what we knew before this line,
+      // not this line's own value.
       const prevPermissionMode = fs.lastPermissionMode;
       if (linePermissionMode !== undefined) fs.lastPermissionMode = linePermissionMode;
 

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -251,6 +251,14 @@ interface FileState {
    *  running" block, which otherwise retires `toolUseId` unconditionally —
    *  see that block for why an api-errored row must NOT lose it. */
   apiErrored: boolean;
+  /** Latest mode-bearing (`system`/`permission-mode`) event seen for this
+   *  subagent, passed to `mapJsonlEventToChunks` so it can suppress a
+   *  same-mode repeat — same emit-on-change scheme as the main stream's
+   *  `SessionState.permissionMode`. Always starts `null` (never rehydrated
+   *  from the DB — nothing persists it), so reattach may re-emit one
+   *  redundant chip for an already-known mode; that's a one-time echo, not
+   *  the per-turn spam this exists to fix. */
+  lastPermissionMode: string | null;
 }
 
 export interface SubagentWatcherHandle {
@@ -459,6 +467,7 @@ export function attachSubagentWatcher(opts: {
         // api-error, followed by the same background agent resuming, must
         // still preserve `toolUseId` in the flip-back block below.
         apiErrored: row.status === "failed",
+        lastPermissionMode: null,
       });
     }
   } catch (e) {
@@ -525,6 +534,7 @@ export function attachSubagentWatcher(opts: {
         endedAt: null,
         toolUseId: meta.toolUseId,
         apiErrored: false,
+        lastPermissionMode: null,
       };
       files.set(id, fs);
       lastChangeAt = Date.now();
@@ -562,6 +572,9 @@ export function attachSubagentWatcher(opts: {
       // `isApiErrorMessage`/`apiErrorStatus` straight off the JSONL line
       // sidesteps both.
       let apiErrorInfo: { detail: string } | null = null;
+      // Peeked but not yet applied to `fs.lastPermissionMode` — see below for
+      // why the apply is deferred past the dedup-skip continue.
+      let linePermissionMode: string | undefined;
       try {
         const o = JSON.parse(line) as {
           uuid?: unknown;
@@ -569,6 +582,7 @@ export function attachSubagentWatcher(opts: {
           message?: { stop_reason?: unknown };
           isApiErrorMessage?: unknown;
           apiErrorStatus?: unknown;
+          permissionMode?: unknown;
         };
         uuid = typeof o.uuid === "string" ? o.uuid : undefined;
         endTurnHint = o.type === "assistant" && o.message?.stop_reason === "end_turn";
@@ -585,7 +599,22 @@ export function attachSubagentWatcher(opts: {
             detail: formatApiErrorDetail(typeof o.apiErrorStatus === "number" ? o.apiErrorStatus : undefined),
           };
         }
+        if ((o.type === "system" || o.type === "permission-mode") && typeof o.permissionMode === "string") {
+          linePermissionMode = o.permissionMode;
+        }
       } catch { /* fall through; mapper will surface the parse error */ }
+
+      // Mirror the mode into `fs.lastPermissionMode` BEFORE the dedup-skip
+      // continue below — same reasoning as `dispatchLine`'s mirror on the
+      // main stream: a boot reattach replays already-persisted lines through
+      // this loop too (dedup skips re-emission, not re-parsing), and without
+      // updating here first, a reattach would leave `lastPermissionMode`
+      // stuck at `null` and re-emit a redundant chip on this subagent's next
+      // genuinely-new mode-bearing line. `prevPermissionMode` is captured
+      // first so the mapper call below (for lines that ARE new) compares
+      // against what we knew before this line, not this line's own value.
+      const prevPermissionMode = fs.lastPermissionMode;
+      if (linePermissionMode !== undefined) fs.lastPermissionMode = linePermissionMode;
 
       if (uuid && fs.seen.has(uuid)) {
         if (endTurnHint) fs.sawEndOfTurn = true;
@@ -645,6 +674,7 @@ export function attachSubagentWatcher(opts: {
         // line. A harmless no-op write when a text block IS present (the
         // common case) — INSERT OR IGNORE just keeps that first row.
         true,
+        prevPermissionMode,
       );
       if (uuid) fs.seen.add(uuid);
       if (endOfTurn) fs.sawEndOfTurn = true;

--- a/src/bun/claude-tmux.test.ts
+++ b/src/bun/claude-tmux.test.ts
@@ -660,6 +660,37 @@ test("mapJsonlEventToChunks: top-level permission-mode (claude variant) surfaces
   expect(out[0]).toEqual({ stream: "status", data: "permission-mode: plan" });
 });
 
+test("mapJsonlEventToChunks: lastPermissionMode matching the event's mode suppresses the status chunk", () => {
+  // Emit-on-change: claude journals a mode-bearing event at the start of
+  // every turn, not just on an actual change. When the caller's 4th arg
+  // already equals the event's mode, no status chunk should be emitted at
+  // all (and nothing else fires for a bare system/permission-mode event).
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({ type: "system", permissionMode: "auto" });
+  const res = mapJsonlEventToChunks(line, onChunk, false, "auto");
+  expect(out).toEqual([]);
+  expect(res.endOfTurn).toBe(false);
+});
+
+test("mapJsonlEventToChunks: lastPermissionMode differing from the event's mode still emits", () => {
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({ type: "permission-mode", permissionMode: "auto" });
+  mapJsonlEventToChunks(line, onChunk, false, "plan");
+  expect(out[0]).toEqual({ stream: "status", data: "permission-mode: auto" });
+});
+
+test("mapJsonlEventToChunks: omitting lastPermissionMode preserves always-emit default", () => {
+  // Cheap explicit check of the `undefined` default (the two tests above at
+  // :649-661 already cover this implicitly by calling with no 4th arg at
+  // all) — passing `undefined` explicitly must behave identically to
+  // omitting it, since real call sites without tracking (e.g. a caller that
+  // predates this param) pass nothing.
+  const { out, onChunk } = recorder();
+  const line = JSON.stringify({ type: "system", permissionMode: "auto" });
+  mapJsonlEventToChunks(line, onChunk, false, undefined);
+  expect(out[0]).toEqual({ stream: "status", data: "permission-mode: auto" });
+});
+
 test("mapJsonlEventToChunks: summary checkpoints surface as a status breadcrumb", () => {
   const { out, onChunk } = recorder();
   const line = JSON.stringify({ type: "summary", summary: "Earlier turns compacted" });
@@ -779,6 +810,67 @@ test("system event updates state.permissionMode (dispatchLine path)", async () =
     JSON.stringify({ type: "permission-mode", permissionMode: "auto" }),
   );
   expect(state.permissionMode).toBe("auto");
+  __forTest.uninstallSession(taskId);
+});
+
+test("dispatchLine: repeated same-mode events emit one status chunk; a mode change emits a second", async () => {
+  // End-to-end emit-on-change through the real dispatch path (mirrors the
+  // spam scenario: claude journals a mode-bearing event at the start of
+  // every turn). Three mode-bearing lines with distinct uuids so dedup
+  // can't suppress them on its own — only the emit-on-change comparison
+  // against SessionState.permissionMode should.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-mode-emit-on-change";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+  const emitted: { stream: string; data: string }[] = [];
+  state.lastChunk = (stream, data) => emitted.push({ stream, data });
+
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "system", uuid: "mode-uuid-1", permissionMode: "auto",
+  }));
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "system", uuid: "mode-uuid-2", permissionMode: "auto",
+  }));
+  const statusChunks = () => emitted.filter((e) => e.stream === "status" && e.data.startsWith("permission-mode: "));
+  expect(statusChunks()).toEqual([{ stream: "status", data: "permission-mode: auto" }]);
+
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "system", uuid: "mode-uuid-3", permissionMode: "plan",
+  }));
+  expect(statusChunks()).toEqual([
+    { stream: "status", data: "permission-mode: auto" },
+    { stream: "status", data: "permission-mode: plan" },
+  ]);
+  __forTest.uninstallSession(taskId);
+});
+
+test("dispatchLine: replayed mode-bearing line rehydrates state without emitting, so the next genuinely-new same-mode line stays suppressed", async () => {
+  // Guards the mirror-above-dedup invariant: on reattach, `seenLineUuids` is
+  // pre-seeded from `run_events`, so the replayed line takes the dedup
+  // early-return (no chunk emission) — but the permissionMode mirror runs
+  // BEFORE that early-return, so state.permissionMode is still rehydrated.
+  // A later, genuinely-new line carrying the SAME mode must therefore also
+  // stay suppressed, not spuriously re-emit because the tracker looked empty.
+  const { __forTest } = await import("./claude-tmux.ts");
+  const taskId = "task-mode-reattach-replay";
+  const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
+  const emitted: { stream: string; data: string }[] = [];
+  state.lastChunk = (stream, data) => emitted.push({ stream, data });
+
+  // Pre-seed the dedup set as boot reconciliation does for an already-persisted line.
+  state.seenLineUuids.add("mode-uuid-replayed");
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "system", uuid: "mode-uuid-replayed", permissionMode: "auto",
+  }));
+  const statusChunks = () => emitted.filter((e) => e.stream === "status" && e.data.startsWith("permission-mode: "));
+  expect(statusChunks()).toEqual([]);
+  expect(state.permissionMode).toBe("auto");
+
+  // A brand-new line (not deduped) with the SAME mode must still be suppressed.
+  __forTest.dispatchLine(state, JSON.stringify({
+    type: "system", uuid: "mode-uuid-fresh", permissionMode: "auto",
+  }));
+  expect(statusChunks()).toEqual([]);
   __forTest.uninstallSession(taskId);
 });
 
@@ -1233,6 +1325,32 @@ test("rebuildEventsFromJsonl: fires staged end_turn at EOF (last line is the tur
   rebuildEventsFromJsonl(lines, (stream, data) => out.push({ stream, data }));
   expect(out.some((r) => r.stream === "assistant" && r.data === "all done")).toBe(true);
   expect(out.some((r) => r.stream === "status" && r.data === "turn complete")).toBe(true);
+});
+
+test("rebuildEventsFromJsonl: emits exactly one permission-mode status entry per mode CHANGE, not per event", () => {
+  // rebuildEventsFromJsonl drives dispatchLine against a synthetic state, so
+  // it inherits the same emit-on-change suppression — this is the "already
+  // persisted spam renders collapsed" acceptance criterion from the plan,
+  // exercised directly against a spammy JSONL: repeated same-mode events
+  // interleaved with unrelated (non-mode) events must collapse to one chip
+  // per actual change (auto -> plan -> auto = 3 chips, not 6).
+  const lines = [
+    JSON.stringify({ type: "system", uuid: "r1", permissionMode: "auto" }),
+    JSON.stringify({ type: "assistant", uuid: "r2",
+      message: { id: "msg-A", role: "assistant", content: [{ type: "text", text: "hi" }], stop_reason: "tool_use" } }),
+    JSON.stringify({ type: "system", uuid: "r3", permissionMode: "auto" }),
+    JSON.stringify({ type: "permission-mode", uuid: "r4", permissionMode: "plan" }),
+    JSON.stringify({ type: "system", uuid: "r5", permissionMode: "plan" }),
+    JSON.stringify({ type: "system", uuid: "r6", permissionMode: "auto" }),
+  ].join("\n");
+  const out: { stream: string; data: string }[] = [];
+  rebuildEventsFromJsonl(lines, (stream, data) => out.push({ stream, data }));
+  const modeChips = out.filter((r) => r.stream === "status" && r.data.startsWith("permission-mode: "));
+  expect(modeChips.map((r) => r.data)).toEqual([
+    "permission-mode: auto",
+    "permission-mode: plan",
+    "permission-mode: auto",
+  ]);
 });
 
 test("dispatchLine: permissionMode still updates when the event's uuid is already in seenLineUuids (reattach path)", async () => {

--- a/src/bun/claude-tmux.test.ts
+++ b/src/bun/claude-tmux.test.ts
@@ -21,6 +21,7 @@ import {
   encodeProjectPath,
   jsonlPathFor,
   mapJsonlEventToChunks,
+  parseSessionActivityLine,
   rebuildEventsFromJsonl,
   sessionNameFor,
   toClaudeModeString,
@@ -54,6 +55,44 @@ test("encodeProjectPath turns every slash and dot into a dash", () => {
 
 test("sessionNameFor uses the first 12 chars of the task id", () => {
   expect(sessionNameFor("abcdef0123456789-rest")).toBe("agetor-abcdef012345");
+});
+
+test("parseSessionActivityLine parses a detached live session", () => {
+  expect(parseSessionActivityLine("0:1785511908")).toEqual({
+    attached: false,
+    // seconds -> ms
+    activityAt: 1785511908 * 1000,
+  });
+});
+
+test("parseSessionActivityLine parses an attached session", () => {
+  expect(parseSessionActivityLine("1:123")).toEqual({ attached: true, activityAt: 123000 });
+});
+
+test("parseSessionActivityLine rejects an empty string", () => {
+  expect(parseSessionActivityLine("")).toBeNull();
+});
+
+test("parseSessionActivityLine rejects the tmux 3.6a empty-target shape", () => {
+  // `display-message -p -t '=<name>'` on tmux 3.6a expands an unresolvable
+  // exact-match target's variables to empty and still exits 0 — this is the
+  // literal stdout that caused the reap-spam bug. list-sessions -f no longer
+  // produces this shape, but the parser must reject it defensively too.
+  expect(parseSessionActivityLine(":")).toBeNull();
+});
+
+test("parseSessionActivityLine rejects non-digit fields", () => {
+  expect(parseSessionActivityLine("abc:123")).toBeNull();
+  expect(parseSessionActivityLine("0:abc")).toBeNull();
+  expect(parseSessionActivityLine("garbage")).toBeNull();
+});
+
+test("parseSessionActivityLine rejects negative and whitespace variants", () => {
+  expect(parseSessionActivityLine("-1:123")).toBeNull();
+  expect(parseSessionActivityLine("0:-123")).toBeNull();
+  expect(parseSessionActivityLine("0: 123")).toBeNull();
+  expect(parseSessionActivityLine(" 0:123 ")).toEqual({ attached: false, activityAt: 123000 });
+  expect(parseSessionActivityLine("0 :123")).toBeNull();
 });
 
 test("buildClaudeSessionEnv pins the classic renderer and re-injects PATH", () => {

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -759,11 +759,15 @@ function formatTurnDuration(ms: number): string {
  * ONLY external caller of this raw-line entry point (`dispatchLine`, the
  * main stream, parses up front and calls `mapParsedEventToChunks` directly)
  * — passes `true`.
+ * @param lastPermissionMode See `mapParsedEventToChunks`'s param of the same
+ * name. Threaded straight through so the subagent tailer gets the same
+ * emit-on-change suppression as the main stream.
  */
 export function mapJsonlEventToChunks(
   line: string,
   onChunk: ChunkHandler,
   includeUuidForApiError = false,
+  lastPermissionMode?: string | null,
 ): { endOfTurn: boolean; lineUuid?: string } {
   let evt: ParsedJsonlEvent;
   try {
@@ -772,7 +776,7 @@ export function mapJsonlEventToChunks(
     onChunk("stderr", `jsonl parse error: ${(e as Error).message}`);
     return { endOfTurn: false };
   }
-  return mapParsedEventToChunks(evt, onChunk, includeUuidForApiError);
+  return mapParsedEventToChunks(evt, onChunk, includeUuidForApiError, lastPermissionMode);
 }
 
 /** String-variant entry point delegates to this once the JSON has been
@@ -797,11 +801,21 @@ export function mapJsonlEventToChunks(
  * that point. When a text block IS present (the common case), the
  * duplicate write is a harmless no-op — INSERT OR IGNORE silently keeps
  * the first (assistant) row, which already carries the same uuid.
+ * @param lastPermissionMode The mode `SessionState.permissionMode` held
+ * BEFORE this event (undefined = caller has no tracking — e.g. a test that
+ * predates this param, or a one-off call site that doesn't care — always
+ * emit, matching pre-existing behavior). Claude journals a mode-bearing
+ * event at every turn start, not just on an actual mode change, so without
+ * this the `system`/`permission-mode` case below would emit an identical
+ * `permission-mode: <mode>` status chip after every single turn. Passing
+ * the previous value lets that case suppress the chunk when nothing
+ * actually changed.
  */
 function mapParsedEventToChunks(
   evt: ParsedJsonlEvent,
   onChunk: ChunkHandler,
   includeUuidForApiError = false,
+  lastPermissionMode?: string | null,
 ): { endOfTurn: boolean; lineUuid?: string } {
   // Claude stamps a uuid on every event line. Forward it as the third arg
   // to onChunk so the orchestrator can persist it as the run_events row's
@@ -998,7 +1012,11 @@ function mapParsedEventToChunks(
 
     case "system":
     case "permission-mode":
-      if (evt.permissionMode) {
+      // Claude journals a mode-bearing event at the start of every turn, not
+      // just when the mode actually changes — emit the chip only when it
+      // differs from what the caller already knows, so identical
+      // "permission-mode: auto" chips don't spam the stream after every turn.
+      if (evt.permissionMode && evt.permissionMode !== lastPermissionMode) {
         onChunk("status", `permission-mode: ${evt.permissionMode}`, uuid);
       } else if (evt.subtype === "turn_duration" && typeof evt.durationMs === "number") {
         // Emitted right after the assistant end_turn. The end_turn itself
@@ -2699,6 +2717,12 @@ function dispatchLine(state: SessionState, line: string): void {
   // On reattach the dedup set is pre-seeded from run_events, so every
   // replayed line — including mode events the prior process recorded — would
   // otherwise be silently skipped and state.permissionMode would stay null.
+  //
+  // Captured BEFORE the mirror writes the new value so the mapper call below
+  // can compare "what the event says" against "what we knew a moment ago"
+  // and suppress a same-mode repeat (see `mapParsedEventToChunks`'s
+  // `lastPermissionMode` param).
+  const prevPermissionMode = state.permissionMode;
   if ((evt.type === "system" || evt.type === "permission-mode")
     && typeof evt.permissionMode === "string") {
     state.permissionMode = evt.permissionMode;
@@ -2797,7 +2821,7 @@ function dispatchLine(state: SessionState, line: string): void {
   // recently popped slot's handler so trailing metadata still reaches the
   // correct run. If neither exists it's safe to drop.
   const onChunk: ChunkHandler = slot?.onChunk ?? state.lastChunk ?? (() => {});
-  const { endOfTurn } = mapParsedEventToChunks(evt, onChunk);
+  const { endOfTurn } = mapParsedEventToChunks(evt, onChunk, false, prevPermissionMode);
   if (uuid) state.seenLineUuids.add(uuid);
   if (endOfTurn) {
     // Stage: don't resolve the turn yet. The banner and slot-pop happen in

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -1155,35 +1155,98 @@ export function sessionExistsByName(name: string): boolean {
 }
 
 /**
+ * Pure parser for one `#{session_attached}:#{session_activity}` line as
+ * produced by `probeSessionActivity`'s `list-sessions -F` call. Exported so
+ * the tmux-version quirk below is unit-testable without a real tmux binary.
+ *
+ * Both fields must be non-empty, all-digit strings BEFORE we hand them to
+ * `Number()` — `Number("")` is `0`, which is a finite number, so a naive
+ * `Number.isFinite` guard silently accepts an empty field as "zero" instead
+ * of rejecting it as malformed. That footgun is exactly what let a tmux 3.6a
+ * quirk (see `probeSessionActivity`'s doc comment) turn "session not found"
+ * into "activity at epoch 0" instead of `null`.
+ */
+export function parseSessionActivityLine(line: string): { attached: boolean; activityAt: number } | null {
+  const trimmed = line.trim();
+  if (trimmed === "") return null;
+  const parts = trimmed.split(":");
+  if (parts.length !== 2) return null;
+  const attachedRaw = parts[0] ?? "";
+  const activityRaw = parts[1] ?? "";
+  const digitsOnly = /^[0-9]+$/;
+  if (!digitsOnly.test(attachedRaw) || !digitsOnly.test(activityRaw)) return null;
+  const attachedNum = Number(attachedRaw);
+  const activitySec = Number(activityRaw);
+  // tmux reports session_activity in epoch SECONDS; callers (idle-clock math
+  // against `Date.now()`) expect milliseconds.
+  return { attached: attachedNum > 0, activityAt: activitySec * 1000 };
+}
+
+/**
  * Keyed, single-round-trip liveness + activity probe for a task's tmux
  * session, with no dependency on in-memory `SessionState`. This is what the
  * reaper falls back to for a task it holds no `SessionState` for (e.g. after
  * a restart, before boot reconciliation reattaches it) instead of a bare
  * `has-session` check that can't tell whether the session is still doing
- * anything. One `tmux display-message` round-trip pulls both
- * `#{session_attached}` (nonzero while a real `tmux attach` is live) and
- * `#{session_activity}` (tmux's own last-activity timestamp for the session —
- * updated on any pane output, independent of whether we're the ones tailing
- * it) in a single call. `-t '=<name>'` forces an exact-match target, matching
- * every other tmux() call in this file — see `sessionExists`'s comment for
- * why an unanchored name prefix-matches a sibling `agetor-<id>` session and
- * would misreport a live, unrelated session as this task's. Returns null
- * when the command fails or the session doesn't exist; the caller treats
- * that as "can't tell," not "definitely dead."
+ * anything. Pulls both `#{session_attached}` (nonzero while a real `tmux
+ * attach` is live) and `#{session_activity}` (tmux's own last-activity
+ * timestamp for the session — updated on any pane output, independent of
+ * whether we're the ones tailing it) in a single round-trip, with no
+ * dependency on `SessionState`.
+ *
+ * Uses `list-sessions -F '#{session_attached}:#{session_activity}' -f
+ * '#{==:#{session_name},<name>}'` rather than `display-message -p -t
+ * '=<name>'`. We used to use `display-message`, but on tmux 3.6a it does NOT
+ * resolve an `=`-prefixed exact-match TARGET the way `has-session` and
+ * `kill-session` do: instead of failing for a nonexistent session, it prints
+ * the requested format with every variable expanded to empty (stdout `:`)
+ * and exits 0 — identically for a live session and a dead one. Parsed the
+ * old way (`Number("") === 0` sailing through `Number.isFinite`), that
+ * turned into `{attached: false, activityAt: 0}` for EVERY task, live or
+ * dead — "idle since epoch 1970" — which made the idle-session reaper
+ * re-reap every candidate task on every sweep. `list-sessions -f
+ * '#{==:...}'` uses a session FILTER, not a resolved target, so it isn't
+ * subject to that `=`-target quirk: verified on tmux 3.6a to return e.g.
+ * `0:1785511908` for a live session and empty stdout (exit 0, server up)
+ * for a dead one.
+ *
+ * `-f '#{==:#{session_name},<name>}'` is an exact-match filter, matching the
+ * `-t '=<name>'` exact-match target used by every other tmux() call in this
+ * file — see `sessionExists`'s comment for why an unanchored name
+ * prefix-matches a sibling `agetor-<id>` session and would misreport a live,
+ * unrelated session as this task's. Since the name is unique, the filter
+ * should never yield more than one line; if it somehow does, we treat that
+ * as ambiguous and return null rather than guess which line is "ours."
+ *
+ * Returns null when the command fails (no tmux server), stdout is empty or
+ * whitespace-only (session doesn't exist), or the output doesn't parse —
+ * the caller treats that as "can't tell," not "definitely dead."
  */
+let probeFailureWarned = false;
 export function probeSessionActivity(taskId: string): { attached: boolean; activityAt: number } | null {
   const r = tmux([
-    "display-message", "-p", "-t", "=" + sessionNameFor(taskId),
-    "#{session_attached}:#{session_activity}",
+    "list-sessions", "-F", "#{session_attached}:#{session_activity}",
+    "-f", "#{==:#{session_name}," + sessionNameFor(taskId) + "}",
   ]);
-  if (!r.ok) return null;
-  const [attachedRaw, activityRaw] = r.stdout.trim().split(":");
-  const attachedNum = Number(attachedRaw);
-  const activitySec = Number(activityRaw);
-  if (!Number.isFinite(attachedNum) || !Number.isFinite(activitySec)) return null;
-  // tmux reports session_activity in epoch SECONDS; callers (idle-clock math
-  // against `Date.now()`) expect milliseconds.
-  return { attached: attachedNum > 0, activityAt: activitySec * 1000 };
+  if (!r.ok) {
+    // A missing server is the routine failure (nothing running → nothing to
+    // probe) — stay silent for that. Anything else gets one warn per
+    // process: `-f` + the `#{==:}` comparison are a newer tmux surface than
+    // the has-session/kill-session calls elsewhere in this file, and a tmux
+    // build that rejects them would otherwise silently disable reaping for
+    // every session with no in-memory SessionState — the same *class* of
+    // invisible misread the display-message quirk this function replaced.
+    if (!probeFailureWarned && !/no server running|error connecting/i.test(r.stderr)) {
+      probeFailureWarned = true;
+      console.warn(`[agetor] probeSessionActivity: tmux list-sessions failed: ${r.stderr.trim()}`);
+    }
+    return null;
+  }
+  const trimmed = r.stdout.trim();
+  if (trimmed === "") return null;
+  const lines = trimmed.split("\n");
+  if (lines.length !== 1) return null;
+  return parseSessionActivityLine(lines[0] ?? "");
 }
 
 /** Tri-state liveness of a tmux session — the safe signal for the death watch. */

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -1018,7 +1018,14 @@ function mapParsedEventToChunks(
       // "permission-mode: auto" chips don't spam the stream after every turn.
       if (evt.permissionMode && evt.permissionMode !== lastPermissionMode) {
         onChunk("status", `permission-mode: ${evt.permissionMode}`, uuid);
-      } else if (evt.subtype === "turn_duration" && typeof evt.durationMs === "number") {
+      }
+      // Independent `if` (not `else if`): a mode-bearing event and a
+      // turn-duration event are conceptually unrelated fields on the same
+      // envelope. Coupling them would mean a future claude build that
+      // stamps `permissionMode` onto a `subtype:"turn_duration"` line
+      // silently swaps the mode-change chip for the duration chip instead
+      // of emitting both.
+      if (evt.subtype === "turn_duration" && typeof evt.durationMs === "number") {
         // Emitted right after the assistant end_turn. The end_turn itself
         // already produced a "turn complete" status; this just adds the
         // duration so the user can see at a glance whether the turn was
@@ -1703,6 +1710,19 @@ interface SessionState {
    */
   permissionMode: string | null;
   /**
+   * The mode value of the last mode-bearing JSONL line `dispatchLine`
+   * processed (or the launch/reattach seed) — the baseline handed to
+   * `mapParsedEventToChunks` as `lastPermissionMode` for chip-suppression
+   * purposes. Unlike `permissionMode`, this field is NEVER written from a
+   * pane scrape (`cycleToModeInner`'s Shift+Tab verification writes only
+   * `permissionMode`) — so when the user switches modes via the UI, this
+   * field still lags the live mode until claude journals the corresponding
+   * JSONL line at the next turn start, and the confirmation chip for that
+   * genuinely user-initiated change is not wrongly suppressed as a "no-op"
+   * repeat.
+   */
+  lastAnnouncedPermissionMode: string | null;
+  /**
    * Whether `bypassPermissions` is in this session's Shift+Tab cycle. True
    * iff the session was launched with `--dangerously-skip-permissions` (the
    * agetor `bypass` mode emits exactly that). Reattached sessions default
@@ -1908,6 +1928,12 @@ interface MakeSessionStateOpts {
   seenLineUuids?: Set<string>;
   onEndOfTurn?: (() => void) | null;
   permissionMode?: string | null;
+  /** Defaults to `permissionMode` (or its own default of `null`) when
+   *  omitted — the common case where the caller has no reason for the two
+   *  fields to start out of sync. See `SessionState.lastAnnouncedPermissionMode`
+   *  for what it means to pass something different (used by `reattachSession`
+   *  to seed the suppression baseline without also seeding `permissionMode`). */
+  lastAnnouncedPermissionMode?: string | null;
   bypassEnabled?: boolean;
 }
 
@@ -1923,6 +1949,7 @@ function makeSessionState(o: MakeSessionStateOpts): SessionState {
     seenLineUuids: o.seenLineUuids ?? new Set(),
     onEndOfTurn: o.onEndOfTurn ?? null,
     permissionMode: o.permissionMode ?? null,
+    lastAnnouncedPermissionMode: o.lastAnnouncedPermissionMode ?? o.permissionMode ?? null,
     bypassEnabled: o.bypassEnabled ?? false,
     // Defaults shared by every site — timers, scrape state, staging buffers.
     watcher: null,
@@ -2719,13 +2746,23 @@ function dispatchLine(state: SessionState, line: string): void {
   // otherwise be silently skipped and state.permissionMode would stay null.
   //
   // Captured BEFORE the mirror writes the new value so the mapper call below
-  // can compare "what the event says" against "what we knew a moment ago"
-  // and suppress a same-mode repeat (see `mapParsedEventToChunks`'s
-  // `lastPermissionMode` param).
-  const prevPermissionMode = state.permissionMode;
+  // can compare "what the event says" against "what we last announced" and
+  // suppress a same-mode repeat (see `mapParsedEventToChunks`'s
+  // `lastPermissionMode` param). Deliberately read from
+  // `lastAnnouncedPermissionMode`, NOT `permissionMode`: `permissionMode` can
+  // also be written by `cycleToModeInner`'s pane-scrape verification when the
+  // USER switches modes via Shift+Tab, which happens before claude journals
+  // the corresponding JSONL line. Using `permissionMode` here would make that
+  // pane-scrape write look like "already announced" and suppress the
+  // legitimate confirmation chip once the JSONL line does arrive.
+  // `lastAnnouncedPermissionMode` is written only from JSONL lines (below and
+  // at the launch/reattach seed), so it always tracks what was actually
+  // announced.
+  const prevAnnouncedPermissionMode = state.lastAnnouncedPermissionMode;
   if ((evt.type === "system" || evt.type === "permission-mode")
     && typeof evt.permissionMode === "string") {
     state.permissionMode = evt.permissionMode;
+    state.lastAnnouncedPermissionMode = evt.permissionMode;
   }
 
   // Staging step: the new line either confirms or cancels the pending end_turn.
@@ -2821,7 +2858,7 @@ function dispatchLine(state: SessionState, line: string): void {
   // recently popped slot's handler so trailing metadata still reaches the
   // correct run. If neither exists it's safe to drop.
   const onChunk: ChunkHandler = slot?.onChunk ?? state.lastChunk ?? (() => {});
-  const { endOfTurn } = mapParsedEventToChunks(evt, onChunk, false, prevPermissionMode);
+  const { endOfTurn } = mapParsedEventToChunks(evt, onChunk, false, prevAnnouncedPermissionMode);
   if (uuid) state.seenLineUuids.add(uuid);
   if (endOfTurn) {
     // Stage: don't resolve the turn yet. The banner and slot-pop happen in
@@ -4525,6 +4562,14 @@ export interface ReattachOptions {
    *  `onEndOfTurn` on end_turn lines belonging to long-completed prior
    *  turns. */
   seenLineUuids: Set<string>;
+  /** The task's agetor mode at reattach time (`task.mode`), used to seed
+   *  `SessionState.lastAnnouncedPermissionMode` so the offset-0 JSONL replay
+   *  doesn't re-emit a "permission-mode: <mode>" chip for a mode-bearing line
+   *  the prior process already announced (those lines carry no uuid, so the
+   *  usual seenLineUuids dedup can't catch them). Optional/nullable because
+   *  a task can have `mode: null` (defaults to `auto`/`workspace-write`
+   *  elsewhere) or reattach can be invoked without task context in tests. */
+  mode?: string | null;
 }
 
 /**
@@ -4574,6 +4619,16 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
     lastChunk: opts.onChunk,
     seenLineUuids: opts.seenLineUuids,
     onEndOfTurn: () => resolveDone?.(0),
+    // Seed the chip-suppression baseline from the task's mode so the
+    // offset-0 JSONL replay doesn't re-announce a mode the prior process
+    // already announced (permission-mode lines carry no uuid, so
+    // seenLineUuids can't dedup them). Deliberately NOT passed as
+    // `permissionMode` — that field feeds `cycleToModeInner`'s "current mode
+    // unknown" guard and Shift+Tab cycle math, and seeding it here (rather
+    // than leaving it null until the JSONL replay re-hydrates it) would
+    // change that guard's semantics on a reattach where the true live mode
+    // might differ from the task's last-saved mode.
+    lastAnnouncedPermissionMode: opts.mode ? toClaudeModeString(opts.mode) : null,
   });
   // Belt to reconcileOrphans's sort-and-dedup suspender: if some prior
   // reattach (or other code path) already left a SessionState in the map

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -749,6 +749,22 @@ export const runs = {
        ORDER BY id ASC`,
     ).all(runId);
   },
+  /** The most recently persisted MAIN-stream event's raw `data` for a run
+   *  (`subagent_id IS NULL`, like `seenLineUuidsForTask`), or `null` if the
+   *  run has none yet.
+   *
+   *  Backs `reapIdleSessions`'s idempotence guard: a re-reap regression
+   *  would try to append the identical hibernate breadcrumb to the same run
+   *  again, and comparing against the last persisted event's exact text is
+   *  enough to catch that without a full row fetch. The breadcrumb itself is
+   *  a main-stream row, so a subagent row landing afterwards must not
+   *  re-arm the guard — hence the filter. */
+  lastEventData(runId: string): string | null {
+    const row = db.query<{ data: string }, [string]>(
+      `SELECT data FROM run_events WHERE run_id = ? AND subagent_id IS NULL ORDER BY id DESC LIMIT 1`,
+    ).get(runId);
+    return row ? row.data : null;
+  },
   /** All events across every run of a task, in event-id order (which is
    *  chronological — id is autoincrement, ts can collide when bursts of
    *  events land in the same Date.now() ms). Used by the unified

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -577,6 +577,7 @@ export function reconcileOrphans(): number {
             configDir: harness?.home ?? null,
             onChunk,
             seenLineUuids: runs.seenLineUuidsForTask(row.task_id),
+            mode: task.mode,
           })
         : reattachCodexSession({
             taskId: row.task_id,

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -2440,8 +2440,21 @@ export async function reapIdleSessions(): Promise<{ reaped: string[] }> {
         const data = findLastClaudeSessionId(taskId)
           ? "session hibernated after 30m idle — next message will resume it"
           : "session hibernated after 30m idle — no saved session id, next message starts a fresh context";
-        runs.appendEvent(recent.id, "status", data);
-        emit({ runId: recent.id, taskId, stream: "status", data, ts: Date.now() });
+        // Idempotence backstop: a re-reap regression (e.g. the tmux 3.6a
+        // `display-message` exact-match bug worked around in
+        // `probeSessionActivity`, which made every probe look like "never
+        // attached, idle since 1970" and re-reaped every candidate on every
+        // sweep) must not re-spam the run with duplicate hibernate
+        // breadcrumbs. A legitimate later hibernate always has intervening
+        // events (resuming creates a new run / new events), so "the last
+        // persisted event for this run is this exact breadcrumb" is safe to
+        // treat as "already reaped, skip" — both the append AND the emit,
+        // since an emit without persistence would still paint a new chip
+        // client-side on every sweep.
+        if (runs.lastEventData(recent.id) !== data) {
+          runs.appendEvent(recent.id, "status", data);
+          emit({ runId: recent.id, taskId, stream: "status", data, ts: Date.now() });
+        }
       }
     }
 

--- a/src/bun/session-reaper.test.ts
+++ b/src/bun/session-reaper.test.ts
@@ -321,3 +321,113 @@ test("back-to-back reap sweeps never reap the same task twice", async () => {
     db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
   }
 });
+
+test("runs.lastEventData returns the most recently appended MAIN-stream event's data, and null for an eventless run", async () => {
+  const { db, runs } = await import("./db.ts");
+
+  // run_events.run_id carries an FK to runs(id) (ON DELETE CASCADE), so this
+  // needs a real task + run row, not a bare uuid.
+  const task = await createClaudeTask("lastEventData accessor");
+  const taskId = task.id;
+  const runId = randomUUID();
+  runs.insert({
+    id: runId,
+    taskId,
+    agent: "claude-code",
+    status: "running",
+    startedAt: Date.now(),
+    endedAt: null,
+    exitCode: null,
+    tmuxSession: null,
+    claudeSessionId: null,
+    codexSessionId: null,
+  });
+
+  try {
+    expect(runs.lastEventData(runId)).toBeNull();
+
+    runs.appendEvent(runId, "status", "first");
+    expect(runs.lastEventData(runId)).toBe("first");
+
+    runs.appendEvent(runId, "status", "second");
+    expect(runs.lastEventData(runId)).toBe("second");
+
+    // Re-appending the same text is exactly what the reap guard checks for —
+    // confirm the accessor reports it as unchanged (still "second", not a
+    // stale read behind the new row).
+    runs.appendEvent(runId, "status", "second");
+    expect(runs.lastEventData(runId)).toBe("second");
+
+    // A subagent row landing after the breadcrumb must NOT become "the last
+    // event" — the guard compares main-stream text against main-stream text.
+    runs.appendEvent(runId, "assistant", "subagent chatter", null, "subagent-1");
+    expect(runs.lastEventData(runId)).toBe("second");
+  } finally {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});
+
+test("never appends the hibernate breadcrumb twice in a row to the same run, even across a re-reap regression", async () => {
+  // Regression guard for the tmux 3.6a `probeSessionActivity` bug (see
+  // docs/plans/fix-permission-mode-status-spam.md, "Follow-up" section): a
+  // broken probe made every idle-fallback check look like "never attached,
+  // idle since 1970", so `reapIdleSessions` re-reaped the same
+  // already-hibernated task on every 5-minute sweep and appended a fresh
+  // duplicate breadcrumb each time (528 rows across 12 tasks in prod). The
+  // probe fix is covered by `parseSessionActivityLine`'s unit tests in
+  // claude-tmux.test.ts; this test exercises the defense-in-depth backstop
+  // instead — it doesn't rely on the probe being broken, it simulates a
+  // re-reap directly (reinstalling an idle in-memory session on the very run
+  // the first sweep already hibernated) and asserts the breadcrumb still
+  // can't duplicate no matter what caused the second sweep to think the task
+  // was idle again.
+  const { startTask, reapIdleSessions } = await import("./orchestrator.ts");
+  const { db, runs } = await import("./db.ts");
+  const claudeTmux = await import("./claude-tmux.ts");
+  const { IDLE_SESSION_REAP_MS } = await import("../shared/types.ts");
+
+  const task = await createClaudeTask("no double hibernate breadcrumb");
+  const taskId = task.id;
+
+  const started = await startTask(taskId);
+  if (!("runId" in started)) throw new Error("expected the run to start");
+  const runId = started.runId;
+  // Let the fake driver's turn resolve so `active` no longer holds this run
+  // — otherwise the in-flight guard would (correctly) block every reap
+  // attempt below regardless of idle time.
+  await new Promise((r) => setTimeout(r, 100));
+
+  try {
+    // First sweep: genuinely idle in-memory session → reaps and appends the
+    // hibernate breadcrumb once.
+    await installIdleSession(taskId, IDLE_SESSION_REAP_MS + 5_000);
+    const first = await reapIdleSessions();
+    expect(first.reaped).toContain(taskId);
+
+    const afterFirst = runs
+      .eventsForTask(taskId)
+      .filter((e) => e.runId === runId && e.stream === "status" && e.data.includes("hibernated"));
+    expect(afterFirst.length).toBe(1);
+
+    // Simulate the regression: something makes the reaper see this exact
+    // task/run as idle again on the very next sweep (in prod this was the
+    // broken tmux probe; here we reinstall an idle session directly so the
+    // test doesn't depend on reproducing the tmux 3.6a bug itself). No
+    // follow-up message was sent, so `recent` still resolves to the same
+    // run — this is the scenario the guard exists for.
+    await installIdleSession(taskId, IDLE_SESSION_REAP_MS + 5_000);
+    const second = await reapIdleSessions();
+    expect(second.reaped).toContain(taskId);
+
+    const afterSecond = runs
+      .eventsForTask(taskId)
+      .filter((e) => e.runId === runId && e.stream === "status" && e.data.includes("hibernated"));
+    // The guard must have skipped the duplicate append — still exactly one
+    // hibernate breadcrumb on this run, not two.
+    expect(afterSecond.length).toBe(1);
+    expect(afterSecond[0]!.data).toBe(afterFirst[0]!.data);
+  } finally {
+    claudeTmux.__forTest.uninstallSession(taskId);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
+});

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -43,6 +43,7 @@ import {
 import { appendReferences } from "../../../shared/refs.ts";
 import { draftsEqual, normalizeDraft } from "@/lib/draft";
 import { createEventDeduper } from "@/lib/event-dedup";
+import { collapseRepeatedModeStatus } from "@/lib/status-collapse";
 import { createEventBuffer } from "@/lib/event-buffer";
 import { invalidatesRebuiltSnapshot } from "@/lib/rebuilt-mask";
 import { cleanPromptPane } from "@/lib/prompt-noise";
@@ -3172,7 +3173,10 @@ function RunEventList({
   // same shape live events use. Without this, replayed history from older
   // runs renders as ugly prefixed text while only the in-flight events get
   // proper cards.
-  const normalised = useMemo(() => events.map(normalizeLegacyEvent), [events]);
+  const normalised = useMemo(
+    () => collapseRepeatedModeStatus(events).map(normalizeLegacyEvent),
+    [events],
+  );
 
   // Index tool_results by their tool_use_id so the tool-use card can show
   // the result inline beneath it. Falls back to a standalone tool-result

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -1148,11 +1148,21 @@ function RunPanelBody({
    *  the appended rebuild set (whose synthetic timestamps are anchored at the
    *  run's start, not real wall-clock time) so a status event doesn't jump to
    *  the wrong end of the transcript. */
+  // `collapseRepeatedModeStatus` MUST run here — not inside `RunEventList`'s
+  // `normalised` memo — because `findMatchingEventIds` below derives each
+  // match's id from an event's own position in `displayedEvents`, and that
+  // same array (uncollapsed) is what supplied the `data-evid` index at render
+  // time. Collapsing downstream of this memo would shorten the rendered
+  // array while search still matched against the longer, uncollapsed one,
+  // scrolling/highlighting the wrong block whenever history has duplicate
+  // permission-mode chips (review-caught bug). Doing it here keeps search,
+  // todo-progress, and rendering all reading from one shared index space.
   const displayedEvents = useMemo(() => {
-    if (activeStream !== "main") return subagentEventsById.get(activeStream) ?? [];
-    if (!rebuilt || !rebuiltRunIds) return mainEvents;
+    if (activeStream !== "main")
+      return collapseRepeatedModeStatus(subagentEventsById.get(activeStream) ?? []);
+    if (!rebuilt || !rebuiltRunIds) return collapseRepeatedModeStatus(mainEvents);
     const others = mainEvents.filter((e) => !rebuiltRunIds.has(e.runId) || e.stream === "status");
-    return [...others, ...rebuilt.events].sort((a, b) => a.ts - b.ts);
+    return collapseRepeatedModeStatus([...others, ...rebuilt.events].sort((a, b) => a.ts - b.ts));
   }, [activeStream, subagentEventsById, mainEvents, rebuilt, rebuiltRunIds]);
 
   /** The current to-do list for whichever stream is selected. Claude re-emits
@@ -3173,10 +3183,7 @@ function RunEventList({
   // same shape live events use. Without this, replayed history from older
   // runs renders as ugly prefixed text while only the in-flight events get
   // proper cards.
-  const normalised = useMemo(
-    () => collapseRepeatedModeStatus(events).map(normalizeLegacyEvent),
-    [events],
-  );
+  const normalised = useMemo(() => events.map(normalizeLegacyEvent), [events]);
 
   // Index tool_results by their tool_use_id so the tool-use card can show
   // the result inline beneath it. Falls back to a standalone tool-result

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -43,7 +43,7 @@ import {
 import { appendReferences } from "../../../shared/refs.ts";
 import { draftsEqual, normalizeDraft } from "@/lib/draft";
 import { createEventDeduper } from "@/lib/event-dedup";
-import { collapseRepeatedModeStatus } from "@/lib/status-collapse";
+import { collapseRepeatedStatusChips } from "@/lib/status-collapse";
 import { createEventBuffer } from "@/lib/event-buffer";
 import { invalidatesRebuiltSnapshot } from "@/lib/rebuilt-mask";
 import { cleanPromptPane } from "@/lib/prompt-noise";
@@ -1148,7 +1148,7 @@ function RunPanelBody({
    *  the appended rebuild set (whose synthetic timestamps are anchored at the
    *  run's start, not real wall-clock time) so a status event doesn't jump to
    *  the wrong end of the transcript. */
-  // `collapseRepeatedModeStatus` MUST run here — not inside `RunEventList`'s
+  // `collapseRepeatedStatusChips` MUST run here — not inside `RunEventList`'s
   // `normalised` memo — because `findMatchingEventIds` below derives each
   // match's id from an event's own position in `displayedEvents`, and that
   // same array (uncollapsed) is what supplied the `data-evid` index at render
@@ -1159,10 +1159,10 @@ function RunPanelBody({
   // todo-progress, and rendering all reading from one shared index space.
   const displayedEvents = useMemo(() => {
     if (activeStream !== "main")
-      return collapseRepeatedModeStatus(subagentEventsById.get(activeStream) ?? []);
-    if (!rebuilt || !rebuiltRunIds) return collapseRepeatedModeStatus(mainEvents);
+      return collapseRepeatedStatusChips(subagentEventsById.get(activeStream) ?? []);
+    if (!rebuilt || !rebuiltRunIds) return collapseRepeatedStatusChips(mainEvents);
     const others = mainEvents.filter((e) => !rebuiltRunIds.has(e.runId) || e.stream === "status");
-    return collapseRepeatedModeStatus([...others, ...rebuilt.events].sort((a, b) => a.ts - b.ts));
+    return collapseRepeatedStatusChips([...others, ...rebuilt.events].sort((a, b) => a.ts - b.ts));
   }, [activeStream, subagentEventsById, mainEvents, rebuilt, rebuiltRunIds]);
 
   /** The current to-do list for whichever stream is selected. Claude re-emits

--- a/src/mainview/lib/status-collapse.test.ts
+++ b/src/mainview/lib/status-collapse.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test";
+import type { RunEvent } from "../../shared/types.ts";
+import { collapseRepeatedModeStatus } from "./status-collapse.ts";
+
+const ev = (e: Partial<RunEvent>): RunEvent => ({
+  runId: "run-1",
+  taskId: "task-1",
+  stream: "status",
+  data: "",
+  ts: 0,
+  ...e,
+});
+
+test("collapseRepeatedModeStatus: consecutive identical permission-mode status events collapse to one", () => {
+  const events = [
+    ev({ data: "permission-mode: auto", ts: 1 }),
+    ev({ data: "permission-mode: auto", ts: 2 }),
+    ev({ data: "permission-mode: auto", ts: 3 }),
+  ];
+  const result = collapseRepeatedModeStatus(events);
+  expect(result).toHaveLength(1);
+  expect(result[0]).toBe(events[0]);
+});
+
+test("collapseRepeatedModeStatus: duplicates are collapsed even with non-status content interleaved", () => {
+  const events = [
+    ev({ data: "permission-mode: auto", ts: 1 }),
+    ev({ stream: "assistant", data: "hello there", ts: 2 }),
+    ev({ stream: "tool_use", data: JSON.stringify({ id: "1", name: "Bash", input: "ls" }), ts: 3 }),
+    ev({ data: "permission-mode: auto", ts: 4 }),
+  ];
+  const result = collapseRepeatedModeStatus(events);
+  expect(result).toEqual(events.slice(0, 3));
+});
+
+test("collapseRepeatedModeStatus: a mode change is kept — auto, auto, plan, plan, auto collapses to auto, plan, auto", () => {
+  const events = [
+    ev({ data: "permission-mode: auto", ts: 1 }),
+    ev({ data: "permission-mode: auto", ts: 2 }),
+    ev({ data: "permission-mode: plan", ts: 3 }),
+    ev({ data: "permission-mode: plan", ts: 4 }),
+    ev({ data: "permission-mode: auto", ts: 5 }),
+  ];
+  const result = collapseRepeatedModeStatus(events);
+  expect(result.map((e) => e.data)).toEqual([
+    "permission-mode: auto",
+    "permission-mode: plan",
+    "permission-mode: auto",
+  ]);
+});
+
+test("collapseRepeatedModeStatus: other status texts are never dropped, even repeated, and don't reset the tracker", () => {
+  const events = [
+    ev({ data: "permission-mode: auto", ts: 1 }),
+    ev({ data: "turn complete", ts: 2 }),
+    ev({ data: "turn complete", ts: 3 }),
+    ev({ data: "turn duration: 2m", ts: 4 }),
+    ev({ data: "turn duration: 2m", ts: 5 }),
+    // Same permission-mode value as before, with unrelated status text in
+    // between — those don't reset the tracked mode, so this is still dropped.
+    ev({ data: "permission-mode: auto", ts: 6 }),
+  ];
+  const result = collapseRepeatedModeStatus(events);
+  expect(result.map((e) => e.data)).toEqual([
+    "permission-mode: auto",
+    "turn complete",
+    "turn complete",
+    "turn duration: 2m",
+    "turn duration: 2m",
+  ]);
+});
+
+test("collapseRepeatedModeStatus: non-status streams with data coincidentally matching a permission-mode string are untouched and don't affect the tracker", () => {
+  const events = [
+    ev({ stream: "assistant", data: "permission-mode: auto", ts: 1 }),
+    ev({ data: "permission-mode: auto", ts: 2 }),
+    ev({ data: "permission-mode: auto", ts: 3 }),
+  ];
+  const result = collapseRepeatedModeStatus(events);
+  // The assistant event passes through untouched; of the two genuine status
+  // events, only the first is kept.
+  expect(result).toEqual(events.slice(0, 2));
+});
+
+test("collapseRepeatedModeStatus: empty list returns an empty list", () => {
+  expect(collapseRepeatedModeStatus([])).toEqual([]);
+});
+
+test("collapseRepeatedModeStatus: does not mutate the input array", () => {
+  const events = [
+    ev({ data: "permission-mode: auto", ts: 1 }),
+    ev({ data: "permission-mode: auto", ts: 2 }),
+    ev({ data: "permission-mode: plan", ts: 3 }),
+  ];
+  const snapshot = [...events];
+  const result = collapseRepeatedModeStatus(events);
+  expect(events).toHaveLength(snapshot.length);
+  expect(events).toEqual(snapshot);
+  // The returned array is a distinct, shorter collapsed list.
+  expect(result).not.toBe(events);
+  expect(result.length).toBeLessThan(events.length);
+});

--- a/src/mainview/lib/status-collapse.test.ts
+++ b/src/mainview/lib/status-collapse.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import type { RunEvent } from "../../shared/types.ts";
-import { collapseRepeatedModeStatus } from "./status-collapse.ts";
+import { collapseRepeatedStatusChips } from "./status-collapse.ts";
 
 const ev = (e: Partial<RunEvent>): RunEvent => ({
   runId: "run-1",
@@ -11,29 +11,29 @@ const ev = (e: Partial<RunEvent>): RunEvent => ({
   ...e,
 });
 
-test("collapseRepeatedModeStatus: consecutive identical permission-mode status events collapse to one", () => {
+test("collapseRepeatedStatusChips: consecutive identical permission-mode status events collapse to one", () => {
   const events = [
     ev({ data: "permission-mode: auto", ts: 1 }),
     ev({ data: "permission-mode: auto", ts: 2 }),
     ev({ data: "permission-mode: auto", ts: 3 }),
   ];
-  const result = collapseRepeatedModeStatus(events);
+  const result = collapseRepeatedStatusChips(events);
   expect(result).toHaveLength(1);
   expect(result[0]).toBe(events[0]);
 });
 
-test("collapseRepeatedModeStatus: duplicates are collapsed even with non-status content interleaved", () => {
+test("collapseRepeatedStatusChips: duplicates are collapsed even with non-status content interleaved", () => {
   const events = [
     ev({ data: "permission-mode: auto", ts: 1 }),
     ev({ stream: "assistant", data: "hello there", ts: 2 }),
     ev({ stream: "tool_use", data: JSON.stringify({ id: "1", name: "Bash", input: "ls" }), ts: 3 }),
     ev({ data: "permission-mode: auto", ts: 4 }),
   ];
-  const result = collapseRepeatedModeStatus(events);
+  const result = collapseRepeatedStatusChips(events);
   expect(result).toEqual(events.slice(0, 3));
 });
 
-test("collapseRepeatedModeStatus: a mode change is kept — auto, auto, plan, plan, auto collapses to auto, plan, auto", () => {
+test("collapseRepeatedStatusChips: a mode change is kept — auto, auto, plan, plan, auto collapses to auto, plan, auto", () => {
   const events = [
     ev({ data: "permission-mode: auto", ts: 1 }),
     ev({ data: "permission-mode: auto", ts: 2 }),
@@ -41,7 +41,7 @@ test("collapseRepeatedModeStatus: a mode change is kept — auto, auto, plan, pl
     ev({ data: "permission-mode: plan", ts: 4 }),
     ev({ data: "permission-mode: auto", ts: 5 }),
   ];
-  const result = collapseRepeatedModeStatus(events);
+  const result = collapseRepeatedStatusChips(events);
   expect(result.map((e) => e.data)).toEqual([
     "permission-mode: auto",
     "permission-mode: plan",
@@ -49,7 +49,7 @@ test("collapseRepeatedModeStatus: a mode change is kept — auto, auto, plan, pl
   ]);
 });
 
-test("collapseRepeatedModeStatus: other status texts are never dropped, even repeated, and don't reset the tracker", () => {
+test("collapseRepeatedStatusChips: other status texts are never dropped, even repeated, and don't reset the tracker", () => {
   const events = [
     ev({ data: "permission-mode: auto", ts: 1 }),
     ev({ data: "turn complete", ts: 2 }),
@@ -60,7 +60,7 @@ test("collapseRepeatedModeStatus: other status texts are never dropped, even rep
     // between — those don't reset the tracked mode, so this is still dropped.
     ev({ data: "permission-mode: auto", ts: 6 }),
   ];
-  const result = collapseRepeatedModeStatus(events);
+  const result = collapseRepeatedStatusChips(events);
   expect(result.map((e) => e.data)).toEqual([
     "permission-mode: auto",
     "turn complete",
@@ -70,30 +70,115 @@ test("collapseRepeatedModeStatus: other status texts are never dropped, even rep
   ]);
 });
 
-test("collapseRepeatedModeStatus: non-status streams with data coincidentally matching a permission-mode string are untouched and don't affect the tracker", () => {
+test("collapseRepeatedStatusChips: non-status streams with data coincidentally matching a permission-mode string are untouched and don't affect the tracker", () => {
   const events = [
     ev({ stream: "assistant", data: "permission-mode: auto", ts: 1 }),
     ev({ data: "permission-mode: auto", ts: 2 }),
     ev({ data: "permission-mode: auto", ts: 3 }),
   ];
-  const result = collapseRepeatedModeStatus(events);
+  const result = collapseRepeatedStatusChips(events);
   // The assistant event passes through untouched; of the two genuine status
   // events, only the first is kept.
   expect(result).toEqual(events.slice(0, 2));
 });
 
-test("collapseRepeatedModeStatus: empty list returns an empty list", () => {
-  expect(collapseRepeatedModeStatus([])).toEqual([]);
+test("collapseRepeatedStatusChips: empty list returns an empty list", () => {
+  expect(collapseRepeatedStatusChips([])).toEqual([]);
 });
 
-test("collapseRepeatedModeStatus: does not mutate the input array", () => {
+test("collapseRepeatedStatusChips: N consecutive identical hibernate chips collapse to one", () => {
+  const hibernate = "session hibernated after 30m idle — next message will resume it";
+  const events = [
+    ev({ data: hibernate, ts: 1 }),
+    ev({ data: hibernate, ts: 2 }),
+    ev({ data: hibernate, ts: 3 }),
+    ev({ data: hibernate, ts: 4 }),
+    ev({ data: hibernate, ts: 5 }),
+  ];
+  const result = collapseRepeatedStatusChips(events);
+  expect(result).toHaveLength(1);
+  expect(result[0]).toBe(events[0]);
+});
+
+test("collapseRepeatedStatusChips: identical hibernate chips from DIFFERENT runs are both kept even when adjacent", () => {
+  // The main tab's JSONL-rebuild path re-stamps a rebuilt run's events with
+  // synthetic clustered timestamps and keeps only live-history `status`
+  // events, which can sort two runs' genuine hibernate breadcrumbs right
+  // next to each other. Same-run adjacency is the reaper-spam signature;
+  // cross-run adjacency is two real hibernates and must survive.
+  const hibernate = "session hibernated after 30m idle — next message will resume it";
+  const events = [
+    ev({ data: hibernate, runId: "run-1", ts: 1 }),
+    ev({ data: hibernate, runId: "run-2", ts: 2 }),
+  ];
+  const result = collapseRepeatedStatusChips(events);
+  expect(result).toEqual(events);
+});
+
+test("collapseRepeatedStatusChips: hibernate chips separated by a user or assistant event are both kept", () => {
+  const hibernate = "session hibernated after 30m idle — next message will resume it";
+  const events = [
+    ev({ data: hibernate, ts: 1 }),
+    ev({ stream: "user", data: "resume please", ts: 2 }),
+    ev({ data: hibernate, ts: 3 }),
+    ev({ stream: "assistant", data: "on it", ts: 4 }),
+    ev({ data: hibernate, ts: 5 }),
+  ];
+  const result = collapseRepeatedStatusChips(events);
+  expect(result).toEqual(events);
+});
+
+test("collapseRepeatedStatusChips: the two different hibernate texts adjacent are both kept", () => {
+  const events = [
+    ev({ data: "session hibernated after 30m idle — next message will resume it", ts: 1 }),
+    ev({
+      data: "session hibernated after 30m idle — no saved session id, next message starts a fresh context",
+      ts: 2,
+    }),
+  ];
+  const result = collapseRepeatedStatusChips(events);
+  expect(result).toEqual(events);
+});
+
+test("collapseRepeatedStatusChips: hibernate collapse and permission-mode tracker don't disturb each other (mixed sequence)", () => {
+  const hibernate = "session hibernated after 30m idle — next message will resume it";
+  const events = [
+    ev({ data: "permission-mode: auto", ts: 1 }),
+    ev({ data: "permission-mode: auto", ts: 2 }), // dropped (mode-tracker dup)
+    ev({ data: hibernate, ts: 3 }),
+    ev({ data: hibernate, ts: 4 }), // dropped (adjacent hibernate dup)
+    ev({ data: hibernate, ts: 5 }), // dropped (adjacent hibernate dup, prev kept was also hibernate)
+    ev({ data: "permission-mode: plan", ts: 6 }), // kept — mode change, also breaks hibernate adjacency
+    ev({ data: hibernate, ts: 7 }), // kept — immediately-preceding kept event is not this same status
+    ev({ data: "permission-mode: plan", ts: 8 }), // dropped (mode-tracker dup, unaffected by hibernate in between)
+  ];
+  const result = collapseRepeatedStatusChips(events);
+  expect(result.map((e) => e.data)).toEqual([
+    "permission-mode: auto",
+    hibernate,
+    "permission-mode: plan",
+    hibernate,
+  ]);
+});
+
+test("collapseRepeatedStatusChips: a non-status event with identical hibernate text doesn't trigger the drop", () => {
+  const hibernate = "session hibernated after 30m idle — next message will resume it";
+  const events = [
+    ev({ stream: "assistant", data: hibernate, ts: 1 }),
+    ev({ data: hibernate, ts: 2 }),
+  ];
+  const result = collapseRepeatedStatusChips(events);
+  expect(result).toEqual(events);
+});
+
+test("collapseRepeatedStatusChips: does not mutate the input array", () => {
   const events = [
     ev({ data: "permission-mode: auto", ts: 1 }),
     ev({ data: "permission-mode: auto", ts: 2 }),
     ev({ data: "permission-mode: plan", ts: 3 }),
   ];
   const snapshot = [...events];
-  const result = collapseRepeatedModeStatus(events);
+  const result = collapseRepeatedStatusChips(events);
   expect(events).toHaveLength(snapshot.length);
   expect(events).toEqual(snapshot);
   // The returned array is a distinct, shorter collapsed list.

--- a/src/mainview/lib/status-collapse.ts
+++ b/src/mainview/lib/status-collapse.ts
@@ -1,0 +1,37 @@
+// Collapse for the already-persisted "permission-mode: <mode>" status spam
+// the unified task-level event stream renders.
+//
+// Claude journals a mode-bearing JSONL event at every turn start, and the
+// server used to unconditionally translate each one into a `status` chunk —
+// so a long-running task's `run_events` history can carry many identical
+// `permission-mode: auto` chips in a row, one per turn, even though the mode
+// never actually changed. The server now emits these on-change only (see
+// `mapParsedEventToChunks` in `claude-tmux.ts`), which stops NEW spam, but it
+// can't rewrite history that's already persisted. This collapses that
+// backlog client-side at render time so old tasks display clean too.
+import type { RunEvent } from "../../shared/types.ts";
+
+const PERMISSION_MODE_PREFIX = "permission-mode: ";
+
+/**
+ * Drop repeated `permission-mode: <mode>` status events that carry the same
+ * value as the previously-KEPT one, regardless of how many other events
+ * (any stream, or other status text) are interleaved between them — those
+ * pass through untouched and don't reset the tracked value. A permission-mode
+ * status with a *different* value is always kept and becomes the new tracked
+ * value, so `auto, auto, plan, plan, auto` collapses to `auto, plan, auto`.
+ *
+ * Does not mutate `events`.
+ */
+export function collapseRepeatedModeStatus(events: RunEvent[]): RunEvent[] {
+  const out: RunEvent[] = [];
+  let lastModeStatus: string | null = null;
+  for (const e of events) {
+    if (e.stream === "status" && e.data?.startsWith(PERMISSION_MODE_PREFIX)) {
+      if (e.data === lastModeStatus) continue;
+      lastModeStatus = e.data;
+    }
+    out.push(e);
+  }
+  return out;
+}

--- a/src/mainview/lib/status-collapse.ts
+++ b/src/mainview/lib/status-collapse.ts
@@ -1,17 +1,31 @@
-// Collapse for the already-persisted "permission-mode: <mode>" status spam
-// the unified task-level event stream renders.
+// Collapse for two kinds of already-persisted status spam the unified
+// task-level event stream renders: repeated `permission-mode: <mode>` chips,
+// and repeated "session hibernated after 30m idle — …" chips.
 //
-// Claude journals a mode-bearing JSONL event at every turn start, and the
-// server used to unconditionally translate each one into a `status` chunk —
-// so a long-running task's `run_events` history can carry many identical
-// `permission-mode: auto` chips in a row, one per turn, even though the mode
-// never actually changed. The server now emits these on-change only (see
-// `mapParsedEventToChunks` in `claude-tmux.ts`), which stops NEW spam, but it
-// can't rewrite history that's already persisted. This collapses that
-// backlog client-side at render time so old tasks display clean too.
+// permission-mode: Claude journals a mode-bearing JSONL event at every turn
+// start, and the server used to unconditionally translate each one into a
+// `status` chunk — so a long-running task's `run_events` history can carry
+// many identical `permission-mode: auto` chips in a row, one per turn, even
+// though the mode never actually changed. The server now emits these
+// on-change only (see `mapParsedEventToChunks` in `claude-tmux.ts`), which
+// stops NEW spam, but it can't rewrite history that's already persisted.
+//
+// session hibernated: a tmux 3.6a bug in `probeSessionActivity`'s
+// `display-message` probe made it report every session as "never attached,
+// idle since 1970" regardless of actual state, so the idle-session reaper
+// re-reaped (and re-appended the hibernate breadcrumb for) the same
+// finished task on every 5-minute sweep — up to 50 consecutive identical
+// rows per run in production. See
+// docs/plans/fix-permission-mode-status-spam.md ("Follow-up") for the root
+// cause and the server-side probe fix (F1) + idempotence guard (F2); this is
+// the client-side cleanup (F3) for the backlog those already wrote.
+//
+// This helper collapses both kinds of backlog client-side at render time so
+// old tasks display clean without a DB rewrite.
 import type { RunEvent } from "../../shared/types.ts";
 
 const PERMISSION_MODE_PREFIX = "permission-mode: ";
+const HIBERNATE_PREFIX = "session hibernated after ";
 
 /**
  * Drop repeated `permission-mode: <mode>` status events that carry the same
@@ -21,15 +35,37 @@ const PERMISSION_MODE_PREFIX = "permission-mode: ";
  * status with a *different* value is always kept and becomes the new tracked
  * value, so `auto, auto, plan, plan, auto` collapses to `auto, plan, auto`.
  *
+ * Separately, drop a "session hibernated after …" status event when the
+ * IMMEDIATELY-preceding kept event is a SAME-RUN status event with
+ * byte-identical `data`. This adjacency rule is deliberately different from
+ * the permission-mode tracker above: unlike a mode change, a genuine *later*
+ * hibernate always has user/agent events in between (resuming a session
+ * creates new events before it can idle out again), so only truly
+ * back-to-back identical chips are reaper spam — any intervening event, even
+ * an unrelated status line, means the next one is real and must be kept.
+ * Reaper spam is always same-run consecutive (`reapIdleSessions` appends to
+ * the task's newest run), which is why the rule requires a matching `runId`:
+ * the main tab's JSONL-rebuild path re-stamps a rebuilt run's events with
+ * synthetic clustered timestamps and keeps only `status` events from live
+ * history, which can sort two different runs' genuine hibernate breadcrumbs
+ * adjacent — those must both survive. Two different hibernate message
+ * variants exist ("— next message will resume it" vs "— no saved session id,
+ * next message starts a fresh context"); comparing `data` byte-for-byte
+ * handles both without special-casing the wording.
+ *
  * Does not mutate `events`.
  */
-export function collapseRepeatedModeStatus(events: RunEvent[]): RunEvent[] {
+export function collapseRepeatedStatusChips(events: RunEvent[]): RunEvent[] {
   const out: RunEvent[] = [];
   let lastModeStatus: string | null = null;
   for (const e of events) {
     if (e.stream === "status" && e.data?.startsWith(PERMISSION_MODE_PREFIX)) {
       if (e.data === lastModeStatus) continue;
       lastModeStatus = e.data;
+    }
+    if (e.stream === "status" && e.data?.startsWith(HIBERNATE_PREFIX)) {
+      const prev = out[out.length - 1];
+      if (prev && prev.runId === e.runId && prev.stream === "status" && prev.data === e.data) continue;
     }
     out.push(e);
   }


### PR DESCRIPTION
## Problem

The Task Details message stream filled up with runs of identical status chips (screenshots showed 8+ in a row):

- `permission-mode: auto` — repeated after every turn
- `session hibernated after 30m idle — next message will resume it` — repeated indefinitely (528 persisted rows across 12 tasks in a production DB, up to 50 per run)

## Root causes

**Permission-mode chips**: claude journals a mode-bearing JSONL event (`type: "permission-mode"` / `system` with `permissionMode`) at **every turn start**, not just on mode changes — and these lines carry no `uuid`, so the `(run_id, line_uuid)` dedup index can't catch them. `mapParsedEventToChunks` translated each one into a persisted status chunk unconditionally.

**Hibernate chips**: a tmux 3.6a quirk — `display-message -p -t '=<name>'` doesn't resolve `=`-prefixed exact-match targets; it prints the format with every variable **empty** and exits 0, identically for live and dead sessions. Combined with `Number("") === 0` slipping past the `Number.isFinite` guard, `probeSessionActivity` reported every session as "never attached, idle since 1970", so `reapIdleSessions` re-reaped every candidate task on **every 5-minute sweep**, appending a fresh breadcrumb each time. The "never reap while attached" guard was dead for the same reason.

## Changes

### Emit permission-mode status only on change
- `mapParsedEventToChunks` / `mapJsonlEventToChunks` take an optional `lastPermissionMode` baseline and suppress same-mode repeats.
- New `SessionState.lastAnnouncedPermissionMode` is the suppression baseline — updated **only** from JSONL lines, never from pane scrapes, so a user-initiated Shift+Tab mode switch still gets its confirmation chip. Seeded from the task mode at spawn **and** reattach (uuid-less mode lines would otherwise re-emit once per restart).
- The subagent tailer gets the same treatment via `FileState.lastPermissionMode`.

### Fix the idle-reaper probe (tmux 3.6a)
- `probeSessionActivity` now uses `list-sessions -F … -f '#{==:#{session_name},<name>}'` — a session *filter* is not subject to the `=`-target quirk (verified on 3.6a: real values for a live session, empty stdout for a dead one, no prefix-matching of sibling `agetor-*` names).
- Parsing extracted into `parseSessionActivityLine`: both fields must be non-empty all-digit strings **before** `Number()`, closing the `Number("") === 0` hole.
- Non-server probe failures log one warning per process, so a tmux build that rejects the newer `-f`/`#{==:}` surface stays diagnosable instead of silently disabling reaping.

### Defense-in-depth: reaper idempotence guard
- New `runs.lastEventData(runId)` (main-stream scoped, `subagent_id IS NULL`); `reapIdleSessions` skips both the append and the SSE emit when the run's last persisted event is already the identical breadcrumb — a future re-reap regression can't spam again.

### Render-time cleanup for the persisted backlog
- The server fixes can't rewrite history, so the client collapses it: `collapseRepeatedStatusChips` (renamed from `collapseRepeatedModeStatus`) drops repeated same-value permission-mode chips (tracker semantics) and same-run back-to-back identical hibernate chips (adjacency semantics — scoped to the run because the JSONL-rebuild path re-stamps events with synthetic clustered timestamps and can sort two different runs' genuine breadcrumbs adjacent).
- Applied in `RunPanel`'s `displayedEvents` memo — upstream of search/todo/render — so `findMatchingEventIds`' position-based ids stay aligned with the rendered `data-evid` indices.

## Review & tests

Two adversarial review passes; all must-fix/should-fix findings addressed (search-index desync, pane-scrape muting genuine mode-change chips, per-restart re-emission on reattach, cross-run hibernate adjacency). Deliberately deferred: legacy `mode: null` tasks still show one initial mode chip; subagent tabs may persist one uuid-less mode chip per restart (masked by the render collapse).

- `bun run typecheck` green
- `bun test`: 1996 pass / 0 fail (new coverage: mapper suppression, dispatch/replay/rebuild flows, probe-line parsing, reaper double-sweep regression, collapse helper incl. cross-run adjacency)

Plan and root-cause notes: `docs/plans/fix-permission-mode-status-spam.md`.