### PR TITLE
fix: Task Details opens pinned to the latest message — stop scroll anchoring from de-arming the scroll pin

### DIFF
--- a/docs/plans/task-details-open-scroll-bottom-regression.md
+++ b/docs/plans/task-details-open-scroll-bottom-regression.md
@@ -1,0 +1,59 @@
+# Plan — Task Details opens mid-scroll despite #132 pin (scroll-anchoring de-arm)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-03 |
+| Source | agetor task: "everytime when opening its task details it loads mid scroll rather than on the bottom of the scroll for showing the most recent message" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/task-not-opening-in-most-recent-message |
+| Base SHA | 03b2328 |
+| Mode | Autonomous /implement run — grill + plan-approval gates bypassed; assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+Opening a task's details panel (RunPanel) must land the message log pinned to the bottom — the most recent message visible — every time, including for tasks whose latest run is finished and triggers the auto-rebuild-from-JSONL snapshot swap. Success: the deterministic mid-scroll landing no longer occurs; `bun run typecheck` and `bun test` stay green; no change to deliberate user-scroll behavior (scrolling up to read history must still prevent yank-to-bottom).
+
+## 2. Context & constraints (grounded findings)
+
+The #132 ResizeObserver pin is present and unchanged on HEAD (verified: `git diff fix/missing-auto-scroll-to-bottom HEAD` shows no scroll-code delta; the installed Aug-1 app bundle contains post-#132 strings). The bug still reproduces because of an uncontrolled `scrollTop` writer the pin design never accounted for:
+
+- On open, three async paths race: SSE replay (server caps at `EVENTS_REPLAY_LIMIT=800`, one coalesced flush via rAF/250ms — `RunPanel.tsx:695-785`), the `runs` fetch, and — once `runs` resolves with a finished claude run — the auto-rebuild fetch (`RunPanel.tsx:1067-1117`).
+- The rebuild swap replaces `displayedEvents` wholesale (`RunPanel.tsx:1186-1192`). Rebuilt events carry synthetic `ts = run.startedAt + i` (`src/bun/server.ts:4009-4021`) and `RunEventList` keys are `` `${e.ts}-${i}` `` (`RunPanel.tsx:3594-3596`) → every key changes → full transcript unmount/remount in one commit.
+- No `overflow-anchor` override exists anywhere in the repo, so WebKit scroll anchoring (present in current WKWebView) responds to the remount by adjusting `scrollTop` to keep some arbitrary new anchor node stationary. That adjustment dispatches a native scroll event ahead of ResizeObserver delivery and React effects.
+- `onScroll` (`RunPanel.tsx:2454-2457`) latches `nearBottomRef` from any scroll event regardless of origin. The anchor-driven event computes dist ≥ 80 → `nearBottomRef=false` → path 1 (`RunPanel.tsx:1020-1024`) and path 2 (`RunPanel.tsx:1026-1047`) both bail on their first guard, permanently. Nothing re-arms the ref except a task/tab switch.
+- Ruled out: `pendingAdjustRef` (user-click only), search-jump effect (`activeMatchId` null on open), scroll-restore effect (user "Load earlier" only), sibling sections writing scrollTop (none do), the initial replay flush itself (appends into an empty tree; keys stable; pins fire correctly).
+
+Constraints: no DOM test harness in this repo (no jsdom/happy-dom — precedent in prior scroll-fix knowledge); WKWebView is the only target engine; keep the existing pin design (two paths + two guards) intact.
+
+## 3. Approach & key decisions
+
+Two surgical changes in `RunPanel.tsx`, no control-flow redesign:
+
+1. **`overflow-anchor: none` on the log scroll container** (`logRef` div, ~line 2471) via Tailwind arbitrary property `[overflow-anchor:none]`. The component implements its own bottom-anchoring; the browser's anchoring is a competing writer and this is the documented escape hatch. Removes the root cause: no anchor adjustment → no spurious scroll event → `nearBottomRef` never falsely latched.
+2. **Convert pin path 1 from `useEffect` to `useLayoutEffect`** (~line 1020). Belt-and-braces: on the rebuilt-swap commit the pin then runs synchronously before paint and before any browser-generated scroll event can dispatch, so even an engine that anchors despite (1) (or a future violent commit) gets pinned first and the subsequent scroll event re-confirms `nearBottomRef=true`. Also removes any one-frame flash of the wrong position on swap commits that only path 1 covers.
+
+Alternatives considered: stable React keys across the live↔rebuilt swap (fixes the remount violence but is a larger, riskier change to event identity — deferred); asymmetric `onScroll` latching (changes user-scroll semantics near the suppression window — rejected as scope creep).
+
+## 4. Work breakdown — implementation tasks
+
+- **T1** (single task, one agent): in `src/mainview/components/kanban/RunPanel.tsx` — (a) add `[overflow-anchor:none]` to the `logRef` container className; (b) change the path-1 pin effect to `useLayoutEffect` (add import if not present); (c) update the adjacent design comment (lines ~973-1019) to document the scroll-anchoring writer and why both changes exist. Owns only `RunPanel.tsx`. Acceptance: typecheck green; comment explains the anchor-de-arm mechanism.
+
+## 5. Work breakdown — test tasks
+
+No DOM harness exists (repo precedent: prior scroll-pin fix shipped with dev:hmr visual verification only). No new unit-test surface is created (CSS class + hook-timing change). Test phase = run the full existing suite (`bun test`) + `bun run typecheck`. Manual visual pass in `bun run dev:hmr` is listed as the user-facing follow-up.
+
+## 6. Execution waves
+
+Wave 1: T1 (implementation, sonnet). Then review (opus), then `bun run typecheck` + `bun test` (haiku).
+
+## 7. Blast radius & risks
+
+- `useLayoutEffect` fires synchronously per commit of `[events, rebuilt, interactions.length, activeStream]` — a single scrollTop assignment, negligible cost; it may pin marginally earlier than the RO path on growth commits, which is behavior-equivalent.
+- `overflow-anchor:none` also disables anchoring for a user parked mid-history while content streams in below: without anchoring, appended content below the viewport doesn't move the viewport (scrollTop is retained) — that is exactly the pre-anchoring behavior the pin design was written against, and content is only ever appended below (prepends via "Load earlier" have their own explicit scrollTop compensation at `RunPanel.tsx:963-970`).
+- Older WKWebViews without `overflow-anchor` support ignore the property — and also lack the anchoring that causes the bug.
+
+## 8. Open questions / assumptions (autonomous run)
+
+- Assumed the user runs the Aug-1 build of Agetor.app (contains #132) — verified via bundle string fingerprints; version string still says 0.0.17 because the version was never bumped for the local build.
+- Assumed WKWebView scroll anchoring as the de-arming writer based on convergent static analysis (no live WKWebView instrumentation performed); the fix is safe even if a second violent-commit variant exists, since path-1-as-layout-effect pins before paint regardless.
+- Final visual confirmation in `bun run dev:hmr` is left to the user (cannot drive the WKWebView UI from this environment).

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -14,6 +14,7 @@ import { findMatchingEventIds, resolveActiveMatchIndex, stepMatchIndex } from "@
 import { latestPrProposal } from "@/lib/pr-proposal";
 import { parsePrUrl, parsePullNumber, canOfferResolveConflicts } from "@/lib/pr-url";
 import { buildResolveConflictsPrompt } from "@/lib/resolve-conflicts-prompt";
+import { eventWindowKeepCount } from "@/lib/event-window";
 import type { GitHubPullPrefill } from "./GitHubDialog";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -385,7 +386,7 @@ function RunPanelBody({
   // to distinguish the two without threading a suppression ref through every
   // collapsible in the tree. A pin skipped because unrelated async content
   // happened to land inside the window is recovered on the next growth event
-  // or by the post-commit pin effect (path 1 below).
+  // or by the pre-paint layout-effect pin (path 1 below).
   const pinSuppressUntilRef = useRef(0);
   // Monotonic id source for `StreamEvent.id`, incremented once per event as
   // it's accepted into the unified stream (see the SSE subscription effect
@@ -737,10 +738,25 @@ function RunPanelBody({
         // functional-setState form (which would run twice under StrictMode's
         // dev double-invoke and could double-decrement counters/side effects
         // if this logic lived inside it).
+        //
+        // The trim itself is deferred (see `eventWindowKeepCount` in
+        // `lib/event-window.ts`) while the user is mid-history
+        // (`!nearBottomRef.current`): trimming unconditionally deletes
+        // content above the viewport on every flush, and with
+        // `[overflow-anchor:none]` on the log container (see that div's
+        // className comment below) there's no browser-side absorber left to
+        // paper over the resulting jump — the reader would get yanked
+        // forward with no pin path armed to catch it (`nearBottomRef` is
+        // false, so neither pin fires, and "Load earlier"'s scroll-restore
+        // only covers its own prepend). Deferral is hard-capped at 2x
+        // `EVENTS_WINDOW_MAX` so memory still stays bounded for a reader who
+        // never returns to the bottom; the jerk can still happen once that
+        // cap is hit, which is the accepted trade-off.
         const merged = [...eventsRef.current, ...batch];
         let next = merged;
-        if (merged.length > EVENTS_WINDOW_MAX) {
-          next = merged.slice(merged.length - EVENTS_WINDOW_MAX);
+        const keep = eventWindowKeepCount(merged.length, nearBottomRef.current, EVENTS_WINDOW_MAX);
+        if (keep != null) {
+          next = merged.slice(merged.length - keep);
           const front = next[0];
           const newEarliestId = front?.dbId ?? null;
           setEarliestId(newEarliestId);
@@ -926,14 +942,14 @@ function RunPanelBody({
         // what a previous fetch (or the live/replayed window) already loaded.
         const fresh = page.events.filter((ev) => !loadedDbIdsRef.current.has(ev.id));
         if (fresh.length > 0) {
-          // Set BEFORE the prepend's setState, not after: the pin-to-bottom
-          // effect below reads `nearBottomRef` on every `events` change, and
-          // runs as a passive effect AFTER this component's commit — if this
-          // flag flipped after `setEvents`, that effect could still see the
-          // pre-prepend (stale) `true` and yank the viewport back to the
-          // bottom, fighting the `useLayoutEffect` scroll restore just below
-          // (which always wins the ordering race, but only for scrollTop —
-          // the pin effect would then immediately override it again).
+          // Set BEFORE the prepend's setState: the pin effect below is a
+          // layout effect declared AFTER this scroll-restore layout effect
+          // (see that effect just below), so on the same commit the restore
+          // runs first and the pin — reading `nearBottomRef` on every
+          // `events` change — would immediately overwrite it if the ref
+          // were still (stale) `true`. This flag is the only thing that
+          // makes the pin skip that commit instead of clobbering the
+          // restored scrollTop.
           nearBottomRef.current = false;
           const mapped: StreamEvent[] = fresh.map((ev) => {
             loadedDbIdsRef.current.add(ev.id);
@@ -972,13 +988,29 @@ function RunPanelBody({
 
   // Two complementary pin-to-bottom paths, both gated on `nearBottomRef` so
   // a user who scrolled up to read history is never yanked back down:
-  //   1. On every event / rebuild / interaction change, scroll once after
-  //      the React commit. This is the cheap backstop: it only fires on
-  //      the dependencies listed below, so it covers commits that change
-  //      content without changing either box the ResizeObserver watches,
-  //      and it also recovers any pin that path 2 skipped under the
-  //      suppression window (see below) once the next real growth or a
-  //      dependency change comes through.
+  //   1. On every event / rebuild / interaction change, scroll once as a
+  //      layout effect — pre-paint, before the browser gets a chance to
+  //      dispatch any scroll event of its own. This is the cheap backstop:
+  //      it only fires on the dependencies listed below, so it covers
+  //      commits that change content without changing either box the
+  //      ResizeObserver watches, and it also recovers any pin that path 2
+  //      skipped under the suppression window (see below) once the next
+  //      real growth or a dependency change comes through. Running
+  //      pre-paint (not as a passive effect) matters most on a violent
+  //      commit — e.g. the live→rebuilt `displayedEvents` swap, where every
+  //      event's key changes and the whole transcript remounts. The two
+  //      changes here are jointly, not independently, sufficient:
+  //      `[overflow-anchor:none]` (see the container's className comment)
+  //      removes native anchoring as a competing `scrollTop` writer — left
+  //      enabled, it runs during layout, which happens AFTER layout
+  //      effects, so even with the pin converted to `useLayoutEffect` an
+  //      anchoring-driven jump would still land after the pin and override
+  //      it. The layout-effect conversion, in turn, closes the remaining
+  //      window where a same-frame scroll event could latch `nearBottomRef`
+  //      false before the pin gets a chance to read it. With both in place,
+  //      the pin runs while `nearBottomRef` still holds its pre-commit
+  //      value, and no post-effect scroll adjustment is left that could
+  //      latch it false first.
   //   2. A ResizeObserver on both the scroll container (`logRef`) and the
   //      content wrapper (`logContentRef`) below. The container's own box
   //      shrinks when something mounts above it in the flex column —
@@ -990,16 +1022,19 @@ function RunPanelBody({
   //      settling after mount, and a `UserMessageBlock`'s "Show more"
   //      toggle appearing once it measures itself. Observing both, rather
   //      than enumerating every async cause as a dependency, makes the pin
-  //      self-healing against future async widgets, and this is the
-  //      lower-latency path of the two: ResizeObserver callbacks are
-  //      delivered pre-paint in the same rendering opportunity as the
-  //      resize, ahead of path 1's passive effect (which only flushes after
-  //      paint). Assigning `scrollTop` does not change either observed
-  //      element's size, so the pin can't feed back into its own observer;
-  //      the resulting scroll event just re-confirms `nearBottomRef` as
-  //      true. Mount-scoped (`[]`) is correct — `RunPanelBody` doesn't
-  //      remount on task switch, so both refs stay attached to the same DOM
-  //      nodes across tasks and a fresh `observe()` isn't needed per task.
+  //      self-healing against future async widgets. Both paths now run
+  //      pre-paint (path 1 as a layout effect, this one via ResizeObserver's
+  //      own pre-paint delivery in the same rendering opportunity as the
+  //      resize), so neither is "ahead" of the other in the sense that used
+  //      to matter; ResizeObserver still earns its keep as a separate path
+  //      because it fires on box-size changes path 1's dependency list
+  //      can't see (see above). Assigning `scrollTop` does not change
+  //      either observed element's size, so the pin can't feed back into
+  //      its own observer; the resulting scroll event just re-confirms
+  //      `nearBottomRef` as true. Mount-scoped (`[]`) is correct —
+  //      `RunPanelBody` doesn't remount on task switch, so both refs stay
+  //      attached to the same DOM nodes across tasks and a fresh
+  //      `observe()` isn't needed per task.
   //
   //      Two additional guards keep path 2 from hijacking a user-initiated
   //      resize (e.g. expanding/collapsing a "Show more" toggle while
@@ -1017,7 +1052,7 @@ function RunPanelBody({
   //          `true` mid-fling. `el.scrollTop` read synchronously is always
   //          current even when scroll events lag, so the pre-resize
   //          distance is trustworthy where the latched ref may not be.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!nearBottomRef.current) return;
     const el = logRef.current;
     if (el) el.scrollTop = el.scrollHeight;
@@ -2468,7 +2503,22 @@ function RunPanelBody({
         // width; `overflow-x-hidden` keeps the panel from gaining a
         // horizontal scrollbar — text wraps via `break-all` on the
         // problematic spots instead.
-        className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden p-3 text-xs leading-relaxed"
+        // `[overflow-anchor:none]` disables the browser's native scroll
+        // anchoring on this container. This component already owns
+        // bottom-pinning end to end (the two pin paths below), so native
+        // anchoring is just a second, uncoordinated writer of `scrollTop`.
+        // It mattered most on the live→rebuilt `displayedEvents` swap: every
+        // event gets a new React key, so the whole transcript remounts, and
+        // anchoring — seeing a wholesale DOM replacement — picked an
+        // arbitrary new anchor node and jumped `scrollTop` to keep it in
+        // view. Before this fix (when path 1 was still a plain `useEffect`
+        // and this property wasn't set), that scroll event landed before
+        // either pin effect got a chance to run, latching `nearBottomRef`
+        // false and permanently de-arming both auto-scroll paths for the
+        // rest of the panel's life — this property, together with
+        // converting path 1 to a layout effect (see the pin-paths comment
+        // above), is what closes that hole.
+        className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden p-3 text-xs leading-relaxed [overflow-anchor:none]"
       >
         <div ref={logContentRef}>
           {/* "Load earlier messages" — only meaningful once we have a real DB

--- a/src/mainview/lib/event-window.test.ts
+++ b/src/mainview/lib/event-window.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { eventWindowKeepCount } from "./event-window.ts";
+import { EVENTS_WINDOW_MAX } from "../../shared/types.ts";
+
+describe("eventWindowKeepCount", () => {
+  const max = 100;
+
+  test("under-cap, near bottom: no trim", () => {
+    expect(eventWindowKeepCount(50, true, max)).toBeNull();
+  });
+
+  test("under-cap, mid-history: no trim", () => {
+    expect(eventWindowKeepCount(50, false, max)).toBeNull();
+  });
+
+  test("length === max, near bottom: no trim (boundary is inclusive)", () => {
+    expect(eventWindowKeepCount(max, true, max)).toBeNull();
+  });
+
+  test("length === max, mid-history: no trim (boundary is inclusive)", () => {
+    expect(eventWindowKeepCount(max, false, max)).toBeNull();
+  });
+
+  test("over-cap, near bottom, just past max: trims to max", () => {
+    expect(eventWindowKeepCount(max + 1, true, max)).toBe(max);
+  });
+
+  test("over-cap, near bottom, far past max: trims to max", () => {
+    expect(eventWindowKeepCount(max * 10, true, max)).toBe(max);
+  });
+
+  test("mid-history deferral: just past max, not near bottom, defers", () => {
+    expect(eventWindowKeepCount(max + 1, false, max)).toBeNull();
+  });
+
+  test("mid-history deferral: length === 2*max, not near bottom, defers (boundary is inclusive)", () => {
+    expect(eventWindowKeepCount(max * 2, false, max)).toBeNull();
+  });
+
+  test("mid-history hard cap: length === 2*max + 1, not near bottom, trims to max", () => {
+    expect(eventWindowKeepCount(max * 2 + 1, false, max)).toBe(max);
+  });
+
+  test("mid-history hard cap: far past 2*max, not near bottom, still trims to max", () => {
+    expect(eventWindowKeepCount(max * 20, false, max)).toBe(max);
+  });
+
+  test("production wiring: EVENTS_WINDOW_MAX sanity check", () => {
+    // Exercise the real constant so the production relationship (front-trim
+    // engages once the live window exceeds EVENTS_WINDOW_MAX, and mid-history
+    // readers get held until 2x that) stays correct if the constant changes.
+    expect(eventWindowKeepCount(EVENTS_WINDOW_MAX, true, EVENTS_WINDOW_MAX)).toBeNull();
+    expect(eventWindowKeepCount(EVENTS_WINDOW_MAX + 1, true, EVENTS_WINDOW_MAX)).toBe(
+      EVENTS_WINDOW_MAX,
+    );
+    expect(
+      eventWindowKeepCount(EVENTS_WINDOW_MAX + 1, false, EVENTS_WINDOW_MAX),
+    ).toBeNull();
+    expect(
+      eventWindowKeepCount(EVENTS_WINDOW_MAX * 2 + 1, false, EVENTS_WINDOW_MAX),
+    ).toBe(EVENTS_WINDOW_MAX);
+  });
+
+  test("degenerate max=0: any positive length is over-cap and trims to 0", () => {
+    // length <= max (0) is only true for length === 0, so any length > 0
+    // exceeds the cap immediately. Near-bottom trims straight to 0; the
+    // mid-history deferral window (max*2 === 0) can never hold anything
+    // back, so mid-history also trims to 0 for any positive length.
+    expect(eventWindowKeepCount(0, true, 0)).toBeNull();
+    expect(eventWindowKeepCount(1, true, 0)).toBe(0);
+    expect(eventWindowKeepCount(1, false, 0)).toBe(0);
+  });
+});

--- a/src/mainview/lib/event-window.ts
+++ b/src/mainview/lib/event-window.ts
@@ -1,0 +1,40 @@
+// Pure decision helper for RunPanel's live-event-window front-trim.
+//
+// Background: RunPanel caps the live `events` array at `EVENTS_WINDOW_MAX` so
+// a long-running task doesn't grow an unbounded in-memory/DOM list — once the
+// window is exceeded, the SSE flush callback trims from the FRONT (oldest
+// events), which is content ABOVE whatever the user is currently looking at.
+// Trimming unconditionally on every flush is fine when the user is pinned to
+// the bottom (the same content they'd never scroll back to is what's getting
+// dropped), but a user parked mid-history to read old messages gets that
+// history yanked out from under them on every flush — `nearBottomRef` is
+// false there, so neither pin-to-bottom path fires to mask the jump, and
+// "Load earlier"'s scroll-restore only compensates for its own prepend, not
+// for a concurrent trim shrinking the front. This module answers "should this
+// flush trim the front now, or defer?" so RunPanel can skip the trim while a
+// reader is mid-history, without letting the window grow forever.
+
+/**
+ * Decides how many of the newest events to keep on this flush, or whether to
+ * skip trimming entirely.
+ *
+ * Returns `null` (don't trim — keep everything) when either:
+ *  - `length` hasn't exceeded `max` yet, so there's nothing to trim; or
+ *  - the user is NOT near the bottom (mid-history) AND `length` is still
+ *    under `max * 2` — deferring the trim so content already on screen (or
+ *    just above it) doesn't vanish out from under a reader. This is a
+ *    deferral, not an exemption: a reader who stays mid-history through
+ *    enough flushes to double the window still hits the hard cap below,
+ *    which is the accepted trade-off that bounds memory over an unbounded
+ *    task.
+ *
+ * Returns `max` (trim to the newest `max` events) once the window would
+ * otherwise exceed the 2x hard cap, or whenever the user IS near the bottom —
+ * trimming content that's already scrolled out of view above a bottom-pinned
+ * reader is invisible to them.
+ */
+export function eventWindowKeepCount(length: number, nearBottom: boolean, max: number): number | null {
+  if (length <= max) return null;
+  if (!nearBottom && length <= max * 2) return null;
+  return max;
+}


### PR DESCRIPTION
## Problem

Opening a task's details panel deterministically landed the message log **mid-scroll** instead of at the most recent message — even though #132's ResizeObserver scroll-pin is present and working.

## Root cause

The pin design trusts `nearBottomRef`, which is latched by the log's `onScroll` handler from **any** scroll event — but not every scroll event is a user scroll:

1. On open, the log pins to the bottom correctly while SSE replay streams in.
2. For any finished claude run, the auto-rebuild-from-JSONL swap then replaces `displayedEvents` wholesale. Rebuilt events carry synthetic timestamps (`run.startedAt + i`) and the list keys are `` `${ts}-${i}` ``, so **every React key changes** and the whole transcript unmounts/remounts in one commit.
3. WKWebView's native **scroll anchoring** (`overflow-anchor` was never overridden anywhere) reacts to that remount by moving `scrollTop` to keep an arbitrary new anchor node in view. That adjustment dispatches a scroll event **before** the ResizeObserver callback or React effects run.
4. `onScroll` latches `nearBottomRef = false` from it, and both pin paths bail on their first guard — **permanently**, since nothing re-arms the ref except a task/tab switch. Every subsequent flush then lands below the viewport.

Deterministic on every reopen of a finished task, which is most tasks a user opens to inspect.

## Fix

Two surgical changes in `RunPanel.tsx` — **jointly** sufficient (anchoring applies its adjustment during layout, which runs *after* layout effects, so neither change alone closes the race):

- **`[overflow-anchor:none]` on the log scroll container.** The panel implements its own bottom-anchoring (the two pin paths); native anchoring was a second, uncoordinated writer of `scrollTop`. This removes it. Non-inherited, so nested scrollers (e.g. `UserMessageBlock`'s expanded overlay) keep native behavior.
- **Pin path 1 converted `useEffect` → `useLayoutEffect`.** The pin now runs pre-paint, reading `nearBottomRef` before any same-frame browser-generated scroll event can falsely latch it; the subsequent scroll event just re-confirms near-bottom.

### Follow-through from review

With anchoring disabled, the `EVENTS_WINDOW_MAX` front-trim in the SSE flush callback lost its implicit absorber: past 3000 windowed events, every flush deletes content *above* the viewport, jerking a user parked mid-history. Rather than compensating `scrollTop` (delta-based compensation is wrong there — trims and appends land in the same flush), the trim is now **deferred while the user is scrolled up**, with a 2× hard cap so memory stays bounded. The decision lives in a new pure helper, `src/mainview/lib/event-window.ts`.

Also: comment corrections around the pin design (the old text described pre-fix ordering), and the plan doc under `docs/plans/`.

## Testing

- `bun run typecheck` clean.
- `bun test`: 2136 pass / 0 fail / 2 skip (full suite), including 12 new unit tests for `eventWindowKeepCount` (boundaries at `max` and `2×max`, near-bottom vs mid-history, degenerate `max=0`).
- The scroll behavior itself isn't unit-testable here (no DOM harness in this repo — established precedent). **Reviewer visual pass requested**: in `bun run dev:hmr`, repeatedly open a finished task's details and confirm the log lands at the bottom; scroll up mid-stream and confirm you're not yanked back down. The previous fix shipped without this pass, which is how the regression went unnoticed.