### PR TITLE
fix: keep tasks in "running" while a Claude Code Workflow (/workflow) is in flight

### DIFF
--- a/docs/plans/claude-code-workflows-as-running-bg-agents.md
+++ b/docs/plans/claude-code-workflows-as-running-bg-agents.md
@@ -124,3 +124,14 @@ When a claude-code task launches a **Workflow** (the `/workflow` multi-agent orc
 - **A5 (kill switch):** `AGETOR_TRACK_WORKFLOWS`, default on, nested under `AGETOR_TRACK_SUBAGENTS` — follows `AGETOR_TRACK_<THING>` convention.
 - **A6 (nested workflows):** `workflow()`-in-workflow children share the parent's transcript dir per the harness contract (one level only); the dir scan handles whatever appears, no special casing.
 - **A7:** no real-app smoke test in this run (unit/integration suite only), matching the predecessor feature's verification bar.
+
+## 9. What actually shipped — deviations from this plan
+
+1. **db.ts was touched after all** (plan preferred zero changes): the pre-existing `toSubagent` read-coercion (`parent_kind === "bg_session" ? … : "subagent"`) silently collapsed unknown kinds to `"subagent"`, which would have neutered every workflow branch on rows read back from SQLite. Replaced with a `PARENT_KINDS` allow-list.
+2. **orchestrator.ts was touched** (plan said no changes needed): review found the hold race — the container row is created by a watcher poll (4–10 s tiers) while `attachDoneHandler` evaluates the hold ~800 ms after end_turn, so the card bounced `running → review → running` on nearly every launch. Fixed by `pumpWatcherForHoldCheck(taskId)` called right before the hold predicate; this also closes the same pre-existing race for async `Agent` subagents launched at the end of a turn.
+3. **Attach-time main-JSONL replay is clamped** to `REPLAY_WINDOW_BYTES` (4 MB) when no toolUseId correlation is pending — without it, boot reconciliation sync-read entire multi-MB transcripts per watcher.
+4. **`workflow_agent` files are tailed past settle** while their container runs, so a journal-receipt settle can't permanently truncate a tab whose terminal lines flush late.
+5. **Notification matching is anchored** on the literal `<task-notification>` substring + `matchAll` (a quoted `<task-id>` in ordinary content must never false-settle a container — that would be unrecoverable).
+6. **The cascade fires the settle hook once, at depth 0**, after all agent rows settle, making the "release sees the whole workflow at once" invariant actually true.
+7. RunPanel.tsx needed no changes — all tab derivation flows through the pure helpers in `subagent-tabs.ts`.
+8. Deferred from review (accepted): a `pendingReceipts` buffer for journal receipts arriving before agent-file discovery (container-settle cascade is the backstop), and deep-idle-tier retention for workflow state (matches existing `files.size` behavior).

--- a/docs/plans/claude-code-workflows-as-running-bg-agents.md
+++ b/docs/plans/claude-code-workflows-as-running-bg-agents.md
@@ -1,0 +1,126 @@
+# Plan — Treat Claude Code Workflows (`/workflow`) as running background agents
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-31 |
+| Source | `/implement` — "add support to claude code workflows `/workflow` as running BG agents, so the task is kept in the `running` status and column" |
+| Config | AGENTS_CONFIG.yml (balanced; `implementation` for T2 overridden to `opus` per `allow_orchestrator_override`) |
+| Branch | `fix/claude-code-workflows-as-running-status` (pre-existing feature branch, clean) |
+| Base SHA | `988b77f` (== main tip at start) |
+| Mode | **Autonomous** — grill + plan-approval gates bypassed; every owner decision below is a logged assumption (§8) |
+
+## 1. Objective & success criteria
+
+When a claude-code task launches a **Workflow** (the `/workflow` multi-agent orchestration tool, run ids `wf_…`), the workflow runs in the background and the main turn ends immediately — today the card jumps to `review` while the workflow is still churning. After this change:
+
+1. Workflow launch (`toolUseResult.taskType === "local_workflow"`, `status === "async_launched"`) → a `subagents` row (`parentKind: "workflow"`) is created `running` → the existing hold gate (`subagents.hasRunning`) keeps the card in `running`.
+2. The workflow-completion `<task-notification>` (whose `<task-id>` equals the launch's `taskId`) settles that row via the **unchanged** existing notification path → last running row gone → card flips to `review`.
+3. Each workflow agent transcript (`<sessionId>/subagents/workflows/<wf_runId>/agent-<id>.jsonl`) is discovered, tailed, and rendered as a read-only tab exactly like regular subagents (`parentKind: "workflow_agent"`).
+4. A workflow launched while the card sits in `review` (follow-up turn) pulls the card back to `running` (existing `pullBackParkedTask`).
+5. Session death, `Stop` on a held task, delete/archive, and boot reconciliation all release the hold (existing orphan paths, unchanged).
+6. Codex/grok tasks and regular subagent behavior are completely unaffected. Everything is behind `AGETOR_TRACK_WORKFLOWS` (default on) nested under `AGETOR_TRACK_SUBAGENTS`.
+
+## 2. Context & constraints (ground truth, empirically verified 2026-07-31 on claude CLI ≥2.1.220 by running a live probe workflow)
+
+- **Launch:** main JSONL `user` line carries `toolUseResult: { status: "async_launched", taskId: "w2u1mlzr0", taskType: "local_workflow", workflowName, runId: "wf_…", summary, transcriptDir, scriptPath }`. `transcriptDir` = `<sessionDir>/subagents/workflows/<wf_runId>` — **inside** the `subagents/` dir agetor already watches, but in a subdirectory the flat `/^agent-(.+)\.jsonl$/` readdir scan (`claude-subagents.ts:506-549`) never sees. Workflows are always background; the tool_result is immediate.
+- **Per-agent files:** `agent-<agentId>.jsonl` + `agent-<agentId>.meta.json` in the wf dir. Meta = `{ agentType: "workflow-subagent", spawnDepth: 1, model }` — **no `toolUseId`, no `description`**. The jsonl is the standard sidechain shape (`isSidechain: true`, parent's `sessionId`, `agentId`, terminal assistant `stop_reason: "end_turn"`) — the existing tailer/mapper consumes it as-is.
+- **`journal.jsonl`** in the wf dir: `{"type":"started","key","agentId"}` / `{"type":"result","key","agentId","result"}` per agent — a harness-written completion receipt, immune to the terminal-line flush-loss failure (fleet knowledge: concurrent subagents can lose their terminal `end_turn` line; workflows run up to ~10 concurrent agents, so this matters).
+- **Completion:** `<task-notification>` in the main JSONL (`queue-operation` enqueue + synthetic `user` shapes, both already parsed by `claude-tmux.ts:dispatchLine`) with `<task-id>` = the **taskId** (`w2u1mlzr0`), `<tool-use-id>` = the launching Workflow tool_use id, `<status>` ∈ completed/failed/killed/stopped.
+- **Existing seams (verified):**
+  - `setBackgroundTaskSettledHandler` → orchestrator wires `(_taskId, agentId) => settleSubagentById(agentId, "completed")` (`orchestrator.ts:292-293`) — settles any row by PK, no-ops on unknown ids. **Row PK = workflow taskId ⇒ live completion path needs zero changes.**
+  - `scanMainForToolResults` (`claude-subagents.ts:737-774`) — watcher-side main-JSONL scan with its own `mainOffset` cursor; only matches file-backed rows with `toolUseId`, so workflow rows are structurally excluded from the false-settle hazard (their tool_result is the immediate `async_launched` stub).
+  - `discover()` fires `fireParkedDiscovery(taskId)` on fresh inserts (`claude-subagents.ts:547`) → pull-back for free.
+  - `orphanRunningSubagents(taskId)` flips **all** running rows for a task (kind-agnostic) → death/stop/boot release for free.
+  - Boot reconciliation re-arms only `attachSubagentWatcher` (no main tmux tailer) — so workflow launch/completion detection must live in the **watcher's** main-JSONL scan, mirroring why the tool_result scan is watcher-side (fleet knowledge c8edc832).
+- **Schema:** `subagents.parent_kind` is TEXT, no CHECK constraint (`022_subagents.sql`), explicitly reserved for new kinds — **no migration needed**. Next free number would be 032 if one becomes necessary; it doesn't.
+- **Test hygiene (fleet-verified):** `bun test` = one process, one SQLite DB. Seed run rows terminal (`succeeded` + `endedAt`), track and hard-delete created tasks in `afterEach`, save/restore hook setters (they return the previous value), use `attachSubagentWatcher({ manual: true })` + `pump(now)` — no real timers.
+
+## 3. Approach & key decisions
+
+**One container row per workflow + one row per workflow agent, all in the existing `subagents` table.**
+
+- The **container row** (`parentKind: "workflow"`, `id` = workflow taskId, `sourcePath` = transcriptDir, `agentType: "workflow"`, `description` = workflowName — with `summary` fallback, `toolUseId` = launching tool_use id) is what carries the **hold**: it's `running` from launch to completion-notification, so `hasRunning` stays true across the gaps *between* agent waves and the card never bounces `running → review → running` mid-workflow.
+- **Agent rows** (`parentKind: "workflow_agent"`, `id` = agentId, `sourcePath` = the agent jsonl) give the read-only tab streams, reusing `tailFile` + the standard mapper untouched.
+- **Container settle:** notification only (live: claude-tmux dispatchLine → existing handler; boot/watcher-only: the watcher's main scan learns to parse the same notification) — plus the generic orphan paths. No idle settle (no file backs it).
+- **Agent-row settle:** existing end_turn idle **plus** journal `result` receipts (covers flush-loss) **plus** cascade — when the container settles, any still-running agent rows under its `transcriptDir` settle with it (a finished workflow cannot have live agents).
+
+**Rejected alternatives:**
+- *Per-agent rows only, no container* — between waves `hasRunning` drops to 0 → premature release + pull-back churn. The container matches the workflow's true lifetime.
+- *Hold on the container only, don't track agents* — cheap, but loses the tab streams users already have for regular bg agents, and the per-agent journal receipts are nearly free.
+- *Detect launches in claude-tmux's `dispatchLine`* — dead after a restart (boot path arms only the watcher). Watcher-side main-scan is the established pattern for exactly this reason.
+- *New table / migration* — `parent_kind` was designed as this seam; no schema change needed.
+
+## 4. Work breakdown — implementation tasks (one wave, disjoint files)
+
+### T1 — Types + UI (runner: sonnet)
+**Owns:** `src/shared/types.ts`, `src/mainview/lib/subagent-tabs.ts`, `src/mainview/components/RunPanel.tsx` (minimal touch)
+1. `types.ts`: widen `Subagent.parentKind` to `"subagent" | "bg_session" | "workflow" | "workflow_agent"`; update its doc comment. Touch nothing else in the file.
+2. `subagent-tabs.ts`: the **container row must not render as a tab** (it has no event stream — an empty tab is confusing). Add/extend the pure helpers so rows with `parentKind === "workflow"` are excluded from the tab list while `workflow_agent` rows render exactly like `subagent` rows. Keep helpers pure; extend the existing unit test file for `subagent-tabs` accordingly (that test file is yours too).
+3. `RunPanel.tsx`: only if the tab derivation doesn't already flow through the helper you changed — keep the diff minimal; do not touch state management, SSE handling, or the composer.
+
+**Acceptance:** typecheck clean; `subagent-tabs` unit tests cover: workflow container excluded, workflow_agent included, mixed list ordering stable.
+
+### T2 — Watcher: workflow discovery, main-scan signals, journal settle, cascade (runner: **opus**)
+**Owns:** `src/bun/claude-subagents.ts` (and `src/bun/db.ts` **only if** a helper is genuinely unavoidable — prefer zero db.ts changes; `insertIfAbsent`/`markSettledById`/`listForTask` should suffice)
+
+1. **Kill switch:** `const WORKFLOWS_ENABLED = ENABLED && process.env.AGETOR_TRACK_WORKFLOWS !== "0"`. All new behavior gated on it.
+2. **Workflow-dir discovery** (extend `discover()` or a sibling called from the same sites): scan `subagentsDir/workflows/` for `wf_*` dirs (tolerate absence); in each, match `/^agent-(.+)\.jsonl$/` → `insertIfAbsent` a `parentKind: "workflow_agent"` row (`sourcePath` = that file, meta read for `agentType`/`spawnDepth`/`model`; description: fall back to the container row's description or the wf dir name; **meta has no toolUseId — leave it null**) → tail via the existing `tailFile` path so events land `subagentId`-tagged. Fresh inserts must fire `fireParkedDiscovery` and count as discovery activity for the DEEP_IDLE clock, same as regular subagents.
+3. **Journal tailing:** per active wf dir, tail `journal.jsonl` (byte-offset cursor like the main scan; re-read partial trailing lines next tick). A `{"type":"result","agentId"}` line → `settleSubagentById(agentId, "completed")` (idempotent, no-op if already settled by end_turn idle).
+4. **Main-scan extension** (rename `scanMainForToolResults` → e.g. `scanMainSignals`, same single `mainOffset` cursor; keep the cheap substring prefilters):
+   - **Launch:** a `user` line whose `toolUseResult` has `taskType === "local_workflow"` && `status === "async_launched"` → `insertIfAbsent` the **container row**: `id` = `taskId`, `parentKind: "workflow"`, `agentType: "workflow"`, `description` = `workflowName ?? summary`, `sourcePath` = `transcriptDir`, `toolUseId` = the enclosing `tool_result` block's `tool_use_id` (metadata only — the container is not in the `files` map, so the tool_result settle scan can never match it). Fire `fireParkedDiscovery` on fresh insert. **Important:** the current early-return (`pending.length === 0`) must not skip workflow-signal scanning when `WORKFLOWS_ENABLED`.
+   - **Completion:** a task-notification payload (both the `queue-operation` enqueue shape and the synthetic `user` shape; match `<task-id>([^<]+)</task-id>`) whose id equals a tracked **running workflow container row** → settle it. Statuses: `completed` → `"completed"`; `failed`/`killed`/`stopped` → also settle (`"completed"` unless a richer mapping is trivial — the hold must release either way). This is the boot-path backstop; live sessions also settle via the untouched claude-tmux handler, and `settleSubagentById` is idempotent so double-fire is safe.
+5. **Cascade:** wrap/extend the settle flow so that when a **container** row settles (any path: notification, watcher scan, orphan), every still-`running` `workflow_agent` row whose `sourcePath` starts with the container's `sourcePath` is settled too (`settleSubagentById` each, so lifecycle emits + the hold re-check fire per row). Implement at the claude-subagents level (e.g. inside `settleSubagentById` when the settled row's `parentKind === "workflow"`, or a small wrapper) — **do not** touch orchestrator.ts.
+6. **Reattach hygiene:** on watcher (re)attach, rehydrate workflow rows like regular ones (existing DB rehydrate loop); do not resurrect settled rows (mirror the grok lesson: check existing row status before re-emitting "started" lifecycle). Replaying the main JSONL from offset 0 will re-see old launch lines — `insertIfAbsent` makes that a no-op; a launch line for an already-settled container must not flip it back.
+
+**Boundaries:** no changes to `claude-tmux.ts`, `orchestrator.ts`, `server.ts`, migrations, or the UI. The `parentKind` union values come from T1's contract above — compile against `"workflow"` / `"workflow_agent"` literals.
+
+**Acceptance:** typecheck clean; existing `claude-subagents.test.ts`, `subagent-settle.test.ts`, `subagent-toolresult-settle.test.ts` still pass unmodified.
+
+## 5. Work breakdown — test tasks (one wave, after review)
+
+### TT1 — Workflow watcher behavior (`src/bun/claude-workflow-agents.test.ts`, new file) — covers T2
+- Launch line in main JSONL → pump → container row `running`, `parentKind: "workflow"`, `hasRunning` true; `fireParkedDiscovery` observed (via saved/restored `setParkedDiscoveryHandler`).
+- wf-dir agent file + meta → pump → `workflow_agent` row, events tagged with the agent id; journal `result` line → row settles even **without** a terminal end_turn line in the agent jsonl (the flush-loss case).
+- Notification enqueue line (queue-operation shape) → pump → container settles; still-running agent rows cascade-settle; settle hook fired.
+- Replay-from-0 idempotency: re-attach the watcher, pump — settled container is not resurrected, no duplicate lifecycle emits.
+- `AGETOR_TRACK_WORKFLOWS=0` → none of the above rows are created (save/restore the env var).
+- Conventions: module-top `AGETOR_DATA_DIR` mkdtemp, `manual: true` + `pump(now)`, terminal-status seeded runs, `createdTaskIds` + `afterEach` cleanup, hook setters saved/restored.
+
+### TT2 — Hold/release + orphan integration (`src/bun/workflow-hold.test.ts`, new file) — covers success criteria 1/2/4/5
+- Succeeded terminal run + running container row → task stays `running` (`isHeldByBackgroundAgents` true); settle container → `review`.
+- Task in `review` + fresh container insert firing parked discovery → back to `running`.
+- `orphanRunningSubagents(taskId)` flips container + agent rows and releases the hold.
+- Same seeding/env idiom as `subagent-hold.test.ts` (fake drivers via env, terminal run rows).
+
+### TT3 — Tabs derivation (extend the existing `subagent-tabs` unit test file — **owned by T1, executed here only if T1 left gaps**; skip if already covered).
+
+## 6. Execution waves
+
+- **Wave 1** — T1 + T2 in parallel (disjoint files). Barrier: `bun run typecheck` + full `bun test` (regression only) → commit `wave 1: …`.
+- **Wave 2** — code review (opus, diff `988bf77f..HEAD` — use recorded base `988b77f`) → triage → fix must-haves.
+- **Wave 3** — TT1 + TT2 in parallel (two new disjoint test files). Barrier: `bun test`.
+- **Wave 4** — fixes to green (max 3 rounds).
+
+## 7. Blast radius & risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Container row wedges `running` if claude dies before writing the notification | Same failure family as before: session-death watch + `disposeSessionState` + boot reconcile all call `orphanRunningSubagents` (kind-agnostic). A wedged-but-alive session still holds — consistent with the owner's prior "no watchdog" decision. |
+| Workflow taskId collides with an agent id as PK | Both are harness-generated short random ids in the same namespace claude itself uses for `<task-id>`; collision would break claude's own notification routing first. Accepted. |
+| Badge over-counts by 1 during waves (container + N agents) | Accepted (assumption A2): between waves the container alone keeps the badge truthful ("still working"). |
+| Old transcripts replayed at attach create rows for long-dead workflows | Launch line precedes notification line in-file; replay settles them in order. Never-completed + dead session → boot orphan pass. |
+| `scanMainForToolResults` early-return starves workflow signals | Called out explicitly in T2.4; TT1 covers launch detection with zero pending toolUseId rows. |
+| Grok/codex regression | Neither writes `workflows/` dirs nor `local_workflow` toolUseResults; all new code paths are claude-watcher-internal and env-gated. |
+| Stop on a held-by-workflow task | `stopHeldTask` → interrupt session + `orphanRunningSubagents` — kind-agnostic, releases the hold. Claude's own Ctrl+C tears down the workflow harness-side. |
+
+**Rollback:** all changes are additive behind `AGETOR_TRACK_WORKFLOWS`; setting it to `0` restores today's behavior exactly (no rows → no hold → no tabs).
+
+## 8. Open questions / assumptions (autonomous mode — owner to audit)
+
+- **A1 (scope):** hold + per-agent tabs + badge; the container row is hidden from the tab strip. UI beyond `subagent-tabs.ts` exclusion (e.g. a "workflow" group header over its agent tabs) is out of scope.
+- **A2 (badge):** `runningCountsByTask` stays generic — the container counts as one background agent. Over-count of 1 during waves accepted for between-wave truthfulness.
+- **A3 (gate):** only `succeeded → review` is gated, mirroring the prior owner decision; cancelled/api-error/session-died outcomes win outright.
+- **A4 (statuses):** notification `<status>` failed/killed/stopped all settle the container as `completed` (release the hold); we do not surface a distinct failed-workflow state on the card. Revisit if users need it.
+- **A5 (kill switch):** `AGETOR_TRACK_WORKFLOWS`, default on, nested under `AGETOR_TRACK_SUBAGENTS` — follows `AGETOR_TRACK_<THING>` convention.
+- **A6 (nested workflows):** `workflow()`-in-workflow children share the parent's transcript dir per the harness contract (one level only); the dir scan handles whatever appears, no special casing.
+- **A7:** no real-app smoke test in this run (unit/integration suite only), matching the predecessor feature's verification bar.

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -32,13 +32,49 @@
  * through `settleSubagentById` so the DB write / lifecycle emit / hold-release
  * bookkeeping only lives in one place.
  *
+ * ── Workflows (`/workflow`) ────────────────────────────────────────────────
+ *
+ * A Workflow is claude's multi-agent orchestration tool. It is ALWAYS launched
+ * in the background (its tool_result is an immediate `async_launched` stub), so
+ * without tracking it the parent turn ends and the card jumps to `review` while
+ * the workflow is still churning. Its on-disk layout is a subdirectory of the
+ * same `subagents/` dir above:
+ *
+ *   <sessionId>/subagents/workflows/<wf_runId>/
+ *         agent-<agentId>.jsonl      ← per workflow-agent transcript (sidechain)
+ *         agent-<agentId>.meta.json  ← { agentType: "workflow-subagent", spawnDepth, model }
+ *         journal.jsonl              ← harness-written per-agent receipts
+ *
+ * We model a workflow as TWO kinds of `subagents` row:
+ *   • one CONTAINER row (`parentKind: "workflow"`, id = the workflow's harness
+ *     taskId, sourcePath = the transcript dir). It is `running` for the
+ *     workflow's WHOLE lifetime — launch line → completion notification — which
+ *     is what keeps the card held in `running` across the idle gaps *between*
+ *     agent waves. Nothing tails it (a directory is not a transcript); it is
+ *     deliberately never entered into the `files` map.
+ *   • one AGENT row per `agent-*.jsonl` (`parentKind: "workflow_agent"`), tailed
+ *     by the exact same machinery regular subagents use, so each renders as a
+ *     read-only tab.
+ *
+ * Container settle signals: (1) the completion `<task-notification>` reaching
+ * claude-tmux live (→ `settleSubagentById` via the orchestrator — that path
+ * needs no code here, the row PK *is* the notification's `<task-id>`);
+ * (2) this module's own main-JSONL scan matching that same notification — the
+ * restart-safe backstop, since boot reconciliation arms only the watcher and no
+ * tmux tailer; (3) the generic orphan paths. Agent rows settle on their own
+ * end_turn idle, on a `journal.jsonl` `result` receipt (the harness receipt is
+ * immune to the terminal-line flush loss that concurrent agents can hit — a
+ * workflow runs up to ~10 at once), or by CASCADE when their container settles.
+ *
  * This module is READ-ONLY w.r.t. the agent: it watches files and tails them.
  * It never spawns, signals, or tears down a tmux session — `detach()` only
  * closes fs watchers + the poll timer.
  *
  * The format is internal to claude and the docs warn it can change between
  * versions, so everything here is defensive (missing dir / meta / fields all
- * degrade gracefully) and gated behind AGETOR_TRACK_SUBAGENTS (default on).
+ * degrade gracefully) and gated behind AGETOR_TRACK_SUBAGENTS (default on),
+ * with the workflow half additionally gated behind AGETOR_TRACK_WORKFLOWS
+ * (default on, nested under the former — see `WORKFLOWS_ENABLED`).
  * A parse error on one subagent file can never affect the main stream — it is
  * isolated to that file's tail.
  * ────────────────────────────────────────────────────────────────────────── */
@@ -63,6 +99,29 @@ import type { RunEvent, Subagent, SubagentEvent, SubagentStatus } from "../share
  *  flag lets us kill it entirely if a future claude layout change breaks the
  *  on-disk assumptions, without shipping a new build. */
 const ENABLED = process.env.AGETOR_TRACK_SUBAGENTS !== "0";
+
+/** Workflow tracking (container row + per-agent rows + journal receipts), off
+ *  only when explicitly disabled — and implicitly off whenever subagent
+ *  tracking as a whole is. Nested deliberately: a workflow is a *kind* of
+ *  background agent, so disabling the outer switch must disable this too.
+ *  Setting `AGETOR_TRACK_WORKFLOWS=0` restores the pre-feature behavior exactly
+ *  (no rows → no hold → no tabs), which is the rollback lever if a future
+ *  claude layout change breaks the on-disk assumptions above.
+ *
+ *  Read once at module load, mirroring `ENABLED`. A test that needs the flag
+ *  off must set the env var and then re-import this module under a
+ *  cache-busting specifier (`./claude-subagents.ts?gate=<uuid>`), the same
+ *  idiom the AGETOR_TRACK_SUBAGENTS test already uses. */
+const WORKFLOWS_ENABLED = ENABLED && process.env.AGETOR_TRACK_WORKFLOWS !== "0";
+
+/** Directory (under `<sessionId>/subagents/`) claude writes workflow transcript
+ *  dirs into — one `<wf_runId>/` subdir per launched workflow. Created lazily,
+ *  so every read of it tolerates ENOENT. */
+const WORKFLOWS_SUBDIR = "workflows";
+
+/** Per-agent completion receipts the workflow harness writes, one NDJSON line
+ *  per lifecycle transition, inside each workflow transcript dir. */
+const JOURNAL_FILE = "journal.jsonl";
 
 /** Poll cadence while at least one subagent is still running — fast enough to
  *  feel live in the panel, cheap enough (a stat per file) to run per task. */
@@ -223,6 +282,14 @@ function readAppendedSync(filePath: string, offset: number): { text: string; nex
 
 interface FileState {
   subagentId: string;
+  /** Which flavour of row this file backs — `"subagent"` for a classic
+   *  in-session sub-agent, `"workflow_agent"` for one agent of a `/workflow`
+   *  run (a file under `subagents/workflows/<wf_runId>/`). Rehydrated rows
+   *  carry whatever the DB recorded, so an older `"bg_session"` row keeps its
+   *  kind instead of silently being rewritten to `"subagent"`. Workflow
+   *  CONTAINER rows never appear here — they're directories, not transcripts
+   *  (see `WorkflowState`). */
+  parentKind: Subagent["parentKind"];
   /** Parent run the events attach to — captured at discovery, then stable. */
   runId: string;
   /** Byte cursor into the subagent JSONL. */
@@ -308,7 +375,7 @@ function toSubagentShape(fs: FileState, taskId: string): Subagent {
     id: fs.subagentId,
     taskId,
     runId: fs.runId,
-    parentKind: "subagent",
+    parentKind: fs.parentKind,
     agentType: fs.agentType,
     description: fs.description,
     spawnDepth: fs.spawnDepth,
@@ -320,12 +387,58 @@ function toSubagentShape(fs: FileState, taskId: string): Subagent {
   };
 }
 
+/**
+ * In-memory twin of a workflow CONTAINER row. Deliberately NOT a `FileState`:
+ * nothing about a container is tailed — its `dir` is a directory, and handing
+ * it to `readAppendedSync` would throw EISDIR out of the tail and abort the
+ * whole cycle. It exists so the watcher can (a) keep the poll on the fast tier
+ * while a workflow is live, (b) recognise the completion notification's
+ * `<task-id>` as one of *its* workflows rather than settling arbitrary ids,
+ * and (c) label freshly-discovered agent rows with the workflow's name.
+ */
+interface WorkflowState {
+  /** Container row PK — claude's harness taskId for the workflow, which is
+   *  also the `<task-id>` its completion notification carries. */
+  id: string;
+  /** `toolUseResult.transcriptDir` — the container row's `sourcePath`, and the
+   *  directory prefix the cascade matches agent rows against. */
+  dir: string;
+  description: string | null;
+  runId: string;
+  status: SubagentStatus;
+  startedAt: number;
+  endedAt: number | null;
+  /** The launching Workflow `tool_use` id. Metadata only — see
+   *  `registerWorkflowContainer` for why it can never settle this row. */
+  toolUseId: string | null;
+}
+
+function toWorkflowShape(w: WorkflowState, taskId: string): Subagent {
+  return {
+    id: w.id,
+    taskId,
+    runId: w.runId,
+    parentKind: "workflow",
+    agentType: "workflow",
+    description: w.description,
+    spawnDepth: 1,
+    sourcePath: w.dir,
+    toolUseId: w.toolUseId,
+    status: w.status,
+    startedAt: w.startedAt,
+    endedAt: w.endedAt,
+  };
+}
+
 /** Same lifecycle-event shape `emitLifecycle` builds from a live `FileState`,
  *  but built straight off a DB row instead — needed for callers (like
  *  `orphanRunningSubagents` below) that fire for a task with no attached
- *  watcher, so there's no `FileState` closure to draw from. */
-function emitLifecycleForRow(sub: Subagent): void {
-  const payload: SubagentEvent = { phase: "finished", subagent: sub };
+ *  watcher, so there's no `FileState` closure to draw from. Defaults to
+ *  `"finished"` because every pre-existing caller settles; workflow CONTAINER
+ *  registration passes `"started"` (it has a DB row but, being
+ *  directory-backed, no `FileState` to hand `emitLifecycle`). */
+function emitLifecycleForRow(sub: Subagent, phase: "started" | "finished" = "finished"): void {
+  const payload: SubagentEvent = { phase, subagent: sub };
   emitFn?.({
     runId: sub.runId ?? sub.id,
     taskId: sub.taskId,
@@ -398,7 +511,17 @@ export function attachSubagentWatcher(opts: {
 
   const sessionId = path.basename(opts.jsonlPath, ".jsonl");
   const subagentsDir = path.join(path.dirname(opts.jsonlPath), sessionId, "subagents");
+  const workflowsDir = path.join(subagentsDir, WORKFLOWS_SUBDIR);
   const files = new Map<string, FileState>();
+  // Workflow CONTAINER rows this watcher knows about, keyed by container id
+  // (= claude's workflow taskId). Populated by the main-JSONL launch scan and
+  // by rehydration; NEVER merged into `files` (see `WorkflowState`).
+  const workflows = new Map<string, WorkflowState>();
+  // Workflow transcript dir -> byte cursor into its `journal.jsonl`. Keyed by
+  // dir rather than by container id because an agent dir can become visible
+  // before (or without) the launch line that names its container — the journal
+  // receipts are useful either way.
+  const wfJournals = new Map<string, number>();
   let timer: ReturnType<typeof setTimeout> | null = null;
   let dirWatcher: FSWatcher | null = null;
   let detached = false;
@@ -432,6 +555,30 @@ export function attachSubagentWatcher(opts: {
   // rather than rely on `cycle()`'s wrapper.
   try {
     for (const row of subagentsDb.listForTask(taskId)) {
+      if (row.parentKind === "workflow") {
+        // Container rows are directory-backed: they must never enter `files`
+        // (nothing to tail) and must never be resurrected here — a row the DB
+        // says is `completed`/`orphaned` is rehydrated with THAT status, so
+        // neither a replayed launch line nor the cadence check can flip it
+        // back to running, and no "started" lifecycle is re-emitted for it.
+        if (WORKFLOWS_ENABLED) {
+          workflows.set(row.id, {
+            id: row.id,
+            dir: row.sourcePath,
+            description: row.description,
+            runId: row.runId ?? resolveRunId(taskId) ?? row.id,
+            status: row.status,
+            startedAt: row.startedAt,
+            endedAt: row.endedAt,
+            toolUseId: row.toolUseId ?? null,
+          });
+          // Journal cursor starts at 0 like every other reattach cursor — the
+          // receipts it replays all funnel through `settleSubagentById`, which
+          // no-ops on already-settled rows.
+          if (row.sourcePath && !wfJournals.has(row.sourcePath)) wfJournals.set(row.sourcePath, 0);
+        }
+        continue;
+      }
       // Pre-fix rows (and any row whose sidecar wasn't parsed for toolUseId
       // yet) have this NULL in the DB even though the sidecar itself carries
       // it — re-read it here so the tool_result scan below can find these
@@ -446,6 +593,7 @@ export function attachSubagentWatcher(opts: {
       }
       files.set(row.id, {
         subagentId: row.id,
+        parentKind: row.parentKind,
         runId: row.runId ?? resolveRunId(taskId) ?? row.id,
         offset: 0,
         seen: runs.seenLineUuidsForSubagent(row.id),
@@ -520,6 +668,7 @@ export function attachSubagentWatcher(opts: {
       const startedAt = Date.now();
       const fs: FileState = {
         subagentId: id,
+        parentKind: "subagent",
         runId,
         offset: 0,
         seen: new Set(),
@@ -545,6 +694,190 @@ export function attachSubagentWatcher(opts: {
       if (fs.toolUseId) mainOffset = 0;
       emitLifecycle(fs, "started");
       fireParkedDiscovery(taskId);
+    }
+  }
+
+  /** The workflow whose transcript dir is `dir`, if this watcher has seen its
+   *  launch line (or rehydrated its row). Used only for labelling — agent
+   *  discovery never waits on it. */
+  function workflowForDir(dir: string): WorkflowState | null {
+    for (const w of workflows.values()) if (w.dir === dir) return w;
+    return null;
+  }
+
+  /**
+   * Register (or re-learn) a workflow CONTAINER row from a launch line. This
+   * is the row that carries the hold: `running` from launch until the
+   * completion notification, so `subagents.hasRunning` stays true across the
+   * quiet gaps between agent waves and the card never bounces
+   * `running → review → running` mid-workflow.
+   *
+   * Idempotent in both directions: an id we already track in memory is left
+   * alone, and an id whose row already exists in the DB is rehydrated with the
+   * status the DB has — so replaying the main JSONL from offset 0 on every
+   * reattach can never resurrect a settled workflow. `insertIfAbsent` is the
+   * only write.
+   */
+  function registerWorkflowContainer(
+    id: string,
+    dir: string,
+    description: string | null,
+    toolUseId: string | null,
+  ): void {
+    if (workflows.has(id)) return;
+    if (!wfJournals.has(dir)) wfJournals.set(dir, 0);
+
+    const existing = subagentsDb.get(id);
+    // An id that already belongs to a row of a DIFFERENT kind is left entirely
+    // alone: adopting it here would let the workflow completion notification
+    // settle someone else's agent. (Harness ids collide only if claude's own
+    // notification routing would already be broken — this is pure paranoia.)
+    if (existing && existing.parentKind !== "workflow") return;
+    if (existing) {
+      workflows.set(id, {
+        id,
+        dir: existing.sourcePath || dir,
+        description: existing.description,
+        runId: existing.runId ?? resolveRunId(taskId) ?? id,
+        status: existing.status,
+        startedAt: existing.startedAt,
+        endedAt: existing.endedAt,
+        toolUseId: existing.toolUseId ?? toolUseId,
+      });
+      lastChangeAt = Date.now();
+      return;
+    }
+
+    const runId = resolveRunId(taskId);
+    // No run to attach to — same defensive skip `discover()` makes; a later
+    // tick re-sees the same launch line only if the offset was rewound, so
+    // rather than rely on that, leave the id untracked and let the next
+    // reattach (offset 0) pick it up. In practice a live session always has a
+    // run by the time a workflow launches.
+    if (!runId) return;
+    const startedAt = Date.now();
+    const w: WorkflowState = {
+      id,
+      dir,
+      description,
+      runId,
+      status: "running",
+      startedAt,
+      endedAt: null,
+      // Recorded for provenance only. The container is deliberately NOT in the
+      // `files` map, and `scanMainForToolResultLine` only ever considers
+      // `files` entries — so the immediate `async_launched` tool_result that
+      // carries this id can never false-settle the container the way it would
+      // if containers were tracked like file-backed agents.
+      toolUseId,
+    };
+    workflows.set(id, w);
+    lastChangeAt = Date.now();
+    subagentsDb.insertIfAbsent(toWorkflowShape(w, taskId));
+    emitLifecycleForRow(toWorkflowShape(w, taskId), "started");
+    // A workflow launched on a follow-up turn must pull a parked (`review`)
+    // card back to `running`, exactly like a freshly-discovered subagent.
+    fireParkedDiscovery(taskId);
+  }
+
+  /** Pick up workflow transcript dirs and the `agent-*.jsonl` files inside
+   *  them. Called from the same sites as `discover()`; tolerates the whole
+   *  `workflows/` tree being absent (the common case — most tasks never launch
+   *  a workflow). Each agent file becomes an ordinary tailed `FileState`, so
+   *  its events land subagentId-tagged and it settles through the existing
+   *  end_turn-idle path with no special casing downstream. */
+  function discoverWorkflowAgents(): void {
+    if (!WORKFLOWS_ENABLED) return;
+    let dirs: string[];
+    try { dirs = readdirSync(workflowsDir); } catch { return; }
+    for (const dirName of dirs) {
+      const dir = path.join(workflowsDir, dirName);
+      let names: string[];
+      // Also the is-it-a-directory probe: a stray file in `workflows/` throws
+      // ENOTDIR here and is skipped, no `statSync` round-trip needed.
+      try { names = readdirSync(dir); } catch { continue; }
+      if (!wfJournals.has(dir)) {
+        wfJournals.set(dir, 0);
+        lastChangeAt = Date.now();
+      }
+      for (const name of names) {
+        const m = /^agent-(.+)\.jsonl$/.exec(name);
+        if (!m) continue;
+        const id = m[1]!;
+        if (files.has(id)) continue;
+        const runId = resolveRunId(taskId);
+        if (!runId) continue; // same defensive skip as `discover()`
+        const meta = readMeta(dir, id);
+        const startedAt = Date.now();
+        const fs: FileState = {
+          subagentId: id,
+          parentKind: "workflow_agent",
+          runId,
+          offset: 0,
+          seen: new Set(),
+          sawEndOfTurn: false,
+          lastAppendAt: startedAt,
+          status: "running",
+          sourcePath: path.join(dir, name),
+          agentType: meta.agentType,
+          // A workflow agent's meta sidecar carries no `description`, so fall
+          // back to the workflow's own name (or, before/without its launch
+          // line, the transcript dir) — an unlabelled tab is worse than a
+          // coarse one.
+          description: meta.description ?? workflowForDir(dir)?.description ?? dirName,
+          spawnDepth: meta.spawnDepth,
+          startedAt,
+          endedAt: null,
+          // No `toolUseId` in a workflow-agent sidecar: these agents are
+          // spawned by the workflow harness, not by a parent `Agent` tool_use,
+          // so there is no tool_result to correlate against. Leaving it null
+          // also keeps them out of `scanMainSignals`'s pending set.
+          toolUseId: null,
+          apiErrored: false,
+          lastPermissionMode: null,
+        };
+        files.set(id, fs);
+        lastChangeAt = Date.now();
+        subagentsDb.insertIfAbsent(toSubagentShape(fs, taskId));
+        emitLifecycle(fs, "started");
+        fireParkedDiscovery(taskId);
+      }
+    }
+  }
+
+  /**
+   * Tail each known workflow dir's `journal.jsonl` — the harness's own
+   * per-agent completion receipts (`{"type":"result","key","agentId","result"}`).
+   * This is the flush-loss backstop: a workflow runs many agents concurrently
+   * and an agent's own transcript can lose its terminal `end_turn` line under
+   * that load, which would strand its row `running` forever (the same failure
+   * class `scanMainForToolResults` exists to cover for synchronous subagents,
+   * except a workflow agent has no tool_use id to correlate on).
+   * `settleSubagentById` is idempotent, so a receipt for a row the idle path
+   * already completed is a free no-op.
+   */
+  function tailJournals(): void {
+    if (!WORKFLOWS_ENABLED) return;
+    for (const [dir, offset] of wfJournals) {
+      try {
+        const { text, next } = readAppendedSync(path.join(dir, JOURNAL_FILE), offset);
+        if (!text) continue;
+        const lines = text.split("\n");
+        const tail = lines.pop() ?? ""; // partial trailing line — re-read next tick
+        wfJournals.set(dir, next - Buffer.byteLength(tail, "utf8"));
+        for (const line of lines) {
+          // Cheap prefilter: `started` receipts outnumber `result` ones and
+          // carry nothing we act on.
+          if (!line || !line.includes("result")) continue;
+          try {
+            const o = JSON.parse(line) as { type?: unknown; agentId?: unknown };
+            if (o.type !== "result" || typeof o.agentId !== "string") continue;
+            settleSubagentById(o.agentId, "completed");
+          } catch { /* one malformed receipt must not abort the rest */ }
+        }
+      } catch (e) {
+        console.error(`[claude-subagents] journal tail failed for ${dir}:`, e);
+      }
     }
   }
 
@@ -720,23 +1053,139 @@ export function attachSubagentWatcher(opts: {
   }
 
   /**
-   * Third settle signal (see module header): scan the MAIN session JSONL for
-   * `tool_result` blocks whose `tool_use_id` matches a tracked `running`
-   * subagent's `toolUseId` — the fallback for a synchronous top-level
-   * subagent whose own transcript never gets a terminal end_turn line and
-   * gets no task-notification either (see claude-tmux.ts's
-   * `fireBackgroundTaskSettled` for that other path). Only reads the main
-   * file — and only advances `mainOffset` — when there's at least one
-   * `running` row with a known `toolUseId` to look for, so a task with no
-   * subagents (the common case) never pays for this scan. A subagent
-   * discovered AFTER the offset has already advanced past its tool_result
-   * (a readdir-visibility race while a sibling kept the scan running) is
-   * covered by `discover()` rewinding `mainOffset` to 0 for one full
-   * rescan — settles are idempotent, so re-reading old lines is harmless.
+   * Third settle signal (see module header): match one MAIN-session-JSONL line
+   * against the `tool_result` blocks whose `tool_use_id` equals a tracked
+   * `running` subagent's `toolUseId` — the fallback for a synchronous
+   * top-level subagent whose own transcript never gets a terminal end_turn
+   * line and gets no task-notification either (see claude-tmux.ts's
+   * `fireBackgroundTaskSettled` for that other path). A subagent discovered
+   * AFTER the offset has already advanced past its tool_result (a
+   * readdir-visibility race while a sibling kept the scan running) is covered
+   * by `discover()` rewinding `mainOffset` to 0 for one full rescan — settles
+   * are idempotent, so re-reading old lines is harmless.
    */
-  function scanMainForToolResults(): void {
+  function scanLineForToolResult(line: string, pending: FileState[]): void {
+    // Cheap prefilter before any JSON.parse: the launching `tool_use` line
+    // and a `<tool-use-id>` notification tag also contain this id string,
+    // so a substring hit is NOT sufficient on its own — it only narrows
+    // which lines are worth the strict parse below.
+    const candidates = pending.filter((fs) => line.includes(fs.toolUseId!));
+    if (candidates.length === 0) return;
+
+    let parsed: { type?: unknown; message?: { content?: unknown } };
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return; // one bad line must not abort the scan of the rest
+    }
+    if (parsed.type !== "user") return;
+    const content = parsed.message?.content;
+    if (!Array.isArray(content)) return;
+    for (const block of content) {
+      if (!block || typeof block !== "object") continue;
+      const b = block as { type?: unknown; tool_use_id?: unknown };
+      if (b.type !== "tool_result") continue;
+      for (const fs of candidates) {
+        if (b.tool_use_id === fs.toolUseId) settleSubagentById(fs.subagentId, "completed");
+      }
+    }
+  }
+
+  /**
+   * Workflow LAUNCH detection: a `user` line whose `toolUseResult` is the
+   * `/workflow` tool's immediate `async_launched` stub. Everything the
+   * container row needs is in that payload — `taskId` (the row PK, and the id
+   * the completion notification will carry), `transcriptDir` (where its agents
+   * write), and a human label (`workflowName`, falling back to `summary`).
+   */
+  function scanLineForWorkflowLaunch(line: string): void {
+    // Two cheap substring prefilters before the parse — the overwhelming
+    // majority of main-JSONL lines have neither.
+    if (!line.includes("local_workflow") || !line.includes("async_launched")) return;
+    let parsed: {
+      type?: unknown;
+      message?: { content?: unknown };
+      toolUseResult?: unknown;
+    };
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return;
+    }
+    const r = parsed.toolUseResult;
+    if (!r || typeof r !== "object") return;
+    const res = r as Record<string, unknown>;
+    if (res.taskType !== "local_workflow" || res.status !== "async_launched") return;
+    const id = typeof res.taskId === "string" ? res.taskId : null;
+    const dir = typeof res.transcriptDir === "string" ? res.transcriptDir : null;
+    // Without both of these there is nothing to hold or to watch — a layout
+    // change that drops either degrades to today's (untracked) behavior
+    // rather than creating a half-formed row.
+    if (!id || !dir) return;
+    const description =
+      (typeof res.workflowName === "string" ? res.workflowName : null) ??
+      (typeof res.summary === "string" ? res.summary : null);
+
+    // The enclosing `tool_result` block's id — the launching Workflow tool_use.
+    let toolUseId: string | null = null;
+    const content = parsed.message?.content;
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (!block || typeof block !== "object") continue;
+        const b = block as { type?: unknown; tool_use_id?: unknown };
+        if (b.type === "tool_result" && typeof b.tool_use_id === "string") {
+          toolUseId = b.tool_use_id;
+          break;
+        }
+      }
+    }
+    registerWorkflowContainer(id, dir, description, toolUseId);
+  }
+
+  /**
+   * Workflow COMPLETION detection — the restart-safe backstop. A live session
+   * settles the container through claude-tmux's `<task-notification>` handler
+   * (`settleSubagentById` by `<task-id>`, which IS the container PK, so that
+   * path needed no changes); but after boot reconciliation only this watcher
+   * is armed — no tmux tailer — so the same notification has to be recognised
+   * here too. Both on-disk shapes (the `queue-operation` enqueue line and the
+   * synthetic `user` message) embed the tag verbatim, so one regex covers both.
+   *
+   * Only ids this watcher knows as its OWN running containers are settled:
+   * a `<task-id>` naming a regular background subagent is left to the existing
+   * paths, exactly as before this feature.
+   *
+   * The notification's `<status>` is deliberately ignored — completed, failed,
+   * killed and stopped all mean "this workflow is over", and the hold must
+   * release in every one of those cases (plan assumption A4).
+   */
+  function scanLineForWorkflowNotification(line: string): void {
+    if (!line.includes("<task-id>")) return;
+    const m = /<task-id>([^<]+)<\/task-id>/.exec(line);
+    if (!m) return;
+    const id = m[1]!.trim();
+    const w = workflows.get(id);
+    if (!w || w.status !== "running") return;
+    settleSubagentById(id, "completed");
+  }
+
+  /**
+   * Single pass over the bytes appended to the MAIN session JSONL since the
+   * last pass, feeding every signal this watcher derives from it: tool_result
+   * correlation settles (above) and — when workflows are tracked — workflow
+   * launch + completion detection.
+   *
+   * One shared `mainOffset` cursor, one read, one split. The early return is
+   * deliberately narrow: bailing on `pending.length === 0` (as this did when
+   * tool_results were its only signal) would starve workflow detection on
+   * exactly the common case — a task with no `toolUseId`-bearing subagent rows
+   * at all. So it only short-circuits when there is nothing of EITHER kind to
+   * look for, which keeps the "task with no background agents never pays for
+   * this scan" property intact whenever workflow tracking is off.
+   */
+  function scanMainSignals(): void {
     const pending = [...files.values()].filter((fs) => fs.status === "running" && fs.toolUseId);
-    if (pending.length === 0) return;
+    if (pending.length === 0 && !WORKFLOWS_ENABLED) return;
 
     const { text, next } = readAppendedSync(opts.jsonlPath, mainOffset);
     if (!text) return;
@@ -746,29 +1195,15 @@ export function attachSubagentWatcher(opts: {
 
     for (const line of lines) {
       if (!line) continue;
-      // Cheap prefilter before any JSON.parse: the launching `tool_use` line
-      // and a `<tool-use-id>` notification tag also contain this id string,
-      // so a substring hit is NOT sufficient on its own — it only narrows
-      // which lines are worth the strict parse below.
-      const candidates = pending.filter((fs) => line.includes(fs.toolUseId!));
-      if (candidates.length === 0) continue;
-
-      let parsed: { type?: unknown; message?: { content?: unknown } };
-      try {
-        parsed = JSON.parse(line);
-      } catch {
-        continue; // one bad line must not abort the scan of the rest
-      }
-      if (parsed.type !== "user") continue;
-      const content = parsed.message?.content;
-      if (!Array.isArray(content)) continue;
-      for (const block of content) {
-        if (!block || typeof block !== "object") continue;
-        const b = block as { type?: unknown; tool_use_id?: unknown };
-        if (b.type !== "tool_result") continue;
-        for (const fs of candidates) {
-          if (b.tool_use_id === fs.toolUseId) settleSubagentById(fs.subagentId, "completed");
-        }
+      if (pending.length > 0) scanLineForToolResult(line, pending);
+      if (WORKFLOWS_ENABLED) {
+        // Launch before completion: on a replay-from-0 both lines are in this
+        // same batch, and in file order the launch always precedes its
+        // notification — so a workflow that started and finished while agetor
+        // was down is registered and then settled within one pass, never left
+        // holding the card.
+        scanLineForWorkflowLaunch(line);
+        scanLineForWorkflowNotification(line);
       }
     }
   }
@@ -781,7 +1216,11 @@ export function attachSubagentWatcher(opts: {
         // Any dir-watcher event is a life signal for the deep-idle tier,
         // independent of whether it turns out to be a new subagent file.
         lastChangeAt = Date.now();
-        try { discover(); for (const fs of files.values()) tailFile(fs); } catch { /* never crash the watcher */ }
+        try {
+          discover();
+          discoverWorkflowAgents();
+          for (const fs of files.values()) tailFile(fs);
+        } catch { /* never crash the watcher */ }
       });
     } catch { /* fs.watch unsupported on this FS — the poll backstop covers it */ }
   }
@@ -792,6 +1231,7 @@ export function attachSubagentWatcher(opts: {
     try {
       armDirWatcher();
       discover();
+      discoverWorkflowAgents();
       // Steady-state: only re-stat/re-read `running` files. Completed ones keep
       // no per-tick cost; a resume (rare) re-opens them via the dir watcher's
       // append notification (see `armDirWatcher`, which tails ALL files). The
@@ -802,7 +1242,8 @@ export function attachSubagentWatcher(opts: {
       for (const fs of files.values()) {
         if (tailAll || fs.status === "running") tailFile(fs);
       }
-      scanMainForToolResults();
+      tailJournals();
+      scanMainSignals();
       checkDone(now);
     } catch { /* swallow — never crash the timer */ }
   }
@@ -811,13 +1252,20 @@ export function attachSubagentWatcher(opts: {
     if (detached) return;
     const now = Date.now();
     cycle(now);
-    const anyRunning = [...files.values()].some((f) => f.status === "running");
+    // A live workflow CONTAINER counts as "running" for cadence purposes even
+    // when no agent file is open right now: between waves it is the only thing
+    // holding the card, and the next wave's files should be picked up on the
+    // fast tier, not four seconds late.
+    const anyRunning =
+      [...files.values()].some((f) => f.status === "running") ||
+      [...workflows.values()].some((w) => w.status === "running");
     let delay: number;
     if (anyRunning) {
       delay = FAST_POLL_MS;
-    } else if (files.size === 0 && now - lastChangeAt >= DEEP_IDLE_AFTER_MS) {
-      // Never discovered a subagent and nothing's happened for a while —
-      // back off further than the ordinary idle cadence.
+    } else if (files.size === 0 && workflows.size === 0 && wfJournals.size === 0
+               && now - lastChangeAt >= DEEP_IDLE_AFTER_MS) {
+      // Never discovered a subagent OR a workflow and nothing's happened for
+      // a while — back off further than the ordinary idle cadence.
       delay = DEEP_IDLE_POLL_MS;
     } else {
       delay = SLOW_POLL_MS;
@@ -849,9 +1297,19 @@ export function attachSubagentWatcher(opts: {
     },
     syncSettled(id: string, status: SubagentStatus, endedAt: number): void {
       const fs = files.get(id);
-      if (!fs) return;
-      fs.status = status;
-      fs.endedAt = endedAt;
+      if (fs) {
+        fs.status = status;
+        fs.endedAt = endedAt;
+        return;
+      }
+      // Workflow containers live in their own map (they back no file), but
+      // need the same in-memory sync so the completion scan doesn't re-settle
+      // a container on every subsequent replay of the notification line, and
+      // so the cadence check above drops back off the fast tier.
+      const w = workflows.get(id);
+      if (!w) return;
+      w.status = status;
+      w.endedAt = endedAt;
     },
   };
   watchers.set(taskId, handle);
@@ -872,6 +1330,50 @@ export function attachSubagentWatcher(opts: {
  * event or firing the settle hook again.
  */
 export function settleSubagentById(id: string, status: "completed" | "orphaned"): boolean {
+  return settleSubagent(id, status, 0);
+}
+
+/**
+ * Cascade: a workflow CONTAINER that just settled cannot still have live
+ * agents under it, so every still-`running` `workflow_agent` row written into
+ * its transcript dir settles with it. Without this, an agent whose transcript
+ * lost its terminal end_turn line AND whose journal receipt never landed
+ * (harness killed mid-flight, `<status>killed</status>`) would keep
+ * `hasRunning` true and hold the card forever, even though the workflow it
+ * belonged to is provably over.
+ *
+ * Runs for every path that settles a container — the watcher's own completion
+ * scan, claude-tmux's live `<task-notification>` handler, boot reconciliation
+ * — because they all funnel through `settleSubagent`. Orphaning is the one
+ * exception that needs nothing here: `subagents.orphanRunning` already flips
+ * every running row for the task in a single kind-agnostic UPDATE.
+ *
+ * Matching is by `sourcePath` prefix (container dir → agent files inside it),
+ * with an explicit separator so a sibling dir sharing a name prefix
+ * (`…/wf_12` vs `…/wf_1`) can never be swept in.
+ */
+function cascadeWorkflowAgents(taskId: string, container: Subagent, depth: number): void {
+  if (!container.sourcePath) return;
+  const prefix = container.sourcePath.endsWith(path.sep)
+    ? container.sourcePath
+    : container.sourcePath + path.sep;
+  try {
+    for (const row of subagentsDb.listForTask(taskId)) {
+      if (row.status !== "running") continue;
+      if (row.parentKind !== "workflow_agent") continue;
+      if (!row.sourcePath.startsWith(prefix)) continue;
+      settleSubagent(row.id, "completed", depth + 1);
+    }
+  } catch (e) {
+    console.error(`[claude-subagents] workflow cascade failed for container ${container.id}:`, e);
+  }
+}
+
+/** Shared body of `settleSubagentById`, carrying the cascade recursion depth.
+ *  Agent rows are never containers, so the cascade is structurally one level
+ *  deep — the depth guard is belt-and-braces against a future kind (or a
+ *  corrupt row) that could make the graph cyclic. */
+function settleSubagent(id: string, status: "completed" | "orphaned", depth: number): boolean {
   let result: { changed: boolean; taskId: string | null };
   try {
     result = subagentsDb.markSettledById(id, status);
@@ -891,6 +1393,11 @@ export function settleSubagentById(id: string, status: "completed" | "orphaned")
     }
   }
   watchers.get(taskId)?.syncSettled(id, status, row?.endedAt ?? now);
+  // Before `fireSettle`, so the orchestrator's release predicate
+  // (`subagents.hasRunning`) sees the whole workflow settled at once rather
+  // than re-checking once per cascaded row with the container's siblings still
+  // running.
+  if (row?.parentKind === "workflow" && depth < 1) cascadeWorkflowAgents(taskId, row, depth);
   fireSettle(taskId);
   return true;
 }

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -123,6 +123,16 @@ const WORKFLOWS_SUBDIR = "workflows";
  *  per lifecycle transition, inside each workflow transcript dir. */
 const JOURNAL_FILE = "journal.jsonl";
 
+/** How far back from the end of the MAIN session JSONL a freshly-attached
+ *  watcher starts scanning for workflow signals (see the clamp in
+ *  `attachSubagentWatcher`). Sized to comfortably span the last few turns of a
+ *  session — a workflow launch line is a few hundred bytes and what matters is
+ *  catching one issued shortly before agetor stopped — while keeping the
+ *  synchronous read at attach bounded no matter how long the session has run
+ *  (real transcripts reach tens of MB, and boot reconciliation attaches
+ *  several watchers in one window). */
+const REPLAY_WINDOW_BYTES = 4 * 1024 * 1024;
+
 /** Poll cadence while at least one subagent is still running — fast enough to
  *  feel live in the panel, cheap enough (a stat per file) to run per task. */
 const FAST_POLL_MS = 600;
@@ -267,6 +277,15 @@ function readMeta(subagentsDir: string, id: string): SubagentMeta {
 function readAppendedSync(filePath: string, offset: number): { text: string; next: number } {
   let st;
   try { st = statSync(filePath); } catch { return { text: "", next: offset }; }
+  // Non-file (in practice: a directory) reads as "nothing appended" instead of
+  // throwing EISDIR out of `readSync` — which, being outside this function's
+  // catch, would abort the caller's whole tail/cycle pass. The only path that
+  // can hand us a directory is a workflow CONTAINER row's `sourcePath`
+  // (`transcriptDir`), which is deliberately kept out of the `files` map — so
+  // this guard exists to make that hazard structurally impossible rather than
+  // convention-dependent, including on a rollback to a build whose
+  // `toSubagent` coerced container rows into ordinary subagent rows.
+  if (!st.isFile()) return { text: "", next: offset };
   if (st.size <= offset) return { text: "", next: offset };
   const len = st.size - offset;
   const buf = Buffer.alloc(len);
@@ -413,6 +432,21 @@ interface WorkflowState {
   toolUseId: string | null;
 }
 
+/**
+ * Is `filePath` inside `dir`? Both sides are `path.resolve`d first because they
+ * come from different producers — a container's dir is claude's own
+ * `transcriptDir` string, while agent paths are built here with `path.join` —
+ * and those can disagree on symlinked or non-normalised roots (`/tmp` vs
+ * `/private/tmp` on macOS, `~` symlinked homes, a trailing `.`). The explicit
+ * separator suffix keeps a sibling dir whose name merely starts the same
+ * (`…/wf_1` vs `…/wf_12`) from matching.
+ */
+function isInsideDir(filePath: string, dir: string): boolean {
+  const resolved = path.resolve(dir);
+  const prefix = resolved.endsWith(path.sep) ? resolved : resolved + path.sep;
+  return path.resolve(filePath).startsWith(prefix);
+}
+
 function toWorkflowShape(w: WorkflowState, taskId: string): Subagent {
   return {
     id: w.id,
@@ -466,14 +500,59 @@ export function orphanRunningSubagents(taskId: string): void {
     return;
   }
   if (rows.length === 0) return;
+  const watcher = watchers.get(taskId);
   for (const row of rows) {
     try {
       emitLifecycleForRow(row);
     } catch (e) {
       console.error(`[claude-subagents] orphan lifecycle emit failed for subagent ${row.id}:`, e);
     }
+    // Mirror the DB flip into the watcher's in-memory state. Not every orphan
+    // path detaches the watcher afterwards — `stopHeldTask` orphans a task
+    // whose session stays alive — so without this the watcher would keep
+    // believing those rows are `running`: a settled workflow container would
+    // pin the poll on `FAST_POLL_MS` forever, and `checkDone`/`tailFile` would
+    // keep re-deriving state for rows the DB has already retired.
+    try {
+      watcher?.syncSettled(row.id, "orphaned", row.endedAt ?? Date.now());
+    } catch (e) {
+      console.error(`[claude-subagents] orphan sync failed for subagent ${row.id}:`, e);
+    }
   }
   fireSettle(taskId);
+}
+
+/**
+ * Run one synchronous watcher cycle for a task, right now, outside the poll
+ * schedule — the deterministic fix for a hold-check race.
+ *
+ * The orchestrator decides whether a finished run must be HELD in `running`
+ * by asking `subagents.hasRunning(taskId)` shortly (~`END_TURN_IDLE_FIRE_MS`)
+ * after the turn's end_turn. But the signals that create those rows are
+ * watcher-side and poll-driven: a task that has not yet discovered any
+ * background agent polls at `SLOW_POLL_MS` (or `DEEP_IDLE_POLL_MS`), so a
+ * workflow (or an async subagent) launched in the closing moments of a turn is
+ * very likely NOT yet in the DB when that predicate runs. The card would then
+ * flip to `review` and only be dragged back by `pullBackParkedTask` on the
+ * next poll — a visible bounce plus a spurious status breadcrumb, on nearly
+ * every workflow launch.
+ *
+ * Pumping here closes the window: the launch line is already in the main JSONL
+ * by the time the turn ends, so one cycle registers the container/subagent rows
+ * before the predicate reads them. A no-op when the task has no watcher (codex,
+ * grok, tracking disabled) — never an error the caller has to handle.
+ */
+export function pumpWatcherForHoldCheck(taskId: string): void {
+  if (!ENABLED) return;
+  const handle = watchers.get(taskId);
+  if (!handle) return;
+  try {
+    handle.pump();
+  } catch (e) {
+    // `pump` → `cycle` already swallows its own failures; this is the
+    // belt-and-braces guard so a future throw can never reach run settlement.
+    console.error(`[claude-subagents] hold-check pump failed for task ${taskId}:`, e);
+  }
 }
 
 /**
@@ -531,11 +610,13 @@ export function attachSubagentWatcher(opts: {
   // polling then only re-reads `running` files; resumes of a finished agent
   // after that are caught by the dir watcher's append notification.
   let firstCycle = true;
-  // Byte cursor into the MAIN session JSONL for `scanMainForToolResults`
-  // below — independent of any per-subagent `FileState.offset`. Starts at 0
-  // so a fresh watcher (boot reattach, held-task repair) sees the full
-  // history on its first scan, the same "offset 0 on attach" idiom the
-  // per-subagent rehydration above relies on.
+  // Byte cursor into the MAIN session JSONL for `scanMainSignals` below —
+  // independent of any per-subagent `FileState.offset`. Starts at 0 so a fresh
+  // watcher (boot reattach, held-task repair) sees the full history on its
+  // first scan, the same "offset 0 on attach" idiom the per-subagent
+  // rehydration above relies on — but see the replay-window clamp after the
+  // rehydration loop, which bounds that first read when the only reason to
+  // scan is workflow signals.
   let mainOffset = 0;
   // `Date.now()` of the last discovery or dir-watcher event — the idle clock
   // for the deep-idle tier (`DEEP_IDLE_POLL_MS`). Only consulted while
@@ -624,6 +705,37 @@ export function attachSubagentWatcher(opts: {
     console.error(`[claude-subagents] rehydration failed for task ${taskId}:`, e);
   }
 
+  // Replay-window clamp. Before workflows, the main scan only ran at all when
+  // some row was waiting on a `tool_result`, so the offset-0 full read was
+  // paid rarely and deliberately. Workflow signals removed that gate — every
+  // attach would otherwise read the WHOLE main transcript synchronously, and
+  // these files reach tens of megabytes on a long-lived session while boot
+  // reconciliation attaches several watchers back-to-back.
+  //
+  // So: when nothing needs the full history (no `running` row waiting on a
+  // tool_result correlation), start the workflow scan `REPLAY_WINDOW_BYTES`
+  // from the end instead of at 0. The tool_result path is untouched — it still
+  // gets its full replay when it needs one, and `discover()` still rewinds to
+  // 0 outright when a new correlation key shows up.
+  //
+  // Accepted edges: (1) the first line read is very likely a partial one; it
+  // fails `JSON.parse` and is skipped, which is exactly what a truncated line
+  // deserves. (2) A workflow whose launch line sits further back than the
+  // window is not re-registered by this scan — but if it was ever seen live
+  // its row is already in the DB and rehydrated above (including its journal
+  // cursor), and a workflow that was never seen at all belongs to a session
+  // whose runs boot reconciliation orphans anyway. The window only needs to
+  // cover "launched shortly before agetor went down", not all history.
+  if (WORKFLOWS_ENABLED) {
+    const needsFullReplay = [...files.values()].some((fs) => fs.status === "running" && fs.toolUseId);
+    if (!needsFullReplay) {
+      try {
+        const size = statSync(opts.jsonlPath).size;
+        if (size > REPLAY_WINDOW_BYTES) mainOffset = size - REPLAY_WINDOW_BYTES;
+      } catch { /* no main JSONL yet — offset 0 is already right */ }
+    }
+  }
+
   function emitLifecycle(fs: FileState, phase: "started" | "finished"): void {
     const payload: SubagentEvent = { phase, subagent: toSubagentShape(fs, taskId) };
     emitFn?.({
@@ -703,6 +815,29 @@ export function attachSubagentWatcher(opts: {
   function workflowForDir(dir: string): WorkflowState | null {
     for (const w of workflows.values()) if (w.dir === dir) return w;
     return null;
+  }
+
+  /**
+   * Should this file keep being tailed even though its row is no longer
+   * `running`? Only for a workflow agent whose CONTAINER is still running.
+   *
+   * Steady-state tailing is restricted to `running` files, and the dir watcher
+   * that would otherwise catch a late append is armed on `subagents/` and is
+   * NOT recursive — so it never fires for writes inside
+   * `subagents/workflows/<wf>/`. A workflow agent can be settled EARLY relative
+   * to its transcript (its `journal.jsonl` receipt lands before the last lines
+   * flush — which is the whole point of the receipt), and without this its tab
+   * would be permanently truncated: the missing lines are never read again.
+   *
+   * Cheap: a settled agent's file has stopped growing, so this is a `statSync`
+   * that reads nothing, and it stops entirely once the container settles.
+   */
+  function tailPastSettle(fs: FileState): boolean {
+    if (fs.parentKind !== "workflow_agent") return false;
+    for (const w of workflows.values()) {
+      if (w.status === "running" && isInsideDir(fs.sourcePath, w.dir)) return true;
+    }
+    return false;
   }
 
   /**
@@ -1155,18 +1290,30 @@ export function attachSubagentWatcher(opts: {
    * a `<task-id>` naming a regular background subagent is left to the existing
    * paths, exactly as before this feature.
    *
+   * BOTH tags are required in the prefilter, not just `<task-id>`: settling a
+   * container is irreversible here (a later launch line for a known id
+   * early-returns in `registerWorkflowContainer`), so a line that merely
+   * mentions a task id — an assistant message quoting a notification back, a
+   * future launch blurb embedding the tag — must not be enough to release the
+   * hold. Requiring the enclosing `<task-notification>` marker, which both real
+   * on-disk shapes carry verbatim, keeps the match anchored to an actual
+   * notification payload.
+   *
    * The notification's `<status>` is deliberately ignored — completed, failed,
    * killed and stopped all mean "this workflow is over", and the hold must
    * release in every one of those cases (plan assumption A4).
    */
   function scanLineForWorkflowNotification(line: string): void {
-    if (!line.includes("<task-id>")) return;
-    const m = /<task-id>([^<]+)<\/task-id>/.exec(line);
-    if (!m) return;
-    const id = m[1]!.trim();
-    const w = workflows.get(id);
-    if (!w || w.status !== "running") return;
-    settleSubagentById(id, "completed");
+    if (!line.includes("<task-notification>") || !line.includes("<task-id>")) return;
+    // `matchAll`, not a single `exec`: one physical line can carry more than
+    // one notification (a batched enqueue), and stopping at the first would
+    // silently drop the rest — leaving a finished workflow holding the card.
+    for (const m of line.matchAll(/<task-id>([^<]+)<\/task-id>/g)) {
+      const id = m[1]!.trim();
+      const w = workflows.get(id);
+      if (!w || w.status !== "running") continue;
+      settleSubagentById(id, "completed");
+    }
   }
 
   /**
@@ -1180,8 +1327,17 @@ export function attachSubagentWatcher(opts: {
    * tool_results were its only signal) would starve workflow detection on
    * exactly the common case — a task with no `toolUseId`-bearing subagent rows
    * at all. So it only short-circuits when there is nothing of EITHER kind to
-   * look for, which keeps the "task with no background agents never pays for
-   * this scan" property intact whenever workflow tracking is off.
+   * look for.
+   *
+   * COST NOTE — that widening means a workflow-tracking watcher scans the main
+   * transcript on every cycle, where before it usually skipped the read
+   * entirely. Two things keep that bounded: the first read after attach starts
+   * at most `REPLAY_WINDOW_BYTES` from the end (see the clamp in
+   * `attachSubagentWatcher`), and every read after it is incremental — the
+   * cursor only ever moves forward, so steady state is one `statSync` plus the
+   * handful of bytes the turn actually appended. The old "a task with no
+   * background agents never pays for this scan at all" property survives only
+   * with `AGETOR_TRACK_WORKFLOWS=0`.
    */
   function scanMainSignals(): void {
     const pending = [...files.values()].filter((fs) => fs.status === "running" && fs.toolUseId);
@@ -1236,11 +1392,12 @@ export function attachSubagentWatcher(opts: {
       // no per-tick cost; a resume (rare) re-opens them via the dir watcher's
       // append notification (see `armDirWatcher`, which tails ALL files). The
       // first cycle is the exception — it tails everything to drain a reattach
-      // backlog.
+      // backlog — as is a settled workflow agent whose workflow is still live
+      // (`tailPastSettle`), which the non-recursive dir watcher cannot cover.
       const tailAll = firstCycle;
       firstCycle = false;
       for (const fs of files.values()) {
-        if (tailAll || fs.status === "running") tailFile(fs);
+        if (tailAll || fs.status === "running" || tailPastSettle(fs)) tailFile(fs);
       }
       tailJournals();
       scanMainSignals();
@@ -1348,20 +1505,22 @@ export function settleSubagentById(id: string, status: "completed" | "orphaned")
  * exception that needs nothing here: `subagents.orphanRunning` already flips
  * every running row for the task in a single kind-agnostic UPDATE.
  *
- * Matching is by `sourcePath` prefix (container dir → agent files inside it),
- * with an explicit separator so a sibling dir sharing a name prefix
- * (`…/wf_12` vs `…/wf_1`) can never be swept in.
+ * Matching is by `sourcePath` containment (container dir → agent files inside
+ * it) via `isInsideDir`, which normalises both sides and requires a separator
+ * boundary — see that helper for why.
+ *
+ * Each cascaded row gets its own DB write, lifecycle emit and watcher sync,
+ * but NOT its own settle-hook fire: the caller fires once, after this returns,
+ * so the orchestrator's release predicate runs a single time against a
+ * fully-settled workflow instead of N+1 times with siblings still running.
  */
 function cascadeWorkflowAgents(taskId: string, container: Subagent, depth: number): void {
   if (!container.sourcePath) return;
-  const prefix = container.sourcePath.endsWith(path.sep)
-    ? container.sourcePath
-    : container.sourcePath + path.sep;
   try {
     for (const row of subagentsDb.listForTask(taskId)) {
       if (row.status !== "running") continue;
       if (row.parentKind !== "workflow_agent") continue;
-      if (!row.sourcePath.startsWith(prefix)) continue;
+      if (!isInsideDir(row.sourcePath, container.sourcePath)) continue;
       settleSubagent(row.id, "completed", depth + 1);
     }
   } catch (e) {
@@ -1372,7 +1531,13 @@ function cascadeWorkflowAgents(taskId: string, container: Subagent, depth: numbe
 /** Shared body of `settleSubagentById`, carrying the cascade recursion depth.
  *  Agent rows are never containers, so the cascade is structurally one level
  *  deep — the depth guard is belt-and-braces against a future kind (or a
- *  corrupt row) that could make the graph cyclic. */
+ *  corrupt row) that could make the graph cyclic.
+ *
+ *  `depth` also decides who fires the settle hook: only the OUTERMOST call
+ *  (depth 0) does, after any cascade beneath it has finished, so a workflow
+ *  releasing N agents costs the orchestrator one release check instead of
+ *  N + 1 — and every one of those checks sees the final state rather than a
+ *  half-settled workflow. */
 function settleSubagent(id: string, status: "completed" | "orphaned", depth: number): boolean {
   let result: { changed: boolean; taskId: string | null };
   try {
@@ -1393,11 +1558,10 @@ function settleSubagent(id: string, status: "completed" | "orphaned", depth: num
     }
   }
   watchers.get(taskId)?.syncSettled(id, status, row?.endedAt ?? now);
-  // Before `fireSettle`, so the orchestrator's release predicate
-  // (`subagents.hasRunning`) sees the whole workflow settled at once rather
-  // than re-checking once per cascaded row with the container's siblings still
-  // running.
+  // Cascade BEFORE the hook (and the hook only at depth 0), so the
+  // orchestrator's release predicate (`subagents.hasRunning`) runs exactly once
+  // per settle event, against a workflow that is settled in full.
   if (row?.parentKind === "workflow" && depth < 1) cascadeWorkflowAgents(taskId, row, depth);
-  fireSettle(taskId);
+  if (depth === 0) fireSettle(taskId);
   return true;
 }

--- a/src/bun/claude-workflow-agents.test.ts
+++ b/src/bun/claude-workflow-agents.test.ts
@@ -1,0 +1,755 @@
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Workflow (`/workflow`) tracking behavior in claude-subagents.ts — the
+ * CONTAINER row (`parentKind: "workflow"`) that holds a task in `running` for
+ * a workflow's whole lifetime, the per-agent `workflow_agent` rows tailed
+ * from `<sessionId>/subagents/workflows/<wf_runId>/`, journal-receipt settle
+ * (the flush-loss backstop), the notification-anchored container settle +
+ * cascade, replay idempotency on reattach, the `pumpWatcherForHoldCheck`
+ * synchronous hold-check path, the `AGETOR_TRACK_WORKFLOWS` kill switch, and
+ * the `REPLAY_WINDOW_BYTES` attach-time clamp.
+ *
+ * Companion to claude-subagents.test.ts — same conventions, disjoint scope
+ * (that file covers classic in-session subagents; this one covers only the
+ * workflow half added on top of it). See docs/plans/
+ * claude-code-workflows-as-running-bg-agents.md §2/§5 (TT1) for the ground
+ * truth this file encodes.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+import { test, expect, describe, beforeAll, afterEach } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { RunEvent } from "../shared/types.ts";
+
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-workflow-agents-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+
+// Whatever the orchestrator registered at its module load (or `null` if this
+// file runs before it). `bun test` shares one process across every file, so
+// hard-resetting these to `null` in `afterEach` would leave every later file
+// with no SSE sink and no release/pull-back path. Capture by
+// read-modify-restore and put the originals back — same idiom as
+// claude-subagents.test.ts.
+let originalEmitter: ((e: RunEvent) => void) | null = null;
+let originalSettleHook: ((taskId: string) => void) | null = null;
+let originalParkedDiscovery: ((taskId: string) => void) | null = null;
+
+beforeAll(async () => {
+  await import("./db.ts");
+  const { setSubagentEmitter, setSubagentSettleHook, setParkedDiscoveryHandler } = await import(
+    "./claude-subagents.ts"
+  );
+  originalEmitter = setSubagentEmitter(null);
+  setSubagentEmitter(originalEmitter);
+  originalSettleHook = setSubagentSettleHook(null);
+  setSubagentSettleHook(originalSettleHook);
+  originalParkedDiscovery = setParkedDiscoveryHandler(null);
+  setParkedDiscoveryHandler(originalParkedDiscovery);
+});
+
+// Every task `seed()` creates is tracked here and torn down in the global
+// `afterEach` below — see claude-subagents.test.ts's identical comment for
+// why: `seed()` inserts the task `running` + the run `succeeded`, exactly the
+// shape reconcileOrphans's held-task sweep looks for, and a leftover row
+// (combined with a `running` subagents row several tests here create) would
+// get silently swept by any later `reconcileOrphans()` call sharing this
+// process's SQLite db (e.g. reconcile.test.ts).
+const createdTaskIds: string[] = [];
+
+afterEach(async () => {
+  const {
+    detachWatcherFor,
+    setSubagentEmitter,
+    setSubagentSettleHook,
+    setParkedDiscoveryHandler,
+  } = await import("./claude-subagents.ts");
+  setSubagentEmitter(originalEmitter);
+  setSubagentSettleHook(originalSettleHook);
+  setParkedDiscoveryHandler(originalParkedDiscovery);
+  if (createdTaskIds.length === 0) return;
+  const { tasks } = await import("./db.ts");
+  for (const id of createdTaskIds) {
+    try {
+      detachWatcherFor(id);
+    } catch {
+      /* best-effort */
+    }
+    try {
+      tasks.delete(id);
+    } catch {
+      /* best-effort */
+    }
+  }
+  createdTaskIds.length = 0;
+});
+
+/** Build a temp `<sessionId>/subagents/` layout + a seeded task/run, returning
+ *  the jsonlPath the watcher derives the subagents dir from. Mirrors
+ *  claude-subagents.test.ts's `seed()` exactly. */
+async function seed() {
+  const { tasks, runs } = await import("./db.ts");
+  const taskId = `task-wf-${randomUUID()}`;
+  const runId = `run-wf-${randomUUID()}`;
+  createdTaskIds.push(taskId);
+  const now = Date.now();
+  tasks.insert({
+    id: taskId, title: "t", prompt: "p", column: "running", agent: "claude-code",
+    workdir: "/tmp", isolation: "none", taskType: "task", branch: null, branchSource: "created", worktreePath: null,
+    baseRef: null, mode: null, model: null, effort: null, references: [], backlog: [], draft: null, runId,
+    prUrl: null,
+    hasOpenableRun: false, pendingInteractionCount: 0, openTerminalCount: 0,
+    archivedAt: null, createdAt: now, updatedAt: now,
+  });
+  // Insert the run as already-terminal — see claude-subagents.test.ts's
+  // identical comment: reconcileOrphans() scans every `running` run globally.
+  runs.insert({
+    id: runId, taskId, agent: "claude-code", status: "succeeded", startedAt: now,
+    endedAt: now, exitCode: 0, tmuxSession: null, claudeSessionId: null, codexSessionId: null,
+  });
+
+  const sessionId = randomUUID();
+  const proj = path.join(DATA_DIR, "projects", "encoded");
+  const subagentsDir = path.join(proj, sessionId, "subagents");
+  mkdirSync(subagentsDir, { recursive: true });
+  const jsonlPath = path.join(proj, `${sessionId}.jsonl`);
+  return { taskId, runId, jsonlPath, subagentsDir };
+}
+
+/** `<sessionId>/subagents/workflows/<wfRunId>/` — where a workflow's
+ *  container `transcriptDir` and its `agent-*.jsonl` files live. */
+function wfDirFor(subagentsDir: string, wfRunId: string): string {
+  return path.join(subagentsDir, "workflows", wfRunId);
+}
+
+/** Main-JSONL `user` line carrying the `/workflow` tool's immediate
+ *  `async_launched` stub — the launch signal `scanLineForWorkflowLaunch`
+ *  parses. `transcriptDir` must be the ABSOLUTE dir the watcher will scan for
+ *  agent files (use `wfDirFor`). */
+function launchLine(opts: {
+  wtaskId: string;
+  workflowName: string;
+  wfRunId: string;
+  transcriptDir: string;
+  toolUseId: string;
+  summary?: string;
+}): string {
+  return JSON.stringify({
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: opts.toolUseId, content: "Workflow launched" }],
+    },
+    toolUseResult: {
+      status: "async_launched",
+      taskId: opts.wtaskId,
+      taskType: "local_workflow",
+      workflowName: opts.workflowName,
+      runId: opts.wfRunId,
+      summary: opts.summary ?? "s",
+      transcriptDir: opts.transcriptDir,
+      scriptPath: "/bin/workflow.sh",
+    },
+    uuid: `launch-${opts.wtaskId}`,
+  }) + "\n";
+}
+
+/** Main-JSONL `queue-operation` enqueue line carrying a completion
+ *  `<task-notification>` payload — the shape claude 2.1.x uses (older
+ *  versions used a synthetic `user`/`origin.kind` shape instead; both are
+ *  parsed identically by `scanLineForWorkflowNotification`, which just
+ *  substring/regex-matches the raw line, so this one shape is sufficient to
+ *  exercise that code path). */
+function notificationLine(opts: { wtaskId: string; toolUseId: string; status?: string; summary?: string }): string {
+  const content =
+    `<task-notification>\n<task-id>${opts.wtaskId}</task-id>\n<tool-use-id>${opts.toolUseId}</tool-use-id>\n` +
+    `<status>${opts.status ?? "completed"}</status>\n<summary>${opts.summary ?? "done"}</summary>\n</task-notification>`;
+  return JSON.stringify({
+    type: "queue-operation",
+    operation: "enqueue",
+    timestamp: new Date().toISOString(),
+    sessionId: randomUUID(),
+    content,
+  }) + "\n";
+}
+
+/** A line that merely QUOTES a `<task-id>` tag without the enclosing
+ *  `<task-notification>` wrapper — the shape `scanLineForWorkflowNotification`
+ *  must NOT treat as a settle signal (fix 4: anchoring on the notification
+ *  marker, not the bare tag). */
+function quoteOnlyLine(wtaskId: string): string {
+  return JSON.stringify({
+    type: "assistant",
+    message: { role: "assistant", content: [{ type: "text", text: `Referring to <task-id>${wtaskId}</task-id> earlier.` }] },
+    uuid: `quote-${wtaskId}`,
+  }) + "\n";
+}
+
+function sidechainUserLine(agentId: string, uuid: string): string {
+  return JSON.stringify({
+    type: "user", isSidechain: true, agentId, uuid,
+    message: { role: "user", content: "go" },
+  }) + "\n";
+}
+
+function sidechainToolUseLine(agentId: string, uuid: string): string {
+  return JSON.stringify({
+    type: "assistant", isSidechain: true, agentId, uuid,
+    message: { role: "assistant", stop_reason: "tool_use", content: [{ type: "tool_use", id: `t-${uuid}`, name: "Bash", input: { command: "ls" } }] },
+  }) + "\n";
+}
+
+function sidechainEndTurnLine(agentId: string, uuid: string, text = "done"): string {
+  return JSON.stringify({
+    type: "assistant", isSidechain: true, agentId, uuid,
+    message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text }] },
+  }) + "\n";
+}
+
+/** A `journal.jsonl` lifecycle receipt line — the harness's own per-agent
+ *  completion record, immune to the terminal-line flush loss a workflow
+ *  agent's own transcript can suffer under concurrency. */
+function journalLine(type: "started" | "result", key: string, agentId: string, result?: string): string {
+  const o: Record<string, unknown> = { type, key, agentId };
+  if (type === "result") o.result = result ?? "ok";
+  return JSON.stringify(o) + "\n";
+}
+
+/** meta.json sidecar for a workflow agent — no `description`, no `toolUseId`
+ *  (empirical ground truth: workflow agents are spawned by the harness, not
+ *  by a parent `Agent` tool_use). */
+function wfAgentMeta(): string {
+  return JSON.stringify({ agentType: "workflow-subagent", spawnDepth: 1, model: "haiku" });
+}
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 1. Container discovery from the launch line
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("workflow container discovery (launch line)", () => {
+  test("registers a running container row, fires parked-discovery once, and holds the task", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setParkedDiscoveryHandler } = await import("./claude-subagents.ts");
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+
+    const wtaskId = `wtask1-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const dir = wfDirFor(subagentsDir, "wf_x");
+    writeFileSync(jsonlPath, launchLine({
+      wtaskId, workflowName: "my-wf", wfRunId: "wf_x", transcriptDir: dir, toolUseId,
+    }));
+
+    const parked: string[] = [];
+    setParkedDiscoveryHandler((tid) => parked.push(tid));
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    w.pump(Date.now());
+
+    const row = subagents.get(wtaskId);
+    expect(row).not.toBeNull();
+    expect(row!.parentKind).toBe("workflow");
+    expect(row!.id).toBe(wtaskId);
+    expect(row!.taskId).toBe(taskId);
+    expect(row!.status).toBe("running");
+    expect(row!.description).toBe("my-wf");
+    expect(row!.sourcePath).toBe(dir);
+    expect(row!.toolUseId).toBe(toolUseId);
+
+    expect(parked).toEqual([taskId]);
+    expect(subagents.hasRunning(taskId)).toBe(true);
+
+    w.detach();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 2. Workflow-agent discovery inside the transcript dir
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("workflow agent discovery (agent-*.jsonl + meta.json inside the wf dir)", () => {
+  test("discovers a workflow_agent row, tags tailed events with the agent id, and falls back the description to the workflow's name", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_y";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "my-wf", wfRunId, transcriptDir: dir, toolUseId }));
+
+    const captured: RunEvent[] = [];
+    setSubagentEmitter((e) => captured.push(e));
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    // Cycle 1: registers the container. No agent files exist yet, so
+    // `discoverWorkflowAgents` (which runs BEFORE `scanMainSignals` inside
+    // one cycle) finds nothing this pass.
+    w.pump(Date.now());
+    expect(subagents.get(wtaskId)!.parentKind).toBe("workflow");
+
+    // Now the agent file appears — after the container is already known, so
+    // the description-fallback chain reaches the container's name.
+    const agentId = `wfagent-${randomUUID().slice(0, 8)}`;
+    writeFileSync(path.join(dir, `agent-${agentId}.meta.json`), wfAgentMeta());
+    writeFileSync(
+      path.join(dir, `agent-${agentId}.jsonl`),
+      sidechainUserLine(agentId, `u-${agentId}`) + sidechainToolUseLine(agentId, `t-${agentId}`),
+    );
+
+    w.pump(Date.now());
+
+    const row = subagents.get(agentId);
+    expect(row).not.toBeNull();
+    expect(row!.parentKind).toBe("workflow_agent");
+    expect(row!.status).toBe("running");
+    expect(row!.description).toBe("my-wf"); // meta has none — falls back to the container's
+
+    const tagged = captured.filter((e) => e.stream === "user" || e.stream === "tool_use");
+    expect(tagged.length).toBe(2);
+    expect(tagged.every((e) => e.subagentId === agentId)).toBe(true);
+    expect(tagged.every((e) => e.taskId === taskId)).toBe(true);
+
+    w.detach();
+  });
+
+  test("with no container ever registered, description falls back to the wf dir name", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+    setSubagentEmitter(() => { /* drain */ });
+
+    // No launch line is ever written to jsonlPath — only the agent file
+    // shows up (e.g. the launch line sat outside the replay window, or this
+    // agetor build never saw it). `workflowForDir` then has nothing to match.
+    const wfRunId = "wf_orphan";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(jsonlPath, "");
+
+    const agentId = `orphanagent-${randomUUID().slice(0, 8)}`;
+    writeFileSync(path.join(dir, `agent-${agentId}.meta.json`), wfAgentMeta());
+    writeFileSync(path.join(dir, `agent-${agentId}.jsonl`), sidechainUserLine(agentId, `u-${agentId}`));
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    w.pump(Date.now());
+
+    const row = subagents.get(agentId);
+    expect(row).not.toBeNull();
+    expect(row!.parentKind).toBe("workflow_agent");
+    expect(row!.description).toBe(wfRunId); // falls back to the dir name itself
+
+    w.detach();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 3. journal.jsonl receipts — the flush-loss backstop
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("journal.jsonl receipts settle an agent row without a terminal end_turn", () => {
+  test("a journal 'result' line settles the agent even though its own jsonl never got an end_turn", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+    setSubagentEmitter(() => { /* drain */ });
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_j";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "journal-wf", wfRunId, transcriptDir: dir, toolUseId }));
+
+    const agentId = `jagent-${randomUUID().slice(0, 8)}`;
+    writeFileSync(path.join(dir, `agent-${agentId}.meta.json`), wfAgentMeta());
+    // Only a user line + an in-flight tool_use — NEVER a terminal end_turn.
+    writeFileSync(
+      path.join(dir, `agent-${agentId}.jsonl`),
+      sidechainUserLine(agentId, `u-${agentId}`) + sidechainToolUseLine(agentId, `t-${agentId}`),
+    );
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    const t0 = Date.now();
+    w.pump(t0);
+    expect(subagents.get(agentId)!.status).toBe("running");
+
+    // The harness's own completion receipt lands in the wf dir's journal.
+    writeFileSync(path.join(dir, "journal.jsonl"), journalLine("started", "k1", agentId) + journalLine("result", "k1", agentId, "ok"));
+    w.pump(t0 + 1); // no DONE_IDLE_MS wait needed — the journal settle is immediate
+
+    const row = subagents.get(agentId)!;
+    expect(row.status).toBe("completed");
+    expect(row.endedAt).not.toBeNull();
+
+    w.detach();
+  });
+
+  test("a 'started' journal line alone does not settle the agent", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+    setSubagentEmitter(() => { /* drain */ });
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_started-only";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "started-wf", wfRunId, transcriptDir: dir, toolUseId }));
+
+    const agentId = `sagent-${randomUUID().slice(0, 8)}`;
+    writeFileSync(path.join(dir, `agent-${agentId}.meta.json`), wfAgentMeta());
+    writeFileSync(path.join(dir, `agent-${agentId}.jsonl`), sidechainUserLine(agentId, `u-${agentId}`));
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    const t0 = Date.now();
+    w.pump(t0);
+
+    writeFileSync(path.join(dir, "journal.jsonl"), journalLine("started", "k1", agentId));
+    w.pump(t0 + 1);
+
+    expect(subagents.get(agentId)!.status).toBe("running");
+
+    w.detach();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 4. tailPastSettle — trailing transcript lines after a journal settle
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("tailPastSettle: an agent settled early by its journal keeps tailing while the container runs", () => {
+  test("lines appended after the journal settle still produce events", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+
+    const captured: RunEvent[] = [];
+    setSubagentEmitter((e) => captured.push(e));
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_t";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "trail-wf", wfRunId, transcriptDir: dir, toolUseId }));
+
+    const agentId = `tagent-${randomUUID().slice(0, 8)}`;
+    writeFileSync(path.join(dir, `agent-${agentId}.meta.json`), wfAgentMeta());
+    writeFileSync(path.join(dir, `agent-${agentId}.jsonl`), sidechainUserLine(agentId, `u-${agentId}`));
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    const t0 = Date.now();
+    w.pump(t0); // registers container + agent
+
+    // Settle via journal receipt WITHOUT a terminal end_turn — the container
+    // itself is untouched and stays running.
+    writeFileSync(path.join(dir, "journal.jsonl"), journalLine("result", "k1", agentId, "ok"));
+    w.pump(t0 + 1);
+    expect(subagents.get(agentId)!.status).toBe("completed");
+    expect(subagents.get(wtaskId)!.status).toBe("running");
+
+    captured.length = 0; // isolate what the NEXT append produces
+
+    // More of the agent's own transcript flushes late — must not be lost.
+    appendFileSync(path.join(dir, `agent-${agentId}.jsonl`), sidechainEndTurnLine(agentId, `e-${agentId}`, "late text"));
+    w.pump(t0 + 2);
+
+    const lateEvents = captured.filter((e) => e.subagentId === agentId);
+    expect(lateEvents.length).toBeGreaterThan(0);
+    expect(lateEvents.some((e) => e.stream === "assistant")).toBe(true);
+    // Surprising but verified: `tailFile`'s own resume-detection treats ANY
+    // append to an already-non-`running` row as a resumed background agent
+    // (the "flip back to running" block), regardless of WHY it was settled.
+    // So tailing past a journal settle doesn't just recover the lost content
+    // — it also flips the row back to `running` (and re-fires
+    // parked-discovery) the moment a trailing line is read. A real workflow
+    // agent's transcript stops growing once the harness kills it, so in
+    // practice this window is short-lived, but it means the row is NOT
+    // stably `completed` immediately after a journal settle if its file
+    // keeps growing afterwards.
+    expect(subagents.get(agentId)!.status).toBe("running");
+
+    w.detach();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 5. Completion notification: container settle + cascade + single settle-hook fire
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("workflow completion notification (queue-operation enqueue)", () => {
+  test("settles the container, cascade-settles a still-running agent row, and fires the settle hook exactly once", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+      "./claude-subagents.ts"
+    );
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+    setSubagentEmitter(() => { /* drain */ });
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_n";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "notif-wf", wfRunId, transcriptDir: dir, toolUseId }));
+
+    const agentId = `nagent-${randomUUID().slice(0, 8)}`;
+    writeFileSync(path.join(dir, `agent-${agentId}.meta.json`), wfAgentMeta());
+    // No end_turn, no journal receipt — still `running` when the notification lands.
+    writeFileSync(path.join(dir, `agent-${agentId}.jsonl`), sidechainUserLine(agentId, `u-${agentId}`));
+
+    const settleCalls: string[] = [];
+    setSubagentSettleHook((tid) => settleCalls.push(tid));
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    const t0 = Date.now();
+    w.pump(t0);
+    expect(subagents.get(wtaskId)!.status).toBe("running");
+    expect(subagents.get(agentId)!.status).toBe("running");
+    expect(settleCalls.length).toBe(0);
+
+    appendFileSync(jsonlPath, notificationLine({ wtaskId, toolUseId }));
+    w.pump(t0 + 1);
+
+    expect(subagents.get(wtaskId)!.status).toBe("completed");
+    expect(subagents.get(agentId)!.status).toBe("completed"); // cascade
+    expect(settleCalls).toEqual([taskId]); // exactly one fire for the whole cascade
+    expect(subagents.hasRunning(taskId)).toBe(false);
+
+    w.detach();
+  });
+
+  test("a failed/killed/stopped status still settles the container (the hold releases either way)", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+    setSubagentEmitter(() => { /* drain */ });
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_kill";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "kill-wf", wfRunId, transcriptDir: dir, toolUseId }));
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    const t0 = Date.now();
+    w.pump(t0);
+    expect(subagents.get(wtaskId)!.status).toBe("running");
+
+    appendFileSync(jsonlPath, notificationLine({ wtaskId, toolUseId, status: "killed" }));
+    w.pump(t0 + 1);
+
+    expect(subagents.get(wtaskId)!.status).toBe("completed");
+
+    w.detach();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 6. Notification anchoring — a bare <task-id> mention must not settle
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("notification anchoring: a bare <task-id> mention is not a settle signal", () => {
+  test("a line quoting <task-id> WITHOUT the enclosing <task-notification> tag leaves the container running", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+    setSubagentEmitter(() => { /* drain */ });
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_q";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "quote-wf", wfRunId, transcriptDir: dir, toolUseId }));
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    const t0 = Date.now();
+    w.pump(t0);
+    expect(subagents.get(wtaskId)!.status).toBe("running");
+
+    appendFileSync(jsonlPath, quoteOnlyLine(wtaskId));
+    w.pump(t0 + 1);
+
+    expect(subagents.get(wtaskId)!.status).toBe("running");
+    expect(subagents.hasRunning(taskId)).toBe(true);
+
+    w.detach();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 7. Replay idempotency on reattach
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("replay idempotency across reattach", () => {
+  test("a settled container is not resurrected, no duplicate parked-discovery, no re-emitted 'started' lifecycle", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter, setParkedDiscoveryHandler } = await import(
+      "./claude-subagents.ts"
+    );
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+
+    const captured: RunEvent[] = [];
+    setSubagentEmitter((e) => captured.push(e));
+    const parked: string[] = [];
+    setParkedDiscoveryHandler((tid) => parked.push(tid));
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_r";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "replay-wf", wfRunId, transcriptDir: dir, toolUseId }));
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    const t0 = Date.now();
+    w.pump(t0);
+    expect(parked).toEqual([taskId]);
+
+    appendFileSync(jsonlPath, notificationLine({ wtaskId, toolUseId }));
+    w.pump(t0 + 1);
+    expect(subagents.get(wtaskId)!.status).toBe("completed");
+
+    w.detach();
+    captured.length = 0;
+    parked.length = 0;
+
+    // Fresh manual watcher: file is well under REPLAY_WINDOW_BYTES, so no
+    // clamp applies — this replays the FULL main JSONL from offset 0 and
+    // re-sees BOTH the launch line and the notification line.
+    const w2 = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    w2.pump(t0 + 2);
+
+    expect(subagents.get(wtaskId)!.status).toBe("completed"); // not resurrected to running
+    expect(parked.length).toBe(0); // no duplicate parked-discovery fire
+
+    const startedForContainer = captured.filter(
+      (e) => e.stream === "subagent" && e.subagentId === wtaskId && JSON.parse(e.data).phase === "started",
+    );
+    expect(startedForContainer.length).toBe(0); // no re-emitted "started" lifecycle for a settled row
+
+    w2.detach();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 8. pumpWatcherForHoldCheck — synchronous registration ahead of the poll timer
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("pumpWatcherForHoldCheck", () => {
+  test("registers a just-written launch line synchronously", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, pumpWatcherForHoldCheck } = await import("./claude-subagents.ts");
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_h";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+
+    // `manual: true` suppresses the self-scheduling poll timer entirely —
+    // nothing discovers the launch line unless something pumps explicitly.
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "hold-wf", wfRunId, transcriptDir: dir, toolUseId }));
+
+    pumpWatcherForHoldCheck(taskId);
+
+    const row = subagents.get(wtaskId);
+    expect(row).not.toBeNull();
+    expect(row!.status).toBe("running");
+    expect(row!.parentKind).toBe("workflow");
+
+    w.detach();
+  });
+
+  test("no-ops on an unknown taskId", async () => {
+    const { pumpWatcherForHoldCheck } = await import("./claude-subagents.ts");
+    expect(() => pumpWatcherForHoldCheck(`no-such-task-${randomUUID()}`)).not.toThrow();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 9. AGETOR_TRACK_WORKFLOWS=0 kill switch
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("AGETOR_TRACK_WORKFLOWS=0 kill switch", () => {
+  test("no container or agent rows are created when the workflow flag is off", async () => {
+    const prev = process.env.AGETOR_TRACK_WORKFLOWS;
+    process.env.AGETOR_TRACK_WORKFLOWS = "0";
+    // Re-import fresh so the module-level WORKFLOWS_ENABLED flag re-reads the
+    // env — the same cache-busting idiom claude-subagents.test.ts uses for
+    // AGETOR_TRACK_SUBAGENTS=0.
+    const mod = await import(`./claude-subagents.ts?gate=${randomUUID()}`);
+    const { subagents } = await import("./db.ts");
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_k";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "kill-wf", wfRunId, transcriptDir: dir, toolUseId }));
+    const agentId = `kagent-${randomUUID().slice(0, 8)}`;
+    writeFileSync(path.join(dir, `agent-${agentId}.meta.json`), wfAgentMeta());
+    writeFileSync(path.join(dir, `agent-${agentId}.jsonl`), sidechainUserLine(agentId, `u-${agentId}`));
+
+    const w = mod.attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    w.pump(Date.now());
+
+    expect(subagents.get(wtaskId)).toBeNull();
+    expect(subagents.get(agentId)).toBeNull();
+    expect(subagents.listForTask(taskId).length).toBe(0);
+    expect(subagents.hasRunning(taskId)).toBe(false);
+
+    w.detach();
+    if (prev === undefined) delete process.env.AGETOR_TRACK_WORKFLOWS;
+    else process.env.AGETOR_TRACK_WORKFLOWS = prev;
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 10. REPLAY_WINDOW_BYTES clamp on attach
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("REPLAY_WINDOW_BYTES clamp on attach", () => {
+  test("a fresh watcher's first scan is clamped to the last ~4MB: an old launch line outside the window is never registered, one inside it is", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter, setParkedDiscoveryHandler } = await import(
+      "./claude-subagents.ts"
+    );
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+    setSubagentEmitter(() => { /* drain */ });
+    setParkedDiscoveryHandler(() => { /* drain */ });
+
+    const oldWtaskId = `wtask-old-${randomUUID()}`;
+    const recentWtaskId = `wtask-recent-${randomUUID()}`;
+    const oldToolUseId = `toolu-old-${randomUUID()}`;
+    const recentToolUseId = `toolu-recent-${randomUUID()}`;
+    const oldDir = wfDirFor(subagentsDir, "wf_old");
+    const recentDir = wfDirFor(subagentsDir, "wf_recent");
+
+    const oldLine = launchLine({
+      wtaskId: oldWtaskId, workflowName: "old-wf", wfRunId: "wf_old", transcriptDir: oldDir, toolUseId: oldToolUseId,
+    });
+    const recentLine = launchLine({
+      wtaskId: recentWtaskId, workflowName: "recent-wf", wfRunId: "wf_recent", transcriptDir: recentDir, toolUseId: recentToolUseId,
+    });
+    // A gap strictly larger than REPLAY_WINDOW_BYTES (4 * 1024 * 1024) so the
+    // old launch line unambiguously falls outside the clamp window while the
+    // recent one falls inside it, regardless of the exact byte accounting.
+    const gap = "F".repeat(4_300_000) + "\n";
+    writeFileSync(jsonlPath, oldLine + gap + recentLine);
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    w.pump(Date.now());
+
+    expect(subagents.get(oldWtaskId)).toBeNull(); // outside the replay window — never seen
+    const recentRow = subagents.get(recentWtaskId);
+    expect(recentRow).not.toBeNull();
+    expect(recentRow!.status).toBe("running");
+
+    w.detach();
+  });
+});

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -909,12 +909,22 @@ interface SubagentRow {
   tool_use_id: string | null;
 }
 
+/** Every `parent_kind` the app understands. The column is plain TEXT with no
+ *  CHECK constraint (see `022_subagents.sql`) precisely so new kinds need no
+ *  migration — but an unknown value read back from a future/foreign build must
+ *  still land on a member of the union, so `toSubagent` falls back to
+ *  `"subagent"` for anything not listed here. Keep in sync with
+ *  `Subagent.parentKind` in shared/types.ts. */
+const PARENT_KINDS = new Set<string>(["subagent", "bg_session", "workflow", "workflow_agent"]);
+
 function toSubagent(r: SubagentRow): Subagent {
   return {
     id: r.id,
     taskId: r.task_id,
     runId: r.run_id,
-    parentKind: r.parent_kind === "bg_session" ? "bg_session" : "subagent",
+    parentKind: PARENT_KINDS.has(r.parent_kind)
+      ? (r.parent_kind as Subagent["parentKind"])
+      : "subagent",
     agentType: r.agent_type,
     description: r.description,
     spawnDepth: r.spawn_depth,

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -78,6 +78,7 @@ import {
   settleSubagentById,
   orphanRunningSubagents,
   attachSubagentWatcher,
+  pumpWatcherForHoldCheck,
 } from "./claude-subagents.ts";
 import {
   prepareWorkdir,
@@ -1032,6 +1033,23 @@ function attachDoneHandler(
         // above, so the concurrent-settle path (`maybeReleaseHeldTask`) reads
         // the correct terminal status; whichever of the two fires last wins and
         // both interleavings converge on the right column, so no lock is needed.
+        // Give the subagent watcher one synchronous cycle before asking it
+        // whether anything is still running. The rows that answer that
+        // question are created by the watcher's own poll, and a task that has
+        // not discovered a background agent yet polls on the SLOW/DEEP_IDLE
+        // tier (4-10s) — while this runs ~END_TURN_IDLE_FIRE_MS after the
+        // turn's end_turn. So an agent (or a `/workflow`) launched in the
+        // closing moments of a turn is usually NOT in the DB yet at this
+        // point, and the card would flip to `review` only to be dragged back
+        // by `pullBackParkedTask` a few seconds later — a visible bounce and a
+        // misleading breadcrumb. Pumping here reads the launch line that is
+        // already on disk and makes the hold decision deterministic.
+        try {
+          pumpWatcherForHoldCheck(taskId);
+        } catch {
+          // Belt-and-braces: the callee already swallows its own errors, but a
+          // watcher problem must never derail run settlement.
+        }
         const holdForSubagents =
           newStatus === "succeeded"
           && !wasCancelled

--- a/src/bun/workflow-hold.test.ts
+++ b/src/bun/workflow-hold.test.ts
@@ -1,0 +1,386 @@
+import { test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+// Only AGETOR_DATA_DIR belongs at module top level: db.ts captures it at first
+// import, `beforeAll` would race a sibling that already imported db.ts, and the
+// value is unique per file so nobody inherits it harmfully. Same convention as
+// subagent-hold.test.ts / subagent-settle.test.ts.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-test-"));
+
+// Every OTHER override is scoped to this file and restored afterwards — see
+// subagent-hold.test.ts's header comment for why a top-level `process.env.X =`
+// would leak into sibling test files sharing this one `bun test` process.
+const ENV_OVERRIDES: Record<string, string> = {
+  AGETOR_CLAUDE_DRIVER: "fake", // in-process fake instead of tmux + the real CLI
+  AGETOR_CLAUDE_BIN: "/bin/echo", // agent-status preflight passes without claude
+  AGETOR_TMUX_BIN: "/bin/echo", // tmux probe in agent-status passes
+  AGETOR_CLAUDE_ARGS: "",
+  AGETOR_CODEX_DRIVER: "fake", // only the codex-inert regression test needs this
+  AGETOR_CODEX_BIN: "/bin/echo",
+};
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeAll(async () => {
+  for (const [k, v] of Object.entries(ENV_OVERRIDES)) {
+    savedEnv[k] = process.env[k];
+    process.env[k] = v;
+  }
+  // Importing orchestrator.ts is what installs the REAL
+  // `setSubagentSettleHook(maybeReleaseHeldTask)`,
+  // `setParkedDiscoveryHandler(pullBackParkedTask)`, and
+  // `setBackgroundTaskSettledHandler((_taskId, agentId) =>
+  // settleSubagentById(agentId, "completed"))` wiring at module load — the
+  // seams every scenario below drives through rather than importing any
+  // orchestrator-private function directly.
+  await import("./orchestrator.ts");
+});
+
+afterAll(() => {
+  for (const k of Object.keys(ENV_OVERRIDES)) {
+    const prev = savedEnv[k];
+    if (prev === undefined) delete process.env[k];
+    else process.env[k] = prev;
+  }
+});
+
+/*
+ * Covers TT2 (docs/plans/claude-code-workflows-as-running-bg-agents.md, §5
+ * TT2): the orchestrator-level hold/release behavior for Claude Code Workflow
+ * (`/workflow`) container rows — `parentKind: "workflow"` — and their
+ * `workflow_agent` children, as implemented in claude-subagents.ts by
+ * commits 186a156 / 897ef10.
+ *
+ * A workflow is modeled as a CONTAINER row (holds the task in `running` for
+ * the workflow's whole lifetime) plus per-agent `workflow_agent` rows (read-
+ * only tab streams). This file seeds both kinds directly via
+ * `subagents.insertIfAbsent` — exactly like subagent-hold.test.ts seeds a
+ * plain `subagent` row — rather than materializing real workflow transcript
+ * files, since the hold/release/cascade/notification logic under test here
+ * never reads file contents for a container (it's directory-backed, never
+ * tailed) and only path-compares `sourcePath` for the cascade.
+ *
+ * IMPORTANT — shared-DB hygiene (see the module CLAUDE.md and
+ * subagent-hold.test.ts's header): `bun test` runs every `*.test.ts` in one
+ * process against one SQLite DB, and boot-style reconciliation sweeps scan
+ * globally. Every task created here is tracked and hard-deleted in
+ * `afterEach` (FK ON DELETE CASCADE covers runs/subagents/run_events), and
+ * every run row this file seeds (via the real `startTask` + fake driver) is
+ * terminal by the time each test's assertions run.
+ */
+
+const createdTaskIds: string[] = [];
+
+afterEach(async () => {
+  const { db } = await import("./db.ts");
+  for (const id of createdTaskIds.splice(0)) {
+    db.run(`DELETE FROM tasks WHERE id = ?`, [id]);
+  }
+});
+
+function wait(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function createClaudeTask(title: string): Promise<string> {
+  const { createTask } = await import("./orchestrator.ts");
+  const created = await createTask({
+    title,
+    prompt: "hello",
+    agent: "claude-code",
+    workdir: process.cwd(),
+    isolation: "none", // don't materialize a worktree off the live repo during tests
+  });
+  if ("error" in created) throw new Error(created.error);
+  createdTaskIds.push(created.task.id);
+  return created.task.id;
+}
+
+/** Seed a `parentKind: "workflow"` CONTAINER row, `running`, the way
+ *  `registerWorkflowContainer` would (minus the file-backed transcript dir
+ *  actually existing on disk — nothing here reads it). `sourcePath` is a real
+ *  temp directory so `isInsideDir` path-comparisons in the cascade behave
+ *  exactly as they would for a genuine workflow. */
+async function insertRunningContainer(taskId: string, dir: string, id?: string): Promise<string> {
+  const { subagents } = await import("./db.ts");
+  const containerId = id ?? `wtask-${randomUUID()}`;
+  subagents.insertIfAbsent({
+    id: containerId,
+    taskId,
+    runId: null, // the gate only keys off task_id — see subagents.hasRunning
+    parentKind: "workflow",
+    agentType: "workflow",
+    description: "test workflow",
+    spawnDepth: 1,
+    sourcePath: dir,
+    status: "running",
+    startedAt: Date.now(),
+    endedAt: null,
+  });
+  return containerId;
+}
+
+/** Seed a `parentKind: "workflow_agent"` row whose `sourcePath` lives INSIDE
+ *  `dir` (the container's transcript dir), matching the real on-disk layout
+ *  (`<transcriptDir>/agent-<agentId>.jsonl`) that `cascadeWorkflowAgents`'s
+ *  `isInsideDir` containment check relies on. */
+async function insertRunningWorkflowAgent(taskId: string, dir: string, id?: string): Promise<string> {
+  const { subagents } = await import("./db.ts");
+  const agentId = id ?? `wagent-${randomUUID()}`;
+  subagents.insertIfAbsent({
+    id: agentId,
+    taskId,
+    runId: null,
+    parentKind: "workflow_agent",
+    agentType: "workflow-subagent",
+    description: "test workflow agent",
+    spawnDepth: 1,
+    sourcePath: path.join(dir, `agent-${agentId}.jsonl`),
+    status: "running",
+    startedAt: Date.now(),
+    endedAt: null,
+  });
+  return agentId;
+}
+
+function mkWorkflowDir(): string {
+  return mkdtempSync(path.join(tmpdir(), "agetor-wf-"));
+}
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 1. Basic hold + settle
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("hold: a running workflow container row keeps the task in running after its terminal run succeeds; settling it releases to review", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks, subagents } = await import("./db.ts");
+  const { settleSubagentById } = await import("./claude-subagents.ts");
+
+  const taskId = await createClaudeTask("wf-hold-basic");
+  const dir = mkWorkflowDir();
+  const containerId = await insertRunningContainer(taskId, dir);
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  await wait(250);
+
+  // Held shape: column running, terminal run succeeded, a running background
+  // (container) row — exactly what isHeldByBackgroundAgents requires.
+  expect(tasks.get(taskId)?.column).toBe("running");
+  expect(subagents.hasRunning(taskId)).toBe(true);
+
+  const changed = settleSubagentById(containerId, "completed");
+  expect(changed).toBe(true);
+
+  expect(subagents.get(containerId)?.status).toBe("completed");
+  expect(subagents.hasRunning(taskId)).toBe(false);
+  expect(tasks.get(taskId)?.column).toBe("review");
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 2. Cascade: container settle takes its running agents with it, one hook fire
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("cascade: settling the container settles both running workflow_agent rows, and the settle hook fires exactly once, after everything is already settled", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks, subagents } = await import("./db.ts");
+  const { settleSubagentById, setSubagentSettleHook } = await import("./claude-subagents.ts");
+
+  const taskId = await createClaudeTask("wf-cascade");
+  const dir = mkWorkflowDir();
+  const containerId = await insertRunningContainer(taskId, dir);
+  const agentA = await insertRunningWorkflowAgent(taskId, dir);
+  const agentB = await insertRunningWorkflowAgent(taskId, dir);
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  await wait(250);
+
+  expect(tasks.get(taskId)?.column).toBe("running");
+  expect(subagents.hasRunning(taskId)).toBe(true);
+
+  // Wrap the real hook (read-modify-restore, same idiom as
+  // setSubagentEmitter/setSubagentSettleHook elsewhere) to observe what the
+  // orchestrator's release predicate sees at the moment it fires.
+  let hookCallsForTask = 0;
+  let hookSawFullySettled: boolean | undefined;
+  const prevHook = setSubagentSettleHook((tid) => {
+    if (tid === taskId) {
+      hookCallsForTask++;
+      hookSawFullySettled = !subagents.hasRunning(taskId);
+    }
+    prevHook?.(tid);
+  });
+  try {
+    const changed = settleSubagentById(containerId, "completed");
+    expect(changed).toBe(true);
+  } finally {
+    setSubagentSettleHook(prevHook);
+  }
+
+  expect(subagents.get(containerId)?.status).toBe("completed");
+  expect(subagents.get(agentA)?.status).toBe("completed");
+  expect(subagents.get(agentB)?.status).toBe("completed");
+  expect(subagents.hasRunning(taskId)).toBe(false);
+
+  // The cascade settles both agent rows at depth 1 (no hook fire each); only
+  // the outermost, depth-0 settle of the container fires the hook — once —
+  // and by the time it does, nothing is left running.
+  expect(hookCallsForTask).toBe(1);
+  expect(hookSawFullySettled).toBe(true);
+
+  expect(tasks.get(taskId)?.column).toBe("review");
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 3. Parked-discovery: a freshly-registered container pulls a review card back
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("parked-discovery: a container registered while the card is parked in review pulls it back to running", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks, subagents } = await import("./db.ts");
+  const { setParkedDiscoveryHandler, settleSubagentById } = await import("./claude-subagents.ts");
+
+  const taskId = await createClaudeTask("wf-parked");
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  await wait(250);
+
+  // No container yet — the run settles straight to review, the "parked"
+  // shape pullBackParkedTask requires (column review, latest run succeeded).
+  expect(tasks.get(taskId)?.column).toBe("review");
+
+  const dir = mkWorkflowDir();
+  const containerId = await insertRunningContainer(taskId, dir);
+
+  // `pullBackParkedTask` isn't exported from orchestrator.ts — it's installed
+  // once, at module load, via `setParkedDiscoveryHandler`. Capture the
+  // currently-registered (real) handler through that seam — read-modify-
+  // restore, same idiom subagent-settle.test.ts uses for the same handler —
+  // then call it directly with taskId, exactly what
+  // `registerWorkflowContainer` does (via `fireParkedDiscovery`) right after
+  // inserting a fresh container row.
+  const real = setParkedDiscoveryHandler(() => {});
+  setParkedDiscoveryHandler(real);
+  if (!real) throw new Error("expected orchestrator.ts to have installed a real parked-discovery handler");
+
+  real(taskId);
+
+  expect(tasks.get(taskId)?.column).toBe("running");
+  expect(subagents.hasRunning(taskId)).toBe(true);
+
+  // Hygiene: leave nothing running for this task.
+  settleSubagentById(containerId, "completed");
+  expect(tasks.get(taskId)?.column).toBe("review");
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 4. orphanRunningSubagents releases the hold and orphans container + agents
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("orphan: orphanRunningSubagents flips the container and its agent rows to orphaned and releases the hold", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks, subagents } = await import("./db.ts");
+  const { orphanRunningSubagents } = await import("./claude-subagents.ts");
+
+  const taskId = await createClaudeTask("wf-orphan");
+  const dir = mkWorkflowDir();
+  const containerId = await insertRunningContainer(taskId, dir);
+  const agentA = await insertRunningWorkflowAgent(taskId, dir);
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  await wait(250);
+
+  expect(tasks.get(taskId)?.column).toBe("running");
+  expect(subagents.hasRunning(taskId)).toBe(true);
+
+  orphanRunningSubagents(taskId);
+
+  const container = subagents.get(containerId);
+  const agent = subagents.get(agentA);
+  expect(container?.status).toBe("orphaned");
+  expect(container?.endedAt).not.toBeNull();
+  expect(agent?.status).toBe("orphaned");
+  expect(agent?.endedAt).not.toBeNull();
+
+  expect(subagents.hasRunning(taskId)).toBe(false);
+  expect(tasks.get(taskId)?.column).toBe("review");
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 5. Regression guard: codex is completely unaffected by the workflow gate
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("regression guard: a codex task with no subagent rows settles straight to review — the workflow gate is inert for codex", async () => {
+  const { createTask, startTask } = await import("./orchestrator.ts");
+  const { tasks, harnesses } = await import("./db.ts");
+
+  // Fresh test DBs ship codex disabled by default (migration
+  // 016_disable_codex.sql) — enable it for this test only and restore.
+  const prevEnabled = harnesses.get("codex")?.enabled ?? false;
+  harnesses.setEnabled("codex", true);
+  try {
+    const created = await createTask({
+      title: "wf-codex-inert",
+      prompt: "hello",
+      agent: "codex",
+      workdir: process.cwd(),
+      isolation: "none",
+    });
+    if ("error" in created) throw new Error(created.error);
+    createdTaskIds.push(created.task.id);
+    const taskId = created.task.id;
+
+    // Codex never writes subagent rows and launches no workflows, so the
+    // hold gate is inert by construction — no need to seed anything.
+    const res = await startTask(taskId);
+    if (!("runId" in res)) throw new Error("expected the run to start");
+    await wait(250);
+
+    expect(tasks.get(taskId)?.column).toBe("review");
+  } finally {
+    harnesses.setEnabled("codex", prevEnabled);
+  }
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 6. The live notification seam end-to-end
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("notification: the real setBackgroundTaskSettledHandler wiring settles a container and releases the hold, exactly like a live <task-notification> line would", async () => {
+  const { startTask } = await import("./orchestrator.ts");
+  const { tasks, subagents } = await import("./db.ts");
+  const { setBackgroundTaskSettledHandler } = await import("./claude-tmux.ts");
+
+  const taskId = await createClaudeTask("wf-notification");
+  const dir = mkWorkflowDir();
+  const containerId = await insertRunningContainer(taskId, dir);
+
+  const res = await startTask(taskId);
+  if (!("runId" in res)) throw new Error("expected the run to start");
+  await wait(250);
+
+  expect(tasks.get(taskId)?.column).toBe("running");
+  expect(subagents.hasRunning(taskId)).toBe(true);
+
+  // Grab the REAL handler orchestrator.ts wired at module load —
+  //   (_taskId, agentId) => settleSubagentById(agentId, "completed")
+  // — through the setBackgroundTaskSettledHandler seam (read-modify-restore),
+  // then invoke it with (taskId, containerId): this is exactly what
+  // claude-tmux's dispatchLine does when it parses a live
+  // `<task-notification><task-id>…</task-id></task-notification>` line whose
+  // id matches the workflow's container row.
+  const real = setBackgroundTaskSettledHandler(() => {});
+  setBackgroundTaskSettledHandler(real);
+  if (!real) throw new Error("expected orchestrator.ts to have installed a real background-task-settled handler");
+
+  real(taskId, containerId);
+
+  expect(subagents.get(containerId)?.status).toBe("completed");
+  expect(subagents.hasRunning(taskId)).toBe(false);
+  expect(tasks.get(taskId)?.column).toBe("review");
+});

--- a/src/mainview/lib/subagent-tabs.test.ts
+++ b/src/mainview/lib/subagent-tabs.test.ts
@@ -9,12 +9,24 @@ import {
   MAX_VISIBLE_TABS,
 } from "./subagent-tabs.ts";
 
-function sub(id: string, status: SubagentStatus, startedAt = 0): Subagent {
+function sub(
+  id: string,
+  status: SubagentStatus,
+  startedAt = 0,
+  parentKind: Subagent["parentKind"] = "subagent",
+): Subagent {
   return {
-    id, taskId: "t", runId: "r", parentKind: "subagent",
+    id, taskId: "t", runId: "r", parentKind,
     agentType: "Explore", description: "x", spawnDepth: 1, sourcePath: `/p/agent-${id}.jsonl`,
     status, startedAt, endedAt: status === "running" ? null : startedAt + 1,
   };
+}
+
+/** Workflow container row helper — id/sourcePath mirror the workflow's own
+ *  background taskId/transcriptDir per the shared-types doc comment, but the
+ *  exact values don't matter for these pure-derivation tests. */
+function container(id: string, status: SubagentStatus, startedAt = 0): Subagent {
+  return sub(id, status, startedAt, "workflow");
 }
 
 test("shouldShowSubagentTabs: hidden with none, shown while a subagent runs", () => {
@@ -108,4 +120,65 @@ test("MAX_VISIBLE_TABS default applies", () => {
   const subs = Array.from({ length: 8 }, (_, i) => sub(`s${i}`, "completed", i));
   const { visible } = splitTabsForOverflow(subs, "main");
   expect(visible.length).toBe(MAX_VISIBLE_TABS);
+});
+
+// ── Claude Code Workflow container/agent rows ───────────────────────────────
+
+test("sortSubagentTabs: excludes a workflow container row from tab derivation", () => {
+  const subs = [container("wf", "running", 0), sub("a", "completed", 1)];
+  expect(sortSubagentTabs(subs).map((s) => s.id)).toEqual(["a"]);
+});
+
+test("sortSubagentTabs: a solo running container yields zero tabs", () => {
+  const subs = [container("wf", "running", 0)];
+  expect(sortSubagentTabs(subs)).toEqual([]);
+});
+
+test("sortSubagentTabs: workflow_agent rows are treated exactly like subagent rows", () => {
+  const subs = [
+    sub("a", "completed", 0, "subagent"),
+    sub("b", "running", 1, "workflow_agent"),
+    sub("c", "completed", 2, "workflow_agent"),
+  ];
+  // Running sorts first regardless of parentKind, finished trail in spawn order.
+  expect(sortSubagentTabs(subs).map((s) => s.id)).toEqual(["b", "a", "c"]);
+});
+
+test("sortSubagentTabs: mixed container + subagent + workflow_agent list — stable ordering, container dropped", () => {
+  const subs = [
+    container("wf", "running", 0),
+    sub("a", "completed", 1, "workflow_agent"),
+    sub("b", "running", 2, "subagent"),
+    sub("c", "completed", 3, "workflow_agent"),
+  ];
+  expect(sortSubagentTabs(subs).map((s) => s.id)).toEqual(["b", "a", "c"]);
+});
+
+test("anySubagentRunning: a running workflow container counts as running", () => {
+  expect(anySubagentRunning([container("wf", "running")])).toBe(true);
+  expect(anySubagentRunning([container("wf", "completed")])).toBe(false);
+});
+
+test("shouldShowSubagentTabs: a solo running container shows no tabs (nothing tabbable yet)", () => {
+  // The container alone satisfies "something is active" but there's nothing to
+  // switch to, so the strip stays collapsed rather than showing an empty shell.
+  expect(shouldShowSubagentTabs([container("wf", "running")], false)).toBe(false);
+});
+
+test("shouldShowSubagentTabs: a running container keeps the strip open around a finished wave", () => {
+  // First wave's agent finished; the container is still running between waves.
+  // The strip must stay open so the finished tab from wave 1 stays readable.
+  const subs = [container("wf", "running", 0), sub("a", "completed", 1, "workflow_agent")];
+  expect(shouldShowSubagentTabs(subs, false)).toBe(true);
+});
+
+test("shouldShowSubagentTabs: a finished container with a finished agent and no running parent turn collapses", () => {
+  const subs = [container("wf", "completed", 0), sub("a", "completed", 1, "workflow_agent")];
+  expect(shouldShowSubagentTabs(subs, false)).toBe(false);
+});
+
+test("resolveActiveStream: a workflow container id is never a valid stream to land on", () => {
+  const subs = [container("wf", "running", 0), sub("a", "running", 1, "workflow_agent")];
+  expect(resolveActiveStream("wf", true, subs)).toBe("main");
+  expect(resolveActiveStream("a", true, subs)).toBe("a");
 });

--- a/src/mainview/lib/subagent-tabs.ts
+++ b/src/mainview/lib/subagent-tabs.ts
@@ -9,6 +9,22 @@ import type { Subagent } from "../../shared/types.ts";
 /** Max tabs rendered before the rest collapse behind a "+N" affordance. */
 export const MAX_VISIBLE_TABS = 6;
 
+/**
+ * A Claude Code Workflow's container row (`parentKind: "workflow"`) has no
+ * event stream of its own — it exists only to hold the task in `running` for
+ * the workflow's lifetime — so it never becomes a tab. Every other row
+ * (`"subagent"`, `"bg_session"`, and `"workflow_agent"` — one agent inside a
+ * workflow, a normal sidechain transcript) is tabbable.
+ */
+function isTabbable(s: Subagent): boolean {
+  return s.parentKind !== "workflow";
+}
+
+/**
+ * A running workflow container still counts as "running" here — the workflow
+ * is genuinely working between agent waves even though it has no tab. Do not
+ * filter containers out of this predicate.
+ */
 export function anySubagentRunning(subs: Subagent[]): boolean {
   return subs.some((s) => s.status === "running");
 }
@@ -18,20 +34,28 @@ export function anySubagentRunning(subs: Subagent[]): boolean {
  * subagent is running, or the parent turn is still running (so a just-finished
  * subagent stays readable until the turn resolves). Once nothing is running the
  * strip collapses back to a plain single-stream log.
+ *
+ * The "is there anything to show" gate counts only tabbable rows (a workflow
+ * container alone shouldn't pop an empty strip), but the "is something still
+ * active" check runs over the full list — a running container keeps the strip
+ * open around the finished tabs from a prior wave, same as `parentRunRunning`
+ * would.
  */
 export function shouldShowSubagentTabs(subs: Subagent[], parentRunRunning: boolean): boolean {
-  return subs.length > 0 && (anySubagentRunning(subs) || parentRunRunning);
+  const tabbable = subs.filter(isTabbable);
+  return tabbable.length > 0 && (anySubagentRunning(subs) || parentRunRunning);
 }
 
 /**
  * Resolve which stream should be active given the current selection. Falls back
  * to "main" when the strip is hidden or the selected subagent no longer exists,
- * so the log + composer can never be stranded on a vanished/hidden tab.
+ * so the log + composer can never be stranded on a vanished/hidden tab. A
+ * workflow container is never a valid stream to land on (it has none).
  */
 export function resolveActiveStream(active: string, show: boolean, subs: Subagent[]): string {
   if (active === "main") return "main";
   if (!show) return "main";
-  return subs.some((s) => s.id === active) ? active : "main";
+  return subs.filter(isTabbable).some((s) => s.id === active) ? active : "main";
 }
 
 /**
@@ -41,12 +65,18 @@ export function resolveActiveStream(active: string, show: boolean, subs: Subagen
  * running→finished boundary — never shuffles among its peers.
  *
  * Returns a NEW array: the caller passes React state (`subagentList`) straight
- * in, and an in-place `.sort()` would mutate it.
+ * in, and an in-place `.sort()` would mutate it. Workflow container rows are
+ * dropped here — this is the single choke point every tab-producing caller
+ * (`SubagentTabs` → `splitTabsForOverflow`) runs through, so filtering here is
+ * enough for the whole render path to exclude them.
  */
 export function sortSubagentTabs(subs: Subagent[]): Subagent[] {
   const running: Subagent[] = [];
   const finished: Subagent[] = [];
-  for (const s of subs) (s.status === "running" ? running : finished).push(s);
+  for (const s of subs) {
+    if (!isTabbable(s)) continue;
+    (s.status === "running" ? running : finished).push(s);
+  }
   return [...running, ...finished];
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1818,9 +1818,14 @@ export type SubagentStatus =
 
 /**
  * A background / sub agent the main agent spawned, tracked so the run panel can
- * offer a read-only tab into its live stream. Today every row is a Claude Code
- * in-session subagent (`parentKind: "subagent"`); `parentKind` leaves room for
- * future `claude --bg` independent sessions without a schema change.
+ * offer a read-only tab into its live stream. `parentKind` distinguishes:
+ * an in-session Claude Code subagent (`"subagent"`); an independent `claude --bg`
+ * session (`"bg_session"`); a Claude Code Workflow (`/workflow`) run's container
+ * row (`"workflow"` — id = the workflow's background taskId, sourcePath = its
+ * transcriptDir, no event stream of its own — exists to hold the task in
+ * `running` for the workflow's lifetime); and one agent inside a workflow
+ * (`"workflow_agent"` — a normal sidechain transcript rendered as a read-only
+ * tab).
  */
 export interface Subagent {
   /** Claude's agentId — the basename of `subagents/agent-<id>.jsonl`. */
@@ -1828,7 +1833,7 @@ export interface Subagent {
   taskId: string;
   /** Parent run that was in flight when this subagent was spawned. */
   runId: string | null;
-  parentKind: "subagent" | "bg_session";
+  parentKind: "subagent" | "bg_session" | "workflow" | "workflow_agent";
   /** Registered subagent type, e.g. "Explore" / "general-purpose". */
   agentType: string | null;
   /** Short human label from the spawning Agent tool call. */


### PR DESCRIPTION
## Problem

A claude-code task that launches a **Workflow** (`/workflow`, the multi-agent orchestration tool, run ids `wf_…`) settles to `review` the moment the main turn ends — while the workflow keeps running in the background, sometimes for many minutes. The existing background-agent hold (#92) never sees workflows because:

- Workflow agent transcripts live in `<sessionId>/subagents/workflows/<wf_runId>/` — *inside* the `subagents/` dir the watcher already owns, but invisible to its flat `agent-*.jsonl` scan.
- The workflow itself has no transcript file at all; its lifetime is bracketed by the launch `tool_result` (`toolUseResult.taskType === "local_workflow"`, `status: "async_launched"`) and a `<task-notification>` whose `<task-id>` is the launch `taskId`.

All on-disk shapes were verified empirically by running a live probe workflow (details in `docs/plans/claude-code-workflows-as-running-bg-agents.md` §2).

## What changed

**One container row per workflow + one row per workflow agent, all in the existing `subagents` table** (no migration — `parent_kind` was designed as this seam):

- **Container row** (`parentKind: "workflow"`, id = the workflow's background taskId, `sourcePath` = its transcriptDir) is registered by the watcher's main-JSONL scan on launch and carries the hold: `hasRunning` stays true across the gaps *between* agent waves, so the card sits in `running` for the workflow's whole lifetime. Because its PK equals the notification's `<task-id>`, the **unchanged** live notification path (`setBackgroundTaskSettledHandler → settleSubagentById`) settles it; a watcher-side notification scan is the restart-safe backstop (after boot reconciliation only the watcher is armed).
- **Agent rows** (`parentKind: "workflow_agent"`) are discovered by scanning `workflows/*/`, tailed with the existing per-file machinery, and render as read-only tabs like regular subagents. They settle via end_turn idle, the wf dir's `journal.jsonl` completion receipts (robust to the terminal-line flush loss seen under concurrency), and a cascade when the container settles.
- A workflow launched while the card is parked in `review` pulls it back to `running` (existing `pullBackParkedTask`); Stop, delete/archive, session death, and boot reconciliation all release the hold through the existing kind-agnostic orphan paths.
- UI: container rows are excluded from the tab strip (they have no event stream) but still count as "running" for the strip/heartbeat; `workflow_agent` tabs behave exactly like subagent tabs. The board badge picks the rows up through the existing `runningSubagents` count.
- Kill switch: `AGETOR_TRACK_WORKFLOWS` (default on), nested under `AGETOR_TRACK_SUBAGENTS`. With it off, behavior is exactly as before.

## Hardening from code review

- **Hold race closed:** container rows are created by a watcher poll (4–10 s tiers) while `attachDoneHandler` decides the column ~800 ms after end_turn — the card bounced `running → review → running` on nearly every launch. `pumpWatcherForHoldCheck(taskId)` now runs one synchronous watcher cycle right before the hold predicate. This also fixes the same pre-existing race for async `Agent` subagents launched at the end of a turn.
- Attach-time main-JSONL replay clamped to a 4 MB window when no toolUseId correlation is pending (transcripts reach 24 MB; boot reconciliation arms several watchers at once).
- `workflow_agent` files keep being tailed while their container runs, so an early journal settle can't truncate a tab whose terminal lines flush late.
- Notification matching anchored on the literal `<task-notification>` + `matchAll` (a quoted `<task-id>` in ordinary content must never false-settle a container).
- Cascade fires the settle hook once, at depth 0, after all agent rows settle.
- `orphanRunningSubagents` syncs in-memory watcher state (Stop no longer pins the fast poll tier); `readAppendedSync` gets an `isFile()` guard; containment checks are path-normalized.
- Latent bug fixed in `db.ts`: the `parent_kind` read-coercion silently collapsed unknown kinds to `"subagent"`, which would have neutered every new-kind branch.

## Tests

- `claude-workflow-agents.test.ts` (14 tests): launch registration, agent discovery/tailing, journal-receipt settle without end_turn, tail-past-settle, notification settle + single-fire cascade, false-settle guard, reattach replay idempotency, `pumpWatcherForHoldCheck`, kill switch.
- `workflow-hold.test.ts` (6 tests): hold/release, cascade release semantics, parked pull-back, orphan release, codex regression guard, the orchestrator's real notification seam.

`bun run typecheck` clean; full suite **2124 pass / 0 fail** across 137 files.

## Notes

- Design doc with logged assumptions and shipped deviations: `docs/plans/claude-code-workflows-as-running-bg-agents.md`.
- A workflow that ends `failed`/`killed`/`stopped` still releases the card to `review` without a distinct failed state (assumption A4 in the plan) — flag if it should surface differently.
- No real-app smoke test in this branch (unit/integration suite only), matching the bar of the original background-agent hold PR.