### PR TITLE
feature: "Resolve Conflicts" button in Task Details when the task's PR has merge conflicts

### DIFF
--- a/docs/plans/resolve-conflicts-from-task-details.md
+++ b/docs/plans/resolve-conflicts-from-task-details.md
@@ -1,0 +1,80 @@
+# Plan — "Resolve Conflicts" button in Task Details (multi-provider PR mergeability)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-31 |
+| Source | /implement conversation (owner request + AskUserQuestion answers) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/git-integration-resolving-conflicts |
+| Base SHA | 5953e190c262b598ad36a10c449b984517bd19a1 (clean tree) |
+
+## 1. Objective & success criteria
+
+When a task has a PR (`task.prUrl`, the "View PR" link from #133) and that PR currently has merge conflicts, the Task Details modal (RunPanel) shows a **Resolve Conflicts** button. Clicking it sends a canned message to the task's agent (via the existing `sendRunInput` plumbing) instructing it to `git fetch origin`, merge `origin/<baseRef>` into the current branch, resolve every conflict treating **both sides' intent as important**, verify, and commit locally — **no push** (owner reviews + pushes via Commit & Push).
+
+Owner decisions (Phase 2):
+- **Push policy:** no push — reuse the #125 review-first contract.
+- **Freshness:** fetch mergeability on panel open (+ the one-shot self-heal retry while the provider is still computing), a manual refresh affordance, and a re-fetch after the resolve/commit-push turn completes.
+- **Scope:** must work for **GitHub, GitLab, and Bitbucket** — mergeability fetching gains GitLab/Bitbucket adapters + facade dispatch.
+
+Success = button appears only for a conflicted, open, same-repo PR; clicking delivers the prompt to the live agent; `bun run typecheck` and full `bun test` green.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- RunPanel **is** the Task Details modal (`App.tsx:844-858`). The durable "View PR" link renders in its header (`RunPanel.tsx:2006-2019`), deliberately outside the composer gate. PR-state-driven actions belong in the header; git-working-tree chips (Commit & push / Open PR) live in the composer row.
+- Canned-send precedent: `sendCommitPush()` (`RunPanel.tsx:1899`) sends a prompt through `api.sendRunInput(resumableRunId, …)` with guards `!resumableRunId || modalPending || sending || backlogBusy`. `api.sendRunInput` is `retry: false` (duplicate paste hazard).
+- `GET /github/pull-mergeability?path&number` (`server.ts:1458-1473`) already returns the full `GitHubPullMergeability` (`shared/types.ts:1636`): `mergeable`, `mergeableState`, `merged`, `headRef`, `baseRef`, `crossRepo`, `repo`, `pullNumber`… It calls `getGitHubPullMergeability` (`github.ts:2336`) **directly — GitHub-only**, with an in-request 3×1.2s retry while GitHub computes mergeability. GitHubDialog's fetch effect is *not* provider-gated, so it already fires (and errors) for GitLab/Bitbucket — facade dispatch fixes that for free.
+- Facade pattern: `git-host.ts` (`pullDiff` at 374-379, `pullChecks` at 457-462): `providerRepoForDir(dir)` → 3-way dispatch → `{ok:true}&Shape | {ok:false,error}`. GitLab/Bitbucket adapters normalize onto the shared `GitHub*` types by convention (adapter doc comments, `gitlab.ts:27-47`, `bitbucket.ts:23-64`).
+- GitLab MR detail: `GET /projects/:id/merge_requests/:iid` (pattern in `getGitLabPullChecks`, `gitlab.ts:848-875`). Response carries `detailed_merge_status`, `merge_status`, `has_conflicts`, `source_branch`, `target_branch`, `state`, `draft`, `source_project_id`/`target_project_id`, `sha`.
+- Bitbucket PR detail: `GET /2.0/repositories/{ws}/{slug}/pullrequests/{id}` (pattern in `getBitbucketPullChecks`, `bitbucket.ts:850-874`) has **no conflict field**; the conflict signal is `/pullrequests/{id}/diffstat` entries with `status: "merge conflict"` (paginated; no diffstat plumbing exists yet).
+- `task.prUrl` is an opaque html URL; per-provider shapes: GitHub `…/pull/N`, GitLab `…/-/merge_requests/N` (`gitlab-test-util.ts:48`), Bitbucket `…/pull-requests/N` (`bitbucket-network.test.ts:209`). No parser exists anywhere yet.
+- Prompt template `buildResolveConflictsPrompt` (`src/mainview/lib/resolve-conflicts-prompt.ts`) already says exactly what the owner asked (fetch origin, merge `origin/<base>`, both intents survive, verify, commit, do not push) but requires `title`, which the mergeability response doesn't carry.
+- `mergeabilityView` (`src/mainview/lib/mergeability.ts`) maps `mergeableState` (`dirty` → "Conflicts must be resolved…", tone bad). Its "GitHub is still checking mergeability…" copy is provider-specific and its tests pin the strings.
+- Test conventions: mainview logic lives in pure `lib/*.ts` modules with `bun:test` files (no component tests). Bun-side network functions are tested with `mockGitHubFetch` route tables (`github-test-util.ts`, reused by `gitlab-test-util.ts` / bitbucket tests) + payload factories (`gitlabMergeRequest`, …).
+
+## 3. Approach & key decisions
+
+1. **No new server endpoint.** The webview parses `{provider, number}` out of `task.prUrl` (new pure lib) and calls the existing `/github/pull-mergeability` route with `path: task.workdir`. Rejected alternative: a task-keyed `GET /tasks/:id/pr-status` — more server surface for no additional capability (`pull-create` already guarantees `task.workdir` matches the PR's repo).
+2. **Facade dispatch, keep names.** New `pullMergeability({dir, number})` in `git-host.ts`; route swaps to it. Route path and `api.getGitHubPullMergeability` keep their GitHub-branded names, matching the existing precedent (`/github/comments` etc. already serve all providers).
+3. **GitLab mapping** (new `getGitLabPullMergeability` + `normalizeGitLabMergeability`): prefer `detailed_merge_status` — `conflict`→`dirty`, `mergeable`→`clean`, `need_rebase`→`behind`, `draft_status`→`draft`, `ci_still_running`→`unstable`, `blocked_status`/`discussions_not_resolved`/`not_approved`→`blocked`, `unchecked`/`checking`→`unknown` with `mergeable: null`; fall back to `has_conflicts`/`merge_status` when `detailed_merge_status` is absent. Reuse the same in-request retry loop (3×1.2s) while the state is `unchecked`/`checking`. `crossRepo` = `source_project_id !== target_project_id`; `headRef`/`baseRef` from `source_branch`/`target_branch`; `merged` = `state === "merged"`.
+4. **Bitbucket mapping** (new `getBitbucketPullMergeability`): fetch PR detail (state, branches, cross-repo via `source.repository.full_name` vs `destination.repository.full_name`); if `state === "OPEN"`, fetch `/diffstat` pages (pagelen 100, follow `next`, cap ~10 pages): any entry with `status === "merge conflict"` → `dirty`/`mergeable:false`; none within cap → `clean`/`mergeable:true`; cap exceeded without a conflict hit, or diffstat error → `unknown`/`mergeable:null` (never false-clean). `MERGED`→`merged:true`. No retry loop (diffstat is synchronous).
+5. **Prompt reuse with optional title.** `ResolveConflictsPromptInput.title` becomes `string | null`; the first line drops the `— "title"` clause when absent. Existing #125 callers unaffected; existing pinned tests updated in the same task.
+6. **Provider-neutral copy** in `mergeabilityView`: "GitHub is still checking…" → "The provider is still checking mergeability…" (tests updated together). No other UI-logic change — GitLab/Bitbucket states arrive pre-mapped to the GitHub vocabulary.
+7. **RunPanel wiring:** new state `prStatus` fetched by an effect gated on a successful `parsePrUrl(task.prUrl)`; one-shot per (task.id, prUrl) with a single 2.5s self-heal re-fetch when `mergeable === null && !merged` (GitHubDialog pattern); manual refresh icon; re-fetch when a turn ends (`task.runId` transitions non-null → null while the panel is open and prUrl is set — covers "after sending" once the resolve/commit-push turn actually finishes, the only moment remote state can have changed). Button gating via pure `canOfferResolveConflicts(...)`: parse ok && `mergeableState === "dirty"` && `!merged` && `!crossRepo`. Rendered in the **header** next to View PR; disabled (with title) when `!canSend || modalPending || sending || backlogBusy`; on click builds the prompt from the mergeability payload (`repo`, `pullNumber`, `headRef`, `baseRef`, title:null) and sends via `api.sendRunInput`, surfacing `res.reason` through the existing `sendHint` on failure, plus a transient "sent" confirmation and an immediate optimistic disable.
+
+## 4. Work breakdown — implementation tasks
+
+**Wave 1** (disjoint, parallel):
+- **T1 — GitLab mergeability fetcher.** Owns `src/bun/gitlab.ts` only. Add `getGitLabPullMergeability(repo, number)` per §3.3, exporting the same `({ok:true} & GitHubPullMergeability) | {ok:false,error}` union; extract/normalize in a pure `normalizeGitLabMergeability` (exported for tests). Acceptance: typechecks; mirrors `getGitLabPullChecks` fetch/auth/error idiom.
+- **T2 — Bitbucket mergeability fetcher.** Owns `src/bun/bitbucket.ts` only. Add `getBitbucketPullMergeability(repo, number)` + diffstat scan per §3.4 (pure `normalizeBitbucketMergeability` exported for tests). Acceptance: typechecks; mirrors `getBitbucketPullChecks` idiom; never returns false-clean on partial diffstat.
+- **T3 — Mainview pure libs.** Owns `src/mainview/lib/pr-url.ts` (new), `src/mainview/lib/resolve-conflicts-prompt.ts` + `resolve-conflicts-prompt.test.ts`, `src/mainview/lib/mergeability.ts` + `mergeability.test.ts`. Add `parsePrUrl(url): {provider: GitProvider; number: number} | null` and `canOfferResolveConflicts(parsed, mergeability): boolean` in `pr-url.ts`; make prompt `title` optional (update pinned tests); provider-neutral "still checking" copy (update pinned tests). Acceptance: `bun test src/mainview/lib/resolve-conflicts-prompt.test.ts src/mainview/lib/mergeability.test.ts` green.
+
+**Wave 2** (disjoint, parallel; after wave 1):
+- **T4 — Facade + route.** Owns `src/bun/git-host.ts`, `src/bun/server.ts`. Add `pullMergeability` facade (model on `pullChecks`); swap the route's import/call to it (route body otherwise unchanged). Acceptance: typechecks; GitHub path still passes `{dir, number}` through to `getGitHubPullMergeability`.
+- **T5 — RunPanel wiring.** Owns `src/mainview/components/kanban/RunPanel.tsx` only. Implement §3.7 (state, fetch effect with the documented dep discipline — key on `[task.id, task.prUrl]`, not `[task]`, because App.tsx's 2s /tasks poll rebuilds the task object; header button; refresh; turn-end re-fetch; send with guards + sendHint). Acceptance: typechecks; no change to existing send/backlog behavior.
+
+## 5. Work breakdown — test tasks (Phase 6)
+
+- **TT1** owns `src/bun/gitlab-network.test.ts`: `getGitLabPullMergeability` — conflict (`detailed_merge_status:"conflict"` → dirty), mergeable → clean, `unchecked` → retries then unknown, fallback path via `has_conflicts` only, cross-repo, merged MR. Use `mockGitLabFetch` + `gitlabMergeRequest` overrides.
+- **TT2** owns `src/bun/bitbucket-network.test.ts`: PR detail + diffstat conflict → dirty; clean diffstat → clean; multi-page `next` follow; page-cap → unknown; diffstat error → unknown; MERGED state; cross-repo fork.
+- **TT3** owns `src/mainview/lib/pr-url.test.ts` (new): all three URL shapes (incl. trailing segments/query/fragment, self-hosted GitLab hosts, non-PR URLs → null) and `canOfferResolveConflicts` gating (dirty/merged/crossRepo/unknown).
+- **TT4** owns `src/bun/git-host-mergeability.test.ts` (new): facade dispatch per provider (mock fetch + `makeGitHubRepo`-style temp repos per each test-util), incl. the previously-untested GitHub path (backfills network coverage for `getGitHubPullMergeability`).
+
+## 6. Execution waves
+
+Phase 4: wave 1 = T1‖T2‖T3 → checkpoint (typecheck + commit) → wave 2 = T4‖T5 → checkpoint. Phase 5 review (opus) on `git diff 5953e19...HEAD`. Phase 6: TT1‖TT2‖TT3‖TT4. Phase 7: full `bun test` + `bun run typecheck` (haiku). Phase 8 as needed.
+
+## 7. Blast radius & risks
+
+- `/github/pull-mergeability` responses for GitLab/Bitbucket projects change from `{error}` to real payloads — GitHubDialog's badge starts working there (improvement, not a break). Its "Resolve with Agetor" button stays `provider === "github"`-gated (untouched).
+- `resolve-conflicts-prompt.ts` is consumed by `ResolveConflictsDialog` (#125) — title stays supported; only the optional-absent branch is new.
+- `mergeability.test.ts` / `resolve-conflicts-prompt.test.ts` pin exact strings — updated in T3, same commit.
+- Bitbucket diffstat adds up to ~11 API calls for a huge conflicted-check; capped, and only on panel-open/refresh (no polling).
+- `sendRunInput` auto-unarchives a task server-side; the button only renders on non-archived panels' header — acceptable.
+- Rollback: revert the branch; no migrations, no schema changes.
+
+## 8. Open questions / assumptions
+
+- Assumes `task.branch` == PR headRef for task-originated PRs (holds by construction: PR is opened from the task's pushed branch; `pull-create` stamps `prUrl` only when `task.workdir` matches). The prompt's "you're already on the head branch" framing therefore stands.
+- Bitbucket "clean" is inferred from absence of conflict-status diffstat entries — Bitbucket offers nothing stronger.
+- GitLab self-hosted variance in `detailed_merge_status` handled by the `merge_status`/`has_conflicts` fallback.

--- a/src/bun/bitbucket-network.test.ts
+++ b/src/bun/bitbucket-network.test.ts
@@ -6,7 +6,8 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test, expect, beforeAll, afterAll } from "bun:test";
-import { makeBitbucketRepo, mockGitHubFetch } from "./bitbucket-test-util.ts";
+import { makeBitbucketPrJson, makeBitbucketRepo, mockGitHubFetch } from "./bitbucket-test-util.ts";
+import type { MockRoute } from "./bitbucket-test-util.ts";
 import {
   closeBitbucketPull,
   createBitbucketComment,
@@ -15,11 +16,13 @@ import {
   createBitbucketPullLineComment,
   getBitbucketPullDefaults,
   getBitbucketPullDiff,
+  getBitbucketPullMergeability,
   getBitbucketViewer,
   listBitbucketComments,
   listBitbucketItems,
   listBitbucketPullReviewComments,
   mergeBitbucketPull,
+  normalizeBitbucketMergeability,
   replyBitbucketLineComment,
   reopenBitbucketPull,
   reviewBitbucketPull,
@@ -492,6 +495,257 @@ test("reviewBitbucketPull REQUEST_CHANGES POSTs /request-changes", async () => {
   try {
     const res = await reviewBitbucketPull(REPO, 7, "REQUEST_CHANGES");
     expect(res).toEqual({ ok: true, message: "Changes requested." });
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// normalizeBitbucketMergeability — pure field mapping (no network)
+// ---------------------------------------------------------------------------
+
+test("normalizeBitbucketMergeability: non-OPEN state ignores conflictScan and always reports mergeable:null/unknown", () => {
+  const res = normalizeBitbucketMergeability(REPO, 7, makeBitbucketPrJson({ state: "MERGED" }), "dirty");
+  expect(res.mergeable).toBeNull();
+  expect(res.mergeableState).toBe("unknown");
+  expect(res.merged).toBe(true);
+  expect(res.state).toBe("merged");
+});
+
+test("normalizeBitbucketMergeability: DECLINED and SUPERSEDED both normalize state to 'closed'", () => {
+  expect(normalizeBitbucketMergeability(REPO, 7, makeBitbucketPrJson({ state: "DECLINED" }), "unknown").state).toBe("closed");
+  expect(normalizeBitbucketMergeability(REPO, 7, makeBitbucketPrJson({ state: "SUPERSEDED" }), "unknown").state).toBe("closed");
+});
+
+// ---------------------------------------------------------------------------
+// getBitbucketPullMergeability / diffstat conflict scan
+// ---------------------------------------------------------------------------
+
+test("getBitbucketPullMergeability: a merge-conflict entry on diffstat page 1 short-circuits — no page 2 fetch — and reports dirty", async () => {
+  const prJson = makeBitbucketPrJson({ state: "OPEN" });
+  const base = "https://api.bitbucket.org/2.0/repositories/acme/app/pullrequests/7/diffstat";
+  const mock = mockGitHubFetch([
+    { match: /\/pullrequests\/7$/, json: prJson },
+    {
+      match: /\/diffstat\?pagelen=100$/,
+      json: { values: [{ status: "merge conflict" }], next: `${base}?pagelen=100&page=2` },
+    },
+    // Deliberately no route for page=2 — if the scan didn't short-circuit on
+    // finding the conflict, this would throw "no route for ..." and fail loudly.
+  ]);
+  try {
+    const res = await getBitbucketPullMergeability(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeable).toBe(false);
+    expect(res.mergeableState).toBe("dirty");
+    expect(res.state).toBe("open");
+    expect(mock.calls).toHaveLength(2); // PR detail + diffstat page 1 only
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullMergeability: OPEN PR + all-clean single diffstat page (no next) → clean, with headRef/baseRef from source/destination", async () => {
+  const prJson = makeBitbucketPrJson({ state: "OPEN", sourceBranch: "feature-x", destBranch: "develop" });
+  const mock = mockGitHubFetch([
+    { match: /\/pullrequests\/7$/, json: prJson },
+    { match: /\/diffstat\?pagelen=100$/, json: { values: [{ status: "modified" }] } },
+  ]);
+  try {
+    const res = await getBitbucketPullMergeability(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeable).toBe(true);
+    expect(res.mergeableState).toBe("clean");
+    expect(res.state).toBe("open");
+    expect(res.headRef).toBe("feature-x");
+    expect(res.baseRef).toBe("develop");
+    expect(mock.calls).toHaveLength(2);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullMergeability: page 1 clean + next, page 2 has the conflict → dirty, both pages fetched", async () => {
+  const prJson = makeBitbucketPrJson({ state: "OPEN" });
+  const base = "https://api.bitbucket.org/2.0/repositories/acme/app/pullrequests/7/diffstat";
+  const mock = mockGitHubFetch([
+    { match: /\/pullrequests\/7$/, json: prJson },
+    {
+      match: /\/diffstat\?pagelen=100$/,
+      json: { values: [{ status: "modified" }], next: `${base}?pagelen=100&page=2` },
+    },
+    { match: /page=2$/, json: { values: [{ status: "merge conflict" }] } },
+  ]);
+  try {
+    const res = await getBitbucketPullMergeability(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeable).toBe(false);
+    expect(res.mergeableState).toBe("dirty");
+    expect(mock.calls).toHaveLength(3); // PR + diffstat page 1 + diffstat page 2
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullMergeability: diffstat entry status 'local deleted' → dirty (delete/modify conflict)", async () => {
+  const prJson = makeBitbucketPrJson({ state: "OPEN" });
+  const mock = mockGitHubFetch([
+    { match: /\/pullrequests\/7$/, json: prJson },
+    { match: /\/diffstat\?pagelen=100$/, json: { values: [{ status: "local deleted" }] } },
+  ]);
+  try {
+    const res = await getBitbucketPullMergeability(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeable).toBe(false);
+    expect(res.mergeableState).toBe("dirty");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullMergeability: diffstat entry status 'remote deleted' → dirty (delete/modify conflict)", async () => {
+  const prJson = makeBitbucketPrJson({ state: "OPEN" });
+  const mock = mockGitHubFetch([
+    { match: /\/pullrequests\/7$/, json: prJson },
+    { match: /\/diffstat\?pagelen=100$/, json: { values: [{ status: "remote deleted" }] } },
+  ]);
+  try {
+    const res = await getBitbucketPullMergeability(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeable).toBe(false);
+    expect(res.mergeableState).toBe("dirty");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullMergeability: diffstat page cap exhausted while pages keep returning next → unknown, never clean on partial data", async () => {
+  const prJson = makeBitbucketPrJson({ state: "OPEN" });
+  const base = "https://api.bitbucket.org/2.0/repositories/acme/app/pullrequests/7/diffstat";
+  // BITBUCKET_DIFFSTAT_PAGE_CAP is 10 — mock exactly that many diffstat pages
+  // (the first, unparameterized page plus page=2..page=10), every one clean
+  // but still carrying a further `next`, so the scan hits the cap with pages
+  // still outstanding instead of reaching a natural end (page 11 is never
+  // fetched — no route is registered for it).
+  const routes: MockRoute[] = [
+    { match: /\/pullrequests\/7$/, json: prJson },
+    { match: /\/diffstat\?pagelen=100$/, json: { values: [{ status: "modified" }], next: `${base}?pagelen=100&page=2` } },
+  ];
+  for (let page = 2; page <= 10; page++) {
+    routes.push({
+      match: new RegExp(`page=${page}$`),
+      json: { values: [{ status: "modified" }], next: `${base}?pagelen=100&page=${page + 1}` },
+    });
+  }
+  const mock = mockGitHubFetch(routes);
+  try {
+    const res = await getBitbucketPullMergeability(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeable).toBeNull();
+    expect(res.mergeableState).toBe("unknown");
+    expect(mock.calls).toHaveLength(11); // PR + 10 diffstat pages (the cap)
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullMergeability: diffstat fetch failure (500) → unknown, but still ok:true with PR fields mapped", async () => {
+  const prJson = makeBitbucketPrJson({ state: "OPEN", sourceBranch: "feature-y" });
+  const mock = mockGitHubFetch([
+    { match: /\/pullrequests\/7$/, json: prJson },
+    { match: /\/diffstat\?pagelen=100$/, status: 500, json: { error: { message: "Internal Server Error" } } },
+  ]);
+  try {
+    const res = await getBitbucketPullMergeability(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeable).toBeNull();
+    expect(res.mergeableState).toBe("unknown");
+    expect(res.state).toBe("open");
+    expect(res.headRef).toBe("feature-y");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullMergeability: hostile off-origin `next` stops paging — unknown, not clean — and the hostile origin is never fetched", async () => {
+  const prJson = makeBitbucketPrJson({ state: "OPEN" });
+  const mock = mockGitHubFetch([
+    { match: /\/pullrequests\/7$/, json: prJson },
+    {
+      match: /\/diffstat\?pagelen=100$/,
+      json: { values: [{ status: "modified" }], next: "http://attacker.example/x" },
+    },
+  ]);
+  try {
+    const res = await getBitbucketPullMergeability(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeable).toBeNull();
+    expect(res.mergeableState).toBe("unknown");
+    expect(mock.calls.some((c) => c.url.includes("attacker.example"))).toBe(false);
+    expect(mock.calls).toHaveLength(2); // PR + diffstat page 1 only
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullMergeability: MERGED PR → merged:true, state:'merged', mergeable unknown, no diffstat fetch at all", async () => {
+  const prJson = makeBitbucketPrJson({ state: "MERGED" });
+  const mock = mockGitHubFetch([
+    { match: /\/pullrequests\/7$/, json: prJson },
+    // Deliberately no diffstat route — a merged PR has nothing left to
+    // conflict against, so fetching diffstat here would throw "no route" and
+    // fail this test loudly.
+  ]);
+  try {
+    const res = await getBitbucketPullMergeability(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.merged).toBe(true);
+    expect(res.state).toBe("merged");
+    expect(res.mergeable).toBeNull();
+    expect(res.mergeableState).toBe("unknown");
+    expect(mock.calls).toHaveLength(1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullMergeability: fork PR (source.repository differs from destination) → crossRepo:true", async () => {
+  const prJson = makeBitbucketPrJson({ state: "OPEN", sourceRepoFullName: "someone-else/app", destRepoFullName: "acme/app" });
+  const mock = mockGitHubFetch([
+    { match: /\/pullrequests\/7$/, json: prJson },
+    { match: /\/diffstat\?pagelen=100$/, json: { values: [] } },
+  ]);
+  try {
+    const res = await getBitbucketPullMergeability(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.crossRepo).toBe(true);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullMergeability: missing source.repository → crossRepo:true (fails closed)", async () => {
+  const prJson = makeBitbucketPrJson({ state: "OPEN", sourceRepoFullName: null });
+  const mock = mockGitHubFetch([
+    { match: /\/pullrequests\/7$/, json: prJson },
+    { match: /\/diffstat\?pagelen=100$/, json: { values: [] } },
+  ]);
+  try {
+    const res = await getBitbucketPullMergeability(REPO, 7);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.crossRepo).toBe(true);
+    expect(res.headRepo).toBeNull();
   } finally {
     mock.restore();
   }

--- a/src/bun/bitbucket-test-util.ts
+++ b/src/bun/bitbucket-test-util.ts
@@ -40,3 +40,49 @@ export function makeBitbucketRepo(
     name,
   };
 }
+
+/**
+ * A minimal Bitbucket pull-request detail JSON body — the shape
+ * `normalizeBitbucketMergeability` reads (`source`/`destination`
+ * branch+commit+repository, `state`, `draft`). Defaults describe an OPEN,
+ * same-repo PR (`acme/app` on both sides) so most mergeability tests only
+ * need to override `state` or layer diffstat-page fixtures on top. Pass
+ * `sourceRepoFullName: null` (or `destRepoFullName: null`) to omit that
+ * side's `repository` key entirely, exercising the fails-closed cross-repo
+ * path.
+ */
+export function makeBitbucketPrJson(overrides: {
+  id?: number;
+  state?: string;
+  draft?: boolean;
+  sourceBranch?: string;
+  destBranch?: string;
+  sourceSha?: string;
+  sourceRepoFullName?: string | null;
+  destRepoFullName?: string | null;
+} = {}): Record<string, unknown> {
+  const {
+    id = 7,
+    state = "OPEN",
+    draft = false,
+    sourceBranch = "feature",
+    destBranch = "main",
+    sourceSha = "abc123",
+    sourceRepoFullName = "acme/app",
+    destRepoFullName = "acme/app",
+  } = overrides;
+  return {
+    id,
+    state,
+    draft,
+    source: {
+      branch: { name: sourceBranch },
+      commit: { hash: sourceSha },
+      ...(sourceRepoFullName !== null ? { repository: { full_name: sourceRepoFullName } } : {}),
+    },
+    destination: {
+      branch: { name: destBranch },
+      ...(destRepoFullName !== null ? { repository: { full_name: destRepoFullName } } : {}),
+    },
+  };
+}

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -8,6 +8,7 @@ import type {
   GitHubListItem,
   GitHubListResult,
   GitHubPullDefaultsResult,
+  GitHubPullMergeability,
   GitHubPullLineComment,
   GitHubPullMergeMethod,
   GitHubPullMergeResult,
@@ -874,6 +875,148 @@ export async function getBitbucketPullChecks(repo: ProviderRepoInfo, number: num
   return { ok: true, repo: `${repo.owner}/${repo.name}`, pullNumber: number, sha, checkRuns };
 }
 
+type BitbucketMergeabilityResponse = ({ ok: true } & GitHubPullMergeability) | BitbucketError;
+
+/** How many diffstat pages `scanBitbucketDiffstatConflicts` will follow before
+ *  giving up and reporting "unknown" rather than risk a false "clean" on
+ *  partial data — 10 pages of `pagelen=100` covers 1000 changed files. */
+const BITBUCKET_DIFFSTAT_PAGE_CAP = 10;
+
+/**
+ * Scans a pull request's diffstat for Bitbucket's per-file `status: "merge
+ * conflict"` marker — Bitbucket Cloud's PR resource has no top-level
+ * mergeable field (unlike GitHub's `mergeable`/`mergeable_state`), so the
+ * diffstat listing is the only conflict signal available. Stops as soon as a
+ * conflicted entry is found. Returns:
+ *  - "dirty" as soon as any page yields a conflicted entry.
+ *  - "clean" only once every page has been walked (no `next` remains) with
+ *    no conflicted entry seen.
+ *  - "unknown" on any fetch/parse failure, or when the page cap is exhausted
+ *    while a `next` link still remains — reporting "clean" on partial data
+ *    would be worse than reporting "unknown".
+ */
+async function scanBitbucketDiffstatConflicts(
+  repo: ProviderRepoInfo,
+  number: number,
+  creds: BitbucketCreds | null,
+): Promise<"dirty" | "clean" | "unknown"> {
+  const firstUrl = new URL(`${BITBUCKET_API_BASE}${repoBasePath(repo)}/pullrequests/${number}/diffstat`);
+  firstUrl.searchParams.set("pagelen", "100");
+  let url: string | null = firstUrl.toString();
+
+  for (let page = 0; page < BITBUCKET_DIFFSTAT_PAGE_CAP && url; page++) {
+    const res = await fetchBitbucket(url, creds, "application/json");
+    if (!("status" in res) || !res.ok) return "unknown";
+    const body = await res.json().catch(() => null);
+    const values = body && typeof body === "object" && Array.isArray((body as { values?: unknown }).values)
+      ? (body as { values: unknown[] }).values
+      : null;
+    if (!values) return "unknown";
+    for (const raw of values) {
+      const obj = raw && typeof raw === "object" ? raw as Record<string, unknown> : null;
+      if (obj && obj.status === "merge conflict") return "dirty";
+    }
+    const next = (body as { next?: unknown }).next;
+    url = typeof next === "string" && next ? next : null;
+  }
+  return url ? "unknown" : "clean";
+}
+
+/**
+ * Pure field mapping from a Bitbucket PR detail JSON plus a pre-computed
+ * `conflictScan` verdict (from `scanBitbucketDiffstatConflicts`) into the
+ * shared `GitHubPullMergeability` shape. Kept separate from the network walk
+ * so the mapping is test-friendly without mocking fetch. `mergeable`/
+ * `mergeableState` only reflect `conflictScan` when the PR is OPEN — a
+ * merged/declined/superseded PR has nothing left to conflict against, so it
+ * always reports "unknown"/null there, matching `getBitbucketPullMergeability`
+ * (which skips the diffstat scan entirely for non-OPEN state).
+ */
+export function normalizeBitbucketMergeability(
+  repo: ProviderRepoInfo,
+  number: number,
+  pr: unknown,
+  conflictScan: "dirty" | "clean" | "unknown",
+): GitHubPullMergeability {
+  const obj = pr && typeof pr === "object" ? pr as Record<string, unknown> : {};
+  const source = obj.source && typeof obj.source === "object" ? obj.source as Record<string, unknown> : {};
+  const destination = obj.destination && typeof obj.destination === "object"
+    ? obj.destination as Record<string, unknown>
+    : {};
+  const sourceBranch = source.branch && typeof source.branch === "object" ? source.branch as Record<string, unknown> : {};
+  const destBranch = destination.branch && typeof destination.branch === "object"
+    ? destination.branch as Record<string, unknown>
+    : {};
+  const sourceCommit = source.commit && typeof source.commit === "object" ? source.commit as Record<string, unknown> : {};
+  const sourceRepo = source.repository && typeof source.repository === "object"
+    ? source.repository as Record<string, unknown>
+    : {};
+  const destRepo = destination.repository && typeof destination.repository === "object"
+    ? destination.repository as Record<string, unknown>
+    : {};
+
+  const headRepo = typeof sourceRepo.full_name === "string" ? sourceRepo.full_name : null;
+  const baseRepo = typeof destRepo.full_name === "string" ? destRepo.full_name : null;
+  const state = typeof obj.state === "string" ? obj.state : "";
+
+  const { mergeable, mergeableState } = state === "OPEN"
+    ? conflictScan === "dirty"
+      ? { mergeable: false, mergeableState: "dirty" }
+      : conflictScan === "clean"
+        ? { mergeable: true, mergeableState: "clean" }
+        : { mergeable: null, mergeableState: "unknown" }
+    : { mergeable: null, mergeableState: "unknown" };
+
+  return {
+    repo: `${repo.owner}/${repo.name}`,
+    pullNumber: number,
+    mergeable,
+    mergeableState,
+    rebaseable: null,
+    merged: state === "MERGED",
+    draft: obj.draft === true,
+    headRef: typeof sourceBranch.name === "string" ? sourceBranch.name : "",
+    baseRef: typeof destBranch.name === "string" ? destBranch.name : "",
+    headSha: typeof sourceCommit.hash === "string" ? sourceCommit.hash : "",
+    autoMerge: false,
+    headRepo,
+    crossRepo: headRepo !== null && baseRepo !== null && headRepo !== baseRepo,
+  };
+}
+
+/**
+ * Bitbucket's PR resource carries no `mergeable`/`mergeable_state` fields
+ * (unlike GitHub), so this fetches the PR detail for the head/base/state
+ * fields and — only when the PR is OPEN — follows up with a diffstat scan
+ * (`scanBitbucketDiffstatConflicts`) for the actual conflict signal. Non-OPEN
+ * PRs (merged/declined/superseded) skip the scan entirely, matching
+ * `normalizeBitbucketMergeability`'s non-OPEN "unknown" mapping. Unlike
+ * `getGitHubPullMergeability`, there's no retry/poll loop — Bitbucket's
+ * diffstat is computed synchronously, not in the background.
+ */
+export async function getBitbucketPullMergeability(
+  repo: ProviderRepoInfo,
+  number: number,
+): Promise<BitbucketMergeabilityResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
+  const creds = await bitbucketCreds(repo.remoteHost);
+
+  const res = await fetchBitbucket(`${repoBasePath(repo)}/pullrequests/${number}`, creds, "application/json");
+  if (!("status" in res)) return res;
+  const json = await res.json().catch(() => null);
+  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!json || typeof json !== "object") {
+    return { ok: false, error: "Bitbucket returned an unexpected pull request response" };
+  }
+
+  const state = typeof (json as Record<string, unknown>).state === "string"
+    ? (json as Record<string, unknown>).state as string
+    : "";
+  const conflictScan = state === "OPEN" ? await scanBitbucketDiffstatConflicts(repo, number, creds) : "unknown";
+
+  return { ok: true, ...normalizeBitbucketMergeability(repo, number, json, conflictScan) };
+}
+
 /** The shared `GitHubPullMergeMethod` enum ("merge"|"squash"|"rebase") maps to
  *  Bitbucket's three `merge_strategy` values. There is no fast-forward entry
  *  in the shared enum, so Bitbucket's `fast_forward` (a linear, no-merge-
@@ -1119,6 +1262,8 @@ export const __bitbucketInternals = {
   normalizeBitbucketComment,
   normalizeBitbucketLineComment,
   normalizeBitbucketCheckRun,
+  normalizeBitbucketMergeability,
+  scanBitbucketDiffstatConflicts,
   escapeBBQLString,
   prStateParams,
   issueStateBBQL,

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -101,9 +101,38 @@ function repoBasePath(repo: ProviderRepoInfo): string {
 
 /** Absolute-URL passthrough: a `next` pagination link (or any other
  *  already-absolute URL a caller builds via `new URL(...)`) is used as-is;
- *  anything else is treated as a path relative to the Bitbucket API base. */
+ *  anything else is treated as a path relative to the Bitbucket API base.
+ *  Every absolute URL that reaches this function today is built internally
+ *  from `BITBUCKET_API_BASE` (e.g. `new URL(\`${BITBUCKET_API_BASE}...\`)`),
+ *  so passthrough is safe here — but a `next` link taken verbatim from a
+ *  Bitbucket response body is NOT internally-constructed, and paging call
+ *  sites must validate it with `sanitizeNextUrl` (below) before ever handing
+ *  it to `fetchBitbucket`/`resolveUrl`, since `fetchBitbucket` attaches the
+ *  user's credentials to whatever host it's given. */
 function resolveUrl(pathOrUrl: string): string {
   return /^https?:\/\//i.test(pathOrUrl) ? pathOrUrl : `${BITBUCKET_API_BASE}${pathOrUrl}`;
+}
+
+const BITBUCKET_API_ORIGIN = new URL(BITBUCKET_API_BASE).origin;
+
+/**
+ * Validates a pagination `next` URL pulled out of a Bitbucket response body
+ * before it's ever fetched. Bitbucket puts `next` directly in the JSON body
+ * (not a header), so a malicious/compromised response — or credentials
+ * reused against a lookalike host — could point `next` at an arbitrary
+ * origin; `fetchBitbucket` would otherwise attach the same Authorization
+ * header to that request via `resolveUrl`'s absolute-URL passthrough. Only a
+ * same-origin-as-`BITBUCKET_API_BASE` absolute URL is accepted; anything
+ * else (wrong origin, unparseable, missing) returns null so paging call
+ * sites can treat it as end-of-pages rather than as a page to fetch.
+ */
+function sanitizeNextUrl(next: unknown): string | null {
+  if (typeof next !== "string" || !next) return null;
+  try {
+    return new URL(next).origin === BITBUCKET_API_ORIGIN ? next : null;
+  } catch {
+    return null;
+  }
 }
 
 /** How many extra pages a comment listing follows beyond the first — 5 pages
@@ -116,12 +145,14 @@ const BITBUCKET_MAX_EXTRA_PAGES = 4;
  * `values`. `firstBody` is the already-fetched, already-error-checked page-1
  * body. A fetch/parse failure mid-pagination stops the walk and returns what
  * has accumulated so far — partial results beat failing a listing whose first
- * page already succeeded.
+ * page already succeeded. Each `next` is validated by `sanitizeNextUrl`
+ * before being fetched, so a hostile/off-origin `next` just ends the walk
+ * rather than leaking credentials to it.
  */
 async function collectRemainingValues(firstBody: unknown, creds: BitbucketCreds | null): Promise<unknown[]> {
   const extra: unknown[] = [];
-  let next = firstBody && typeof firstBody === "object" ? (firstBody as { next?: unknown }).next : null;
-  for (let i = 0; i < BITBUCKET_MAX_EXTRA_PAGES && typeof next === "string" && next; i++) {
+  let next = sanitizeNextUrl(firstBody && typeof firstBody === "object" ? (firstBody as { next?: unknown }).next : null);
+  for (let i = 0; i < BITBUCKET_MAX_EXTRA_PAGES && next; i++) {
     const res = await fetchBitbucket(next, creds, "application/json");
     if (!("status" in res) || !res.ok) break;
     const body = await res.json().catch(() => null);
@@ -130,7 +161,7 @@ async function collectRemainingValues(firstBody: unknown, creds: BitbucketCreds 
       : null;
     if (!values) break;
     extra.push(...values);
-    next = (body as { next?: unknown }).next;
+    next = sanitizeNextUrl((body as { next?: unknown }).next);
   }
   return extra;
 }
@@ -891,9 +922,10 @@ const BITBUCKET_DIFFSTAT_PAGE_CAP = 10;
  *  - "dirty" as soon as any page yields a conflicted entry.
  *  - "clean" only once every page has been walked (no `next` remains) with
  *    no conflicted entry seen.
- *  - "unknown" on any fetch/parse failure, or when the page cap is exhausted
- *    while a `next` link still remains — reporting "clean" on partial data
- *    would be worse than reporting "unknown".
+ *  - "unknown" on any fetch/parse failure, when the page cap is exhausted
+ *    while a `next` link still remains, or when a `next` link is rejected by
+ *    `sanitizeNextUrl` (off-origin/malformed) — reporting "clean" on partial
+ *    data would be worse than reporting "unknown".
  */
 async function scanBitbucketDiffstatConflicts(
   repo: ProviderRepoInfo,
@@ -914,10 +946,26 @@ async function scanBitbucketDiffstatConflicts(
     if (!values) return "unknown";
     for (const raw of values) {
       const obj = raw && typeof raw === "object" ? raw as Record<string, unknown> : null;
-      if (obj && obj.status === "merge conflict") return "dirty";
+      const status = obj && typeof obj.status === "string" ? obj.status : "";
+      // "merge conflict" covers a modify/modify conflict; a delete/modify
+      // conflict instead surfaces as a per-side "local deleted"/"remote
+      // deleted" status with no "conflict" substring of its own — without
+      // this, a deleted-vs-modified file would walk through as clean.
+      if (status.includes("conflict") || status === "local deleted" || status === "remote deleted") return "dirty";
     }
-    const next = (body as { next?: unknown }).next;
-    url = typeof next === "string" && next ? next : null;
+    const rawNext = (body as { next?: unknown }).next;
+    // A `next` link present but rejected by `sanitizeNextUrl` (off-origin,
+    // malformed) is NOT the same as no `next` at all — there may be more
+    // pages this scan is refusing to follow, so it must not fall through to
+    // "clean" below. Distinguish "no next" (natural end) from "next present
+    // but untrusted" (unresolved end) explicitly.
+    if (typeof rawNext === "string" && rawNext) {
+      const sanitized = sanitizeNextUrl(rawNext);
+      if (!sanitized) return "unknown";
+      url = sanitized;
+    } else {
+      url = null;
+    }
   }
   return url ? "unknown" : "clean";
 }
@@ -967,6 +1015,8 @@ export function normalizeBitbucketMergeability(
         : { mergeable: null, mergeableState: "unknown" }
     : { mergeable: null, mergeableState: "unknown" };
 
+  const normalizedState = state === "OPEN" ? "open" : state === "MERGED" ? "merged" : (state === "DECLINED" || state === "SUPERSEDED") ? "closed" : "unknown";
+
   return {
     repo: `${repo.owner}/${repo.name}`,
     pullNumber: number,
@@ -975,12 +1025,16 @@ export function normalizeBitbucketMergeability(
     rebaseable: null,
     merged: state === "MERGED",
     draft: obj.draft === true,
+    state: normalizedState,
     headRef: typeof sourceBranch.name === "string" ? sourceBranch.name : "",
     baseRef: typeof destBranch.name === "string" ? destBranch.name : "",
     headSha: typeof sourceCommit.hash === "string" ? sourceCommit.hash : "",
     autoMerge: false,
     headRepo,
-    crossRepo: headRepo !== null && baseRepo !== null && headRepo !== baseRepo,
+    // Fail closed: only a confirmed same-full_name match is same-repo. A
+    // missing head or base repo (can't confirm) is treated as cross-repo,
+    // matching github.ts's normalizeMergeability contract.
+    crossRepo: headRepo === null || baseRepo === null || headRepo !== baseRepo,
   };
 }
 

--- a/src/bun/git-host-mergeability.test.ts
+++ b/src/bun/git-host-mergeability.test.ts
@@ -1,0 +1,220 @@
+import { test, expect, beforeEach, afterEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pullMergeability } from "./git-host.ts";
+import { makeGitHubRepo, mockGitHubFetch, type FetchMock } from "./github-test-util.ts";
+
+// Facade-level dispatch tests for `pullMergeability` (src/bun/git-host.ts),
+// mirroring git-host.test.ts's idiom exactly: a real throwaway git repo per
+// provider (so `providerRepoForDir` resolves off an actual `git remote`, the
+// same way the route in server.ts would see it) plus `mockGitHubFetch`
+// (host-agnostic despite the name — see github-test-util.ts) stubbed onto
+// `globalThis.fetch`. Deep per-provider mapping matrices already live in
+// github.test.ts/gitlab-network.test.ts/bitbucket.test.ts; this file only
+// pins that the facade calls the right adapter for the right remote and
+// preserves the adapter's response shape end to end.
+const ORIGINAL_DATA_DIR = process.env.AGETOR_DATA_DIR;
+const ENV_KEYS = ["GITHUB_TOKEN", "GH_TOKEN", "GITLAB_TOKEN", "BITBUCKET_TOKEN", "BITBUCKET_EMAIL"] as const;
+let dataDir: string;
+let savedEnv: Record<string, string | undefined> = {};
+let createdDirs: string[] = [];
+let fetchMock: FetchMock | null = null;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(path.join(tmpdir(), "agetor-git-host-mergeability-"));
+  process.env.AGETOR_DATA_DIR = dataDir;
+  savedEnv = {};
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.GITHUB_TOKEN = "gh-test-token";
+  process.env.GITLAB_TOKEN = "glab-test-token";
+});
+
+afterEach(() => {
+  fetchMock?.restore();
+  fetchMock = null;
+  rmSync(dataDir, { recursive: true, force: true });
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  for (const dir of createdDirs) rmSync(dir, { recursive: true, force: true });
+  createdDirs = [];
+});
+
+afterAll(() => {
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.AGETOR_DATA_DIR;
+  else process.env.AGETOR_DATA_DIR = ORIGINAL_DATA_DIR;
+});
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+}
+
+/** Local temp-repo builder for gitlab/bitbucket remotes — no shared
+ *  gitlab/bitbucket-test-util.ts equivalent exists because gitlab.ts/
+ *  bitbucket.ts's own adapters take an already-resolved `ProviderRepoInfo`
+ *  and never touch git themselves (see those test-util files' doc comments).
+ *  The facade, by contrast, resolves the remote itself via
+ *  `providerRepoForDir`, so it needs a real `git remote` on disk — this
+ *  mirrors git-host.test.ts's own `makeRepo` helper. */
+async function makeRepo(remoteUrl: string): Promise<string> {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-git-host-mergeability-repo-"));
+  createdDirs.push(dir);
+  await git(["init", "-b", "main"], dir);
+  await git(["remote", "add", "origin", remoteUrl], dir);
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// No remote
+// ---------------------------------------------------------------------------
+
+test("pullMergeability on a repo with no supported git remote returns the facade's NO_REMOTE_ERROR", async () => {
+  const dir = await makeRepo("git@example.com:acme/app.git");
+  const res = await pullMergeability({ dir, number: 1 });
+  expect(res).toEqual({
+    ok: false,
+    error: "project does not have a supported git remote (GitHub, GitLab, or Bitbucket)",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHub dispatch (also pins getGitHubPullMergeability's in-request retry —
+// previously untested at the network level)
+// ---------------------------------------------------------------------------
+
+test("pullMergeability on a github repo dispatches to GitHub, retries once on mergeable:null, and maps a dirty verdict", async () => {
+  const dir = await makeGitHubRepo("o", "r");
+  createdDirs.push(dir);
+
+  let calls = 0;
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (!url.includes("api.github.com/repos/o/r/pulls/9")) {
+      throw new Error(`unexpected fetch: ${url}`);
+    }
+    calls++;
+    const body = calls === 1
+      ? {
+        state: "open",
+        merged: false,
+        draft: false,
+        mergeable: null,
+        mergeable_state: "unknown",
+        head: { ref: "feature", sha: "sha1", repo: { full_name: "o/r" } },
+        base: { ref: "main", repo: { full_name: "o/r" } },
+      }
+      : {
+        state: "open",
+        merged: false,
+        draft: false,
+        mergeable: false,
+        mergeable_state: "dirty",
+        head: { ref: "feature", sha: "sha2", repo: { full_name: "o/r" } },
+        base: { ref: "main", repo: { full_name: "o/r" } },
+      };
+    return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+
+  try {
+    const res = await pullMergeability({ dir, number: 9 });
+    expect(calls).toBe(2);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeableState).toBe("dirty");
+    expect(res.mergeable).toBe(false);
+    expect(res.state).toBe("open");
+    expect(res.headRef).toBe("feature");
+    expect(res.baseRef).toBe("main");
+  } finally {
+    globalThis.fetch = original;
+  }
+}, 10_000);
+
+// ---------------------------------------------------------------------------
+// GitLab dispatch
+// ---------------------------------------------------------------------------
+
+test("pullMergeability on a gitlab repo dispatches to GitLab and maps a dirty verdict", async () => {
+  const dir = await makeRepo("https://gitlab.com/acme/app.git");
+  fetchMock = mockGitHubFetch([
+    {
+      match: /gitlab\.com\/api\/v4\/projects\/acme%2Fapp\/merge_requests\/5$/,
+      json: {
+        iid: 5,
+        state: "opened",
+        draft: false,
+        detailed_merge_status: "conflict",
+        source_branch: "feature",
+        target_branch: "main",
+        source_project_id: 1,
+        target_project_id: 1,
+        diff_refs: { head_sha: "sha1" },
+      },
+    },
+  ]);
+
+  const res = await pullMergeability({ dir, number: 5 });
+  expect(res.ok).toBe(true);
+  if (!res.ok) throw new Error(res.error);
+  expect(res.mergeableState).toBe("dirty");
+  expect(res.mergeable).toBe(false);
+  expect(res.state).toBe("open");
+  expect(res.headRef).toBe("feature");
+  expect(res.baseRef).toBe("main");
+
+  const call = fetchMock.calls.find((c) => c.url.includes("merge_requests/5"));
+  expect(call?.url).toContain("/projects/acme%2Fapp/merge_requests/5");
+});
+
+// ---------------------------------------------------------------------------
+// Bitbucket dispatch
+// ---------------------------------------------------------------------------
+
+test("pullMergeability on a bitbucket repo dispatches to Bitbucket, scans the diffstat, and maps a dirty verdict", async () => {
+  const dir = await makeRepo("https://bitbucket.org/acme/app.git");
+  fetchMock = mockGitHubFetch([
+    {
+      match: /\/pullrequests\/7\/diffstat/,
+      json: {
+        values: [{ status: "merge conflict", old: null, new: { path: "src/foo.ts" } }],
+      },
+    },
+    {
+      match: /\/pullrequests\/7$/,
+      json: {
+        state: "OPEN",
+        draft: false,
+        source: {
+          branch: { name: "feature" },
+          commit: { hash: "sha1" },
+          repository: { full_name: "acme/app" },
+        },
+        destination: {
+          branch: { name: "main" },
+          repository: { full_name: "acme/app" },
+        },
+      },
+    },
+  ]);
+
+  const res = await pullMergeability({ dir, number: 7 });
+  expect(res.ok).toBe(true);
+  if (!res.ok) throw new Error(res.error);
+  expect(res.mergeableState).toBe("dirty");
+  expect(res.mergeable).toBe(false);
+  expect(res.state).toBe("open");
+  expect(res.headRef).toBe("feature");
+  expect(res.baseRef).toBe("main");
+
+  const detailCall = fetchMock.calls.find((c) => /\/pullrequests\/7$/.test(c.url));
+  expect(detailCall?.url).toContain("/2.0/repositories/acme/app/pullrequests/7");
+  const diffstatCall = fetchMock.calls.find((c) => c.url.includes("diffstat"));
+  expect(diffstatCall?.url).toContain("/pullrequests/7/diffstat");
+});

--- a/src/bun/git-host.ts
+++ b/src/bun/git-host.ts
@@ -9,6 +9,7 @@ import type {
   GitHubListResult,
   GitHubPullDefaultsResult,
   GitHubPullLineComment,
+  GitHubPullMergeability,
   GitHubPullMergeMethod,
   GitHubPullMergeResult,
   GitHubPullReviewCommentsResult,
@@ -26,6 +27,7 @@ import {
   getGitHubPullChecks,
   getGitHubPullDefaults,
   getGitHubPullDiff,
+  getGitHubPullMergeability,
   getGitHubViewer,
   listGitHubComments,
   listGitHubItems,
@@ -49,6 +51,7 @@ import {
   getGitLabPullChecks,
   getGitLabPullDefaults,
   getGitLabPullDiff,
+  getGitLabPullMergeability,
   getGitLabViewer,
   listGitLabComments,
   listGitLabItems,
@@ -69,6 +72,7 @@ import {
   getBitbucketPullChecks,
   getBitbucketPullDefaults,
   getBitbucketPullDiff,
+  getBitbucketPullMergeability,
   getBitbucketViewer,
   listBitbucketComments,
   listBitbucketItems,
@@ -126,6 +130,7 @@ type CommentResponse = ({ ok: true; comment: GitHubComment }) | FacadeError;
 type LineCommentResponse = ({ ok: true; comment: GitHubPullLineComment }) | FacadeError;
 type ReviewCommentsResponse = ({ ok: true } & GitHubPullReviewCommentsResult) | FacadeError;
 type ChecksResponse = ({ ok: true } & GitHubChecksResult) | FacadeError;
+type MergeabilityResponse = ({ ok: true } & GitHubPullMergeability) | FacadeError;
 type MergeResponse = GitHubPullMergeResult | FacadeError;
 type ActionResponse = ({ ok: true; message?: string; item?: GitHubListItem; commentPosted?: boolean }) | FacadeError;
 type ViewerResponse = ({ ok: true; login: string }) | FacadeError;
@@ -459,6 +464,15 @@ export async function pullChecks(input: { dir: string; number: number }): Promis
   if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
   if (repoInfo.provider === "github") return getGitHubPullChecks(input);
   return repoInfo.provider === "gitlab" ? getGitLabPullChecks(repoInfo, input.number) : getBitbucketPullChecks(repoInfo, input.number);
+}
+
+export async function pullMergeability(input: { dir: string; number: number }): Promise<MergeabilityResponse> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return getGitHubPullMergeability(input);
+  return repoInfo.provider === "gitlab"
+    ? getGitLabPullMergeability(repoInfo, input.number)
+    : getBitbucketPullMergeability(repoInfo, input.number);
 }
 
 export interface PullMergeInput {

--- a/src/bun/github.test.ts
+++ b/src/bun/github.test.ts
@@ -231,6 +231,7 @@ test("normalizeMergeability reads mergeable/state and refs, defaulting the unkno
     rebaseable: true,
     merged: false,
     draft: false,
+    state: "unknown",
     headRef: "feature",
     baseRef: "main",
     headSha: "abc123",

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -2312,14 +2312,17 @@ function normalizeMergeability(repo: GitHubRepo, number: number, raw: unknown): 
   const baseSlug = repoSlug(repo);
   const baseRepoObj = base.repo && typeof base.repo === "object" ? base.repo as Record<string, unknown> : null;
   const baseFullName = baseRepoObj && typeof baseRepoObj.full_name === "string" ? baseRepoObj.full_name : baseSlug;
+  const merged = obj.merged === true;
+  const state = obj.state === "open" ? "open" : obj.state === "closed" ? (merged ? "merged" : "closed") : "unknown";
   return {
     repo: baseSlug,
     pullNumber: number,
     mergeable: typeof obj.mergeable === "boolean" ? obj.mergeable : null,
     mergeableState: pickString(obj, "mergeable_state") || "unknown",
     rebaseable: typeof obj.rebaseable === "boolean" ? obj.rebaseable : null,
-    merged: obj.merged === true,
+    merged,
     draft: obj.draft === true,
+    state,
     headRef: pickString(head, "ref"),
     baseRef: pickString(base, "ref"),
     headSha: pickString(head, "sha"),

--- a/src/bun/gitlab-network.test.ts
+++ b/src/bun/gitlab-network.test.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { mockGitLabFetch, sampleRepo } from "./gitlab-test-util.ts";
+import { gitlabMergeRequest, mockGitLabFetch, sampleRepo } from "./gitlab-test-util.ts";
 import {
   closeGitLabPull,
   createGitLabComment,
@@ -16,11 +16,13 @@ import {
   getGitLabPullChecks,
   getGitLabPullDefaults,
   getGitLabPullDiff,
+  getGitLabPullMergeability,
   getGitLabViewer,
   listGitLabComments,
   listGitLabItems,
   listGitLabLabels,
   mergeGitLabPull,
+  normalizeGitLabMergeability,
   replyGitLabLineComment,
   reopenGitLabPull,
   reviewGitLabPull,
@@ -681,6 +683,235 @@ test("a 401 response surfaces the authHint wording pointing at Settings", async 
   } finally {
     mock.restore();
   }
+});
+
+// ---------------------------------------------------------------------------
+// getGitLabPullMergeability / normalizeGitLabMergeability
+// ---------------------------------------------------------------------------
+
+test("getGitLabPullMergeability: detailed_merge_status:conflict -> dirty/mergeable:false, headRef/baseRef from branches, state:open", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: "/merge_requests/5",
+      json: gitlabMergeRequest({
+        iid: 5,
+        state: "opened",
+        detailed_merge_status: "conflict",
+        source_branch: "feature",
+        target_branch: "main",
+        source_project_id: 1,
+        target_project_id: 1,
+      }),
+    },
+  ]);
+  try {
+    const res = await getGitLabPullMergeability(REPO, 5);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeableState).toBe("dirty");
+    expect(res.mergeable).toBe(false);
+    expect(res.headRef).toBe("feature");
+    expect(res.baseRef).toBe("main");
+    expect(res.state).toBe("open");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullMergeability: detailed_merge_status:mergeable -> clean/mergeable:true", async () => {
+  const mock = mockGitLabFetch([
+    { match: "/merge_requests/5", json: gitlabMergeRequest({ detailed_merge_status: "mergeable" }) },
+  ]);
+  try {
+    const res = await getGitLabPullMergeability(REPO, 5);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeableState).toBe("clean");
+    expect(res.mergeable).toBe(true);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullMergeability: detailed_merge_status:unchecked retries (1.2s apart) until the verdict settles", async () => {
+  // mockGitLabFetch's route table always returns the first matching route's
+  // fixed response, so it can't express "different body on the 2nd call" —
+  // stub globalThis.fetch directly here instead, call-count keyed.
+  let calls = 0;
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (_input: string | URL | Request, _init?: RequestInit) => {
+    calls++;
+    const detailed = calls === 1 ? "unchecked" : "conflict";
+    return new Response(JSON.stringify(gitlabMergeRequest({ detailed_merge_status: detailed })), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  try {
+    const res = await getGitLabPullMergeability(REPO, 5);
+    expect(calls).toBe(2);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeableState).toBe("dirty");
+  } finally {
+    globalThis.fetch = original;
+  }
+}, 10_000);
+
+test("getGitLabPullMergeability: falls back to has_conflicts:true -> dirty when detailed_merge_status is absent", async () => {
+  const mock = mockGitLabFetch([
+    { match: "/merge_requests/5", json: gitlabMergeRequest({ has_conflicts: true }) },
+  ]);
+  try {
+    const res = await getGitLabPullMergeability(REPO, 5);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeableState).toBe("dirty");
+    expect(res.mergeable).toBe(false);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullMergeability: falls back to merge_status:can_be_merged -> clean when neither detailed_merge_status nor has_conflicts is present", async () => {
+  const mock = mockGitLabFetch([
+    { match: "/merge_requests/5", json: gitlabMergeRequest({ merge_status: "can_be_merged" }) },
+  ]);
+  try {
+    const res = await getGitLabPullMergeability(REPO, 5);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeableState).toBe("clean");
+    expect(res.mergeable).toBe(true);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullMergeability: ci_must_pass (an explicit blocking reason) maps to blocked", async () => {
+  const mock = mockGitLabFetch([
+    { match: "/merge_requests/5", json: gitlabMergeRequest({ detailed_merge_status: "ci_must_pass", merge_status: "can_be_merged" }) },
+  ]);
+  try {
+    const res = await getGitLabPullMergeability(REPO, 5);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeableState).toBe("blocked");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullMergeability: a genuinely unrecognized detailed_merge_status fails safe to blocked, NOT falling back to merge_status", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: "/merge_requests/5",
+      json: gitlabMergeRequest({ detailed_merge_status: "future_status", merge_status: "can_be_merged", has_conflicts: false }),
+    },
+  ]);
+  try {
+    const res = await getGitLabPullMergeability(REPO, 5);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.mergeableState).toBe("blocked");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullMergeability: source_project_id !== target_project_id -> crossRepo:true, headRepo:null", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: "/merge_requests/5",
+      json: gitlabMergeRequest({ detailed_merge_status: "mergeable", source_project_id: 1, target_project_id: 2 }),
+    },
+  ]);
+  try {
+    const res = await getGitLabPullMergeability(REPO, 5);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.crossRepo).toBe(true);
+    expect(res.headRepo).toBe(null);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullMergeability: missing source_project_id/target_project_id fails closed to crossRepo:true", async () => {
+  const mock = mockGitLabFetch([
+    { match: "/merge_requests/5", json: gitlabMergeRequest({ detailed_merge_status: "mergeable" }) },
+  ]);
+  try {
+    const res = await getGitLabPullMergeability(REPO, 5);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.crossRepo).toBe(true);
+    expect(res.headRepo).toBe(null);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullMergeability: state:merged -> merged:true, state:'merged'", async () => {
+  const mock = mockGitLabFetch([
+    { match: "/merge_requests/5", json: gitlabMergeRequest({ state: "merged", detailed_merge_status: "mergeable" }) },
+  ]);
+  try {
+    const res = await getGitLabPullMergeability(REPO, 5);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.merged).toBe(true);
+    expect(res.state).toBe("merged");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullMergeability: a malformed (non-object) response body fails with the unexpected-response error", async () => {
+  const mock = mockGitLabFetch([
+    { match: "/merge_requests/5", json: null },
+  ]);
+  try {
+    const res = await getGitLabPullMergeability(REPO, 5);
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toContain("unexpected merge request response");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("normalizeGitLabMergeability: draft:true via the `draft` field", () => {
+  const result = normalizeGitLabMergeability(REPO, 5, gitlabMergeRequest({ draft: true, detailed_merge_status: "mergeable" }));
+  expect(result?.draft).toBe(true);
+});
+
+test("normalizeGitLabMergeability: draft:true via `work_in_progress` when `draft` is false", () => {
+  const result = normalizeGitLabMergeability(
+    REPO,
+    5,
+    gitlabMergeRequest({ draft: false, work_in_progress: true, detailed_merge_status: "mergeable" }),
+  );
+  expect(result?.draft).toBe(true);
+});
+
+test("normalizeGitLabMergeability: headSha prefers diff_refs.head_sha over the top-level sha", () => {
+  const result = normalizeGitLabMergeability(
+    REPO,
+    5,
+    gitlabMergeRequest({ sha: "sha-fallback", diff_refs: { head_sha: "diff-refs-head" } }),
+  );
+  expect(result?.headSha).toBe("diff-refs-head");
+});
+
+test("normalizeGitLabMergeability: headSha falls back to the top-level sha when diff_refs is absent", () => {
+  const result = normalizeGitLabMergeability(REPO, 5, gitlabMergeRequest({ sha: "sha-fallback" }));
+  expect(result?.headSha).toBe("sha-fallback");
+});
+
+test("normalizeGitLabMergeability: autoMerge:true from merge_when_pipeline_succeeds", () => {
+  const result = normalizeGitLabMergeability(REPO, 5, gitlabMergeRequest({ merge_when_pipeline_succeeds: true }));
+  expect(result?.autoMerge).toBe(true);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/bun/gitlab.ts
+++ b/src/bun/gitlab.ts
@@ -850,7 +850,8 @@ function pickString(obj: Record<string, unknown>, key: string): string {
  *  older instances or an unrecognized/missing `detailed_merge_status`. Pure —
  *  unit-tested via `__gitlabInternals`. */
 function mapMergeableState(obj: Record<string, unknown>): string {
-  switch (typeof obj.detailed_merge_status === "string" ? obj.detailed_merge_status : "") {
+  const detailed = typeof obj.detailed_merge_status === "string" ? obj.detailed_merge_status : "";
+  switch (detailed) {
     case "conflict": return "dirty";
     case "mergeable": return "clean";
     case "need_rebase": return "behind";
@@ -860,11 +861,25 @@ function mapMergeableState(obj: Record<string, unknown>): string {
     case "discussions_not_resolved":
     case "not_approved":
     case "external_status_checks":
+    case "ci_must_pass":
+    case "status_checks_must_pass":
+    case "requested_changes":
+    case "jira_association_missing":
+    case "security_policy_violations":
+    case "locked_paths":
+    case "broken_status":
       return "blocked";
     case "unchecked":
     case "checking":
+    case "preparing":
+    case "approvals_syncing":
+    case "not_open":
       return "unknown";
   }
+  // A present-but-unrecognized `detailed_merge_status` is fail-safe: don't
+  // fall through to the coarser `merge_status`/`has_conflicts` pair, which
+  // could report "clean" on a status this code doesn't understand yet.
+  if (detailed !== "") return "blocked";
   if (obj.has_conflicts === true) return "dirty";
   const mergeStatus = typeof obj.merge_status === "string" ? obj.merge_status : "";
   if (mergeStatus === "can_be_merged") return "clean";
@@ -891,23 +906,30 @@ function computeMergeable(mergeableState: string, obj: Record<string, unknown>):
  *  no owner/name to report in the fork case. Exported (rather than folded
  *  into `__gitlabInternals` like the other pure normalizers) so tests can
  *  exercise it directly. */
-export function normalizeGitLabMergeability(repo: ProviderRepoInfo, number: number, mr: unknown): GitHubPullMergeability {
-  const obj = mr && typeof mr === "object" ? mr as Record<string, unknown> : {};
+export function normalizeGitLabMergeability(repo: ProviderRepoInfo, number: number, mr: unknown): GitHubPullMergeability | null {
+  if (!mr || typeof mr !== "object") return null;
+  const obj = mr as Record<string, unknown>;
   const mergeableState = mapMergeableState(obj);
   const diffRefs = obj.diff_refs && typeof obj.diff_refs === "object" ? obj.diff_refs as Record<string, unknown> : null;
   const headSha = (diffRefs ? pickString(diffRefs, "head_sha") : "") || pickString(obj, "sha");
   const sourceProjectId = obj.source_project_id;
   const targetProjectId = obj.target_project_id;
-  const crossRepo = typeof sourceProjectId === "number" && typeof targetProjectId === "number" && sourceProjectId !== targetProjectId;
+  // Fail closed: only a confirmed same-numeric-id match is same-repo. Missing
+  // or non-numeric ids (can't confirm) are treated as cross-repo, matching
+  // github.ts's normalizeMergeability contract.
+  const crossRepo = typeof sourceProjectId !== "number" || typeof targetProjectId !== "number" || sourceProjectId !== targetProjectId;
   const repoSlug = `${repo.owner}/${repo.name}`;
+  const merged = obj.state === "merged";
+  const state = obj.state === "opened" ? "open" : merged ? "merged" : (obj.state === "closed" || obj.state === "locked") ? "closed" : "unknown";
   return {
     repo: repoSlug,
     pullNumber: number,
     mergeable: computeMergeable(mergeableState, obj),
     mergeableState,
     rebaseable: null,
-    merged: obj.state === "merged",
+    merged,
     draft: obj.draft === true || obj.work_in_progress === true,
+    state,
     headRef: pickString(obj, "source_branch"),
     baseRef: pickString(obj, "target_branch"),
     headSha,
@@ -940,6 +962,7 @@ export async function getGitLabPullMergeability(repo: ProviderRepoInfo, number: 
     const json = await res.json().catch(() => null);
     if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!token) };
     const parsed = normalizeGitLabMergeability(repo, number, json);
+    if (!parsed) return { ok: false, error: "GitLab returned an unexpected merge request response" };
     last = parsed;
     if (parsed.merged || parsed.mergeable !== null || parsed.mergeableState !== "unknown") break;
   }

--- a/src/bun/gitlab.ts
+++ b/src/bun/gitlab.ts
@@ -12,6 +12,7 @@ import type {
   GitHubMilestone,
   GitHubPullDefaultsResult,
   GitHubPullLineComment,
+  GitHubPullMergeability,
   GitHubPullMergeMethod,
   GitHubPullMergeResult,
   GitHubPullReviewCommentsResult,
@@ -64,6 +65,7 @@ type GitLabCommentResponse = ({ ok: true; comment: GitHubComment }) | GitLabErro
 type GitLabPullLineCommentResponse = ({ ok: true; comment: GitHubPullLineComment }) | GitLabError;
 type GitLabPullReviewCommentsResponse = ({ ok: true } & GitHubPullReviewCommentsResult) | GitLabError;
 type GitLabChecksResponse = ({ ok: true } & GitHubChecksResult) | GitLabError;
+type GitLabMergeabilityResponse = ({ ok: true } & GitHubPullMergeability) | GitLabError;
 type GitLabPullMergeResponse = GitHubPullMergeResult | GitLabError;
 type GitLabActionResponse = ({ ok: true; message?: string; item?: GitHubListItem; commentPosted?: boolean }) | GitLabError;
 type GitLabViewerResponse = ({ ok: true; login: string }) | GitLabError;
@@ -835,6 +837,113 @@ export async function replyGitLabLineComment(repo: ProviderRepoInfo, number: num
   const comment = normalizeLineComment(json, repo, number);
   if (!comment) return { ok: false, error: "GitLab returned an unexpected reply response" };
   return { ok: true, comment };
+}
+
+function pickString(obj: Record<string, unknown>, key: string): string {
+  return typeof obj[key] === "string" ? (obj[key] as string) : "";
+}
+
+/** Maps GitLab's MR merge-status fields onto GitHub's `mergeableState`
+ *  vocabulary (`clean|dirty|behind|blocked|unstable|draft|unknown`). Prefers
+ *  the newer `detailed_merge_status` (GitLab 15.6+) when it's a recognized
+ *  value; falls back to the coarser `merge_status`/`has_conflicts` pair for
+ *  older instances or an unrecognized/missing `detailed_merge_status`. Pure —
+ *  unit-tested via `__gitlabInternals`. */
+function mapMergeableState(obj: Record<string, unknown>): string {
+  switch (typeof obj.detailed_merge_status === "string" ? obj.detailed_merge_status : "") {
+    case "conflict": return "dirty";
+    case "mergeable": return "clean";
+    case "need_rebase": return "behind";
+    case "draft_status": return "draft";
+    case "ci_still_running": return "unstable";
+    case "blocked_status":
+    case "discussions_not_resolved":
+    case "not_approved":
+    case "external_status_checks":
+      return "blocked";
+    case "unchecked":
+    case "checking":
+      return "unknown";
+  }
+  if (obj.has_conflicts === true) return "dirty";
+  const mergeStatus = typeof obj.merge_status === "string" ? obj.merge_status : "";
+  if (mergeStatus === "can_be_merged") return "clean";
+  if (mergeStatus === "cannot_be_merged") return "dirty";
+  return "unknown";
+}
+
+/** `mergeable` boolean for a given `mergeableState`: `dirty`/`clean`/`unknown`
+ *  map directly; the remaining states (`behind`/`blocked`/`unstable`/`draft`)
+ *  don't imply a verdict on their own, so `has_conflicts` (when GitLab
+ *  actually reports it as a boolean) is used as the best available signal. */
+function computeMergeable(mergeableState: string, obj: Record<string, unknown>): boolean | null {
+  if (mergeableState === "dirty") return false;
+  if (mergeableState === "clean") return true;
+  if (mergeableState === "unknown") return null;
+  return typeof obj.has_conflicts === "boolean" ? !obj.has_conflicts : null;
+}
+
+/** Maps a GitLab MR detail payload (`GET /merge_requests/:iid`) onto
+ *  `GitHubPullMergeability` — see `mapMergeableState`/`computeMergeable` for
+ *  the vocabulary mapping. GitLab's MR payload doesn't carry the source
+ *  project's path (only its numeric id), so `headRepo` reports the repo
+ *  itself for a same-repo MR and `null` for a cross-repo (fork) one — there's
+ *  no owner/name to report in the fork case. Exported (rather than folded
+ *  into `__gitlabInternals` like the other pure normalizers) so tests can
+ *  exercise it directly. */
+export function normalizeGitLabMergeability(repo: ProviderRepoInfo, number: number, mr: unknown): GitHubPullMergeability {
+  const obj = mr && typeof mr === "object" ? mr as Record<string, unknown> : {};
+  const mergeableState = mapMergeableState(obj);
+  const diffRefs = obj.diff_refs && typeof obj.diff_refs === "object" ? obj.diff_refs as Record<string, unknown> : null;
+  const headSha = (diffRefs ? pickString(diffRefs, "head_sha") : "") || pickString(obj, "sha");
+  const sourceProjectId = obj.source_project_id;
+  const targetProjectId = obj.target_project_id;
+  const crossRepo = typeof sourceProjectId === "number" && typeof targetProjectId === "number" && sourceProjectId !== targetProjectId;
+  const repoSlug = `${repo.owner}/${repo.name}`;
+  return {
+    repo: repoSlug,
+    pullNumber: number,
+    mergeable: computeMergeable(mergeableState, obj),
+    mergeableState,
+    rebaseable: null,
+    merged: obj.state === "merged",
+    draft: obj.draft === true || obj.work_in_progress === true,
+    headRef: pickString(obj, "source_branch"),
+    baseRef: pickString(obj, "target_branch"),
+    headSha,
+    // `merge_when_pipeline_succeeds` is GitLab's counterpart to GitHub's
+    // `auto_merge` — true once the "merge when pipeline succeeds" toggle is on.
+    autoMerge: obj.merge_when_pipeline_succeeds === true,
+    headRepo: crossRepo ? null : repoSlug,
+    crossRepo,
+  };
+}
+
+/** Matches `getGitHubPullMergeability`'s shape and polling behavior. GitLab
+ *  also computes mergeability asynchronously (`detailed_merge_status:
+ *  "unchecked"`/`"checking"` right after a push) — poll up to 3 times,
+ *  1.2s apart, stopping early once the verdict settles (merged, a resolved
+ *  `mergeable`, or any `mergeableState` other than `"unknown"`). Always
+ *  returns the last successful parse even if it's still unresolved; only
+ *  `ok:false` when every fetch attempt failed. */
+export async function getGitLabPullMergeability(repo: ProviderRepoInfo, number: number): Promise<GitLabMergeabilityResponse> {
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
+  const token = await gitlabToken(repo.remoteHost);
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const url = `${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`;
+
+  let last: GitHubPullMergeability | null = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt > 0) await new Promise((r) => setTimeout(r, 1_200));
+    const res = await fetchGitLab(url, token);
+    if (!("status" in res)) return res;
+    const json = await res.json().catch(() => null);
+    if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!token) };
+    const parsed = normalizeGitLabMergeability(repo, number, json);
+    last = parsed;
+    if (parsed.merged || parsed.mergeable !== null || parsed.mergeableState !== "unknown") break;
+  }
+  return last ? { ok: true, ...last } : { ok: false, error: "GitLab did not return mergeability for this merge request" };
 }
 
 /** Matches `getGitHubPullChecks`'s shape. GitLab has no single "check-runs"

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -97,7 +97,6 @@ import {
   getGitHubPullLinkedIssues,
   getGitHubRepoPermissions,
   getGitHubThreadSubscription,
-  getGitHubPullMergeability,
   getGitHubPullReviewThreads,
   listGitHubAssignees,
   listGitHubDiscussions,
@@ -1464,7 +1463,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (!Number.isInteger(number) || number <= 0) {
             return json({ error: "valid pull request number required" }, { status: 400, headers: corsHeaders(req) });
           }
-          const result = await getGitHubPullMergeability({ dir, number });
+          const result = await gitHost.pullMergeability({ dir, number });
           if (!result.ok) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -443,6 +443,22 @@ function RunPanelBody({
     setSearchQuery("");
     setActiveMatchId(null);
     nearBottomRef.current = true;
+    // Old task's PR mergeability (and "Resolve Conflicts" send confirmation)
+    // must not survive into the new task: RunPanelBody isn't remounted on
+    // task switch, so without this a stale `prStatus` from task A could sit
+    // around and let the button send task A's PR prompt into task B's agent
+    // before the `[task.id, task.prUrl]` fetch effect below resolves. These
+    // setters/refs are declared further down this component (with the rest
+    // of the PR-status state) — safe to reference here since this closure
+    // only runs after the full component body (and their declarations) has
+    // executed at least once.
+    setPrStatus(null);
+    setPrStatusError(null);
+    setResolveConflictsSent(false);
+    if (prStatusRetryTimerRef.current) clearTimeout(prStatusRetryTimerRef.current);
+    prStatusRetryTimerRef.current = null;
+    if (resolveConflictsSentTimerRef.current) clearTimeout(resolveConflictsSentTimerRef.current);
+    resolveConflictsSentTimerRef.current = null;
   }, [task.id]);
 
   // Latest run for this task — drives the send button, indicator, and
@@ -1709,17 +1725,31 @@ function RunPanelBody({
   // GitHubDialog's mergeability self-heal) before giving up; reset to 0
   // whenever a fresh fetch starts (manual refresh or turn-end retrigger).
   const prStatusRetriesRef = useRef(0);
+  // Holds the self-heal retry's `setTimeout` id so it can be cancelled on
+  // unmount (or superseded by a fresh fetch) instead of firing later against
+  // an unmounted tree — see the mount-scoped cleanup effect below.
+  const prStatusRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fetchPrStatus = useCallback((path: string, number: number) => {
     const requestId = ++prStatusSeqRef.current;
-    setPrStatusLoading(true);
+    if (prStatusRetryTimerRef.current) {
+      clearTimeout(prStatusRetryTimerRef.current);
+      prStatusRetryTimerRef.current = null;
+    }
+    // Clear stale data at fetch start (not just on completion) so a task
+    // switch never leaves the previous task's mergeability visible — and
+    // therefore actionable via "Resolve Conflicts" — while this fetch is
+    // still in flight.
+    setPrStatus(null);
     setPrStatusError(null);
+    setPrStatusLoading(true);
     api.getGitHubPullMergeability({ path, number })
       .then((payload) => {
         if (requestId !== prStatusSeqRef.current) return;
         setPrStatus(payload);
         if (payload.mergeable === null && !payload.merged && prStatusRetriesRef.current < 1) {
           prStatusRetriesRef.current += 1;
-          setTimeout(() => {
+          prStatusRetryTimerRef.current = setTimeout(() => {
+            prStatusRetryTimerRef.current = null;
             if (requestId !== prStatusSeqRef.current) return;
             fetchPrStatus(path, number);
           }, 2_500);
@@ -1734,6 +1764,16 @@ function RunPanelBody({
         if (requestId !== prStatusSeqRef.current) return;
         setPrStatusLoading(false);
       });
+  }, []);
+  // Mount-scoped cleanup: drop any in-flight fetch/self-heal retry and clear
+  // its timer on unmount, so a late response never calls setState on an
+  // unmounted tree (RunPanelBody isn't remounted on task switch, but it *is*
+  // unmounted when the run panel itself closes).
+  useEffect(() => {
+    return () => {
+      prStatusSeqRef.current++;
+      if (prStatusRetryTimerRef.current) clearTimeout(prStatusRetryTimerRef.current);
+    };
   }, []);
 
   // Deps are `[task.id, task.prUrl]` ONLY — not `[task]` — for the same
@@ -1756,21 +1796,24 @@ function RunPanelBody({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [task.id, task.prUrl]);
 
-  // Re-check mergeability at turn-end: track the previous `task.runId` and
-  // refetch when it transitions non-null → null (a turn just finished) —
-  // the agent may have pushed commits that resolve, or newly introduce, a
-  // conflict. `task.runId` only changes value on a genuine transition, so
-  // (unlike the effects above) this is safe to depend on directly.
-  const prevRunIdForPrStatusRef = useRef<string | null>(task.runId);
+  // Re-check mergeability at turn-end: track whether the task was "running"
+  // on the previous render and refetch once it transitions away from
+  // "running" (succeeded, failed, blocked, …) — the agent may have pushed
+  // commits that resolve, or newly introduce, a conflict. `task.runId` is
+  // NOT a usable signal for this: it's never nulled on normal turn
+  // completion (only the orphan-reconciliation/error paths null it — see
+  // the comment at `liveRunTerminal` above), so a non-null → null transition
+  // never fires in the common case. `task.column` is authoritative instead.
+  const wasRunningForPrStatusRef = useRef(task.column === "running");
   useEffect(() => {
-    const prevRunId = prevRunIdForPrStatusRef.current;
-    prevRunIdForPrStatusRef.current = task.runId;
-    if (prevRunId == null || task.runId != null) return;
+    const wasRunning = wasRunningForPrStatusRef.current;
+    wasRunningForPrStatusRef.current = task.column === "running";
+    if (!wasRunning || task.column === "running") return;
     const parsed = parsePrUrl(task.prUrl);
     if (!parsed) return;
     prStatusRetriesRef.current = 0;
     fetchPrStatus(task.workdir, parsed.number);
-  }, [task.runId, task.prUrl, task.workdir, fetchPrStatus]);
+  }, [task.column, task.prUrl, task.workdir, fetchPrStatus]);
 
   const refreshPrStatus = () => {
     if (!parsedPrUrl) return;
@@ -2027,8 +2070,17 @@ function RunPanelBody({
     if (resolveConflictsSentTimerRef.current) clearTimeout(resolveConflictsSentTimerRef.current);
   }, []);
   const sendResolveConflicts = async () => {
-    if (!resumableRunId || modalPending || sending || backlogBusy || resolvingConflicts) return;
-    if (!prStatus) return;
+    // `resolveConflictsSent` in the guard turns the 5s "Sent to agent"
+    // confirmation window into a lockout, not just a label — otherwise the
+    // button re-enables the instant `resolvingConflicts` resets in `finally`
+    // and a second click pastes a duplicate merge prompt into the live tmux
+    // session (`sendRunInput` is deliberately retry:false).
+    if (!resumableRunId || modalPending || sending || backlogBusy || resolvingConflicts || resolveConflictsSent) return;
+    // Belt-and-braces against the stale-`prStatus` case: even though the
+    // reset effect and fetch-start clear above should keep `prStatus` in
+    // sync with the current task's PR, refuse to send unless it still
+    // matches the PR the button is currently showing.
+    if (!parsedPrUrl || !prStatus || prStatus.pullNumber !== parsedPrUrl.number) return;
     const prompt = buildResolveConflictsPrompt({
       repo: prStatus.repo,
       number: prStatus.pullNumber,
@@ -2042,6 +2094,10 @@ function RunPanelBody({
       const res = await api.sendRunInput(resumableRunId, prompt);
       if (!res.delivered) {
         setSendHint(res.reason);
+        // The button can be hidden (archived, subagent tab) by the time this
+        // resolves, which would make `sendHint` invisible — toast so the
+        // failure is surfaced regardless.
+        toast.error(res.reason);
       } else {
         setRebuilt(null);
         setRebuildNote(null);
@@ -2055,7 +2111,9 @@ function RunPanelBody({
         resolveConflictsSentTimerRef.current = setTimeout(() => setResolveConflictsSent(false), 5_000);
       }
     } catch (e) {
-      setSendHint(e instanceof Error ? e.message : String(e));
+      const msg = e instanceof Error ? e.message : String(e);
+      setSendHint(msg);
+      toast.error(msg);
     } finally {
       setResolvingConflicts(false);
     }
@@ -2159,25 +2217,33 @@ function RunPanelBody({
               variant="ghost"
               onClick={refreshPrStatus}
               disabled={prStatusLoading}
-              title="Re-check PR mergeability"
+              title={prStatusError ?? "Re-check PR mergeability"}
             >
               <RefreshCw className="size-3.5" />
             </Button>
           )}
-          {canOfferResolveConflicts(parsedPrUrl, prStatus) && (
+          {/* Gated on `!archived` (the server silently auto-unarchives on
+              other mutations, but this button must not act as though it
+              were live on a frozen task) and on `activeStream === "main"`
+              (mirrors Stop below — a read-only subagent stream tab has no
+              `sendHint` rendered, so a failure here would be invisible;
+              `sendResolveConflicts` also toasts for the same reason). */}
+          {!archived && activeStream === "main" && canOfferResolveConflicts(parsedPrUrl, prStatus) && (
             <Button
               size="sm"
               variant="outline"
               onClick={() => void sendResolveConflicts()}
-              disabled={!canSend || modalPending || sending || backlogBusy || resolvingConflicts}
+              disabled={!canSend || modalPending || sending || backlogBusy || resolvingConflicts || resolveConflictsSent}
               title={
                 !canSend
                   ? "Start the task before asking the agent to resolve conflicts"
                   : modalPending
                     ? "Answer the pending prompt before sending another message"
-                    : sending || backlogBusy || resolvingConflicts
-                      ? "A message is already being sent"
-                      : "Ask the agent to merge the base branch and resolve the reported conflicts"
+                    : resolveConflictsSent
+                      ? "Already sent — waiting for the agent to pick it up"
+                      : sending || backlogBusy || resolvingConflicts
+                        ? "A message is already being sent"
+                        : "Ask the agent to merge the base branch and resolve the reported conflicts"
               }
             >
               <GitMerge className="mr-1 size-3" /> {resolveConflictsSent ? "Sent to agent" : "Resolve Conflicts"}

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -4,7 +4,7 @@ import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
 import {
   Archive, ArchiveRestore, ArrowDown, ArrowUp, BookmarkPlus, Bot, Check, ChevronDown, ChevronUp, ClipboardList, Copy, CornerDownRight, Eye, FolderOpen, FileText, FilePenLine, FilePlus, Folder,
-  GitCommit, GitCompare, GitPullRequest, Globe, HelpCircle, ListTodo, Plug, Search, Send, Slash, SquareSlash,
+  GitCommit, GitCompare, GitMerge, GitPullRequest, Globe, HelpCircle, ListTodo, Plug, RefreshCw, Search, Send, Slash, SquareSlash,
   Sparkles, Square, Terminal, Trash2, Wrench, X,
 } from "lucide-react";
 import { api, commitPushPrompt, type AgentModelMap, type AvailableCommand, type AvailableExtension, type PendingInteraction } from "@/lib/api";
@@ -12,6 +12,8 @@ import { shouldShowSubagentTabs, resolveActiveStream, splitTabsForOverflow, sort
 import { shouldOfferCommitPush, shouldOfferOpenPr, type TaskGitStatus } from "@/lib/commit-push";
 import { findMatchingEventIds, resolveActiveMatchIndex, stepMatchIndex } from "@/lib/event-search";
 import { latestPrProposal } from "@/lib/pr-proposal";
+import { parsePrUrl, canOfferResolveConflicts } from "@/lib/pr-url";
+import { buildResolveConflictsPrompt } from "@/lib/resolve-conflicts-prompt";
 import type { GitHubPullPrefill } from "./GitHubDialog";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -31,6 +33,7 @@ import {
   type AgentStatus,
   type Harness,
   type BacklogMessage,
+  type GitHubPullMergeability,
   type Run,
   type RunEvent,
   type Subagent,
@@ -1690,6 +1693,91 @@ function RunPanelBody({
     return () => { cancelled = true; };
   }, [task.id]);
 
+  // PR mergeability for the header "Resolve Conflicts" button. `parsedPrUrl`
+  // is derived once per `task.prUrl` change and reused for both the fetch
+  // effect and the render-time gate (`canOfferResolveConflicts`).
+  const parsedPrUrl = useMemo(() => parsePrUrl(task.prUrl), [task.prUrl]);
+  const [prStatus, setPrStatus] = useState<GitHubPullMergeability | null>(null);
+  const [prStatusLoading, setPrStatusLoading] = useState(false);
+  const [prStatusError, setPrStatusError] = useState<string | null>(null);
+  // Invalidates an in-flight fetch (including a pending self-heal retry)
+  // when a newer one starts — manual refresh, turn-end retrigger, or the
+  // task switching to a different PR before the previous fetch settled.
+  const prStatusSeqRef = useRef(0);
+  // Self-heal retry budget: GitHub's `mergeable` field is null while it's
+  // still computing in the background. One delayed re-poll (mirrors
+  // GitHubDialog's mergeability self-heal) before giving up; reset to 0
+  // whenever a fresh fetch starts (manual refresh or turn-end retrigger).
+  const prStatusRetriesRef = useRef(0);
+  const fetchPrStatus = useCallback((path: string, number: number) => {
+    const requestId = ++prStatusSeqRef.current;
+    setPrStatusLoading(true);
+    setPrStatusError(null);
+    api.getGitHubPullMergeability({ path, number })
+      .then((payload) => {
+        if (requestId !== prStatusSeqRef.current) return;
+        setPrStatus(payload);
+        if (payload.mergeable === null && !payload.merged && prStatusRetriesRef.current < 1) {
+          prStatusRetriesRef.current += 1;
+          setTimeout(() => {
+            if (requestId !== prStatusSeqRef.current) return;
+            fetchPrStatus(path, number);
+          }, 2_500);
+        }
+      })
+      .catch((e: unknown) => {
+        if (requestId !== prStatusSeqRef.current) return;
+        setPrStatus(null);
+        setPrStatusError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (requestId !== prStatusSeqRef.current) return;
+        setPrStatusLoading(false);
+      });
+  }, []);
+
+  // Deps are `[task.id, task.prUrl]` ONLY — not `[task]` — for the same
+  // reason as the git-status poll effect above: App.tsx's 2s /tasks poll
+  // rebuilds the task object every tick, and depending on the whole object
+  // (or on `task.workdir`, read via closure below) would refetch on every
+  // poll tick instead of only on an actual task/PR change.
+  useEffect(() => {
+    const parsed = parsePrUrl(task.prUrl);
+    if (!parsed) {
+      prStatusSeqRef.current++; // invalidate any in-flight fetch/retry
+      prStatusRetriesRef.current = 0;
+      setPrStatus(null);
+      setPrStatusLoading(false);
+      setPrStatusError(null);
+      return;
+    }
+    prStatusRetriesRef.current = 0;
+    fetchPrStatus(task.workdir, parsed.number);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [task.id, task.prUrl]);
+
+  // Re-check mergeability at turn-end: track the previous `task.runId` and
+  // refetch when it transitions non-null → null (a turn just finished) —
+  // the agent may have pushed commits that resolve, or newly introduce, a
+  // conflict. `task.runId` only changes value on a genuine transition, so
+  // (unlike the effects above) this is safe to depend on directly.
+  const prevRunIdForPrStatusRef = useRef<string | null>(task.runId);
+  useEffect(() => {
+    const prevRunId = prevRunIdForPrStatusRef.current;
+    prevRunIdForPrStatusRef.current = task.runId;
+    if (prevRunId == null || task.runId != null) return;
+    const parsed = parsePrUrl(task.prUrl);
+    if (!parsed) return;
+    prStatusRetriesRef.current = 0;
+    fetchPrStatus(task.workdir, parsed.number);
+  }, [task.runId, task.prUrl, task.workdir, fetchPrStatus]);
+
+  const refreshPrStatus = () => {
+    if (!parsedPrUrl) return;
+    prStatusRetriesRef.current = 0;
+    fetchPrStatus(task.workdir, parsedPrUrl.number);
+  };
+
   const send = async () => {
     const line = input.trim();
     if (!line && !sendRefs.length) return;
@@ -1927,6 +2015,52 @@ function RunPanelBody({
     }
   };
 
+  // One-click follow-up: ask the agent to merge the base branch and resolve
+  // the conflicts blocking this task's PR. Reuses the same `sendRunInput`
+  // plumbing as `sendCommitPush`. `resolvingConflicts` is its own in-flight
+  // flag (rather than reusing `sending`) so the button's own disabled state
+  // and "Sent to agent" confirmation don't get tangled up with the composer's.
+  const [resolvingConflicts, setResolvingConflicts] = useState(false);
+  const [resolveConflictsSent, setResolveConflictsSent] = useState(false);
+  const resolveConflictsSentTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (resolveConflictsSentTimerRef.current) clearTimeout(resolveConflictsSentTimerRef.current);
+  }, []);
+  const sendResolveConflicts = async () => {
+    if (!resumableRunId || modalPending || sending || backlogBusy || resolvingConflicts) return;
+    if (!prStatus) return;
+    const prompt = buildResolveConflictsPrompt({
+      repo: prStatus.repo,
+      number: prStatus.pullNumber,
+      title: null,
+      headRef: prStatus.headRef,
+      baseRef: prStatus.baseRef,
+    });
+    setResolvingConflicts(true);
+    setSendHint(null);
+    try {
+      const res = await api.sendRunInput(resumableRunId, prompt);
+      if (!res.delivered) {
+        setSendHint(res.reason);
+      } else {
+        setRebuilt(null);
+        setRebuildNote(null);
+        void api.listRuns(task.id).then((list) => setRuns(list)).catch(() => {});
+        nearBottomRef.current = true;
+        requestAnimationFrame(() => {
+          logRef.current?.scrollTo({ top: logRef.current.scrollHeight });
+        });
+        if (resolveConflictsSentTimerRef.current) clearTimeout(resolveConflictsSentTimerRef.current);
+        setResolveConflictsSent(true);
+        resolveConflictsSentTimerRef.current = setTimeout(() => setResolveConflictsSent(false), 5_000);
+      }
+    } catch (e) {
+      setSendHint(e instanceof Error ? e.message : String(e));
+    } finally {
+      setResolvingConflicts(false);
+    }
+  };
+
   // Drag/drop + paste capture for the message textarea. Mirrors the
   // NewTaskForm sidebar flow: pathful files come straight through, blob
   // screenshots (macOS floating thumbnail, clipboard paste) get uploaded
@@ -2016,6 +2150,38 @@ function RunPanelBody({
             >
               <GitPullRequest className="mr-1 size-3" /> View PR
             </ExternalLink>
+          )}
+          {/* Manual re-check — only once a first fetch has settled, so it
+              doesn't appear (and immediately duplicate) the initial load. */}
+          {parsedPrUrl && (prStatus != null || prStatusError != null) && (
+            <Button
+              size="icon"
+              variant="ghost"
+              onClick={refreshPrStatus}
+              disabled={prStatusLoading}
+              title="Re-check PR mergeability"
+            >
+              <RefreshCw className="size-3.5" />
+            </Button>
+          )}
+          {canOfferResolveConflicts(parsedPrUrl, prStatus) && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void sendResolveConflicts()}
+              disabled={!canSend || modalPending || sending || backlogBusy || resolvingConflicts}
+              title={
+                !canSend
+                  ? "Start the task before asking the agent to resolve conflicts"
+                  : modalPending
+                    ? "Answer the pending prompt before sending another message"
+                    : sending || backlogBusy || resolvingConflicts
+                      ? "A message is already being sent"
+                      : "Ask the agent to merge the base branch and resolve the reported conflicts"
+              }
+            >
+              <GitMerge className="mr-1 size-3" /> {resolveConflictsSent ? "Sent to agent" : "Resolve Conflicts"}
+            </Button>
           )}
           <Button
             size="sm"

--- a/src/mainview/lib/mergeability.test.ts
+++ b/src/mainview/lib/mergeability.test.ts
@@ -11,6 +11,7 @@ function m(overrides: Partial<GitHubPullMergeability>): GitHubPullMergeability {
     rebaseable: true,
     merged: false,
     draft: false,
+    state: "open",
     headRef: "feature",
     baseRef: "main",
     headSha: "abc",
@@ -41,11 +42,11 @@ test("dirty, blocked, and draft all block the merge button", () => {
   expect(mergeabilityView(m({ mergeableState: "draft" }))).toMatchObject({ canMerge: false, showUpdateBranch: false, tone: "muted" });
 });
 
-test("mergeable === null (still computing) blocks merge; offers Update branch only when behind", () => {
+test("mergeable === null (still computing, or a permanent unknown) keeps merge enabled; offers Update branch only when behind", () => {
   expect(mergeabilityView(m({ mergeable: null, mergeableState: "unknown" })))
-    .toMatchObject({ canMerge: false, showUpdateBranch: false, tone: "muted" });
+    .toMatchObject({ canMerge: true, showUpdateBranch: false, tone: "muted" });
   expect(mergeabilityView(m({ mergeable: null, mergeableState: "behind" })))
-    .toMatchObject({ canMerge: false, showUpdateBranch: true });
+    .toMatchObject({ canMerge: true, showUpdateBranch: true });
 });
 
 test("an unknown state falls back to the computed mergeable flag", () => {

--- a/src/mainview/lib/mergeability.ts
+++ b/src/mainview/lib/mergeability.ts
@@ -14,10 +14,16 @@ export interface MergeabilityView {
  *  Pure — drives whether a PR can be merged from the UI, so it's unit-tested. */
 export function mergeabilityView(m: GitHubPullMergeability): MergeabilityView {
   if (m.mergeable === null) {
+    // `mergeable === null` can be a transient "still computing" state
+    // (GitHub) or a PERMANENT unknown (Bitbucket, when the diffstat scan
+    // fails or hits its page cap) — there's no way to tell them apart from
+    // this shape alone. Keeping the merge button enabled here matches the
+    // pre-mergeability-feature baseline (no verdict meant merge stayed
+    // enabled) rather than regressing Bitbucket to a permanently dead button.
     return {
-      label: "Mergeability is still being checked…",
+      label: "Mergeability hasn't been verified — merging will be attempted as-is",
       tone: "muted",
-      canMerge: false,
+      canMerge: true,
       showUpdateBranch: m.mergeableState === "behind",
     };
   }

--- a/src/mainview/lib/mergeability.ts
+++ b/src/mainview/lib/mergeability.ts
@@ -15,7 +15,7 @@ export interface MergeabilityView {
 export function mergeabilityView(m: GitHubPullMergeability): MergeabilityView {
   if (m.mergeable === null) {
     return {
-      label: "GitHub is still checking mergeability…",
+      label: "Mergeability is still being checked…",
       tone: "muted",
       canMerge: false,
       showUpdateBranch: m.mergeableState === "behind",

--- a/src/mainview/lib/pr-url.test.ts
+++ b/src/mainview/lib/pr-url.test.ts
@@ -1,0 +1,167 @@
+import { expect, test } from "bun:test";
+import { canOfferResolveConflicts, parsePrUrl } from "./pr-url.ts";
+import type { GitHubPullMergeability } from "../../shared/types.ts";
+
+function m(overrides: Partial<GitHubPullMergeability> = {}): GitHubPullMergeability {
+  return {
+    repo: "o/r",
+    pullNumber: 42,
+    mergeable: false,
+    mergeableState: "dirty",
+    rebaseable: false,
+    merged: false,
+    draft: false,
+    state: "open",
+    headRef: "feature",
+    baseRef: "main",
+    headSha: "abc",
+    autoMerge: false,
+    headRepo: "o/r",
+    crossRepo: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parsePrUrl — accepted shapes
+// ---------------------------------------------------------------------------
+
+test("parses a plain github.com PR URL", () => {
+  expect(parsePrUrl("https://github.com/o/r/pull/42")).toEqual({ provider: "github", number: 42 });
+});
+
+test("parses a self-hosted GitHub-Enterprise-style host with the same path shape", () => {
+  expect(parsePrUrl("https://github.mycorp.internal/o/r/pull/42")).toEqual({ provider: "github", number: 42 });
+});
+
+test("parses a github PR URL with a trailing path segment", () => {
+  expect(parsePrUrl("https://github.com/o/r/pull/42/files")).toEqual({ provider: "github", number: 42 });
+});
+
+test("parses a github PR URL with a query string", () => {
+  expect(parsePrUrl("https://github.com/o/r/pull/42?diff=unified")).toEqual({ provider: "github", number: 42 });
+});
+
+test("parses a github PR URL with a fragment", () => {
+  expect(parsePrUrl("https://github.com/o/r/pull/42#discussion_r1")).toEqual({ provider: "github", number: 42 });
+});
+
+test("parses a gitlab merge request URL", () => {
+  expect(parsePrUrl("https://gitlab.example.com/g/p/-/merge_requests/7")).toEqual({ provider: "gitlab", number: 7 });
+});
+
+test("parses a gitlab merge request URL with a nested group path", () => {
+  expect(parsePrUrl("https://gitlab.example.com/g/subgroup/p/-/merge_requests/7")).toEqual({
+    provider: "gitlab",
+    number: 7,
+  });
+});
+
+test("parses a bitbucket pull request URL", () => {
+  expect(parsePrUrl("https://bitbucket.org/w/r/pull-requests/11")).toEqual({ provider: "bitbucket", number: 11 });
+});
+
+test("parses a bitbucket pull request URL with a trailing /diff segment", () => {
+  expect(parsePrUrl("https://bitbucket.org/w/r/pull-requests/11/diff")).toEqual({
+    provider: "bitbucket",
+    number: 11,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePrUrl — rejections
+// ---------------------------------------------------------------------------
+
+test("rejects null, undefined, and empty string", () => {
+  expect(parsePrUrl(null)).toBeNull();
+  expect(parsePrUrl(undefined)).toBeNull();
+  expect(parsePrUrl("")).toBeNull();
+});
+
+test("rejects a non-URL garbage string", () => {
+  expect(parsePrUrl("not a url")).toBeNull();
+});
+
+test("rejects a GitHub compare/new-PR URL (no PR number in the path)", () => {
+  expect(parsePrUrl("https://github.com/o/r/pull/new/branch")).toBeNull();
+});
+
+test("rejects a GitHub issue URL", () => {
+  expect(parsePrUrl("https://github.com/o/r/issues/42")).toBeNull();
+});
+
+test("rejects PR number 0", () => {
+  expect(parsePrUrl("https://github.com/o/r/pull/0")).toBeNull();
+});
+
+test("rejects a negative PR number", () => {
+  expect(parsePrUrl("https://github.com/o/r/pull/-3")).toBeNull();
+});
+
+test("rejects a PR number with trailing non-digit characters glued on", () => {
+  expect(parsePrUrl("https://github.com/o/r/pull/12abc")).toBeNull();
+});
+
+test("rejects a URL whose path doesn't match any known PR/MR shape", () => {
+  expect(parsePrUrl("https://github.com/o/r/commits/main")).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// canOfferResolveConflicts — passing case
+// ---------------------------------------------------------------------------
+
+test("offers resolve-conflicts when parsed ok, dirty, open, not merged, same-repo, refs non-empty", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, m())).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// canOfferResolveConflicts — failing cases
+// ---------------------------------------------------------------------------
+
+test("does not offer when the URL failed to parse", () => {
+  expect(canOfferResolveConflicts(null, m())).toBe(false);
+});
+
+test("does not offer when mergeability is null", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, null)).toBe(false);
+});
+
+test("does not offer when mergeableState is clean", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, m({ mergeableState: "clean" }))).toBe(false);
+});
+
+test("does not offer when mergeableState is unknown", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, m({ mergeableState: "unknown" }))).toBe(false);
+});
+
+test("does not offer when mergeableState is behind", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, m({ mergeableState: "behind" }))).toBe(false);
+});
+
+test("does not offer when the PR is already merged", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, m({ merged: true }))).toBe(false);
+});
+
+test("does not offer when the PR is cross-repo", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, m({ crossRepo: true }))).toBe(false);
+});
+
+test("does not offer when state is closed", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, m({ state: "closed" }))).toBe(false);
+});
+
+test("does not offer when state is merged", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, m({ state: "merged" }))).toBe(false);
+});
+
+test("does not offer when state is an unrecognized value", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, m({ state: "unknown" }))).toBe(false);
+});
+
+test("does not offer when headRef is empty", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, m({ headRef: "" }))).toBe(false);
+});
+
+test("does not offer when baseRef is empty", () => {
+  expect(canOfferResolveConflicts({ provider: "github", number: 42 }, m({ baseRef: "" }))).toBe(false);
+});

--- a/src/mainview/lib/pr-url.ts
+++ b/src/mainview/lib/pr-url.ts
@@ -1,0 +1,64 @@
+import type { GitHubPullMergeability, GitProvider } from "../../shared/types.ts";
+
+/** Result of successfully parsing a PR/MR URL: which forge it came from and
+ *  the item's number. */
+export interface ParsedPrUrl {
+  provider: GitProvider;
+  number: number;
+}
+
+/**
+ * Path-shape patterns that identify a pull/merge request URL per provider.
+ * Matched against `URL.pathname` only — query string and fragment are already
+ * stripped by `URL`, and a trailing path segment after the number (or nothing
+ * at all) is allowed. Hostname is deliberately not checked: self-hosted
+ * GitLab/Bitbucket/GitHub Enterprise instances use the same path shapes on
+ * arbitrary domains.
+ */
+const PR_URL_PATTERNS: { provider: GitProvider; re: RegExp }[] = [
+  // GitLab first — its path contains "merge_requests", which never collides
+  // with the other two providers' patterns, but checking it before the
+  // narrower "pull"/"pull-requests" patterns keeps intent obvious.
+  { provider: "gitlab", re: /\/-\/merge_requests\/(\d+)(?:[/?#]|$)/ },
+  { provider: "bitbucket", re: /\/pull-requests\/(\d+)(?:[/?#]|$)/ },
+  { provider: "github", re: /\/pull\/(\d+)(?:[/?#]|$)/ },
+];
+
+/**
+ * Detect which git forge a PR/MR html URL belongs to and extract its number,
+ * by matching the URL's *path shape* rather than its hostname (self-hosted
+ * instances exist on arbitrary domains). Returns null for an unparseable
+ * URL, a URL that doesn't match any known PR/MR path shape, or a matched
+ * number that isn't a positive integer.
+ */
+export function parsePrUrl(url: string | null | undefined): ParsedPrUrl | null {
+  if (!url) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  for (const { provider, re } of PR_URL_PATTERNS) {
+    const match = re.exec(parsed.pathname);
+    if (!match) continue;
+    const number = Number(match[1]);
+    if (!Number.isInteger(number) || number <= 0) return null;
+    return { provider, number };
+  }
+  return null;
+}
+
+/**
+ * Whether the "Resolve Conflicts" button should be offered: the task's
+ * `prUrl` parsed to a recognized PR/MR, its mergeability was fetched, and
+ * that mergeability describes an open, same-repo PR that's actually
+ * conflicted (`mergeableState === "dirty"`). Mirrors the "Resolve with
+ * Agetor" gating already applied to `crossRepo` in `ResolveConflictsDialog`.
+ */
+export function canOfferResolveConflicts(
+  parsed: ReturnType<typeof parsePrUrl>,
+  m: GitHubPullMergeability | null,
+): boolean {
+  return parsed != null && m != null && m.mergeableState === "dirty" && !m.merged && !m.crossRepo;
+}

--- a/src/mainview/lib/pr-url.ts
+++ b/src/mainview/lib/pr-url.ts
@@ -53,12 +53,17 @@ export function parsePrUrl(url: string | null | undefined): ParsedPrUrl | null {
  * Whether the "Resolve Conflicts" button should be offered: the task's
  * `prUrl` parsed to a recognized PR/MR, its mergeability was fetched, and
  * that mergeability describes an open, same-repo PR that's actually
- * conflicted (`mergeableState === "dirty"`). Mirrors the "Resolve with
- * Agetor" gating already applied to `crossRepo` in `ResolveConflictsDialog`.
+ * conflicted (`mergeableState === "dirty"`), with non-empty head/base refs.
+ * Mirrors the "Resolve with Agetor" gating already applied to `crossRepo` in
+ * `ResolveConflictsDialog`. The `state === "open"` check guards against a
+ * stale/closed PR still reporting a conflicted `mergeableState`; the ref
+ * checks guard against building a resolve-conflicts prompt from an empty
+ * `origin/` ref (a malformed or partially-normalized mergeability payload).
  */
 export function canOfferResolveConflicts(
   parsed: ReturnType<typeof parsePrUrl>,
   m: GitHubPullMergeability | null,
 ): boolean {
-  return parsed != null && m != null && m.mergeableState === "dirty" && !m.merged && !m.crossRepo;
+  return parsed != null && m != null && m.mergeableState === "dirty" && !m.merged && !m.crossRepo
+    && m.state === "open" && m.headRef !== "" && m.baseRef !== "";
 }

--- a/src/mainview/lib/resolve-conflicts-prompt.test.ts
+++ b/src/mainview/lib/resolve-conflicts-prompt.test.ts
@@ -81,3 +81,18 @@ test("special characters in title don't break the prompt and core instructions s
   expect(prompt).toContain("Do not push");
   expect(prompt).toContain("Commit the merge locally");
 });
+
+test("null title drops the dash/quotes clause but keeps the rest of the template intact", () => {
+  const prompt = buildResolveConflictsPrompt(input({ title: null }));
+  const firstLine = prompt.split("\n")[0];
+
+  expect(firstLine).toBe("Resolve the merge conflicts blocking acme/widgets PR #42.");
+  expect(firstLine).not.toContain("—");
+  expect(firstLine).not.toContain('"');
+  expect(prompt).toContain("`feature/resize`");
+  expect(prompt).toContain("origin/main");
+  expect(prompt).toContain("Both branches' changes matter here");
+  expect(prompt).toContain("Do not push");
+  expect(prompt).toContain("Commit the merge locally");
+  expect(prompt).toContain("references PR #42");
+});

--- a/src/mainview/lib/resolve-conflicts-prompt.ts
+++ b/src/mainview/lib/resolve-conflicts-prompt.ts
@@ -1,15 +1,22 @@
 export interface ResolveConflictsPromptInput {
   repo: string;
   number: number;
-  title: string;
+  /** PR/MR title, when known. Null when the caller only has mergeability
+   *  data (which doesn't carry a title) — the first line drops the
+   *  `— "title"` clause in that case. */
+  title: string | null;
   headRef: string;
   baseRef: string;
 }
 
 export function buildResolveConflictsPrompt(input: ResolveConflictsPromptInput): string {
   const { repo, number, title, headRef, baseRef } = input;
+  const firstLine =
+    typeof title === "string" && title.length > 0
+      ? `Resolve the merge conflicts blocking ${repo} PR #${number} — "${title}".`
+      : `Resolve the merge conflicts blocking ${repo} PR #${number}.`;
   return [
-    `Resolve the merge conflicts blocking ${repo} PR #${number} — "${title}".`,
+    firstLine,
     `You're already on the PR's head branch (\`${headRef}\`). Run \`git fetch origin\` first, then merge \`origin/${baseRef}\` into \`${headRef}\` (the branch currently checked out).`,
     "Both branches' changes matter here — this is a real merge, not a rebase you can shortcut by favoring one side. For every conflict, read both versions closely enough to understand what each side was trying to do, then combine them so both intents survive. Never resolve a conflict by blindly taking \"ours\" or \"theirs\" wholesale; if the two changes are genuinely incompatible, pick the combination that best preserves the goals of both, and say so in the commit message.",
     "Once every conflict marker is gone, verify the result — run a quick typecheck, build, or the fastest relevant test subset if the repo makes that practical, so you're not committing a merge that doesn't compile.",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1641,6 +1641,10 @@ export interface GitHubPullMergeability {
   rebaseable: boolean | null;
   merged: boolean;
   draft: boolean;
+  /** Normalized to `"open" | "closed" | "merged" | "unknown"` — provider
+   *  state vocabularies collapsed onto one small set so callers don't need
+   *  provider-specific branching. */
+  state: string;
   headRef: string;
   baseRef: string;
   headSha: string;


### PR DESCRIPTION
## What

When a task has a PR (the durable **View PR** link from #133) and that PR currently has merge conflicts, the Task Details panel header now shows a **Resolve Conflicts** button. Clicking it sends a canned prompt to the task's live agent instructing it to:

1. `git fetch origin`, then merge `origin/<base branch>` into the branch it's already on,
2. resolve every conflict treating **both sides' changes as important** (never blind "ours"/"theirs"),
3. verify (typecheck/build/fast tests where practical) and commit locally with a message summarizing the resolution,
4. **not push** — the user reviews the merge and pushes via the existing Commit & Push flow (same contract as #125's resolve-conflicts prompt, which this reuses).

## How

**Multi-provider mergeability.** Conflict detection previously existed only for GitHub. This adds:

- `getGitLabPullMergeability` — maps `detailed_merge_status` onto the shared `mergeableState` vocabulary (`conflict`→`dirty`, `mergeable`→`clean`, …), retries while GitLab reports `unchecked`/`checking`, and **fails safe to `blocked`** on unrecognized statuses (GitLab reports `can_be_merged` whenever there are merely no conflicts, so trusting the coarse field would show blocked MRs as clean). Falls back to `has_conflicts`/`merge_status` only when the detailed field is absent.
- `getBitbucketPullMergeability` — Bitbucket's PR resource has no conflict field, so open PRs are scanned via `/diffstat`: any `merge conflict` / `local deleted` / `remote deleted` entry ⇒ `dirty`. Paging follows `next` (origin-checked before fetching, so a hostile URL never receives credentials) with a 10-page cap; cap-exceeded or fetch failure ⇒ `unknown`, never a false `clean`.
- A `pullMergeability` facade in `git-host.ts`; the `/github/pull-mergeability` route now dispatches through it, so the GitHub dialog's mergeability badge also starts working for GitLab/Bitbucket projects.
- `GitHubPullMergeability` gains a normalized `state` field (`open`/`closed`/`merged`/`unknown`), and `crossRepo` fails **closed** in all adapters (unknown head-repo identity ⇒ treated as a fork, button hidden).

**UI wiring.** New pure lib `pr-url.ts` parses the provider + PR number out of `task.prUrl` by URL path shape (`/pull/N`, `/-/merge_requests/N`, `/pull-requests/N` — host-agnostic for self-hosted instances) and gates the button (`dirty` && open && !merged && !crossRepo && refs present). RunPanel fetches mergeability on open (with one self-heal retry while the provider computes), offers a manual re-check, and re-checks when a turn ends (keyed on `task.column` leaving `running` — `task.runId` is never nulled on normal completion). Sending mirrors the Commit & Push guards (`resumableRunId`, `modalPending`), is locked out during the 5s sent-confirmation to prevent duplicate pastes into the live tmux session, is hidden on archived tasks and read-only subagent tabs, and surfaces failures via toast. Per-task PR state is explicitly reset on task switch (the panel doesn't remount), so one task's PR can never be sent into another task's agent.

The `buildResolveConflictsPrompt` title became optional (`string | null`) since the mergeability payload carries no PR title; the "still checking" mergeability copy is now provider-neutral, and a permanently-unverifiable verdict (Bitbucket diffstat failure) no longer dead-locks the dialog's Merge button.

## Testing

- 67 new tests: GitLab mapping/retry/fail-safe (17), Bitbucket diffstat scan/paging/cap/hostile-`next` (16), URL parsing + gating truth table (30), facade dispatch per provider incl. GitHub retry backfill (4).
- Full suite: **2031 pass / 2 skip / 0 fail**; `bun run typecheck` clean.
- No migrations, no schema changes.

Plan: `docs/plans/resolve-conflicts-from-task-details.md`.