### PR TITLE
fix: move "Resolve Conflicts" button from Task Details header to the composer action-chip row

### DIFF
--- a/docs/plans/move-resolve-conflicts-button-to-composer.md
+++ b/docs/plans/move-resolve-conflicts-button-to-composer.md
@@ -1,0 +1,50 @@
+# Plan — Move "Resolve Conflicts" to the composer action-chip row
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-03 |
+| Source | /implement request (conversation) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/move-resolve-conflicts-button-to-message |
+| Base SHA | 0a7cf7697cc13cb0092b31469ff4cf177887bab1 |
+| Mode | Autonomous — grill gate and plan-approval gate bypassed (owner not present); assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+Relocate the "Resolve Conflicts" button in Task Details (RunPanel) from the modal header's action cluster to the action-chip row that sits directly above the message textarea — the same row that hosts "Save for later", "Commit & push", and "Open PR". Behavior (gating, prompt, toasts, "Sent to agent" feedback) is unchanged; only placement and chip styling change.
+
+Success: button renders next to Commit & push above the composer, no longer in the header; all existing gates preserved; typecheck + `bun test` green.
+
+## 2. Context & constraints
+
+- Header instance today: `RunPanel.tsx:2297-2323` — gated on `!archived && activeStream === "main" && canOfferResolveConflicts(parsedPrUrl, prStatus)`, disabled on `!canSend || modalPending || sending || backlogBusy || resolvingConflicts || resolveConflictsSent`, `variant="outline"`, `GitMerge` icon, label flips to "Sent to agent" for 5s after send.
+- Target row: `RunPanel.tsx:2669-2745`, rendered when `(canSend || input.trim() || sendRefs.length > 0)`; right-side group holds Save for later (ghost), Commit & push (secondary), Open PR (secondary).
+- `canSend = !!resumableRunId` (`:1475`). `canOfferResolveConflicts` requires a parsed PR URL + fetched mergeability with conflicts — a PR implies prior runs, so the row's `canSend` gate cannot realistically hide an offerable button. The `!canSend` disabled-branch is kept as a belt-and-braces guard.
+- The header keeps the PR mergeability re-check (`RefreshCw`) button and "View PR" link — only Resolve Conflicts moves.
+- Comment at `:1765` ("PR mergeability for the header \"Resolve Conflicts\" button") must be updated to point at the composer row.
+
+## 3. Approach & key decisions
+
+Cut the button JSX (with its gating comment) from the header cluster and re-insert it in the right-side chip group, after "Open PR" (they're near-mutually-exclusive: Open PR shows pre-PR, Resolve Conflicts post-PR-with-conflicts). Switch `variant="outline"` → `variant="secondary"` to match its new siblings. Keep the full disabled expression and title ladder verbatim. Alternative considered: hide-on-`sending` like Commit & push — rejected; the disabled ladder carries the "Sent to agent" cooldown state that hiding would lose.
+
+## 4. Work breakdown — implementation
+
+- **T1** (sonnet, wave 1): move the button block in `src/mainview/components/kanban/RunPanel.tsx` as per §3; update the `:1765` comment. Owns only this file. Acceptance: button gone from header, present after Open PR in chip row, gates/disabled/title/label logic byte-identical apart from variant.
+
+## 5. Work breakdown — tests
+
+None. Pure JSX relocation; gating helpers (`canOfferResolveConflicts`, `buildResolveConflictsPrompt`) are untouched and already covered by `pr-url.test.ts` / `resolve-conflicts-prompt.test.ts`. Existing suite runs in Phase 7.
+
+## 6. Execution waves
+
+Wave 1: T1. Then review (opus), then typecheck + `bun test` (haiku).
+
+## 7. Blast radius & risks
+
+Single component. Risk: the chip row doesn't render for `!canSend && no draft` — accepted per §2 (unreachable when the button is offerable). Archived tasks: row renders (Send is offered) but the button keeps its own `!archived` gate, matching prior behavior.
+
+## 8. Open questions / assumptions
+
+- Assumed placement after "Open PR" in the right-side group (user said "like the Commit and push one" — exact ordering unspecified).
+- Assumed `secondary` variant to match row siblings rather than keeping header `outline`.
+- Assumed the header's mergeability re-check icon button stays in the header (user asked only about Resolve Conflicts).

--- a/docs/plans/move-resolve-conflicts-button-to-composer.md
+++ b/docs/plans/move-resolve-conflicts-button-to-composer.md
@@ -27,6 +27,10 @@ Success: button renders next to Commit & push above the composer, no longer in t
 
 Cut the button JSX (with its gating comment) from the header cluster and re-insert it in the right-side chip group, after "Open PR" (they're near-mutually-exclusive: Open PR shows pre-PR, Resolve Conflicts post-PR-with-conflicts). Switch `variant="outline"` → `variant="secondary"` to match its new siblings. Keep the full disabled expression and title ladder verbatim. Alternative considered: hide-on-`sending` like Commit & push — rejected; the disabled ladder carries the "Sent to agent" cooldown state that hiding would lose.
 
+This supersedes the placement convention stated in `docs/plans/resolve-conflicts-from-task-details.md` ("PR-state-driven actions belong in the header; git-working-tree chips live in the composer row"): Resolve Conflicts now joins the composer row deliberately, because it composes a message to the agent — same interaction family as Commit & push / Open PR — even though its trigger is PR state. The header keeps View PR and the mergeability re-check.
+
+Post-review amendments (Phase 8): the row gate gains `|| showResolveConflicts` so an offerable button isn't hidden when `canSend` is false (orphan-reconciled runs), and the dead `activeStream === "main"` clause was dropped — the composer dock already excludes subagent tabs.
+
 ## 4. Work breakdown — implementation
 
 - **T1** (sonnet, wave 1): move the button block in `src/mainview/components/kanban/RunPanel.tsx` as per §3; update the `:1765` comment. Owns only this file. Acceptance: button gone from header, present after Open PR in chip row, gates/disabled/title/label logic byte-identical apart from variant.

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -1762,7 +1762,7 @@ function RunPanelBody({
     return () => { cancelled = true; };
   }, [task.id]);
 
-  // PR mergeability for the header "Resolve Conflicts" button. `parsedPrUrl`
+  // PR mergeability for the composer-row "Resolve Conflicts" button. `parsedPrUrl`
   // is derived once per `task.prUrl` change and reused for both the fetch
   // effect and the render-time gate (`canOfferResolveConflicts`).
   const parsedPrUrl = useMemo(() => parsePrUrl(task.prUrl), [task.prUrl]);
@@ -2294,33 +2294,6 @@ function RunPanelBody({
               <RefreshCw className="size-3.5" />
             </Button>
           )}
-          {/* Gated on `!archived` (the server silently auto-unarchives on
-              other mutations, but this button must not act as though it
-              were live on a frozen task) and on `activeStream === "main"`
-              (mirrors Stop below — a read-only subagent stream tab has no
-              `sendHint` rendered, so a failure here would be invisible;
-              `sendResolveConflicts` also toasts for the same reason). */}
-          {!archived && activeStream === "main" && canOfferResolveConflicts(parsedPrUrl, prStatus) && (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => void sendResolveConflicts()}
-              disabled={!canSend || modalPending || sending || backlogBusy || resolvingConflicts || resolveConflictsSent}
-              title={
-                !canSend
-                  ? "Start the task before asking the agent to resolve conflicts"
-                  : modalPending
-                    ? "Answer the pending prompt before sending another message"
-                    : resolveConflictsSent
-                      ? "Already sent — waiting for the agent to pick it up"
-                      : sending || backlogBusy || resolvingConflicts
-                        ? "A message is already being sent"
-                        : "Ask the agent to merge the base branch and resolve the reported conflicts"
-              }
-            >
-              <GitMerge className="mr-1 size-3" /> {resolveConflictsSent ? "Sent to agent" : "Resolve Conflicts"}
-            </Button>
-          )}
           <Button
             size="sm"
             variant="outline"
@@ -2738,6 +2711,35 @@ function RunPanelBody({
                     title="Open a pull request for this task's branch — prefilled from the agent's summary when available"
                   >
                     <GitPullRequest className="mr-1 size-3" /> Open PR
+                  </Button>
+                )}
+                {/* Post-PR counterpart to "Open PR" above: offered once the
+                    task's PR reports merge conflicts. Gated on `!archived`
+                    (the server silently auto-unarchives on other mutations,
+                    but this button must not act as though it were live on a
+                    frozen task) and on `activeStream === "main"` (a read-only
+                    subagent stream tab has no `sendHint` rendered, so a
+                    failure here would be invisible; `sendResolveConflicts`
+                    also toasts for the same reason). */}
+                {!archived && activeStream === "main" && canOfferResolveConflicts(parsedPrUrl, prStatus) && (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => void sendResolveConflicts()}
+                    disabled={!canSend || modalPending || sending || backlogBusy || resolvingConflicts || resolveConflictsSent}
+                    title={
+                      !canSend
+                        ? "Start the task before asking the agent to resolve conflicts"
+                        : modalPending
+                          ? "Answer the pending prompt before sending another message"
+                          : resolveConflictsSent
+                            ? "Already sent — waiting for the agent to pick it up"
+                            : sending || backlogBusy || resolvingConflicts
+                              ? "A message is already being sent"
+                              : "Ask the agent to merge the base branch and resolve the reported conflicts"
+                    }
+                  >
+                    <GitMerge className="mr-1 size-3" /> {resolveConflictsSent ? "Sent to agent" : "Resolve Conflicts"}
                   </Button>
                 )}
               </div>

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -2118,6 +2118,10 @@ function RunPanelBody({
   // and "Sent to agent" confirmation don't get tangled up with the composer's.
   const [resolvingConflicts, setResolvingConflicts] = useState(false);
   const [resolveConflictsSent, setResolveConflictsSent] = useState(false);
+  // Offer survives `!canSend` (e.g. an orphan-reconciled run) — the button
+  // then renders disabled with its "start the task" tooltip instead of
+  // vanishing from the row.
+  const showResolveConflicts = !archived && canOfferResolveConflicts(parsedPrUrl, prStatus);
   const resolveConflictsSentTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => () => {
     if (resolveConflictsSentTimerRef.current) clearTimeout(resolveConflictsSentTimerRef.current);
@@ -2147,9 +2151,10 @@ function RunPanelBody({
       const res = await api.sendRunInput(resumableRunId, prompt);
       if (!res.delivered) {
         setSendHint(res.reason);
-        // The button can be hidden (archived, subagent tab) by the time this
-        // resolves, which would make `sendHint` invisible — toast so the
-        // failure is surfaced regardless.
+        // The button can be hidden by the time this resolves — archived,
+        // a subagent tab (dock-level), or the mergeability re-fetch clearing
+        // `prStatus` — any of which would make `sendHint` invisible, so
+        // toast to surface the failure regardless.
         toast.error(res.reason);
       } else {
         setRebuilt(null);
@@ -2638,8 +2643,11 @@ function RunPanelBody({
             </p>
           )}
           {/* Shown once the task is sendable, OR as soon as there's something to
-              stash — that's what lets "Save for later" work pre-run. */}
-          {(canSend || input.trim() || sendRefs.length > 0) && (
+              stash — that's what lets "Save for later" work pre-run. Also
+              shown whenever Resolve Conflicts is offerable (even disabled),
+              so an offerable-but-not-yet-sendable task doesn't have the
+              button pop in and out as the draft is typed. */}
+          {(canSend || input.trim() || sendRefs.length > 0 || showResolveConflicts) && (
             // Picker on the left; "Save for later" / "Commit & push" pushed to
             // the right so they aren't stacked directly on top of the picker.
             <div className="flex items-center justify-between gap-2">
@@ -2717,11 +2725,14 @@ function RunPanelBody({
                     task's PR reports merge conflicts. Gated on `!archived`
                     (the server silently auto-unarchives on other mutations,
                     but this button must not act as though it were live on a
-                    frozen task) and on `activeStream === "main"` (a read-only
-                    subagent stream tab has no `sendHint` rendered, so a
-                    failure here would be invisible; `sendResolveConflicts`
-                    also toasts for the same reason). */}
-                {!archived && activeStream === "main" && canOfferResolveConflicts(parsedPrUrl, prStatus) && (
+                    frozen task — an archived-but-`canSend` task DOES render
+                    this dock, so the clause is live, not dead code). The
+                    composer dock as a whole already excludes subagent tabs
+                    (`activeStream !== "main"` renders a read-only footer
+                    instead), so no separate check is needed here. Rendered
+                    even when `!canSend` (see `showResolveConflicts` above) —
+                    disabled, with a tooltip explaining why. */}
+                {showResolveConflicts && (
                   <Button
                     size="sm"
                     variant="secondary"


### PR DESCRIPTION
## What

Moves the **Resolve Conflicts** button in Task Details from the modal header's action cluster into the action-chip row directly above the message input — next to "Commit & push" / "Open PR" — and restyles it from `outline` to `secondary` to match its new siblings. The header keeps the "View PR" link and the PR-mergeability re-check icon.

## Why

Resolve Conflicts composes a message to the agent, the same interaction family as "Commit & push" and "Open PR", so it belongs with them above the composer rather than in the header. (This deliberately supersedes the earlier "PR-state-driven actions live in the header" placement from the original feature.)

## Details

- The button's gating, disabled ladder, tooltips, prompt, toasts, and the 5s "Sent to agent" cooldown are preserved verbatim — only placement and variant changed.
- **Gating fix found in review:** the chip row was gated on `(canSend || draft)`, but `canSend` tracks a *resumable* run, not "has ever run" — e.g. a codex task orphan-reconciled at boot has `run_id = NULL` while its PR still reports conflicts. The offerable button would vanish entirely (and pop in/out as a draft was typed). The offer condition is now hoisted:

  ```tsx
  const showResolveConflicts = !archived && canOfferResolveConflicts(parsedPrUrl, prStatus);
  ```

  and OR-ed into the row gate, so an offerable button always renders — disabled with its "start the task" tooltip when the task isn't sendable.
- Dropped the dead `activeStream === "main"` clause carried over from the header: the composer dock already renders a read-only footer for subagent tabs, so the button-level check was unreachable. The `!archived` clause stays — an archived-but-sendable task does render the dock.
- Updated the comments that referenced the old header placement, and added the plan doc under `docs/plans/`.

## Verification

- `bun run typecheck` green.
- `bun test`: 2146 pass / 0 fail / 2 skip.
- Note: `claude-tmux-queue.test.ts` has a pre-existing timing assertion (`< 500ms`) that fails when the file runs in isolation but passes in the full suite — untouched by this branch.

## Heads-up

`feature/rename-open-pr-by-create-pr` (in flight) renames the adjacent "Open PR" chip; whichever merges second will hit a trivial conflict in this chip row.