### PR TITLE
fix: subagent tabs and task card stuck on "running" after background agents finish

### DIFF
--- a/docs/plans/fix-stuck-subagent-running-detection.md
+++ b/docs/plans/fix-stuck-subagent-running-detection.md
@@ -1,0 +1,185 @@
+# Plan — Fix false "background agent running" detection (stuck subagent rows)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-03 |
+| Source | /implement — "no bg agent/workflow running, but Task Details shows one running" (screenshot of task 24d7cbf2 "Notion Integration") |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/fix-non-running-bg-agent-detection |
+| Base SHA | 03b2328 |
+| Mode | **Autonomous** — grill & approval gates bypassed (owner unavailable); all assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+A subagent row must never stay `status='running'` after its agent has actually
+finished, and a settled row must never be resurrected by replayed history.
+Success: (a) the two live stuck tasks (`24d7cbf2` "Notion Integration": row
+`a3a86e7bc6cae5560`; `8e2c5112` "Auto indenting the Code": 5 rows) self-heal at
+the first watcher attach after this fix ships — verified by a repro harness
+against copies of the real prod data; (b) new unit tests pin every wedge
+scenario; (c) full suite + typecheck green.
+
+## 2. Context & constraints (root cause, verified on live prod data)
+
+All evidence gathered read-only from `~/.agetor/agetor.sqlite` and the real
+session JSONLs. Confirmed mechanism — three compounding defects in
+`src/bun/claude-subagents.ts`:
+
+**D1 — The tool_result scan false-settles ASYNC agents on their launch stub.**
+An `Agent(run_in_background: true)` tool_use gets an *immediate* `tool_result`
+whose `toolUseResult` is `{ isAsync:true, status:"async_launched", agentId, … }`
+(verified in devgantry session `64a7d8b1`, e.g. agent `ac784f36c351a7029`:
+launch 02:49:48Z, stub 02:49:50Z). `scanLineForToolResult`
+(claude-subagents.ts:1202) has no stub guard — the module header even says
+signal (3) is for *synchronous* agents (claude-subagents.ts:29), but async rows
+are never excluded from `pending`. The row is settled `completed` while the
+agent is still working.
+
+**D2 — The flip-back resurrects settled rows on every reattach and retires
+their only remaining settle key.** `tailFile`'s resume-detection
+(claude-subagents.ts:1100-1133) flips any non-`running` row back to `running`
+when it sees an *unseen* line, and retires `fs.toolUseId` in-memory (line
+1128). But every transcript contains lines whose uuids are **never persisted**
+to `run_events` (mapper-silent lines — measured 10–17 per transcript, types
+`attachment`/`assistant`, in stuck AND completed transcripts alike), so the
+offset-0 replay at *every* attach finds "unseen" lines and flips completed rows
+back to running. Because `tailFile` runs before `scanMainSignals` in `cycle()`
+(claude-subagents.ts:1385-1406), the retirement removes the row from the scan's
+`pending` in the same cycle — the row ends the attach `running` and
+unsettleable.
+
+**D3 — Once the one-shot real signal is consumed, nothing can ever settle the
+row.** The stuck class is precisely "transcript never got its terminal
+`end_turn` line" (verified: all 6 stuck transcripts end `stop_reason:null`; a
+completed control ends `end_turn`) — the long-known claude flush-loss bug. For
+such a row: `checkDone` can never fire; the real receipt (`<task-notification>`
+for async — present in the main JSONL for 4 of the 5 devgantry rows, minutes
+after launch; a real `tool_result` for sync — present for Notion's T4 since
+Jul 10) is only dispatched **live** by claude-tmux (dedup'd via
+`seenLineUuids`, never re-dispatched on reattach) or consumed once by the
+watcher scan whose cursor only moves forward. The watcher's own notification
+backstop (`scanLineForWorkflowNotification`, claude-subagents.ts:1306) settles
+*workflow container ids only* — a `<task-id>` naming a regular async subagent
+is deliberately skipped (comment at :1289-1291). One devgantry row
+(`ace01c07…`, launched 25s before the run's final turn ended) has **no**
+notification line at all — the enqueue only lands on a next prompt that never
+came — so it has *no* signal on disk, ever.
+
+The card is then held in `column='running'` forever via
+`subagentsDb.hasRunning` (orchestrator release predicate + `isReapable`
+refusing to reap, orchestrator.ts:2404) even though every run of the task
+succeeded — exactly the reported symptom.
+
+Constraints:
+- No DB migration needed; all new state is in-memory `FileState`/watcher state.
+- `bun test` files that import db.ts must keep the `AGETOR_DATA_DIR` mkdtemp
+  pattern.
+- Existing tests pin the current flip-back-on-replay behavior
+  (claude-workflow-agents.test.ts:462-473 "surprising but verified") — they
+  must be updated to the new semantics, not deleted.
+- Read-only prod: never write to `~/.agetor` — repro harnesses use temp DBs.
+
+## 3. Approach & key decisions
+
+Restore the invariant *"settled rows stay settled unless genuinely-new bytes
+arrive; every running row keeps at least one live settle signal, with a
+terminal backstop"* via five fixes in `claude-subagents.ts` (W1–W5) plus two
+small workflow-journal hardenings (W6–W7) that close the deferred
+`pendingReceipts` gap while we're here:
+
+- **W1 Replay floor.** `FileState.replayFloor` = source file size at
+  attach/rehydration (0 for freshly-discovered files). In `tailFile`, a batch
+  whose *starting* offset is below the floor never triggers the flip-back
+  block (no status flip, no `toolUseId` retirement, no `started` re-emit);
+  unseen replayed lines still map/emit chunks and still latch `sawEndOfTurn`.
+  Bytes beyond the floor behave exactly as today. Kills D2 for every row kind.
+- **W2 Async-stub guard.** In `scanLineForToolResult`, when the matching line's
+  `toolUseResult?.status === "async_launched"`, do **not** settle; instead mark
+  the row `isAsync = true` and retire its `toolUseId` (no real tool_result will
+  ever come; prevents any later stub mis-settle). Kills D1.
+- **W3 Generalized notification backstop.** Extend
+  `scanLineForWorkflowNotification` → also settle a *regular* tracked row
+  (`files` map) whose id matches a `<task-id>` and whose status is `running`.
+  Restart-safe settle for async agents, symmetric to the workflow container
+  backstop. With W1 in place, replays can no longer resurrect what this
+  settles. Heals 4 of the 5 devgantry rows (their notifications are on disk).
+- **W4 Staleness backstop.** A `running` file-backed row whose transcript has
+  produced no new bytes for `AGETOR_SUBAGENT_STALE_MS` (default 10 min) and has
+  no `sawEndOfTurn` pending is settled `completed` by a new check alongside
+  `checkDone`. Rehydration sets `lastAppendAt` to attach time (currently 0) so
+  the clock starts at attach. If the agent was actually alive and writes again,
+  W1's beyond-floor path flips it back to running — a brief card bounce instead
+  of a forever-stuck card. Heals `ace01c07…` (no signal on disk) and any future
+  signal-less wedge. Kills D3's endgame.
+- **W5 Self-heal validation.** Repro harness (scratchpad, not shipped) drives
+  `attachSubagentWatcher` against the real prod JSONLs with a temp DB seeded
+  from the real stuck rows; must show all 6 rows settle and STAY settled across
+  repeated re-attaches.
+- **W6 Journal cursor rewind on late agent discovery.** In
+  `discoverWorkflowAgents`, when a new `agent-*.jsonl` appears in an
+  already-tracked workflow dir, rewind that dir's `wfJournals` cursor to 0
+  (receipts are idempotent) — the exact analog of `discover()`'s
+  `mainOffset = 0` rewind (claude-subagents.ts:806), closing the deferred
+  early-receipt race.
+- **W7 Settle-on-discovery under a settled container.** A newly-discovered
+  workflow agent whose container row is already settled is inserted `completed`
+  directly (the cascade invariant: nothing under a settled container can be
+  running).
+
+Alternatives considered: (a) blanket settle of subagent rows at run
+resolution — rejected, async agents/workflows legitimately outlive the turn
+(the #140 hold feature depends on that); (b) persisting per-row byte offsets
+in a migration — rejected, replay floor achieves the same without schema
+changes; (c) manual prod-DB repair — rejected, the fix self-heals at next
+attach and proves itself on real data.
+
+## 4. Work breakdown — implementation
+
+| ID | Goal | Files owned | Deps |
+| --- | --- | --- | --- |
+| I1 | W1+W2+W3+W4+W6+W7 in the watcher, plus module-header doc updates | `src/bun/claude-subagents.ts` | — |
+
+Single file ⇒ single implementation agent (no fan-out possible without
+collision).
+
+## 5. Work breakdown — tests
+
+| ID | Goal | Files owned | Covers |
+| --- | --- | --- | --- |
+| T1 | New file `src/bun/subagent-stuck-detection.test.ts`: replay-floor no-resurrect; async-stub no-settle + async marking; notification backstop settles regular async row on reattach; staleness settle + genuine-resume flip-back; end-to-end "T4 scenario" (sync, no end_turn, tool_result present, survives repeated re-attaches settled) | `src/bun/subagent-stuck-detection.test.ts` | W1–W4 |
+| T2 | Update pinned old-behavior tests to new semantics + journal rewind & settle-on-discovery cases | `src/bun/claude-workflow-agents.test.ts`, `src/bun/subagent-toolresult-settle.test.ts`, `src/bun/subagent-settle.test.ts` (as needed) | W1, W6, W7 |
+
+## 6. Execution waves
+
+1. Wave A: I1 (one agent).
+2. Review (opus) on the diff.
+3. Wave B: T1 ∥ T2 (disjoint files).
+4. Run full suite (haiku background agent) + repro harness W5.
+5. Fixes loop as needed (max 3 rounds).
+
+## 7. Blast radius & risks
+
+- `tailFile` flip-back is shared by ALL row kinds — W1 must not break the
+  legitimate resumed-background-agent path (covered: beyond-floor bytes keep
+  today's behavior; existing resume tests must stay green).
+- `scanLineForWorkflowNotification` widening: a `<task-id>` false-positive
+  would settle a live agent → guarded by requiring the enclosing
+  `<task-notification>` marker (unchanged) + id ∈ tracked running rows.
+- W4 threshold: a >10-min silent tool call settles early → self-corrects via
+  flip-back on next append; env-tunable.
+- UI needs no changes (tabs mirror row status; hold release is the existing
+  settle-hook path).
+
+## 8. Open questions / assumptions (autonomous mode log)
+
+- A1: Staleness default 10 min (`AGETOR_SUBAGENT_STALE_MS` override). Not
+  user-confirmed.
+- A2: Staleness settles as `completed` (not `orphaned`) — in every observed
+  case the agent's work had reached the parent; `orphaned` is kept for
+  session-death.
+- A3: No manual repair of the two stuck prod tasks — they self-heal on next
+  attach after the app updates; validated by W5 harness.
+- A4: The `<task-notification>` `<status>` value remains ignored for regular
+  rows too (any status ⇒ the agent is over), mirroring the container decision.
+- A5: Grill/approval gates bypassed — user invoked /implement and is not
+  available mid-run.

--- a/src/bun/claude-subagents-apierror.test.ts
+++ b/src/bun/claude-subagents-apierror.test.ts
@@ -275,7 +275,7 @@ test("a retry after an api-error settle flips the row back to running and preser
   const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
     "./claude-subagents.ts"
   );
-  const { taskId, jsonlPath, subagentsDir } = await seed();
+  const { taskId, runId, jsonlPath, subagentsDir } = await seed();
 
   setSubagentEmitter(() => { /* drain */ });
   setSubagentSettleHook(() => { /* drain */ });
@@ -283,27 +283,29 @@ test("a retry after an api-error settle flips the row back to running and preser
   const agentId = `apierr4-${randomUUID()}`;
   const toolUseId = "toolu_retry_x";
   const file = path.join(subagentsDir, `agent-${agentId}.jsonl`);
-  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
-    JSON.stringify({ agentType: "Explore", description: "retry", spawnDepth: 1, toolUseId }));
-  writeFileSync(file, sidechainLines() + apiErrorLine({ uuid: "err4", status: 529 }) + "\n");
+  // Seed the row directly as already `failed` from a prior api-error settle
+  // (rehydration reconstructs the `apiErrored` latch from `status ===
+  // "failed"` — see claude-subagents.ts), with nothing on disk yet at attach
+  // time: `replayFloor` pins to 0 there, so the retry line written below is
+  // unambiguously "beyond the floor" (W1) rather than replayed history that
+  // the flip-back block must ignore.
+  writeFileSync(file, "");
+  const now = Date.now();
+  subagents.insertIfAbsent({
+    id: agentId, taskId, runId, parentKind: "subagent",
+    agentType: "Explore", description: "retry", spawnDepth: 1,
+    sourcePath: file, status: "failed", startedAt: now - 60_000, endedAt: now - 30_000,
+    toolUseId,
+  });
 
   const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
   const t0 = Date.now();
-  w.pump(t0);
-  expect(subagents.get(agentId)!.status).toBe("failed");
-
-  // Retry: a resumed background agent appends a fresh (non-terminal) turn.
-  // Steady-state polling only re-reads `running` files (a real dir-watcher
-  // append event is what re-opens a non-running one in production — see
-  // `armDirWatcher`'s doc comment); the deterministic way to force a full
-  // re-tail in a `manual: true` test, exactly like claude-subagents.test.ts's
-  // own "resumed subagent" test, is to detach and attach a fresh watcher
-  // (its first cycle always tails every file, regardless of status).
-  appendFileSync(file,
+  // Retry: a resumed background agent appends a fresh (non-terminal) turn,
+  // written strictly after attach — beyond the replay floor, so it flips the
+  // `failed` row back to running.
+  writeFileSync(file,
     JSON.stringify({ type: "assistant", isSidechain: true, uuid: "retryA", message: { role: "assistant", stop_reason: "tool_use", content: [{ type: "tool_use", id: "t2", name: "Bash", input: { command: "pwd" } }] } }) + "\n");
-  w.detach();
-  const w2 = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
-  w2.pump(t0 + 1);
+  w.pump(t0);
   expect(subagents.get(agentId)!.status).toBe("running");
 
   // Prove `toolUseId` survived the flip-back (the `apiErrored` latch's whole
@@ -314,11 +316,11 @@ test("a retry after an api-error settle flips the row back to running and preser
   // matched and the row would stay stuck `running` forever.
   writeFileSync(jsonlPath,
     JSON.stringify({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: toolUseId, content: "ok" }] } }) + "\n");
-  w2.pump(t0 + 2);
+  w.pump(t0 + 1);
 
   expect(subagents.get(agentId)!.status).toBe("completed");
 
-  w2.detach();
+  w.detach();
 });
 
 /* ────────────────────────────────────────────────────────────────────────── *

--- a/src/bun/claude-subagents.test.ts
+++ b/src/bun/claude-subagents.test.ts
@@ -196,48 +196,48 @@ test("marks a subagent completed after end_turn + idle, without double-emitting 
 test("a resumed (re-running) subagent is not re-completed until its new turn ends", async () => {
   const { subagents } = await import("./db.ts");
   const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
-  const { taskId, jsonlPath, subagentsDir } = await seed();
+  const { taskId, runId, jsonlPath, subagentsDir } = await seed();
   setSubagentEmitter(() => { /* drain */ });
 
   const agentId = "resume0a1b2c3";
   const file = path.join(subagentsDir, `agent-${agentId}.jsonl`);
   writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
     JSON.stringify({ agentType: "Explore", description: "resumable", spawnDepth: 1 }));
-  // First turn: ends with end_turn → completes.
-  writeFileSync(file,
-    JSON.stringify({ type: "user", isSidechain: true, uuid: "ru", message: { role: "user", content: "go" } }) + "\n" +
-    JSON.stringify({ type: "assistant", isSidechain: true, uuid: "rA", message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "done turn 1" }] } }) + "\n");
+  // Nothing on disk yet at attach time: the row is seeded directly as already
+  // `completed` (a prior turn that ended with end_turn), with an empty
+  // transcript file — so `replayFloor` pins to 0 and everything written from
+  // here on is unambiguously "beyond the floor" (W1), not replayed history.
+  writeFileSync(file, "");
+  const now = Date.now();
+  subagents.insertIfAbsent({
+    id: agentId, taskId, runId, parentKind: "subagent",
+    agentType: "Explore", description: "resumable", spawnDepth: 1,
+    sourcePath: file, status: "completed", startedAt: now - 60_000, endedAt: now - 30_000,
+  });
 
   const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
   const t0 = Date.now();
-  w.pump(t0);
-  w.pump(t0 + 10_000);
-  expect(subagents.get(agentId)!.status).toBe("completed");
-
-  // Resume: append a NEW turn that has NOT ended yet (a tool_use, stop_reason
-  // "tool_use"). Re-tail via a fresh watcher (reattach path re-reads from 0;
-  // the DB-seeded dedup skips the old lines, and the unfinished new line flips
-  // the agent back to running).
-  appendFileSync(file,
+  // Resume: a NEW turn that has NOT ended yet (a tool_use, stop_reason
+  // "tool_use"), written strictly after attach. Beyond the replay floor, this
+  // flips the settled row back to running and resets `sawEndOfTurn`.
+  writeFileSync(file,
     JSON.stringify({ type: "assistant", isSidechain: true, uuid: "rB", message: { role: "assistant", stop_reason: "tool_use", content: [{ type: "tool_use", id: "t9", name: "Bash", input: { command: "ls" } }] } }) + "\n");
-  w.detach();
-
-  const w2 = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
-  w2.pump(t0 + 10_001);
+  w.pump(t0);
   expect(subagents.get(agentId)!.status).toBe("running");
   // Idle WITHOUT a fresh end_turn: the reset `sawEndOfTurn` must keep it
-  // running (the bug this guards against would re-complete it here).
-  w2.pump(t0 + 40_000);
+  // running (the bug this guards against would re-complete it here on the
+  // stale latch from the row's prior, pre-resume completion).
+  w.pump(t0 + 40_000);
   expect(subagents.get(agentId)!.status).toBe("running");
 
   // The resumed turn finally ends → completes again.
   appendFileSync(file,
     JSON.stringify({ type: "assistant", isSidechain: true, uuid: "rC", message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "done turn 2" }] } }) + "\n");
-  w2.pump(t0 + 40_001);
-  w2.pump(t0 + 80_000);
+  w.pump(t0 + 40_001);
+  w.pump(t0 + 80_000);
   expect(subagents.get(agentId)!.status).toBe("completed");
 
-  w2.detach();
+  w.detach();
   setSubagentEmitter(null);
 });
 

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -18,19 +18,46 @@
  * per-subagent tab. The main session JSONL still shows the launching `Agent`
  * tool-use card; the tab is the drill-in.
  *
- * A `running` row settles via one of THREE signals, in rough order of how
+ * A `running` row settles via one of FOUR signals, in rough order of how
  * often each fires: (1) the subagent's own file reaching an assistant
  * `stop_reason:"end_turn"` line and then going idle for `DONE_IDLE_MS`
  * (`checkDone` below); (2) a `<task-notification>` for it landing in the MAIN
- * session JSONL (async/background + nested agents only — claude-tmux.ts's
- * `fireBackgroundTaskSettled` calls into `settleSubagentById`); (3) this
- * module's own scan of the MAIN session JSONL for a `tool_result` block whose
- * `tool_use_id` matches a tracked subagent's `toolUseId` (`scanMainForToolResults`
- * below) — the fallback for a *synchronous* top-level subagent whose own file
- * never gets a terminal end_turn line (a flush loss under concurrent
- * subagents) and which gets no task-notification either. All three funnel
- * through `settleSubagentById` so the DB write / lifecycle emit / hold-release
- * bookkeeping only lives in one place.
+ * session JSONL — this covers BOTH workflow containers AND ordinary
+ * async/background subagent rows (`scanLineForTaskNotification` below; live
+ * dispatch of the same notification via claude-tmux's `fireBackgroundTaskSettled`
+ * is one-shot and never re-dispatched on reattach, so once the tmux tailer is
+ * gone this scan is the only restart-safe path left for an async agent); (3)
+ * this module's own scan of the MAIN session JSONL for a `tool_result` block
+ * whose `tool_use_id` matches a tracked subagent's `toolUseId`
+ * (`scanLineForToolResult` below) — the fallback for a *synchronous*
+ * top-level subagent whose own file never gets a terminal end_turn line (a
+ * flush loss under concurrent subagents) and which gets no task-notification
+ * either; (4) a terminal staleness backstop (`checkStale` below) that settles
+ * a `running` row with no `sawEndOfTurn` and no newly-appended bytes for
+ * `STALE_SUBAGENT_SETTLE_MS` — the last resort for a row whose transcript
+ * lost its end_turn AND whose one-shot receipt (2)/(3) is gone or was never
+ * written. All four funnel through `settleSubagentById` so the DB write /
+ * lifecycle emit / hold-release bookkeeping only lives in one place.
+ *
+ * Signal (3) has a stub guard in front of it: an ASYNC agent's `tool_result`
+ * is an *immediate* launch acknowledgement (`toolUseResult.status ===
+ * "async_launched"`), not a real completion. `scanLineForToolResult` detects
+ * that shape and, instead of settling, marks the row `isAsync` and retires
+ * its `toolUseId` — a real `tool_result` never arrives for an async agent, so
+ * leaving the id live would only risk a future mis-settle. From then on,
+ * signals (2) and (4) are the only ones that can close the row.
+ *
+ * A settled row can never be resurrected by REPLAYED history. Every row
+ * records a `replayFloor` — the source file's size at the moment its
+ * `FileState` was created (0 for a freshly-discovered file, so a brand-new
+ * file has no "history" to distrust). `tailFile`'s resume-detection (the
+ * "flip back to running" block) only fires for a batch whose *starting*
+ * offset is at or beyond that floor; bytes below the floor are replayed
+ * history — read again on every attach/reattach from offset 0 — and must
+ * never flip a settled row back to running, retire its `toolUseId`, or
+ * re-emit a `started` lifecycle, even though those same bytes still flow
+ * through the mapper (persist/emit) and still latch `sawEndOfTurn` like any
+ * other unseen line.
  *
  * ── Workflows (`/workflow`) ────────────────────────────────────────────────
  *
@@ -156,6 +183,22 @@ const DEEP_IDLE_AFTER_MS = 60_000;
  *  long, treat it as finished. A later append (a resumed background agent)
  *  flips it back to running. */
 const DONE_IDLE_MS = 1500;
+/** W4 — terminal staleness backstop. A `running` file-backed row that has
+ *  produced NO new bytes for this long, and never latched `sawEndOfTurn`, is
+ *  settled `completed` by `checkStale` regardless of whether any of the other
+ *  three settle signals ever fires — the last resort for a transcript that
+ *  lost its terminal end_turn line (a known claude flush-loss class) AND
+ *  whose one-shot notification/tool_result receipt is gone or was never
+ *  written (root-caused as D3 in the plan doc — see the module header).
+ *  Deliberately long: this is a backstop for a truly wedged row, not a
+ *  substitute for `DONE_IDLE_MS`, so it must comfortably outlast any
+ *  legitimate long-running tool call. Overridable via `AGETOR_SUBAGENT_STALE_MS`
+ *  for tests and for an operator who hits a false-positive with an unusually
+ *  slow agent — `Number(...)` on an unset/invalid value yields `NaN`, and
+ *  `NaN || default` falls through to the default exactly like the falsy-string
+ *  case, so any non-numeric override is silently ignored rather than crashing
+ *  the watcher. */
+const STALE_SUBAGENT_SETTLE_MS = Number(process.env.AGETOR_SUBAGENT_STALE_MS) || 10 * 60_000;
 
 /**
  * SSE sink, injected once by the orchestrator at startup (which owns the
@@ -247,7 +290,7 @@ interface SubagentMeta {
   description: string | null;
   spawnDepth: number;
   /** The parent `Agent` tool_use id — the correlation key for
-   *  `scanMainForToolResults`. Not parsed by earlier builds, so a pre-fix row
+   *  `scanLineForToolResult`. Not parsed by earlier builds, so a pre-fix row
    *  has this NULL in the DB even though the sidecar itself carries it; the
    *  rehydration loop below re-reads the sidecar to backfill it. */
   toolUseId: string | null;
@@ -313,6 +356,15 @@ interface FileState {
   runId: string;
   /** Byte cursor into the subagent JSONL. */
   offset: number;
+  /** Source file size at the moment this `FileState` was created — 0 for a
+   *  freshly-discovered file (all its bytes are new by definition), else the
+   *  size at attach/rehydration time. `tailFile`'s flip-back block (status →
+   *  `running`, `toolUseId` retirement, `started` re-emit) only runs for a
+   *  batch whose *starting* offset is at/beyond this floor — see the module
+   *  header. Never mutated after creation: as `fs.offset` advances past it on
+   *  its own, later batches naturally satisfy the floor without this needing
+   *  to move. */
+  replayFloor: number;
   /** Line uuids already dispatched (dedup; seeded from DB on reattach). */
   seen: Set<string>;
   /** Whether we've observed an assistant end_turn — gate for done-detection. */
@@ -326,7 +378,7 @@ interface FileState {
   spawnDepth: number;
   startedAt: number;
   endedAt: number | null;
-  /** The parent `Agent` tool_use id — the correlation key `scanMainForToolResults`
+  /** The parent `Agent` tool_use id — the correlation key `scanLineForToolResult`
    *  matches against `tool_result` blocks in the main session JSONL. Null until
    *  discovery (or rehydration backfill) finds one in the meta sidecar. */
   toolUseId: string | null;
@@ -337,6 +389,16 @@ interface FileState {
    *  running" block, which otherwise retires `toolUseId` unconditionally —
    *  see that block for why an api-errored row must NOT lose it. */
   apiErrored: boolean;
+  /** Set once `scanLineForToolResult` recognises this row's `tool_result` as
+   *  the immediate `async_launched` launch stub rather than a real
+   *  completion (see the module header's stub-guard paragraph). Informational
+   *  only — nothing branches on it besides the guard that sets it — but kept
+   *  on the row (rather than discarded) so a future signal that needs to
+   *  distinguish "known-async" from "unknown" has it available without
+   *  re-deriving it from the transcript. Defaults `false`; never rehydrated
+   *  from the DB (not persisted) — a reattach re-derives it the next time the
+   *  stub line replays, which is harmless since the guard is idempotent. */
+  isAsync: boolean;
   /** Latest mode-bearing (`system`/`permission-mode`) event seen for this
    *  subagent, passed to `mapJsonlEventToChunks` so it can suppress a
    *  same-mode repeat — same emit-on-change scheme as the main stream's
@@ -634,6 +696,11 @@ export function attachSubagentWatcher(opts: {
   // synchronously inside `reattachSession`/the spawn IIFE, outside any tick's
   // try/catch, so it's the one place in this file that must guard itself
   // rather than rely on `cycle()`'s wrapper.
+  // Captured once, not per row: this is the staleness clock's start time
+  // (W4) — every rehydrated row is "last heard from" as of THIS attach, not
+  // the epoch (`lastAppendAt: 0` would otherwise make every reattached row
+  // instantly eligible for `checkStale` on the very next pass).
+  const attachedAt = Date.now();
   try {
     for (const row of subagentsDb.listForTask(taskId)) {
       if (row.parentKind === "workflow") {
@@ -672,14 +739,27 @@ export function attachSubagentWatcher(opts: {
           subagentsDb.setToolUseId(row.id, meta.toolUseId);
         }
       }
+      // Replay floor (W1): the source file's size RIGHT NOW, before this
+      // watcher ever reads a byte of it. Every attach re-tails from offset 0
+      // (see `offset: 0` below), so without a floor the very first batch —
+      // pure replay of history the row already settled from — would look
+      // like "new bytes" to the flip-back block and resurrect a completed
+      // row on every restart. Guarded: a file that vanished between the DB
+      // read and this `statSync` (deleted transcript, race with cleanup)
+      // reads as size 0 rather than throwing — an empty floor is the safe
+      // default (equivalent to "treat as freshly-discovered"), not a crash
+      // of the whole rehydration loop.
+      let replayFloor = 0;
+      try { replayFloor = statSync(row.sourcePath).size; } catch { /* floor stays 0 */ }
       files.set(row.id, {
         subagentId: row.id,
         parentKind: row.parentKind,
         runId: row.runId ?? resolveRunId(taskId) ?? row.id,
         offset: 0,
+        replayFloor,
         seen: runs.seenLineUuidsForSubagent(row.id),
         sawEndOfTurn: false,
-        lastAppendAt: 0,
+        lastAppendAt: attachedAt,
         status: row.status,
         sourcePath: row.sourcePath,
         agentType: row.agentType,
@@ -696,6 +776,7 @@ export function attachSubagentWatcher(opts: {
         // api-error, followed by the same background agent resuming, must
         // still preserve `toolUseId` in the flip-back block below.
         apiErrored: row.status === "failed",
+        isAsync: false,
         lastPermissionMode: null,
       });
     }
@@ -783,6 +864,10 @@ export function attachSubagentWatcher(opts: {
         parentKind: "subagent",
         runId,
         offset: 0,
+        // A freshly-discovered file is all-new by definition — nothing about
+        // it has been read yet, let alone settled, so there is no history to
+        // distrust. See `FileState.replayFloor` / the module header.
+        replayFloor: 0,
         seen: new Set(),
         sawEndOfTurn: false,
         lastAppendAt: startedAt,
@@ -795,6 +880,7 @@ export function attachSubagentWatcher(opts: {
         endedAt: null,
         toolUseId: meta.toolUseId,
         apiErrored: false,
+        isAsync: false,
         lastPermissionMode: null,
       };
       files.set(id, fs);
@@ -815,6 +901,30 @@ export function attachSubagentWatcher(opts: {
   function workflowForDir(dir: string): WorkflowState | null {
     for (const w of workflows.values()) if (w.dir === dir) return w;
     return null;
+  }
+
+  /** The CONTAINER's current status for the workflow whose transcript dir is
+   *  `dir` — preferring the in-memory `workflows` entry, falling back to the
+   *  DB row when this watcher never saw (or has since forgotten) that
+   *  container. The fallback matters because agent-file discovery and
+   *  container-launch-line discovery are two independent scans of two
+   *  different streams (a directory listing vs the main JSONL) — an agent
+   *  file can become readdir-visible before this watcher's own main-JSONL
+   *  scan has reached the launch line that would have populated `workflows`.
+   *  `null` when neither source knows the container at all (still launching,
+   *  or a layout this watcher has no visibility into). Used only by the W7
+   *  settle-on-discovery check in `discoverWorkflowAgents`. */
+  function containerStatusForDir(dir: string): SubagentStatus | null {
+    const w = workflowForDir(dir);
+    if (w) return w.status;
+    try {
+      const row = subagentsDb
+        .listForTask(taskId)
+        .find((r) => r.parentKind === "workflow" && r.sourcePath === dir);
+      return row?.status ?? null;
+    } catch {
+      return null;
+    }
   }
 
   /**
@@ -943,16 +1053,29 @@ export function attachSubagentWatcher(opts: {
         const runId = resolveRunId(taskId);
         if (!runId) continue; // same defensive skip as `discover()`
         const meta = readMeta(dir, id);
-        const startedAt = Date.now();
+        const now = Date.now();
+        // W7 — settle-on-discovery under an already-settled container.
+        // `cascadeWorkflowAgents` only sweeps rows that exist in the DB at the
+        // moment the container itself settles; an agent file that only
+        // becomes readdir-visible AFTER that (a straggling flush, a slow
+        // `readdir` race) is never touched by the cascade. Inserting such a
+        // row `running` would resurrect a hold the container's settle already
+        // released — so a container found settled at discovery time makes
+        // this row `completed` from birth instead, never `running`.
+        const containerStatus = containerStatusForDir(dir);
+        const bornSettled = containerStatus !== null && containerStatus !== "running";
         const fs: FileState = {
           subagentId: id,
           parentKind: "workflow_agent",
           runId,
           offset: 0,
+          // Freshly discovered — see `discover()`'s identical rationale in
+          // the module header / `FileState.replayFloor` doc.
+          replayFloor: 0,
           seen: new Set(),
           sawEndOfTurn: false,
-          lastAppendAt: startedAt,
-          status: "running",
+          lastAppendAt: now,
+          status: bornSettled ? "completed" : "running",
           sourcePath: path.join(dir, name),
           agentType: meta.agentType,
           // A workflow agent's meta sidecar carries no `description`, so fall
@@ -961,21 +1084,39 @@ export function attachSubagentWatcher(opts: {
           // coarse one.
           description: meta.description ?? workflowForDir(dir)?.description ?? dirName,
           spawnDepth: meta.spawnDepth,
-          startedAt,
-          endedAt: null,
+          startedAt: now,
+          endedAt: bornSettled ? now : null,
           // No `toolUseId` in a workflow-agent sidecar: these agents are
           // spawned by the workflow harness, not by a parent `Agent` tool_use,
           // so there is no tool_result to correlate against. Leaving it null
           // also keeps them out of `scanMainSignals`'s pending set.
           toolUseId: null,
           apiErrored: false,
+          isAsync: false,
           lastPermissionMode: null,
         };
         files.set(id, fs);
         lastChangeAt = Date.now();
         subagentsDb.insertIfAbsent(toSubagentShape(fs, taskId));
-        emitLifecycle(fs, "started");
-        fireParkedDiscovery(taskId);
+        // W6 — journal cursor rewind. A `result` receipt naming this exact
+        // agent may already have been consumed by `tailJournals` before this
+        // row existed — the same readdir-visibility race `discover()`'s
+        // `mainOffset = 0` rewind covers for the main-JSONL scan, mirrored
+        // here for the per-workflow journal cursor. Unconditional (not only
+        // when `wfJournals` already had `dir`): rewinding a cursor that was
+        // just initialised to 0 above is a harmless 0-to-0 no-op, and
+        // `settleSubagentById` is idempotent, so replaying an
+        // already-applied receipt costs nothing either.
+        wfJournals.set(dir, 0);
+        if (bornSettled) {
+          emitLifecycle(fs, "finished");
+        } else {
+          emitLifecycle(fs, "started");
+          // Only a genuinely-running discovery should be able to pull a
+          // parked task back — a row born settled has no hold implications
+          // (W7's whole point).
+          fireParkedDiscovery(taskId);
+        }
       }
     }
   }
@@ -986,7 +1127,7 @@ export function attachSubagentWatcher(opts: {
    * This is the flush-loss backstop: a workflow runs many agents concurrently
    * and an agent's own transcript can lose its terminal `end_turn` line under
    * that load, which would strand its row `running` forever (the same failure
-   * class `scanMainForToolResults` exists to cover for synchronous subagents,
+   * class `scanLineForToolResult` exists to cover for synchronous subagents,
    * except a workflow agent has no tool_use id to correlate on).
    * `settleSubagentById` is idempotent, so a receipt for a row the idle path
    * already completed is a free no-op.
@@ -1019,6 +1160,18 @@ export function attachSubagentWatcher(opts: {
   /** Tail one subagent file: dispatch newly-appended lines through the shared
    *  mapper, persisting + emitting each chunk tagged with the subagent id. */
   function tailFile(fs: FileState): void {
+    // Captured BEFORE the read advances `fs.offset` — this is the replay-floor
+    // check's input (W1). A batch that STARTS below `fs.replayFloor` is, in
+    // full or in part, replayed history (every attach re-tails from offset 0),
+    // so the flip-back block below must not treat it as evidence of a genuine
+    // resume. A batch that straddles the floor (starts below, ends at/beyond
+    // it) is conservatively treated as replay for THIS batch — the very next
+    // batch (if the agent is actually still writing) starts at/beyond the
+    // floor and flips then, at most one poll interval later. That's a
+    // deliberate trade: a false "still replay" for one extra tick is cheap: a
+    // false "genuine resume" would resurrect a settled row and retire its
+    // `toolUseId`, so no floor check is what we're guarding against.
+    const batchStart = fs.offset;
     const { text, next } = readAppendedSync(fs.sourcePath, fs.offset);
     if (!text) return;
     const lines = text.split("\n");
@@ -1097,23 +1250,43 @@ export function attachSubagentWatcher(opts: {
       // Reset the end-of-turn latch so the new turn must produce its OWN
       // end_turn before `checkDone` can complete it again — otherwise the stale
       // `sawEndOfTurn` from the prior turn would mark it done mid-resume.
-      if (fs.status !== "running") {
+      //
+      // Gated on `batchStart >= fs.replayFloor` (W1): a batch that STARTS
+      // below the floor is replayed history — every attach re-tails this
+      // file from offset 0 — not evidence the agent is genuinely alive again.
+      // Without this gate, EVERY attach flips EVERY settled row back to
+      // running on its very first batch, because a transcript's
+      // mapper-silent lines (types the mapper doesn't persist, e.g.
+      // `attachment`) are never recorded in `fs.seen`/`run_events.line_uuid`
+      // and so always look "unseen" on replay — measured 10-17 such lines per
+      // real transcript, present in both stuck AND normally-completed
+      // sessions alike. This was the actual mechanism behind rows getting
+      // stuck `running` forever (root-caused in the plan doc as D2). A batch
+      // below the floor still falls through to the mapper call below
+      // unchanged — it still persists/emits its chunks and still latches
+      // `sawEndOfTurn` — only the status flip / `toolUseId` retirement /
+      // `started` re-emit are skipped. A batch that straddles the floor
+      // (starts below it, ends beyond it) is conservatively treated as replay
+      // for THIS batch; if the agent really is still writing, its very next
+      // batch starts at/beyond the floor and flips then — at most one poll
+      // interval later, versus a settled row resurrected forever.
+      if (fs.status !== "running" && batchStart >= fs.replayFloor) {
         fs.status = "running";
         fs.endedAt = null;
         fs.sawEndOfTurn = false;
         // Retire the tool_result correlation key: the parent's receipt for
         // the ORIGINAL Agent tool_use predates this resume, so from here on
-        // it can only mis-settle the agent (a reattach replays the main
-        // JSONL from offset 0 and would re-serve it). In-memory only — the
-        // DB keeps the id, and a post-restart replay can still transiently
-        // re-settle a resumed agent, but the next append flips it right
-        // back (dir watcher) and its real completion arrives via
-        // task-notification / its own end_turn.
+        // it can only mis-settle the agent. Thanks to the replay-floor gate
+        // above, this branch by construction only ever runs for a batch
+        // AT/BEYOND the floor — bytes this watcher has never read before, a
+        // genuine resume — so (unlike before W1) there is no "transient
+        // post-restart re-settle via replay" case left to worry about here;
+        // the floor already ruled that out before this line runs.
         //
         // EXCEPT when the row being flipped was settled `failed` via an
         // API error (`fs.apiErrored`): for a SYNCHRONOUS subagent,
         // `toolUseId` is the ONLY remaining fallback settle signal
-        // (`scanMainForToolResults`) — the agent's own transcript may never
+        // (`scanLineForToolResult`) — the agent's own transcript may never
         // produce another terminal end_turn (that is the exact hang class
         // this feature exists to fix) and there is no task-notification for
         // a synchronous agent either. Retiring the id here would stop that
@@ -1188,6 +1361,51 @@ export function attachSubagentWatcher(opts: {
   }
 
   /**
+   * W4 — terminal staleness backstop. Flips a `running` row `completed` when
+   * it has NEVER seen its transcript's terminal end_turn line (the
+   * `checkDone` path never applies to it) AND has produced no new bytes for
+   * `STALE_SUBAGENT_SETTLE_MS`. This is the settle-of-last-resort for a row
+   * whose transcript lost its end_turn to the known claude flush-loss class
+   * AND whose one-shot receipt (an async task-notification, or a synchronous
+   * tool_result) is gone from disk or was never written at all — with no
+   * bytes left to arrive and no receipt left to consume, nothing else in this
+   * module can ever close the row otherwise, and it would hold its task's
+   * card in `running` forever.
+   *
+   * Deliberately restricted to FILE-BACKED rows (`files`, not `workflows`):
+   * a workflow CONTAINER is directory-backed — it has no transcript of its
+   * own to go quiet, and its lifetime legitimately spans long idle gaps
+   * BETWEEN agent waves — so it is settled only by its completion
+   * notification or the generic orphan paths, never by staleness.
+   *
+   * Same DB-write-before-`fireSettle` ordering as `checkDone`, for the same
+   * reason: the orchestrator's release predicate reads `subagentsDb.hasRunning`
+   * and must see the write.
+   *
+   * If the agent WAS actually still alive and later appends again, W1's
+   * beyond-floor flip-back in `tailFile` returns the row to `running` — a
+   * brief card bounce (running → review → running) rather than the
+   * pre-fix failure mode of a card stuck `running` forever. A conservative
+   * default (10 minutes) keeps that bounce rare; `AGETOR_SUBAGENT_STALE_MS`
+   * exists for the operator/test who needs a different threshold.
+   */
+  function checkStale(now: number): void {
+    for (const fs of files.values()) {
+      if (
+        fs.status === "running" &&
+        !fs.sawEndOfTurn &&
+        now - fs.lastAppendAt > STALE_SUBAGENT_SETTLE_MS
+      ) {
+        fs.status = "completed";
+        fs.endedAt = now;
+        subagentsDb.setStatus(fs.subagentId, "completed", now);
+        emitLifecycle(fs, "finished");
+        fireSettle(taskId);
+      }
+    }
+  }
+
+  /**
    * Third settle signal (see module header): match one MAIN-session-JSONL line
    * against the `tool_result` blocks whose `tool_use_id` equals a tracked
    * `running` subagent's `toolUseId` — the fallback for a synchronous
@@ -1198,6 +1416,26 @@ export function attachSubagentWatcher(opts: {
    * readdir-visibility race while a sibling kept the scan running) is covered
    * by `discover()` rewinding `mainOffset` to 0 for one full rescan — settles
    * are idempotent, so re-reading old lines is harmless.
+   *
+   * W2 — async-stub guard. When `Agent(run_in_background: true)` launches a
+   * subagent, claude writes an IMMEDIATE `tool_result` for the launching
+   * `tool_use` whose `toolUseResult` is `{ isAsync:true,
+   * status:"async_launched", agentId, … }` — not a completion, just an
+   * acknowledgement that the background agent started. Ground truth verified
+   * live: `{"type":"user","message":{...content:[{type:"tool_result",
+   * tool_use_id,...}]},"toolUseResult":{"isAsync":true,
+   * "status":"async_launched","agentId":"...",...}}`. This function has no
+   * stub guard prior to W2 — every `running` row whose `toolUseId` happens to
+   * match is settled `completed` on this stub alone, while the agent is still
+   * working (the false-settle root-caused as D1 in the plan doc). The guard
+   * below keys on the STRUCTURAL `toolUseResult.status === "async_launched"`
+   * marker, never the human-readable text (which is not a stable contract) —
+   * and on a match, does NOT settle: it marks the row `isAsync` and retires
+   * its `toolUseId` instead, since a REAL `tool_result` will never arrive for
+   * an async agent (retiring prevents the stub — or a resend of it on replay
+   * — from ever being mis-read as a completion again). From there the row's
+   * only remaining settle paths are the task-notification backstop (W3) and
+   * the staleness backstop (W4).
    */
   function scanLineForToolResult(line: string, pending: FileState[]): void {
     // Cheap prefilter before any JSON.parse: the launching `tool_use` line
@@ -1207,7 +1445,7 @@ export function attachSubagentWatcher(opts: {
     const candidates = pending.filter((fs) => line.includes(fs.toolUseId!));
     if (candidates.length === 0) return;
 
-    let parsed: { type?: unknown; message?: { content?: unknown } };
+    let parsed: { type?: unknown; message?: { content?: unknown }; toolUseResult?: unknown };
     try {
       parsed = JSON.parse(line);
     } catch {
@@ -1216,12 +1454,21 @@ export function attachSubagentWatcher(opts: {
     if (parsed.type !== "user") return;
     const content = parsed.message?.content;
     if (!Array.isArray(content)) return;
+    const tr = parsed.toolUseResult;
+    const isAsyncLaunchStub =
+      !!tr && typeof tr === "object" && (tr as Record<string, unknown>).status === "async_launched";
     for (const block of content) {
       if (!block || typeof block !== "object") continue;
       const b = block as { type?: unknown; tool_use_id?: unknown };
       if (b.type !== "tool_result") continue;
       for (const fs of candidates) {
-        if (b.tool_use_id === fs.toolUseId) settleSubagentById(fs.subagentId, "completed");
+        if (b.tool_use_id !== fs.toolUseId) continue;
+        if (isAsyncLaunchStub) {
+          fs.isAsync = true;
+          fs.toolUseId = null;
+        } else {
+          settleSubagentById(fs.subagentId, "completed");
+        }
       }
     }
   }
@@ -1278,41 +1525,66 @@ export function attachSubagentWatcher(opts: {
   }
 
   /**
-   * Workflow COMPLETION detection — the restart-safe backstop. A live session
-   * settles the container through claude-tmux's `<task-notification>` handler
-   * (`settleSubagentById` by `<task-id>`, which IS the container PK, so that
-   * path needed no changes); but after boot reconciliation only this watcher
-   * is armed — no tmux tailer — so the same notification has to be recognised
-   * here too. Both on-disk shapes (the `queue-operation` enqueue line and the
-   * synthetic `user` message) embed the tag verbatim, so one regex covers both.
+   * COMPLETION notification detection — the restart-safe backstop, generalized
+   * (W3) beyond just workflow containers. A live session settles a container
+   * through claude-tmux's `<task-notification>` handler (`settleSubagentById`
+   * by `<task-id>`, which IS the container PK, so that path needed no
+   * changes); but after boot reconciliation only this watcher is armed — no
+   * tmux tailer — so the same notification has to be recognised here too.
+   * Both on-disk shapes (the `queue-operation` enqueue line and the synthetic
+   * `user` message) embed the tag verbatim, so one regex covers both.
    *
-   * Only ids this watcher knows as its OWN running containers are settled:
-   * a `<task-id>` naming a regular background subagent is left to the existing
-   * paths, exactly as before this feature.
+   * Superseded rationale: earlier, a `<task-id>` naming a regular (non-
+   * workflow) background subagent was deliberately left to "the existing
+   * paths" — the reasoning being that claude-tmux's own live dispatch
+   * (`fireBackgroundTaskSettled`) would catch it. That reasoning doesn't
+   * survive a restart: claude-tmux's dispatch is one-shot and dedup'd, never
+   * re-issued on reattach, so once the tmux tailer that originally would have
+   * seen it is gone, NOTHING settles that row's live notification ever again
+   * — this scan is the only restart-safe path left for an async agent. It is
+   * now safe to widen the match to `files` (ordinary tracked rows) as well as
+   * `workflows` (containers): with W1's replay floor in place, a settle this
+   * scan performs can no longer be undone by a later replay resurrecting the
+   * row, which is what made the old narrower scope a deliberate, necessary
+   * caution rather than an oversight.
+   *
+   * Only ids this watcher already tracks as `running` — container OR regular
+   * row — are settled; an unrelated id is left alone.
    *
    * BOTH tags are required in the prefilter, not just `<task-id>`: settling a
-   * container is irreversible here (a later launch line for a known id
-   * early-returns in `registerWorkflowContainer`), so a line that merely
-   * mentions a task id — an assistant message quoting a notification back, a
-   * future launch blurb embedding the tag — must not be enough to release the
-   * hold. Requiring the enclosing `<task-notification>` marker, which both real
-   * on-disk shapes carry verbatim, keeps the match anchored to an actual
-   * notification payload.
+   * row here is otherwise irreversible in the same tick (a later launch line
+   * for a known container id early-returns in `registerWorkflowContainer`),
+   * so a line that merely mentions a task id — an assistant message quoting a
+   * notification back, a future launch blurb embedding the tag — must not be
+   * enough to release the hold. Requiring the enclosing `<task-notification>`
+   * marker, which both real on-disk shapes carry verbatim, keeps the match
+   * anchored to an actual notification payload.
    *
    * The notification's `<status>` is deliberately ignored — completed, failed,
-   * killed and stopped all mean "this workflow is over", and the hold must
-   * release in every one of those cases (plan assumption A4).
+   * killed and stopped all mean "this agent/workflow is over", and the hold
+   * must release in every one of those cases (plan assumption A4, extended to
+   * regular rows by the same logic).
    */
-  function scanLineForWorkflowNotification(line: string): void {
+  function scanLineForTaskNotification(line: string): void {
     if (!line.includes("<task-notification>") || !line.includes("<task-id>")) return;
     // `matchAll`, not a single `exec`: one physical line can carry more than
     // one notification (a batched enqueue), and stopping at the first would
-    // silently drop the rest — leaving a finished workflow holding the card.
+    // silently drop the rest — leaving a finished workflow/agent holding the
+    // card.
     for (const m of line.matchAll(/<task-id>([^<]+)<\/task-id>/g)) {
       const id = m[1]!.trim();
       const w = workflows.get(id);
-      if (!w || w.status !== "running") continue;
-      settleSubagentById(id, "completed");
+      if (w) {
+        if (w.status === "running") settleSubagentById(id, "completed");
+        continue;
+      }
+      // Not a container id this watcher knows — check whether it names an
+      // ordinary tracked subagent/workflow-agent row instead (the W3
+      // widening). `files.get` is a plain map lookup, so trying it
+      // unconditionally for every id costs nothing on the common case where
+      // the id matches neither.
+      const fs = files.get(id);
+      if (fs && fs.status === "running") settleSubagentById(id, "completed");
     }
   }
 
@@ -1320,14 +1592,26 @@ export function attachSubagentWatcher(opts: {
    * Single pass over the bytes appended to the MAIN session JSONL since the
    * last pass, feeding every signal this watcher derives from it: tool_result
    * correlation settles (above) and — when workflows are tracked — workflow
-   * launch + completion detection.
+   * launch detection plus the generalized task-notification backstop (W3,
+   * `scanLineForTaskNotification`).
    *
    * One shared `mainOffset` cursor, one read, one split. The early return is
    * deliberately narrow: bailing on `pending.length === 0` (as this did when
-   * tool_results were its only signal) would starve workflow detection on
-   * exactly the common case — a task with no `toolUseId`-bearing subagent rows
-   * at all. So it only short-circuits when there is nothing of EITHER kind to
-   * look for.
+   * tool_results were its only signal) would starve workflow/notification
+   * detection on exactly the common case — a task with no `toolUseId`-bearing
+   * subagent rows at all (which, post-W2, includes every async subagent as
+   * soon as its launch stub is scanned). So it only short-circuits when there
+   * is nothing of EITHER kind to look for.
+   *
+   * NOTE — `scanLineForTaskNotification` is gated behind `WORKFLOWS_ENABLED`
+   * below along with workflow launch detection, even though it now also
+   * backstops plain (non-workflow) async subagents. That's a deliberate
+   * scope-preserving choice, not an oversight: `WORKFLOWS_ENABLED` defaults
+   * on, so this covers the overwhelming majority of installs unchanged; an
+   * operator who explicitly sets `AGETOR_TRACK_WORKFLOWS=0` also loses the
+   * async-notification backstop for ordinary subagents (they still have the
+   * end_turn-idle and staleness backstops) — a narrower rollback lever was
+   * judged preferable to adding a second independent env var for one scan.
    *
    * COST NOTE — that widening means a workflow-tracking watcher scans the main
    * transcript on every cycle, where before it usually skipped the read
@@ -1359,7 +1643,7 @@ export function attachSubagentWatcher(opts: {
         // was down is registered and then settled within one pass, never left
         // holding the card.
         scanLineForWorkflowLaunch(line);
-        scanLineForWorkflowNotification(line);
+        scanLineForTaskNotification(line);
       }
     }
   }
@@ -1402,6 +1686,7 @@ export function attachSubagentWatcher(opts: {
       tailJournals();
       scanMainSignals();
       checkDone(now);
+      checkStale(now);
     } catch { /* swallow — never crash the timer */ }
   }
 

--- a/src/bun/claude-subagents.ts
+++ b/src/bun/claude-subagents.ts
@@ -49,15 +49,35 @@
  *
  * A settled row can never be resurrected by REPLAYED history. Every row
  * records a `replayFloor` — the source file's size at the moment its
- * `FileState` was created (0 for a freshly-discovered file, so a brand-new
- * file has no "history" to distrust). `tailFile`'s resume-detection (the
- * "flip back to running" block) only fires for a batch whose *starting*
- * offset is at or beyond that floor; bytes below the floor are replayed
- * history — read again on every attach/reattach from offset 0 — and must
- * never flip a settled row back to running, retire its `toolUseId`, or
- * re-emit a `started` lifecycle, even though those same bytes still flow
- * through the mapper (persist/emit) and still latch `sawEndOfTurn` like any
- * other unseen line.
+ * `FileState` was created: for a rehydrated row (reattach/boot) that's the
+ * file's size as of THAT attach; for a row that is BORN settled (a workflow
+ * agent discovered under an already-settled container — see W7 below) it's
+ * the file's size at the moment of discovery, not 0, precisely because such a
+ * row already has "history" (its own never-before-tailed content) that must
+ * not be mistaken for a live resume; a genuinely freshly-discovered RUNNING
+ * file gets floor 0, since nothing about it has been read yet, let alone
+ * settled. `tailFile`'s resume-detection (the "flip back to running" block)
+ * only fires for a batch whose *starting* offset is at or beyond that floor;
+ * bytes below the floor are replayed history — read again on every
+ * attach/reattach from offset 0 — and must never flip a settled row back to
+ * running, retire its `toolUseId`, or re-emit a `started` lifecycle, even
+ * though those same bytes still flow through the mapper (persist/emit) and
+ * still latch `sawEndOfTurn` like any other unseen line. A workflow agent row
+ * additionally can never flip back while its CONTAINER is settled, regardless
+ * of the floor — the cascade invariant ("nothing under a settled container
+ * runs") holds at every tick, not just at discovery.
+ *
+ * A row settled via an AUTHORITATIVE receipt (a `<task-notification>` or a
+ * journal `result` line — `receiptSettled` on the `FileState`) is even harder
+ * to resurrect than an ordinary (`inferred`, e.g. `checkDone`/`checkStale`/a
+ * real `tool_result`) settle: once receipt-settled, only a genuinely new `user`
+ * line (a fresh prompt to a resumed agent) can flip it back to running —
+ * trailing `assistant`/`attachment` lines flushed after the receipt cannot,
+ * since the harness receipt is authoritative and claude never continues a
+ * finished agent without a new user turn. An inferred settle of a fresh
+ * in-session row stays flippable by ANY unseen line beyond the floor, by
+ * design — `checkStale`'s self-correction (a falsely-stale row resuming)
+ * depends on that looseness.
  *
  * ── Workflows (`/workflow`) ────────────────────────────────────────────────
  *
@@ -150,6 +170,12 @@ const WORKFLOWS_SUBDIR = "workflows";
  *  per lifecycle transition, inside each workflow transcript dir. */
 const JOURNAL_FILE = "journal.jsonl";
 
+/** Fix 9 — `<status>` values `scanLineForTaskNotification` recognises as
+ *  terminal ("this agent/workflow is over, settle it"). Any OTHER non-empty
+ *  status is treated conservatively as unrecognised (skip the settle, log
+ *  once) rather than assumed terminal — see that function's doc. */
+const TERMINAL_NOTIFICATION_STATUSES = new Set(["completed", "failed", "killed", "stopped"]);
+
 /** How far back from the end of the MAIN session JSONL a freshly-attached
  *  watcher starts scanning for workflow signals (see the clamp in
  *  `attachSubagentWatcher`). Sized to comfortably span the last few turns of a
@@ -197,7 +223,15 @@ const DONE_IDLE_MS = 1500;
  *  slow agent — `Number(...)` on an unset/invalid value yields `NaN`, and
  *  `NaN || default` falls through to the default exactly like the falsy-string
  *  case, so any non-numeric override is silently ignored rather than crashing
- *  the watcher. */
+ *  the watcher. Note `0` also cannot disable this backstop — `0 || default`
+ *  falls through to the default exactly like `NaN`/unset, so there is no
+ *  env-var kill switch for this specific check (use `AGETOR_TRACK_SUBAGENTS=0`
+ *  to disable the whole module instead). Read once at module load, mirroring
+ *  `WORKFLOWS_ENABLED` above — a test that needs a different threshold must
+ *  set the env var and re-import this module under a cache-busting specifier
+ *  (`./claude-subagents.ts?stale=<uuid>`), the same idiom `WORKFLOWS_ENABLED`'s
+ *  own doc describes; setting `AGETOR_SUBAGENT_STALE_MS` after this module has
+ *  already loaded has no effect on the constant below. */
 const STALE_SUBAGENT_SETTLE_MS = Number(process.env.AGETOR_SUBAGENT_STALE_MS) || 10 * 60_000;
 
 /**
@@ -389,6 +423,39 @@ interface FileState {
    *  running" block, which otherwise retires `toolUseId` unconditionally —
    *  see that block for why an api-errored row must NOT lose it. */
   apiErrored: boolean;
+  /** Fix 13 — mirrors `apiErrored`'s latch, but for the W4 staleness backstop
+   *  (`checkStale`) instead of the api-error path. Set when THIS row was
+   *  settled `completed` by `checkStale` (not `checkDone`, not a receipt, not
+   *  a real `tool_result`), cleared the next time the row flips back to
+   *  `running`. Distinguishes a stale-settled row from an ordinary
+   *  end-of-turn-settled one in the "flip back to running" block: a
+   *  stale-settled SYNCHRONOUS subagent's `toolUseId` is its only remaining
+   *  fallback settle signal (the same reasoning `apiErrored` documents above),
+   *  so retiring it on a later resume would strand the row `running` again if
+   *  that resume also loses its terminal end_turn line. Defaults `false`;
+   *  never rehydrated from the DB (not persisted) — unlike `apiErrored`,
+   *  `checkStale`'s settle shares the ordinary `"completed"` status with every
+   *  other settle path, so there is no way to reconstruct this latch from the
+   *  DB row alone on reattach. */
+  staleSettled: boolean;
+  /** Fix 4 — set when this row was settled via an AUTHORITATIVE receipt (a
+   *  `<task-notification>` in `scanLineForTaskNotification`, or a workflow
+   *  journal `result` line in `tailJournals`) rather than an inferred signal
+   *  (`checkDone`'s end-of-turn idle, `checkStale`'s staleness backstop, or a
+   *  real `tool_result` in `scanLineForToolResult`). Threaded in via
+   *  `settleSubagentById`'s `source` param → `settleSubagent` →
+   *  `SubagentWatcherHandle.syncSettled`. Once set, `tailFile`'s flip-back
+   *  block only resurrects the row for a genuinely new `user` line (a fresh
+   *  prompt to a resumed agent) — a trailing `assistant`/`attachment` flush
+   *  that lands after the receipt must NOT resurrect it, since the harness
+   *  receipt is authoritative and claude never continues a finished agent
+   *  without a new user turn (see the module header). Cleared on any flip
+   *  back to running. Defaults `false`; never rehydrated from the DB (not
+   *  persisted) — mirrors `isAsync`/`staleSettled`'s posture, and closing the
+   *  live trailing-flush race only matters for rows this SAME watcher
+   *  instance settled, since a rehydrated row is already protected by its
+   *  `replayFloor`. */
+  receiptSettled: boolean;
   /** Set once `scanLineForToolResult` recognises this row's `tool_result` as
    *  the immediate `async_launched` launch stub rather than a real
    *  completion (see the module header's stub-guard paragraph). Informational
@@ -422,8 +489,11 @@ export interface SubagentWatcherHandle {
    *  just keeps the tailer's resume-detection (`tailFile`'s
    *  `fs.status !== "running"` check) and `checkDone`'s idle-detection from
    *  re-deriving a status the external settle already decided, which would
-   *  otherwise re-fire a duplicate lifecycle/settle signal on the next tick. */
-  syncSettled(id: string, status: SubagentStatus, endedAt: number): void;
+   *  otherwise re-fire a duplicate lifecycle/settle signal on the next tick.
+   *  `source` (fix 4) — when `"receipt"`, latches `FileState.receiptSettled`
+   *  so `tailFile`'s flip-back narrows to user-line-only resurrection for this
+   *  row; omitted/`"inferred"` leaves the row's existing flippability alone. */
+  syncSettled(id: string, status: SubagentStatus, endedAt: number, source?: "receipt" | "inferred"): void;
 }
 
 /** One live watcher per task, tops — a second `attachSubagentWatcher` for the
@@ -744,13 +814,28 @@ export function attachSubagentWatcher(opts: {
       // (see `offset: 0` below), so without a floor the very first batch —
       // pure replay of history the row already settled from — would look
       // like "new bytes" to the flip-back block and resurrect a completed
-      // row on every restart. Guarded: a file that vanished between the DB
-      // read and this `statSync` (deleted transcript, race with cleanup)
-      // reads as size 0 rather than throwing — an empty floor is the safe
-      // default (equivalent to "treat as freshly-discovered"), not a crash
-      // of the whole rehydration loop.
+      // row on every restart.
+      //
+      // Fix 7 — the floor's error fallback must distinguish "no file" from
+      // "file exists but couldn't be stat'd": a file that's genuinely gone
+      // (deleted transcript, race with cleanup) has no history to distrust,
+      // so floor 0 (== "treat as freshly-discovered") is the safe default.
+      // But a file that EXISTS and merely failed to `statSync` (permissions,
+      // a transient FS error, an exotic mount) is the opposite case — there
+      // IS history on disk, we just can't measure it right now — and 0 would
+      // wrongly tell the flip-back block "everything in this file is new",
+      // resurrecting a settled row (or worse, mis-treating its full replayed
+      // content as a genuine resume) the moment it becomes readable again.
+      // `Number.MAX_SAFE_INTEGER` makes every batch from this row read as
+      // replay until a later `statSync` succeeds and the real size is used.
       let replayFloor = 0;
-      try { replayFloor = statSync(row.sourcePath).size; } catch { /* floor stays 0 */ }
+      if (existsSync(row.sourcePath)) {
+        try {
+          replayFloor = statSync(row.sourcePath).size;
+        } catch {
+          replayFloor = Number.MAX_SAFE_INTEGER;
+        }
+      }
       files.set(row.id, {
         subagentId: row.id,
         parentKind: row.parentKind,
@@ -776,6 +861,11 @@ export function attachSubagentWatcher(opts: {
         // api-error, followed by the same background agent resuming, must
         // still preserve `toolUseId` in the flip-back block below.
         apiErrored: row.status === "failed",
+        // `staleSettled`/`receiptSettled` are never rehydrated (see their
+        // doc on `FileState`) — a restart re-derives whichever of them
+        // matters the next time this row's settle-relevant signal replays.
+        staleSettled: false,
+        receiptSettled: false,
         isAsync: false,
         lastPermissionMode: null,
       });
@@ -880,6 +970,8 @@ export function attachSubagentWatcher(opts: {
         endedAt: null,
         toolUseId: meta.toolUseId,
         apiErrored: false,
+        staleSettled: false,
+        receiptSettled: false,
         isAsync: false,
         lastPermissionMode: null,
       };
@@ -897,9 +989,17 @@ export function attachSubagentWatcher(opts: {
 
   /** The workflow whose transcript dir is `dir`, if this watcher has seen its
    *  launch line (or rehydrated its row). Used only for labelling — agent
-   *  discovery never waits on it. */
+   *  discovery never waits on it.
+   *
+   *  Fix 10 — both sides are `path.resolve`d before comparison, mirroring
+   *  `isInsideDir`'s posture: a container's `dir` comes from claude's own
+   *  `transcriptDir` string while an agent's dir is built here with
+   *  `path.join`, and those can disagree on a symlinked or non-normalised
+   *  root (`/tmp` vs `/private/tmp` on macOS) even though they name the same
+   *  directory — a naive `===` would then miss the match. */
   function workflowForDir(dir: string): WorkflowState | null {
-    for (const w of workflows.values()) if (w.dir === dir) return w;
+    const resolved = path.resolve(dir);
+    for (const w of workflows.values()) if (path.resolve(w.dir) === resolved) return w;
     return null;
   }
 
@@ -912,15 +1012,19 @@ export function attachSubagentWatcher(opts: {
    *  file can become readdir-visible before this watcher's own main-JSONL
    *  scan has reached the launch line that would have populated `workflows`.
    *  `null` when neither source knows the container at all (still launching,
-   *  or a layout this watcher has no visibility into). Used only by the W7
-   *  settle-on-discovery check in `discoverWorkflowAgents`. */
+   *  or a layout this watcher has no visibility into). Used by the W7
+   *  settle-on-discovery check in `discoverWorkflowAgents` and by `tailFile`'s
+   *  flip-back guard (fix 1). Same path-normalization posture as
+   *  `workflowForDir` (fix 10) — `path.resolve` both sides of the DB fallback
+   *  comparison too. */
   function containerStatusForDir(dir: string): SubagentStatus | null {
     const w = workflowForDir(dir);
     if (w) return w.status;
     try {
+      const resolved = path.resolve(dir);
       const row = subagentsDb
         .listForTask(taskId)
-        .find((r) => r.parentKind === "workflow" && r.sourcePath === dir);
+        .find((r) => r.parentKind === "workflow" && path.resolve(r.sourcePath) === resolved);
       return row?.status ?? null;
     } catch {
       return null;
@@ -1045,6 +1149,17 @@ export function attachSubagentWatcher(opts: {
         wfJournals.set(dir, 0);
         lastChangeAt = Date.now();
       }
+      // Fix 10 — resolve the container's status ONCE per dir, before the
+      // per-file loop, not once per discovered file. A workflow can spawn
+      // many agents into the same dir in one pass; the container's status
+      // cannot change mid-loop (nothing in this loop settles anything), so
+      // recomputing it per file was pure waste.
+      const containerStatus = containerStatusForDir(dir);
+      const bornSettled = containerStatus !== null && containerStatus !== "running";
+      // Fix 11 — rewind this dir's journal cursor AT MOST ONCE per pass, only
+      // if the pass actually discovered ≥1 new agent file here — not once per
+      // file (see the W6 comment below for why a rewind is needed at all).
+      let discoveredAny = false;
       for (const name of names) {
         const m = /^agent-(.+)\.jsonl$/.exec(name);
         if (!m) continue;
@@ -1054,6 +1169,7 @@ export function attachSubagentWatcher(opts: {
         if (!runId) continue; // same defensive skip as `discover()`
         const meta = readMeta(dir, id);
         const now = Date.now();
+        const filePath = path.join(dir, name);
         // W7 — settle-on-discovery under an already-settled container.
         // `cascadeWorkflowAgents` only sweeps rows that exist in the DB at the
         // moment the container itself settles; an agent file that only
@@ -1062,21 +1178,31 @@ export function attachSubagentWatcher(opts: {
         // row `running` would resurrect a hold the container's settle already
         // released — so a container found settled at discovery time makes
         // this row `completed` from birth instead, never `running`.
-        const containerStatus = containerStatusForDir(dir);
-        const bornSettled = containerStatus !== null && containerStatus !== "running";
+        //
+        // Fix 1 — a born-settled row's `replayFloor` must be the file's size
+        // AT DISCOVERY, not 0. This row already has content on disk (it was
+        // written before we ever looked at it) that fix 2 below will drain
+        // exactly once; without a floor pinned here, that very drain would
+        // look like "new bytes" to `tailFile`'s flip-back block on the SAME
+        // cycle and immediately flip the row back to `running` — resurrecting
+        // it before it ever renders as settled. Guarded: a file that vanished
+        // between the `readdir` above and this `statSync` reads as floor 0
+        // (equivalent to "freshly discovered"), not a crash of the pass.
+        let replayFloor = 0;
+        if (bornSettled) {
+          try { replayFloor = statSync(filePath).size; } catch { /* floor stays 0 */ }
+        }
         const fs: FileState = {
           subagentId: id,
           parentKind: "workflow_agent",
           runId,
           offset: 0,
-          // Freshly discovered — see `discover()`'s identical rationale in
-          // the module header / `FileState.replayFloor` doc.
-          replayFloor: 0,
+          replayFloor,
           seen: new Set(),
           sawEndOfTurn: false,
           lastAppendAt: now,
           status: bornSettled ? "completed" : "running",
-          sourcePath: path.join(dir, name),
+          sourcePath: filePath,
           agentType: meta.agentType,
           // A workflow agent's meta sidecar carries no `description`, so fall
           // back to the workflow's own name (or, before/without its launch
@@ -1092,22 +1218,15 @@ export function attachSubagentWatcher(opts: {
           // also keeps them out of `scanMainSignals`'s pending set.
           toolUseId: null,
           apiErrored: false,
+          staleSettled: false,
+          receiptSettled: false,
           isAsync: false,
           lastPermissionMode: null,
         };
         files.set(id, fs);
         lastChangeAt = Date.now();
+        discoveredAny = true;
         subagentsDb.insertIfAbsent(toSubagentShape(fs, taskId));
-        // W6 — journal cursor rewind. A `result` receipt naming this exact
-        // agent may already have been consumed by `tailJournals` before this
-        // row existed — the same readdir-visibility race `discover()`'s
-        // `mainOffset = 0` rewind covers for the main-JSONL scan, mirrored
-        // here for the per-workflow journal cursor. Unconditional (not only
-        // when `wfJournals` already had `dir`): rewinding a cursor that was
-        // just initialised to 0 above is a harmless 0-to-0 no-op, and
-        // `settleSubagentById` is idempotent, so replaying an
-        // already-applied receipt costs nothing either.
-        wfJournals.set(dir, 0);
         if (bornSettled) {
           emitLifecycle(fs, "finished");
         } else {
@@ -1118,6 +1237,15 @@ export function attachSubagentWatcher(opts: {
           fireParkedDiscovery(taskId);
         }
       }
+      // W6 — journal cursor rewind. A `result` receipt naming an agent
+      // discovered in THIS pass may already have been consumed by
+      // `tailJournals` before that row existed — the same readdir-visibility
+      // race `discover()`'s `mainOffset = 0` rewind covers for the main-JSONL
+      // scan, mirrored here for the per-workflow journal cursor.
+      // `settleSubagentById` is idempotent, so replaying an already-applied
+      // receipt costs nothing — fix 11 only trims the rewind to once per
+      // pass-with-a-discovery instead of once per file.
+      if (discoveredAny) wfJournals.set(dir, 0);
     }
   }
 
@@ -1148,7 +1276,9 @@ export function attachSubagentWatcher(opts: {
           try {
             const o = JSON.parse(line) as { type?: unknown; agentId?: unknown };
             if (o.type !== "result" || typeof o.agentId !== "string") continue;
-            settleSubagentById(o.agentId, "completed");
+            // Fix 4 — this is the harness's own authoritative completion
+            // receipt, so it settles with `source: "receipt"`.
+            settleSubagentById(o.agentId, "completed", "receipt");
           } catch { /* one malformed receipt must not abort the rest */ }
         }
       } catch (e) {
@@ -1177,6 +1307,23 @@ export function attachSubagentWatcher(opts: {
     const lines = text.split("\n");
     const tail = lines.pop() ?? ""; // partial trailing line — re-read next tick
     fs.offset = next - Buffer.byteLength(tail, "utf8");
+    // Fix 1 (general guard) — a workflow agent whose CONTAINER is settled must
+    // never flip back to `running`, independent of `replayFloor`. The floor
+    // covers the discovery-time case (a row born under an already-settled
+    // container, fix 1's other half in `discoverWorkflowAgents`); this covers
+    // every OTHER tick — e.g. the container settles WHILE this row's own file
+    // is still trickling a trailing flush, or settles between two batches of
+    // an otherwise-legitimate-looking resume. Computed once per call (not per
+    // line): `fs.parentKind`/`fs.sourcePath` never change across this batch,
+    // and the container's status cannot change mid-batch either (nothing in
+    // this function settles a container). Cheap — a plain map lookup, falling
+    // back to one DB scan only when this watcher never saw the launch line.
+    const containerSettled =
+      fs.parentKind === "workflow_agent" &&
+      (() => {
+        const status = containerStatusForDir(path.dirname(fs.sourcePath));
+        return status !== null && status !== "running";
+      })();
     for (const line of lines) {
       if (!line) continue;
       // Line-level dedup (the mapper can fire onChunk several times per line —
@@ -1196,6 +1343,10 @@ export function attachSubagentWatcher(opts: {
       // Peeked but not yet applied to `fs.lastPermissionMode` — see below for
       // why the apply is deferred past the dedup-skip continue.
       let linePermissionMode: string | undefined;
+      // Fix 4 — this line's `type`, peeked for the receipt-settled flip-back
+      // guard below: only a genuine new `user` line (a fresh prompt to a
+      // resumed agent) may resurrect a `receiptSettled` row.
+      let lineType: string | undefined;
       try {
         const o = JSON.parse(line) as {
           uuid?: unknown;
@@ -1206,6 +1357,7 @@ export function attachSubagentWatcher(opts: {
           permissionMode?: unknown;
         };
         uuid = typeof o.uuid === "string" ? o.uuid : undefined;
+        lineType = typeof o.type === "string" ? o.type : undefined;
         endTurnHint = o.type === "assistant" && o.message?.stop_reason === "end_turn";
         // Gate the WHOLE api-error settle on `uuid` being a string: a
         // uuid-less line has no durable dedup key (`fs.seen` and
@@ -1270,7 +1422,22 @@ export function attachSubagentWatcher(opts: {
       // for THIS batch; if the agent really is still writing, its very next
       // batch starts at/beyond the floor and flips then — at most one poll
       // interval later, versus a settled row resurrected forever.
-      if (fs.status !== "running" && batchStart >= fs.replayFloor) {
+      //
+      // Fix 4 — a `receiptSettled` row narrows this further: an authoritative
+      // receipt (a `<task-notification>` or journal `result` line) already
+      // said the agent is over, so only a genuinely NEW `user` line (a fresh
+      // prompt to a resumed agent) may resurrect it. A trailing
+      // `assistant`/`attachment` flush landing just after the receipt — the
+      // live race this fix closes — must not resurrect the row: claude never
+      // continues a finished agent without a new user turn, so the harness
+      // receipt outranks a stray beyond-floor line that isn't one.
+      const blockedByReceiptSettle = fs.receiptSettled && lineType !== "user";
+      if (
+        fs.status !== "running" &&
+        batchStart >= fs.replayFloor &&
+        !containerSettled &&
+        !blockedByReceiptSettle
+      ) {
         fs.status = "running";
         fs.endedAt = null;
         fs.sawEndOfTurn = false;
@@ -1284,7 +1451,8 @@ export function attachSubagentWatcher(opts: {
         // the floor already ruled that out before this line runs.
         //
         // EXCEPT when the row being flipped was settled `failed` via an
-        // API error (`fs.apiErrored`): for a SYNCHRONOUS subagent,
+        // API error (`fs.apiErrored`) OR `completed` via the staleness
+        // backstop (`fs.staleSettled`, fix 13): for a SYNCHRONOUS subagent,
         // `toolUseId` is the ONLY remaining fallback settle signal
         // (`scanLineForToolResult`) — the agent's own transcript may never
         // produce another terminal end_turn (that is the exact hang class
@@ -1294,12 +1462,14 @@ export function attachSubagentWatcher(opts: {
         // forever after this trailing append — reintroducing the bug.
         // Keeping it means trailing garbage appended after the abort can
         // still be reconciled via the tool_result scan. The asymmetry with
-        // the `completed`-row case above is deliberate: a completed row's
-        // stale tool_result genuinely predates the resume and retiring it
-        // there only prevents a MIS-settle, never a stuck one — so that
-        // case still retires unconditionally.
-        if (!fs.apiErrored) fs.toolUseId = null;
+        // the `completed`-via-`checkDone`-row case above is deliberate: an
+        // ordinarily-completed row's stale tool_result genuinely predates the
+        // resume and retiring it there only prevents a MIS-settle, never a
+        // stuck one — so that case still retires unconditionally.
+        if (!fs.apiErrored && !fs.staleSettled) fs.toolUseId = null;
         fs.apiErrored = false;
+        fs.staleSettled = false;
+        fs.receiptSettled = false;
         subagentsDb.setStatus(fs.subagentId, "running", null);
         emitLifecycle(fs, "started");
         fireParkedDiscovery(taskId);
@@ -1328,7 +1498,15 @@ export function attachSubagentWatcher(opts: {
       // `fs.seen` is seeded from `run_events.line_uuid` on rehydrate, so the
       // dedup check above (`if (uuid && fs.seen.has(uuid))`) skips the line
       // — and this whole per-line block — before we ever get here again.
-      if (apiErrorInfo !== null) {
+      //
+      // Fix 12 — additionally gated on `batchStart >= fs.replayFloor`, the
+      // same floor `tailFile`'s flip-back block uses: a genuine NEW api-error
+      // always arrives in a batch beyond the floor, so this can never exclude
+      // a real live error. It closes the symmetric edge the dedup comment
+      // above doesn't cover — a mapper-silent/uuid-less error-shaped line (no
+      // durable dedup key) replayed below the floor on a born-settled or
+      // rehydrated row must not be mistaken for a fresh failure.
+      if (apiErrorInfo !== null && batchStart >= fs.replayFloor) {
         // Settle immediately — do NOT wait for `DONE_IDLE_MS`. Mirrors
         // `checkDone`'s completed block, but `failed` instead of
         // `completed`; DB write must land before `fireSettle` for the same
@@ -1398,6 +1576,11 @@ export function attachSubagentWatcher(opts: {
       ) {
         fs.status = "completed";
         fs.endedAt = now;
+        // Fix 13 — latch, mirroring `apiErrored`: lets `tailFile`'s flip-back
+        // keep this row's `toolUseId` alive on a later resume, since a
+        // stale-settled synchronous subagent has no other fallback settle
+        // signal left (see `FileState.staleSettled`'s doc).
+        fs.staleSettled = true;
         subagentsDb.setStatus(fs.subagentId, "completed", now);
         emitLifecycle(fs, "finished");
         fireSettle(taskId);
@@ -1436,13 +1619,32 @@ export function attachSubagentWatcher(opts: {
    * — from ever being mis-read as a completion again). From there the row's
    * only remaining settle paths are the task-notification backstop (W3) and
    * the staleness backstop (W4).
+   *
+   * Fix 5 — the stub guard is now CORRELATED per candidate, not just derived
+   * once for the whole line: a `toolUseResult.status === "async_launched"`
+   * line is only treated as the launch stub for a given candidate `fs` when
+   * `toolUseResult.agentId` is either absent OR equals `fs.subagentId` — the
+   * stub's `agentId` field IS the subagent row's own id (verified live), so
+   * this is the correlation key, not just the shape. A candidate that doesn't
+   * match (a coincidental substring hit for a DIFFERENT agent's stub sharing
+   * this batch) falls through to normal settle handling instead of being
+   * wrongly marked async.
    */
   function scanLineForToolResult(line: string, pending: FileState[]): void {
     // Cheap prefilter before any JSON.parse: the launching `tool_use` line
     // and a `<tool-use-id>` notification tag also contain this id string,
     // so a substring hit is NOT sufficient on its own — it only narrows
     // which lines are worth the strict parse below.
-    const candidates = pending.filter((fs) => line.includes(fs.toolUseId!));
+    //
+    // Fix 6 — `fs.toolUseId != null` is required BEFORE the substring check.
+    // `pending` is built once per `scanMainSignals` call and shared across
+    // every line in the batch; a candidate's `toolUseId` can be retired to
+    // `null` mid-scan (the async-stub branch below does exactly that), and
+    // without this guard `line.includes(fs.toolUseId!)` would coerce `null`
+    // to the string `"null"` and match every later line that happens to
+    // contain that four-character substring — a false-positive candidate on
+    // every subsequent line of the batch.
+    const candidates = pending.filter((fs) => fs.toolUseId != null && line.includes(fs.toolUseId));
     if (candidates.length === 0) return;
 
     let parsed: { type?: unknown; message?: { content?: unknown }; toolUseResult?: unknown };
@@ -1455,15 +1657,18 @@ export function attachSubagentWatcher(opts: {
     const content = parsed.message?.content;
     if (!Array.isArray(content)) return;
     const tr = parsed.toolUseResult;
-    const isAsyncLaunchStub =
-      !!tr && typeof tr === "object" && (tr as Record<string, unknown>).status === "async_launched";
+    const trObj = tr && typeof tr === "object" ? (tr as Record<string, unknown>) : null;
+    const stubStatus = trObj?.status === "async_launched";
+    const stubAgentId = typeof trObj?.agentId === "string" ? trObj.agentId : undefined;
     for (const block of content) {
       if (!block || typeof block !== "object") continue;
       const b = block as { type?: unknown; tool_use_id?: unknown };
       if (b.type !== "tool_result") continue;
       for (const fs of candidates) {
         if (b.tool_use_id !== fs.toolUseId) continue;
-        if (isAsyncLaunchStub) {
+        // Fix 5 — correlate the stub to THIS candidate specifically.
+        const isStubForThisCandidate = stubStatus && (stubAgentId === undefined || stubAgentId === fs.subagentId);
+        if (isStubForThisCandidate) {
           fs.isAsync = true;
           fs.toolUseId = null;
         } else {
@@ -1560,22 +1765,49 @@ export function attachSubagentWatcher(opts: {
    * marker, which both real on-disk shapes carry verbatim, keeps the match
    * anchored to an actual notification payload.
    *
-   * The notification's `<status>` is deliberately ignored — completed, failed,
-   * killed and stopped all mean "this agent/workflow is over", and the hold
-   * must release in every one of those cases (plan assumption A4, extended to
-   * regular rows by the same logic).
+   * Fix 9 — the notification's `<status>` is now parsed when present:
+   * `completed`, `failed`, `killed` and `stopped` all mean "this agent/
+   * workflow is over" and settle as before (plan assumption A4, extended to
+   * regular rows by the same logic); an UNKNOWN status value is treated
+   * conservatively — skip the settle and log once, rather than guess, since a
+   * future claude release could introduce a non-terminal status this code
+   * doesn't know about yet; an ABSENT `<status>` tag still settles
+   * unconditionally, preserving back-compat with on-disk shapes (and older
+   * fixture lines) that never carried one.
+   *
+   * Settles performed here pass `source: "receipt"` (fix 4) to
+   * `settleSubagentById` — this scan only ever fires on an actual
+   * `<task-notification>` payload, the harness's own authoritative
+   * completion receipt, so a row it settles should resist resurrection by a
+   * trailing non-`user` line the way an inferred (`checkDone`/`checkStale`/
+   * real-`tool_result`) settle does not.
    */
   function scanLineForTaskNotification(line: string): void {
     if (!line.includes("<task-notification>") || !line.includes("<task-id>")) return;
-    // `matchAll`, not a single `exec`: one physical line can carry more than
-    // one notification (a batched enqueue), and stopping at the first would
-    // silently drop the rest — leaving a finished workflow/agent holding the
-    // card.
-    for (const m of line.matchAll(/<task-id>([^<]+)<\/task-id>/g)) {
-      const id = m[1]!.trim();
+    // Match each whole `<task-notification>…</task-notification>` block, not
+    // just each `<task-id>` tag: fix 9 needs each notification's OWN
+    // `<status>`, and a batched enqueue line can carry more than one
+    // notification. `matchAll` with a non-greedy body (`[\s\S]*?`) covers
+    // multiple blocks on one line without the first block's match swallowing
+    // the rest.
+    for (const nm of line.matchAll(/<task-notification>([\s\S]*?)<\/task-notification>/g)) {
+      const body = nm[1]!;
+      const idMatch = /<task-id>([^<]+)<\/task-id>/.exec(body);
+      if (!idMatch) continue;
+      const id = idMatch[1]!.trim();
+
+      const statusMatch = /<status>([^<]+)<\/status>/.exec(body);
+      const statusRaw = statusMatch ? statusMatch[1]!.trim() : null;
+      if (statusRaw !== null && !TERMINAL_NOTIFICATION_STATUSES.has(statusRaw)) {
+        console.error(
+          `[claude-subagents] task-notification for id ${id} has unrecognised <status>"${statusRaw}"> — skipping settle`,
+        );
+        continue;
+      }
+
       const w = workflows.get(id);
       if (w) {
-        if (w.status === "running") settleSubagentById(id, "completed");
+        if (w.status === "running") settleSubagentById(id, "completed", "receipt");
         continue;
       }
       // Not a container id this watcher knows — check whether it names an
@@ -1584,7 +1816,7 @@ export function attachSubagentWatcher(opts: {
       // unconditionally for every id costs nothing on the common case where
       // the id matches neither.
       const fs = files.get(id);
-      if (fs && fs.status === "running") settleSubagentById(id, "completed");
+      if (fs && fs.status === "running") settleSubagentById(id, "completed", "receipt");
     }
   }
 
@@ -1672,16 +1904,44 @@ export function attachSubagentWatcher(opts: {
       armDirWatcher();
       discover();
       discoverWorkflowAgents();
-      // Steady-state: only re-stat/re-read `running` files. Completed ones keep
-      // no per-tick cost; a resume (rare) re-opens them via the dir watcher's
-      // append notification (see `armDirWatcher`, which tails ALL files). The
-      // first cycle is the exception — it tails everything to drain a reattach
-      // backlog — as is a settled workflow agent whose workflow is still live
-      // (`tailPastSettle`), which the non-recursive dir watcher cannot cover.
+      // Steady-state: only re-stat/re-read `running` files (plus a couple of
+      // narrow exceptions below). Completed ones keep no per-tick cost beyond
+      // fix 3's cheap `statSync` backstop; a resume also re-opens them via the
+      // dir watcher's append notification (see `armDirWatcher`, which tails
+      // ALL files) where available. The first cycle is the exception — it
+      // tails everything to drain a reattach backlog — as is a settled
+      // workflow agent whose workflow is still live (`tailPastSettle`), which
+      // the non-recursive dir watcher cannot cover.
       const tailAll = firstCycle;
       firstCycle = false;
       for (const fs of files.values()) {
-        if (tailAll || fs.status === "running" || tailPastSettle(fs)) tailFile(fs);
+        // Fix 2 — `fs.offset === 0` drains a row that has NEVER been read,
+        // even though it isn't `running` — the born-settled (W7) case: its
+        // content sits below `replayFloor` (fix 1), so draining it here can
+        // never flip it back, but without this it would never be tailed at
+        // all (steady-state only re-tails `running` rows) and its transcript
+        // tab would render permanently empty.
+        if (tailAll || fs.status === "running" || tailPastSettle(fs) || fs.offset === 0) {
+          tailFile(fs);
+          continue;
+        }
+        // Fix 3 — poll backstop for post-settle resume detection. Before
+        // this, a settled regular row's later growth was only ever seen via
+        // the `fs.watch` dir watcher (steady-state polling above only
+        // re-tails `running`/never-read/`tailPastSettle` rows), which makes
+        // resume detection watcher-only: non-deterministic under manual
+        // `pump()`-driven tests, and silently unavailable on filesystems
+        // where `fs.watch` isn't supported (the dir watcher's own `armDirWatcher`
+        // already tolerates that — "the poll backstop covers it" — but until
+        // now there wasn't one for this specific case). A `statSync` per
+        // non-running row is microsecond-cheap, so doing it every cycle for
+        // every settled row is not a meaningful cost even on a task with many
+        // subagents. Guarded: a file that vanished (or is momentarily
+        // unreadable) is skipped, not treated as an error — the dir watcher
+        // or a later tick picks it up if it reappears.
+        try {
+          if (statSync(fs.sourcePath).size > fs.offset) tailFile(fs);
+        } catch { /* file gone/unreadable this tick — try again next cycle */ }
       }
       tailJournals();
       scanMainSignals();
@@ -1737,11 +1997,14 @@ export function attachSubagentWatcher(opts: {
     pump(now?: number): void {
       cycle(now ?? Date.now());
     },
-    syncSettled(id: string, status: SubagentStatus, endedAt: number): void {
+    syncSettled(id: string, status: SubagentStatus, endedAt: number, source?: "receipt" | "inferred"): void {
       const fs = files.get(id);
       if (fs) {
         fs.status = status;
         fs.endedAt = endedAt;
+        // Fix 4 — latch `receiptSettled` for an authoritative settle so
+        // `tailFile`'s flip-back narrows to user-line-only resurrection.
+        if (source === "receipt") fs.receiptSettled = true;
         return;
       }
       // Workflow containers live in their own map (they back no file), but
@@ -1770,9 +2033,22 @@ export function attachSubagentWatcher(opts: {
  * duplicate/late signal (e.g. this races the watcher's own `checkDone`) is a
  * harmless no-op that returns `false` without emitting a second lifecycle
  * event or firing the settle hook again.
+ *
+ * `source` (fix 4) — `"receipt"` for a settle driven by an authoritative
+ * completion receipt (a `<task-notification>`, live via claude-tmux's
+ * `setBackgroundTaskSettledHandler` wiring in orchestrator.ts, or restart-safe
+ * via `scanLineForTaskNotification`/`tailJournals`'s journal `result` line);
+ * `"inferred"` (the default) for everything else — `checkDone`'s end-of-turn
+ * idle, `checkStale`'s staleness backstop, a real `tool_result` in
+ * `scanLineForToolResult`, and orphaning. See `FileState.receiptSettled`'s doc
+ * for what the distinction buys.
  */
-export function settleSubagentById(id: string, status: "completed" | "orphaned"): boolean {
-  return settleSubagent(id, status, 0);
+export function settleSubagentById(
+  id: string,
+  status: "completed" | "orphaned",
+  source: "receipt" | "inferred" = "inferred",
+): boolean {
+  return settleSubagent(id, status, 0, source);
 }
 
 /**
@@ -1822,8 +2098,21 @@ function cascadeWorkflowAgents(taskId: string, container: Subagent, depth: numbe
  *  (depth 0) does, after any cascade beneath it has finished, so a workflow
  *  releasing N agents costs the orchestrator one release check instead of
  *  N + 1 — and every one of those checks sees the final state rather than a
- *  half-settled workflow. */
-function settleSubagent(id: string, status: "completed" | "orphaned", depth: number): boolean {
+ *  half-settled workflow.
+ *
+ *  `source` (fix 4) — threaded through to `syncSettled` so it can latch
+ *  `FileState.receiptSettled`; the cascade call below deliberately does NOT
+ *  propagate the parent container's source and defaults to `"inferred"` for
+ *  cascaded agent rows — cascading is itself already an unconditional,
+ *  invariant-driven settle (the container guard in `tailFile` independently
+ *  blocks a cascaded row from flipping back for as long as its container
+ *  stays settled), so it doesn't need the extra receipt latch to be safe. */
+function settleSubagent(
+  id: string,
+  status: "completed" | "orphaned",
+  depth: number,
+  source: "receipt" | "inferred" = "inferred",
+): boolean {
   let result: { changed: boolean; taskId: string | null };
   try {
     result = subagentsDb.markSettledById(id, status);
@@ -1842,7 +2131,7 @@ function settleSubagent(id: string, status: "completed" | "orphaned", depth: num
       console.error(`[claude-subagents] settle lifecycle emit failed for subagent ${id}:`, e);
     }
   }
-  watchers.get(taskId)?.syncSettled(id, status, row?.endedAt ?? now);
+  watchers.get(taskId)?.syncSettled(id, status, row?.endedAt ?? now, source);
   // Cascade BEFORE the hook (and the hook only at depth 0), so the
   // orchestrator's release predicate (`subagents.hasRunning`) runs exactly once
   // per settle event, against a workflow that is settled in full.

--- a/src/bun/claude-workflow-agents.test.ts
+++ b/src/bun/claude-workflow-agents.test.ts
@@ -6,7 +6,12 @@
  * (the flush-loss backstop), the notification-anchored container settle +
  * cascade, replay idempotency on reattach, the `pumpWatcherForHoldCheck`
  * synchronous hold-check path, the `AGETOR_TRACK_WORKFLOWS` kill switch, and
- * the `REPLAY_WINDOW_BYTES` attach-time clamp.
+ * the `REPLAY_WINDOW_BYTES` attach-time clamp. Also covers W6/W7 from
+ * docs/plans/fix-stuck-subagent-running-detection.md §3: the journal-cursor
+ * rewind on late agent discovery (an early receipt consumed before its row
+ * existed must still settle it once discovered) and settle-on-discovery under
+ * an already-settled container (a straggling agent file must never read as
+ * `running` for even one tick once its container is over).
  *
  * Companion to claude-subagents.test.ts — same conventions, disjoint scope
  * (that file covers classic in-session subagents; this one covers only the
@@ -460,17 +465,18 @@ describe("tailPastSettle: an agent settled early by its journal keeps tailing wh
     const lateEvents = captured.filter((e) => e.subagentId === agentId);
     expect(lateEvents.length).toBeGreaterThan(0);
     expect(lateEvents.some((e) => e.stream === "assistant")).toBe(true);
-    // Surprising but verified: `tailFile`'s own resume-detection treats ANY
-    // append to an already-non-`running` row as a resumed background agent
-    // (the "flip back to running" block), regardless of WHY it was settled.
-    // So tailing past a journal settle doesn't just recover the lost content
-    // — it also flips the row back to `running` (and re-fires
-    // parked-discovery) the moment a trailing line is read. A real workflow
-    // agent's transcript stops growing once the harness kills it, so in
-    // practice this window is short-lived, but it means the row is NOT
-    // stably `completed` immediately after a journal settle if its file
-    // keeps growing afterwards.
-    expect(subagents.get(agentId)!.status).toBe("running");
+    // Updated for fix 4 (docs/plans/fix-stuck-subagent-running-detection.md
+    // §3): a journal `result` receipt settles with `source: "receipt"`,
+    // latching `FileState.receiptSettled`. Previously (see git history)
+    // `tailFile`'s resume-detection treated ANY append to an already-settled
+    // row as a resumed background agent, regardless of why it was settled —
+    // so tailing past a journal settle didn't just recover the lost content,
+    // it also flipped the row back to `running`. That was the live
+    // trailing-flush race fix 4 closes: the harness's journal receipt is
+    // authoritative, and a trailing `assistant` line (not a fresh `user`
+    // prompt) landing after it must NOT resurrect the row. The content is
+    // still recovered (`lateEvents` above) — only the status flip is gone.
+    expect(subagents.get(agentId)!.status).toBe("completed");
 
     w.detach();
   });
@@ -749,6 +755,155 @@ describe("REPLAY_WINDOW_BYTES clamp on attach", () => {
     const recentRow = subagents.get(recentWtaskId);
     expect(recentRow).not.toBeNull();
     expect(recentRow!.status).toBe("running");
+
+    w.detach();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 11. W6 — journal cursor rewind on late agent discovery
+ * (docs/plans/fix-stuck-subagent-running-detection.md §3)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("W6: journal cursor rewind on late agent discovery", () => {
+  test("a result receipt consumed before its agent's file existed still settles it once the file appears", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter, setParkedDiscoveryHandler } = await import(
+      "./claude-subagents.ts"
+    );
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+    setSubagentEmitter(() => { /* drain */ });
+    setParkedDiscoveryHandler(() => { /* drain */ });
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_rewind";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "rewind-wf", wfRunId, transcriptDir: dir, toolUseId }));
+
+    const agentId = `rwagent-${randomUUID().slice(0, 8)}`;
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    const t0 = Date.now();
+    w.pump(t0); // registers the container; arms this dir's journal cursor at 0
+
+    // The harness's own completion receipt for `agentId` lands in the journal
+    // BEFORE its own `agent-<id>.jsonl` ever becomes readdir-visible — the
+    // exact early-receipt race W6 closes (the analog of `discover()`'s own
+    // `mainOffset = 0` rewind for the main-JSONL scan). Consumed now, the row
+    // doesn't exist yet in the DB, so `settleSubagentById` is a silent no-op —
+    // but the journal cursor has already moved past this line.
+    writeFileSync(path.join(dir, "journal.jsonl"), journalLine("result", "k1", agentId, "ok"));
+    w.pump(t0 + 1);
+    expect(subagents.get(agentId)).toBeNull(); // nothing to settle yet — the row doesn't exist
+
+    // The agent's transcript materializes late (readdir-visibility race).
+    writeFileSync(path.join(dir, `agent-${agentId}.meta.json`), wfAgentMeta());
+    writeFileSync(path.join(dir, `agent-${agentId}.jsonl`), sidechainUserLine(agentId, `u-${agentId}`));
+    w.pump(t0 + 2);
+
+    // `discoverWorkflowAgents` rewound this dir's journal cursor back to 0 the
+    // moment it registered the new file, so the already-consumed receipt was
+    // re-read (idempotent settle) and closed the row instead of stranding it
+    // `running` forever with no signal left to consume.
+    const row = subagents.get(agentId)!;
+    expect(row.status).toBe("completed");
+    expect(row.endedAt).not.toBeNull();
+    expect(subagents.get(wtaskId)!.status).toBe("running"); // container untouched
+
+    w.detach();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * 12. W7 — settle-on-discovery under an already-settled container
+ * (docs/plans/fix-stuck-subagent-running-detection.md §3)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+describe("W7: settle-on-discovery under an already-settled container", () => {
+  test("a workflow agent discovered after its container already settled is inserted completed, never running — no parked-discovery, hasRunning stays false", async () => {
+    const { subagents } = await import("./db.ts");
+    const { attachSubagentWatcher, setSubagentEmitter, setParkedDiscoveryHandler } = await import(
+      "./claude-subagents.ts"
+    );
+    const { taskId, jsonlPath, subagentsDir } = await seed();
+
+    const captured: RunEvent[] = [];
+    setSubagentEmitter((e) => captured.push(e));
+    const parked: string[] = [];
+    setParkedDiscoveryHandler((tid) => parked.push(tid));
+
+    const wtaskId = `wtask-${randomUUID()}`;
+    const toolUseId = `toolu-${randomUUID()}`;
+    const wfRunId = "wf_late";
+    const dir = wfDirFor(subagentsDir, wfRunId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(jsonlPath, launchLine({ wtaskId, workflowName: "late-wf", wfRunId, transcriptDir: dir, toolUseId }));
+
+    const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+    const t0 = Date.now();
+    w.pump(t0);
+    expect(parked).toEqual([taskId]);
+    expect(subagents.hasRunning(taskId)).toBe(true);
+
+    // Settle the container via its completion notification, BEFORE any agent
+    // file has appeared under it at all — the cascade invariant this test
+    // pins is: nothing under a settled container may ever read as running,
+    // including a row discovered after the fact.
+    appendFileSync(jsonlPath, notificationLine({ wtaskId, toolUseId }));
+    w.pump(t0 + 1);
+    expect(subagents.get(wtaskId)!.status).toBe("completed");
+    expect(subagents.hasRunning(taskId)).toBe(false);
+    parked.length = 0;
+    captured.length = 0;
+
+    // A straggling agent file only becomes readdir-visible AFTER the
+    // container already settled (a slow flush / readdir race).
+    const agentId = `lateagent-${randomUUID().slice(0, 8)}`;
+    writeFileSync(path.join(dir, `agent-${agentId}.meta.json`), wfAgentMeta());
+    writeFileSync(path.join(dir, `agent-${agentId}.jsonl`), sidechainUserLine(agentId, `u-${agentId}`));
+    w.pump(t0 + 2);
+
+    const row = subagents.get(agentId)!;
+    expect(row).not.toBeNull();
+    expect(row.status).toBe("completed"); // born settled — never running, not even for one tick
+    expect(row.endedAt).not.toBeNull();
+    expect(parked.length).toBe(0); // no parked-discovery for a row born settled
+    expect(subagents.hasRunning(taskId)).toBe(false);
+
+    const lifecycleForAgent = captured.filter((e) => e.stream === "subagent" && e.subagentId === agentId);
+    expect(lifecycleForAgent.length).toBe(1);
+    expect(JSON.parse(lifecycleForAgent[0]!.data).phase).toBe("finished"); // not "started"
+
+    // Fix 2 — a born-settled row's transcript must still be drained (tailed)
+    // once, even though it never renders as `running`: fix 1's
+    // discovery-time floor is what keeps that drain from flipping the row
+    // back to running on the SAME pump, but without fix 2's `fs.offset === 0`
+    // steady-state exception the content would never be read at all (a
+    // non-`running` row is otherwise only re-tailed via `tailPastSettle` —
+    // false here, the container is settled — or fix 3's poll backstop, which
+    // only fires once there's something new to see). `sidechainUserLine`
+    // writes a single plain "go" user turn, so exactly one content chunk
+    // (not a lifecycle event) should have been emitted for it.
+    const contentEvents = captured.filter((e) => e.subagentId === agentId && e.stream !== "subagent");
+    expect(contentEvents.length).toBe(1);
+    expect(contentEvents[0]!.stream).toBe("user");
+    expect(contentEvents[0]!.data).toBe("go");
+
+    // And the row must never flip back to running across further pumps —
+    // the general container-settled guard in `tailFile` (fix 1's other
+    // half) holds even once the drain above has advanced `fs.offset` past 0
+    // (so the primary tail predicate no longer applies and fix 3's poll
+    // backstop is what would otherwise re-tail it, finding nothing new).
+    captured.length = 0;
+    parked.length = 0;
+    w.pump(t0 + 3);
+    w.pump(t0 + 4);
+    expect(subagents.get(agentId)!.status).toBe("completed");
+    expect(subagents.hasRunning(taskId)).toBe(false);
+    expect(parked.length).toBe(0);
+    expect(captured.filter((e) => e.subagentId === agentId).length).toBe(0); // no re-drain, no re-flip
 
     w.detach();
   });

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -289,9 +289,13 @@ setActiveRunProbe((taskId) => {
 // way a naturally-detected completion would (DB flip → lifecycle emit →
 // settle hook → `maybeReleaseHeldTask`). Tolerant by design: a line whose id
 // matches no row, or a duplicate fired again on reattach replay, is a no-op
-// inside `settleSubagentById`.
+// inside `settleSubagentById`. `source: "receipt"` (claude-subagents.ts fix 4)
+// — this IS the live `<task-notification>` dispatch, the harness's own
+// authoritative completion signal, so the settled row should resist a
+// trailing assistant/attachment flush resurrecting it the way an inferred
+// settle would allow.
 setBackgroundTaskSettledHandler((_taskId, agentId) => {
-  settleSubagentById(agentId, "completed");
+  settleSubagentById(agentId, "completed", "receipt");
 });
 
 /**

--- a/src/bun/subagent-stuck-detection.test.ts
+++ b/src/bun/subagent-stuck-detection.test.ts
@@ -1,0 +1,482 @@
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Regression tests for the "stuck subagent stays running forever" fix
+ * (docs/plans/fix-stuck-subagent-running-detection.md). Four compounding
+ * defects (D1-D3 in the plan) let a subagent row wedge at `status='running'`
+ * even after its agent had genuinely finished, holding the parent task's card
+ * in `running` forever. Four fixes close the gap, each pinned here:
+ *
+ *   W1 — replay floor: a batch that starts BELOW `FileState.replayFloor`
+ *        (the source file's size at attach/rehydration) can never flip a
+ *        settled row back to `running` — it's replayed history, not a
+ *        genuine resume. Bytes at/beyond the floor behave exactly as before.
+ *   W2 — async-stub guard: `Agent(run_in_background:true)`'s immediate
+ *        `tool_result` (`toolUseResult.status === "async_launched"`) is a
+ *        launch acknowledgement, not a completion — `scanLineForToolResult`
+ *        must not settle on it, only mark the row async and retire its
+ *        `toolUseId`.
+ *   W3 — generalized notification backstop: `scanLineForTaskNotification`
+ *        also settles an ordinary tracked (`files`) row, not just a workflow
+ *        container — the only restart-safe path left for an async agent once
+ *        claude-tmux's one-shot live dispatch is gone.
+ *   W4 — staleness backstop: a `running` row that never latched
+ *        `sawEndOfTurn` and has produced no new bytes for
+ *        `AGETOR_SUBAGENT_STALE_MS` (default 10 min) settles `completed` as
+ *        a last resort; a genuine later append flips it back via W1.
+ *
+ * Harness mirrors subagent-toolresult-settle.test.ts exactly: mkdtemp
+ * AGETOR_DATA_DIR before importing db.ts, save/restore the process-wide
+ * emitter/settle/parked hooks (bun test shares one process across files),
+ * per-test `seed()`, and `attachSubagentWatcher({ manual: true })` driven by
+ * `w.pump(t)` so timing is deterministic instead of racing real timers.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+import { test, expect, beforeAll, afterEach } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { RunEvent } from "../shared/types.ts";
+
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-stuck-detection-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+
+// Save/restore the process-wide injected hooks (bun test shares one process
+// across files — see claude-subagents.test.ts for the full rationale).
+let originalEmitter: ((e: RunEvent) => void) | null = null;
+let originalSettleHook: ((taskId: string) => void) | null = null;
+let originalParkedHandler: ((taskId: string) => void) | null = null;
+
+beforeAll(async () => {
+  await import("./db.ts");
+  const { setSubagentEmitter, setSubagentSettleHook, setParkedDiscoveryHandler } = await import(
+    "./claude-subagents.ts"
+  );
+  originalEmitter = setSubagentEmitter(null);
+  setSubagentEmitter(originalEmitter);
+  originalSettleHook = setSubagentSettleHook(null);
+  setSubagentSettleHook(originalSettleHook);
+  originalParkedHandler = setParkedDiscoveryHandler(null);
+  setParkedDiscoveryHandler(originalParkedHandler);
+});
+
+const createdTaskIds: string[] = [];
+
+afterEach(async () => {
+  const { detachWatcherFor, setSubagentEmitter, setSubagentSettleHook, setParkedDiscoveryHandler } =
+    await import("./claude-subagents.ts");
+  setSubagentEmitter(originalEmitter);
+  setSubagentSettleHook(originalSettleHook);
+  setParkedDiscoveryHandler(originalParkedHandler);
+  if (createdTaskIds.length === 0) return;
+  const { tasks } = await import("./db.ts");
+  for (const id of createdTaskIds) {
+    try { detachWatcherFor(id); } catch { /* best-effort */ }
+    try { tasks.delete(id); } catch { /* best-effort */ }
+  }
+  createdTaskIds.length = 0;
+});
+
+/** Temp `<sessionId>/subagents/` layout + seeded task/run (run pre-terminal so
+ *  a leaked row can't pollute reconcile.test.ts's global scan — same trap as
+ *  claude-subagents.test.ts documents on its own `seed`). */
+async function seed() {
+  const { tasks, runs } = await import("./db.ts");
+  const taskId = `task-sd-${randomUUID()}`;
+  const runId = `run-sd-${randomUUID()}`;
+  createdTaskIds.push(taskId);
+  const now = Date.now();
+  tasks.insert({
+    id: taskId, title: "t", prompt: "p", column: "running", agent: "claude-code",
+    workdir: "/tmp", isolation: "none", taskType: "task", branch: null, branchSource: "created", worktreePath: null,
+    baseRef: null, mode: null, model: null, effort: null, references: [], backlog: [], draft: null, runId,
+    prUrl: null,
+    hasOpenableRun: false, pendingInteractionCount: 0, openTerminalCount: 0,
+    archivedAt: null, createdAt: now, updatedAt: now,
+  });
+  runs.insert({
+    id: runId, taskId, agent: "claude-code", status: "succeeded", startedAt: now,
+    endedAt: now, exitCode: 0, tmuxSession: null, claudeSessionId: null, codexSessionId: null,
+  });
+
+  const sessionId = randomUUID();
+  const proj = path.join(DATA_DIR, "projects", "encoded");
+  const subagentsDir = path.join(proj, sessionId, "subagents");
+  mkdirSync(subagentsDir, { recursive: true });
+  const jsonlPath = path.join(proj, `${sessionId}.jsonl`);
+  return { taskId, runId, jsonlPath, subagentsDir };
+}
+
+/** The real-world stuck shape: a transcript whose LAST line is an assistant
+ *  text block with stop_reason:null — no terminal end_turn line, ever (the
+ *  claude flush-loss class the whole plan is about). */
+function stuckSidechainLines(): string {
+  return [
+    JSON.stringify({ type: "user", isSidechain: true, uuid: `u-${randomUUID()}`, message: { role: "user", content: "do the thing" } }),
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: `a-${randomUUID()}`, message: { role: "assistant", stop_reason: null, content: [{ type: "text", text: "final answer, but the terminal line never flushed" }] } }),
+  ].join("\n") + "\n";
+}
+
+/** An assistant line representing a genuinely-still-alive agent continuing to
+ *  work — fresh uuid, no end_turn, used to prove a resume flips a settled row
+ *  back to `running` without itself re-settling anything. */
+function continuingTurnLine(): string {
+  return JSON.stringify({
+    type: "assistant", isSidechain: true, uuid: `c-${randomUUID()}`,
+    message: { role: "assistant", stop_reason: "tool_use", content: [{ type: "tool_use", id: `t-${randomUUID()}`, name: "Bash", input: { command: "ls" } }] },
+  }) + "\n";
+}
+
+function writeSubagent(subagentsDir: string, agentId: string, toolUseId: string | null): string {
+  const meta: Record<string, unknown> = { agentType: "general-purpose", description: "work", spawnDepth: 1 };
+  if (toolUseId !== null) meta.toolUseId = toolUseId;
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`), JSON.stringify(meta));
+  const file = path.join(subagentsDir, `agent-${agentId}.jsonl`);
+  writeFileSync(file, stuckSidechainLines());
+  return file;
+}
+
+/** The `Agent(run_in_background:true)` immediate launch acknowledgement — NOT
+ *  a completion (W2's target shape). */
+function asyncStubLine(toolUseId: string, agentId: string): string {
+  return JSON.stringify({
+    type: "user",
+    uuid: `u-stub-${randomUUID()}`,
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content: [{ type: "text", text: "Async agent launched successfully." }] }],
+    },
+    toolUseResult: { isAsync: true, status: "async_launched", agentId },
+  }) + "\n";
+}
+
+/** A main-session line carrying the REAL tool_result for `toolUseId` — full
+ *  content, no `toolUseResult` async-stub marker (signal (3), synchronous
+ *  subagent path). */
+function toolResultLine(toolUseId: string): string {
+  return JSON.stringify({
+    type: "user", uuid: `u-tr-${randomUUID()}`,
+    message: { role: "user", content: [{ type: "tool_result", tool_use_id: toolUseId, content: [{ type: "text", text: "done" }] }] },
+  }) + "\n";
+}
+
+/** A `<task-notification>` completion receipt naming `id` — either a workflow
+ *  container id or (post-W3) an ordinary tracked subagent id. */
+function notificationLine(id: string): string {
+  return JSON.stringify({
+    type: "queue-operation", operation: "enqueue", timestamp: new Date().toISOString(),
+    sessionId: randomUUID(),
+    content: `<task-notification>\n<task-id>${id}</task-id>\n<status>completed</status>\n</task-notification>`,
+  }) + "\n";
+}
+
+test("W2: an async-launch tool_result stub does not settle the row (only a real tool_result may)", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+  setSubagentEmitter(() => { /* drain */ });
+  const settleCalls: string[] = [];
+  setSubagentSettleHook((tid) => settleCalls.push(tid));
+
+  const agentId = `async-${randomUUID()}`;
+  const toolUseId = `toolu_${randomUUID()}`;
+  writeSubagent(subagentsDir, agentId, toolUseId);
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0); // discovers the file — row starts running
+  expect(subagents.get(agentId)!.status).toBe("running");
+
+  appendFileSync(jsonlPath, asyncStubLine(toolUseId, agentId));
+  w.pump(t0 + 1);
+  expect(subagents.get(agentId)!.status).toBe("running");
+  expect(settleCalls.length).toBe(0);
+
+  // Even well past the classic idle window, the stub alone must never settle it.
+  w.pump(t0 + 60_000);
+  expect(subagents.get(agentId)!.status).toBe("running");
+  expect(settleCalls.length).toBe(0);
+
+  w.detach();
+});
+
+test("W2 + W3: after the async stub retires the tool_result key, a queue-operation notification settles the row and stays settled", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+  const captured: RunEvent[] = [];
+  setSubagentEmitter((e) => captured.push(e));
+  const settleCalls: string[] = [];
+  setSubagentSettleHook((tid) => settleCalls.push(tid));
+
+  const agentId = `lifecycle-${randomUUID()}`;
+  const toolUseId = `toolu_${randomUUID()}`;
+  writeSubagent(subagentsDir, agentId, toolUseId);
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0);
+  expect(subagents.get(agentId)!.status).toBe("running");
+
+  appendFileSync(jsonlPath, asyncStubLine(toolUseId, agentId));
+  w.pump(t0 + 1);
+  expect(subagents.get(agentId)!.status).toBe("running");
+
+  // The queue-operation notification is the async agent's real completion
+  // receipt — AID matches the subagent row's own id.
+  appendFileSync(jsonlPath, notificationLine(agentId));
+  w.pump(t0 + 2);
+  const settled = subagents.get(agentId)!;
+  expect(settled.status).toBe("completed");
+  expect(settled.endedAt).not.toBeNull();
+  expect(settleCalls).toEqual([taskId]);
+  const finished = captured.filter((e) => e.stream === "subagent" && JSON.parse(e.data).phase === "finished");
+  expect(finished.length).toBe(1);
+  expect(finished[0]!.subagentId).toBe(agentId);
+
+  // Further pumps must not re-settle or re-emit.
+  w.pump(t0 + 60_000);
+  w.pump(t0 + 120_000);
+  expect(subagents.get(agentId)!.status).toBe("completed");
+  expect(settleCalls).toEqual([taskId]);
+  expect(captured.filter((e) => e.stream === "subagent" && JSON.parse(e.data).phase === "finished").length).toBe(1);
+
+  w.detach();
+});
+
+test("W3 restart-safe: a notification already on disk before attach settles a pre-existing running row on the first pump", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, runId, jsonlPath, subagentsDir } = await seed();
+  setSubagentEmitter(() => { /* drain */ });
+  const settleCalls: string[] = [];
+  setSubagentSettleHook((tid) => settleCalls.push(tid));
+
+  const agentId = `restart-${randomUUID()}`;
+  const toolUseId = `toolu_${randomUUID()}`;
+  const file = writeSubagent(subagentsDir, agentId, toolUseId);
+
+  // Row already `running` as of a prior process (boot reattach scenario) —
+  // async stub already resolved, real toolUseId already retired in that
+  // prior process too, so only the notification backstop can close it.
+  subagents.insertIfAbsent({
+    id: agentId, taskId, runId, parentKind: "subagent",
+    agentType: "general-purpose", description: "work", spawnDepth: 1,
+    sourcePath: file, status: "running", startedAt: Date.now() - 60_000, endedAt: null,
+  });
+
+  // The completion receipt already landed in the main transcript before
+  // agetor restarted — nothing live is around to have dispatched it.
+  writeFileSync(jsonlPath, notificationLine(agentId));
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  w.pump(Date.now());
+  const row = subagents.get(agentId)!;
+  expect(row.status).toBe("completed");
+  expect(settleCalls).toEqual([taskId]);
+
+  // Idempotent on later pumps too.
+  w.pump(Date.now() + 1);
+  expect(subagents.get(agentId)!.status).toBe("completed");
+  expect(settleCalls).toEqual([taskId]);
+
+  w.detach();
+});
+
+test("W1: a completed row's pre-existing unseen-uuid line does not resurrect it on rehydration", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+  const { taskId, runId, jsonlPath, subagentsDir } = await seed();
+  const captured: RunEvent[] = [];
+  setSubagentEmitter((e) => captured.push(e));
+
+  const agentId = `w1-noresurrect-${randomUUID()}`;
+  const file = path.join(subagentsDir, `agent-${agentId}.jsonl`);
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "general-purpose", description: "work", spawnDepth: 1 }));
+  // The transcript already has content with uuids run_events never persisted
+  // (this row was never tailed by this process before) — the exact shape of
+  // the D2 "mapper-silent line" resurrection bug.
+  writeFileSync(file, stuckSidechainLines());
+
+  const now = Date.now();
+  subagents.insertIfAbsent({
+    id: agentId, taskId, runId, parentKind: "subagent",
+    agentType: "general-purpose", description: "work", spawnDepth: 1,
+    sourcePath: file, status: "completed", startedAt: now - 120_000, endedAt: now - 60_000,
+  });
+
+  // Fresh attach = rehydration path: replayFloor is pinned to the file's
+  // CURRENT size, so everything already on disk reads as replay.
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0);
+  w.pump(t0 + 5_000);
+  const row = subagents.get(agentId)!;
+  expect(row.status).toBe("completed");
+  const started = captured.filter((e) => e.stream === "subagent" && JSON.parse(e.data).phase === "started");
+  expect(started.length).toBe(0);
+
+  w.detach();
+});
+
+test("W1: bytes appended AFTER attach (beyond the replay floor) still flip a completed row back to running", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
+  const { taskId, runId, jsonlPath, subagentsDir } = await seed();
+  const captured: RunEvent[] = [];
+  setSubagentEmitter((e) => captured.push(e));
+
+  const agentId = `w1-resume-${randomUUID()}`;
+  const file = path.join(subagentsDir, `agent-${agentId}.jsonl`);
+  writeFileSync(path.join(subagentsDir, `agent-${agentId}.meta.json`),
+    JSON.stringify({ agentType: "general-purpose", description: "work", spawnDepth: 1 }));
+  writeFileSync(file, stuckSidechainLines());
+
+  const now = Date.now();
+  subagents.insertIfAbsent({
+    id: agentId, taskId, runId, parentKind: "subagent",
+    agentType: "general-purpose", description: "work", spawnDepth: 1,
+    sourcePath: file, status: "completed", startedAt: now - 120_000, endedAt: now - 60_000,
+  });
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0); // pure replay — stays completed (pinned by the previous test too)
+  expect(subagents.get(agentId)!.status).toBe("completed");
+
+  // Genuinely new bytes, appended after the watcher's offset already caught
+  // up to the replay floor. Deterministic via a plain `pump()` (fix 3's poll
+  // backstop): a non-`running` file-backed row gets a cheap `statSync` check
+  // every cycle, so resume detection no longer depends on the real
+  // `fs.watch` dir watcher firing its async callback.
+  appendFileSync(file, continuingTurnLine());
+  w.pump(t0 + 1);
+  expect(subagents.get(agentId)!.status).toBe("running");
+  const started = captured.filter((e) => e.stream === "subagent" && JSON.parse(e.data).phase === "started");
+  expect(started.length).toBe(1);
+  expect(started[0]!.subagentId).toBe(agentId);
+
+  w.detach();
+});
+
+test("W4: a running row with no end_turn and no signals on disk settles completed after the stale threshold, then self-corrects on a genuine later append", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+  setSubagentEmitter(() => { /* drain */ });
+  const settleCalls: string[] = [];
+  setSubagentSettleHook((tid) => settleCalls.push(tid));
+
+  const agentId = `stale-${randomUUID()}`;
+  // No toolUseId — no async/sync tool_result fallback either; and no main
+  // JSONL content at all — no notification. Staleness is the ONLY signal
+  // left that can ever close this row.
+  const file = writeSubagent(subagentsDir, agentId, null);
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0); // discovers the file, running
+  expect(subagents.get(agentId)!.status).toBe("running");
+
+  w.pump(t0 + 11 * 60_000);
+  const row = subagents.get(agentId)!;
+  expect(row.status).toBe("completed");
+  expect(settleCalls).toEqual([taskId]);
+
+  // Self-correction: the agent turns out to still be alive after all.
+  // Deterministic via a plain `pump()` (fix 3's poll backstop) instead of
+  // waiting on the real directory watcher. Pumped with the REAL current time
+  // (no synthetic huge offset) rather than continuing to advance the
+  // synthetic clock: `checkStale` runs in the same `cycle()` pass as the
+  // tail that flips this row back to `running`, and `lastAppendAt` is always
+  // stamped with the real wall clock (see `tailFile`) — so pumping with a
+  // `now` still 11 synthetic minutes ahead of real time would make the row
+  // look stale again the instant it flips, undoing the very resume this
+  // assertion is checking for.
+  appendFileSync(file, continuingTurnLine());
+  w.pump();
+  expect(subagents.get(agentId)!.status).toBe("running");
+
+  w.detach();
+});
+
+test("W4: does not fire before the stale threshold", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, jsonlPath, subagentsDir } = await seed();
+  setSubagentEmitter(() => { /* drain */ });
+  const settleCalls: string[] = [];
+  setSubagentSettleHook((tid) => settleCalls.push(tid));
+
+  const agentId = `notyet-${randomUUID()}`;
+  writeSubagent(subagentsDir, agentId, null);
+
+  const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t0 = Date.now();
+  w.pump(t0);
+  expect(subagents.get(agentId)!.status).toBe("running");
+
+  w.pump(t0 + 5 * 60_000);
+  expect(subagents.get(agentId)!.status).toBe("running");
+  expect(settleCalls.length).toBe(0);
+
+  w.detach();
+});
+
+test("end-to-end T4 scenario: a stuck sync subagent settles via the real tool_result signal and stays settled across a second fresh reattach (no oscillation)", async () => {
+  const { subagents } = await import("./db.ts");
+  const { attachSubagentWatcher, setSubagentEmitter, setSubagentSettleHook } = await import(
+    "./claude-subagents.ts"
+  );
+  const { taskId, runId, jsonlPath, subagentsDir } = await seed();
+  setSubagentEmitter(() => { /* drain */ });
+  const settleCalls: string[] = [];
+  setSubagentSettleHook((tid) => settleCalls.push(tid));
+
+  const agentId = `t4-${randomUUID()}`;
+  const toolUseId = `toolu_${randomUUID()}`;
+  const file = writeSubagent(subagentsDir, agentId, toolUseId);
+
+  // Pre-existing running row — the exact shape of the reported prod tasks:
+  // discovered by a prior process, own transcript never got end_turn
+  // (stop_reason:null), no async marker anywhere.
+  subagents.insertIfAbsent({
+    id: agentId, taskId, runId, parentKind: "subagent",
+    agentType: "general-purpose", description: "work", spawnDepth: 1,
+    sourcePath: file, status: "running", startedAt: Date.now() - 120_000, endedAt: null,
+    toolUseId,
+  });
+
+  // The real completion tool_result already sits in the main transcript
+  // since before this attach — full content, no toolUseResult stub marker.
+  writeFileSync(jsonlPath, toolResultLine(toolUseId));
+
+  const w1 = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  w1.pump(Date.now());
+  expect(subagents.get(agentId)!.status).toBe("completed");
+  expect(settleCalls).toEqual([taskId]);
+  w1.detach();
+
+  // A SECOND fresh watcher attach (agetor restarts again) must not resurrect
+  // it — this is the regression test for the prod bug: replayed history read
+  // from offset 0 on every reattach used to flip a completed row back to
+  // running via `tailFile`'s resume-detection (D2 in the plan doc).
+  const w2 = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  const t1 = Date.now();
+  w2.pump(t1);
+  w2.pump(t1 + 1_000);
+  w2.pump(t1 + 60_000);
+  expect(subagents.get(agentId)!.status).toBe("completed");
+  expect(settleCalls).toEqual([taskId]); // never re-fired
+  w2.detach();
+});

--- a/src/bun/subagent-toolresult-settle.test.ts
+++ b/src/bun/subagent-toolresult-settle.test.ts
@@ -271,10 +271,10 @@ test("meta without toolUseId degrades gracefully: unaffected by tool_results, st
   w.detach();
 });
 
-test("resume flip-back: a tool_result-settled subagent whose file grows again returns to running", async () => {
+test("resume flip-back is gated by the replay floor: pre-reattach growth stays settled, post-attach growth flips to running", async () => {
   const { subagents } = await import("./db.ts");
   const { attachSubagentWatcher, setSubagentEmitter } = await import("./claude-subagents.ts");
-  const { taskId, jsonlPath, subagentsDir } = await seed();
+  const { taskId, runId, jsonlPath, subagentsDir } = await seed();
   const captured: RunEvent[] = [];
   setSubagentEmitter((e) => captured.push(e));
 
@@ -286,30 +286,64 @@ test("resume flip-back: a tool_result-settled subagent whose file grows again re
   const w = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
   w.pump(Date.now());
   expect(subagents.get(agentId)!.status).toBe("completed");
+  // One "started" lifecycle from `w`'s own discovery of the file, before it
+  // ever settled — the baseline every later count is compared against, since
+  // a "resurrected" row would add a SECOND one.
+  const startedForAgent = () =>
+    captured.filter(
+      (e) => e.stream === "subagent" && e.subagentId === agentId && JSON.parse(e.data).phase === "started",
+    ).length;
+  expect(startedForAgent()).toBe(1);
 
-  // Resume: new turn appended. Steady-state pumps skip completed files (the
-  // production dir-watcher covers this); mirror the module's own resume test
-  // by re-attaching, whose first cycle tails everything.
+  // (a) Growth that lands BEFORE a reattach is replayed history — every
+  // attach pins `replayFloor` to the file's size AT THAT MOMENT, and this
+  // growth is already on disk by then — so under W1 it must NOT resurrect the
+  // row, even though the resumed line's own content still flows through the
+  // mapper (persist + emit) like any other unseen line.
   appendFileSync(file,
     JSON.stringify({ type: "assistant", isSidechain: true, uuid: `r-${randomUUID()}`, message: { role: "assistant", stop_reason: "tool_use", content: [{ type: "tool_use", id: "t9", name: "Bash", input: { command: "ls" } }] } }) + "\n");
   w.detach();
   const w2 = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
   const t1 = Date.now();
   w2.pump(t1);
-  expect(subagents.get(agentId)!.status).toBe("running");
-  expect(captured.some((e) => e.stream === "subagent" && JSON.parse(e.data).phase === "started" && e.subagentId === agentId)).toBe(true);
-  // The flip-back retires the correlation key, so the stale tool_result
-  // (re-served by the fresh watcher's offset-0 replay) can never re-settle
-  // the resumed agent — not on this pump, not on later ones.
-  w2.pump(t1 + 60_000);
-  expect(subagents.get(agentId)!.status).toBe("running");
-  // Its real completion still lands via its own end_turn.
-  appendFileSync(file,
-    JSON.stringify({ type: "assistant", isSidechain: true, uuid: `r2-${randomUUID()}`, message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "resumed turn done" }] } }) + "\n");
-  w2.pump(t1 + 60_001);
-  w2.pump(t1 + 120_000);
   expect(subagents.get(agentId)!.status).toBe("completed");
+  // The gap-grown line's content still made it through...
+  expect(captured.some((e) => e.stream === "tool_use" && e.subagentId === agentId)).toBe(true);
+  // ...but no ADDITIONAL "started" lifecycle was emitted for it — the row was
+  // never flipped back to running.
+  expect(startedForAgent()).toBe(1);
+  // Stays settled on further pumps too, not just the first.
+  w2.pump(t1 + 60_000);
+  expect(subagents.get(agentId)!.status).toBe("completed");
+  expect(startedForAgent()).toBe(1);
   w2.detach();
+
+  // (b) Growth that lands AFTER attach is beyond the replay floor and DOES
+  // flip a settled row back to running. Give this second row nothing on disk
+  // at attach time (so `replayFloor` pins to 0), then write its resumed turn
+  // strictly afterward — unambiguously "new bytes since attach".
+  const agentId2 = `resume-post-${randomUUID()}`;
+  const file2 = path.join(subagentsDir, `agent-${agentId2}.jsonl`);
+  writeFileSync(file2, "");
+  const now2 = Date.now();
+  subagents.insertIfAbsent({
+    id: agentId2, taskId, runId, parentKind: "subagent",
+    agentType: "general-purpose", description: "work", spawnDepth: 1,
+    sourcePath: file2, status: "completed", startedAt: now2 - 60_000, endedAt: now2 - 30_000,
+  });
+
+  const w3 = attachSubagentWatcher({ taskId, jsonlPath, manual: true });
+  writeFileSync(file2,
+    JSON.stringify({ type: "assistant", isSidechain: true, uuid: `r2-${randomUUID()}`, message: { role: "assistant", stop_reason: "tool_use", content: [{ type: "tool_use", id: "t10", name: "Bash", input: { command: "ls" } }] } }) + "\n");
+  w3.pump(Date.now());
+  expect(subagents.get(agentId2)!.status).toBe("running");
+  expect(
+    captured.some(
+      (e) => e.stream === "subagent" && e.subagentId === agentId2 && JSON.parse(e.data).phase === "started",
+    ),
+  ).toBe(true);
+
+  w3.detach();
 });
 
 test("late discovery rewinds the scan: a tool_result consumed before its agent's file existed still settles it", async () => {


### PR DESCRIPTION
## Problem

Task Details kept showing a subagent tab as green/"running" (and the task card pinned in the `running` column via `hasRunning()`) long after everything had actually finished — observed live on two tasks, with rows stuck for up to a month across dozens of runs.

## Root cause (verified on live data)

The stuck class is exactly "transcript never got its terminal `end_turn` line" (the known claude flush-loss bug under concurrent subagents — every stuck transcript ends `stop_reason:null`). Three compounding defects in `src/bun/claude-subagents.ts` then strand such rows forever:

1. **Async-stub false-settle.** An `Agent(run_in_background: true)` tool_use gets an *immediate* `tool_result` whose `toolUseResult.status === "async_launched"`. The tool_result-correlation scan had no stub guard, so async rows were settled `completed` seconds after launch while still working.
2. **Reattach flip-back resurrection.** Every transcript contains lines whose uuids are never persisted to `run_events` (mapper-silent lines, 10–17 per transcript), so the offset-0 replay at *every* watcher attach found "unseen" lines, flipped settled rows back to `running`, and retired their `toolUseId` in-memory — removing them from the scan in the same cycle. Rows oscillated `completed↔running` on every attach.
3. **One-shot receipts.** The real completion signals were on disk (`<task-notification>` for async agents, a full `tool_result` for sync ones) but only claude-tmux's live tailer dispatched notifications (dedup'd, never replayed on reattach), and the watcher's own notification backstop deliberately settled workflow *container* ids only. An async agent finishing after the session's last turn gets no notification line at all.

## Fix (no migration; all state in-memory)

- **Replay floor** — bytes that existed at attach can never flip a settled row back to `running`; genuine post-attach appends still do.
- **Async-stub guard** — the stub (matched structurally via `toolUseResult.status`, correlated by its `agentId`) marks the row async and retires its correlation key instead of settling it.
- **Generalized notification backstop** — `scanLineForWorkflowNotification` → `scanLineForTaskNotification`: the watcher's main-JSONL scan now also settles regular tracked rows named by a `<task-id>` (restart-safe, with a `<status>` terminal-set check).
- **Staleness backstop** — a running row silent past `AGETOR_SUBAGENT_STALE_MS` (default 10 min) with no `end_turn` settles `completed`; if the agent was actually alive, its next write flips it back — a brief bounce instead of stuck-forever.
- **Receipt-settled guard** — rows settled by a harness receipt (notification/journal) only resurrect on a genuine `type:"user"` line, closing the live trailing-flush race where the last transcript bytes land right after the receipt.
- **Poll backstop** — post-settle resume detection no longer depends solely on `fs.watch`: a cheap per-cycle `statSync` size check re-tails settled rows that grew.
- **Workflow hardening** — journal cursor rewind on late agent discovery (the deferred `pendingReceipts` gap), and agents discovered under an already-settled container are born `completed` (with a real replay floor and a one-shot content drain).

Plus smaller review fixes: retired-key `null` guard in the scan's candidate filter, `MAX_SAFE_INTEGER` floor for unstatable (vs missing) files, api-error settle gated by the floor, `staleSettled` latch preserving `toolUseId` for resumed sync agents, normalized + memoized container-dir lookup.

## Verification

- `bun run typecheck` clean; full suite **2134 pass / 2 skip / 0 fail**.
- New `src/bun/subagent-stuck-detection.test.ts` (8 scenarios, including an end-to-end regression of the exact real-world stuck case: sync agent, no `end_turn`, real `tool_result` on disk — settles and stays settled across repeated re-attaches). Three existing tests that pinned the old resurrect-on-replay behavior updated to the new semantics; W6/W7 coverage added to the workflow tests.
- A harness drove the fixed watcher against the **real stuck production data** (temp DB over the actual session JSONLs): all stuck rows settle within seconds of attach via the notification backstop and stay settled across re-attaches, releasing the card. Existing stuck tasks self-heal at their first watcher attach on this build — no DB surgery needed.

Plan and logged assumptions: `docs/plans/fix-stuck-subagent-running-detection.md`.