### PR TITLE
feature: rename Task Details "Open PR" chip to "Create PR"

### DIFF
--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -2735,9 +2735,9 @@ function RunPanelBody({
                         taskId: task.id,
                       });
                     }}
-                    title="Open a pull request for this task's branch — prefilled from the agent's summary when available"
+                    title="Create a pull request for this task's branch — prefilled from the agent's summary when available"
                   >
-                    <GitPullRequest className="mr-1 size-3" /> Open PR
+                    <GitPullRequest className="mr-1 size-3" /> Create PR
                   </Button>
                 )}
               </div>


### PR DESCRIPTION
## What changed

Renamed the git-action chip in Task Details (RunPanel) from **"Open PR"** to **"Create PR"**, and updated its tooltip to match ("Create a pull request for this task's branch — prefilled from the agent's summary when available").

## Why

The chip opens the PR composer modal, whose submit button already says **Create PR** (`Create {caps.pullAbbrev}` in `PullComposer`). Calling the chip "Open PR" was misleading — it read like "open the PR link" for an existing pull request (that's what the **View PR** link in the panel header does once a PR exists). Using the same verb as the composer removes that ambiguity.

## Notes

- Label + tooltip only — no behavior change (`src/mainview/components/kanban/RunPanel.tsx`).
- Internal code comments that mention the old "Open PR" name (gating logic in `shared/types.ts`, `commit-push.ts`, etc.) were left untouched.
- `bun run typecheck` is green.