### PR TITLE
fix: Bitbucket PRs not loading — provider-generic credential UX for alias hosts

### DIFF
--- a/docs/plans/actionable-credential-error-panel.md
+++ b/docs/plans/actionable-credential-error-panel.md
@@ -1,0 +1,77 @@
+# Plan — Actionable credential-error panel in the Git dialog
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-05 |
+| Source | /implement follow-up: "let it well explained for the user" — the one-time Bitbucket credential setup must be clearly explained in-app, at the point of failure |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/bitbucket-git-integration-not-loading-pr |
+| Base SHA | 19ea57c |
+| Mode | Autonomous — gates bypassed; assumptions in §8 |
+
+## 1. Objective & success criteria
+
+When loading PRs/issues fails because of a missing/invalid git-host credential,
+the dialog shows a friendly explainer panel — what happened, the one-time fix
+(create the token, save it as `email:api_token` / PAT for the repo's host), and
+a button that closes the dialog and opens Settings (where the "Git host tokens"
+section and its setup guide live) — instead of a bare red error row.
+
+## 2. Context & constraints
+
+- Credential errors are already enriched server-side with the marker phrase
+  "Settings → Git host tokens" (github.ts `privateRepoHint`, gitlab.ts
+  `authHint`, bitbucket.ts `bitbucketAccessHint`). The webview shows them
+  verbatim: main list error block at GitHubDialog.tsx:3829-3833.
+- SettingsDialog opens via App.tsx `settingsOpen` state (App.tsx:153, 909);
+  GitHubDialog has no Settings affordance today.
+- The setup guide (GitHubSetupDialog) already documents the full Bitbucket
+  (API token with scopes → email:api_token) and GitLab flows; the missing link
+  is discoverability from the error.
+
+## 3. Approach & key decisions
+
+- Single source of truth for detection: add a `GIT_HOST_TOKENS_SECTION`
+  constant ("Git host tokens") to src/shared/types.ts; bun hint builders
+  interpolate it, and the webview detects a credential error with
+  `error.includes(\`Settings → ${GIT_HOST_TOKENS_SECTION}\`)` — no duplicated
+  magic string. Rendered wording unchanged (existing tests keep passing).
+- Panel over toast: render an explainer card in place of the current error row
+  (title, the server's enriched message, a short numbered one-time-setup
+  summary, "Open Settings" + "Dismiss"-free — the panel IS the error state).
+- `onOpenSettings?: () => void` prop threaded from App.tsx (closes the git
+  dialog, opens SettingsDialog). Optional so other mounts don't break.
+
+## 4. Work breakdown — implementation tasks
+
+Single task/agent (small, interdependent): owns src/shared/types.ts,
+src/bun/github.ts, src/bun/gitlab.ts, src/bun/bitbucket.ts (constant
+interpolation only — no wording change), src/mainview/components/kanban/
+GitHubDialog.tsx, src/mainview/App.tsx.
+
+## 5. Work breakdown — test tasks
+
+Existing wording tests already pin the hint text (unchanged). Add none unless
+the constant refactor breaks one (then fix in place). E2e: not applicable —
+no runnable e2e harness on this branch; visual change verified by typecheck +
+unchanged hint-wording tests.
+
+## 6. Execution waves
+
+1. T1 → typecheck + targeted tests → commit. 2. Opus review → fixes if needed.
+3. Full suite.
+
+## 7. Blast radius & risks
+
+- Hint strings byte-identical after constant interpolation (tests prove it).
+- GitHubDialog is large; change is confined to the list-error block + prop.
+- Marker-phrase detection is heuristic; acceptable — false negative degrades
+  to today's behavior (plain error text).
+
+## 8. Open questions / assumptions
+
+- A1: Panel appears for the main list error only (where "not loading PRs"
+  manifests); per-sub-panel errors keep plain text (they're post-load actions
+  and already carry the hint text).
+- A2: "Open Settings" opens the Settings dialog root (no deep-link/scroll to
+  the section) — the section is prominent enough; deep-linking is future work.

--- a/docs/plans/consolidate-git-host-discovery.md
+++ b/docs/plans/consolidate-git-host-discovery.md
@@ -1,0 +1,94 @@
+# Plan — Consolidate git-host discovery + bound the Settings host scan
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-05 |
+| Source | Deferred findings from the opus review of the bitbucket alias-host fix (docs/plans/fix-bitbucket-alias-host-credentials.md) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/bitbucket-git-integration-not-loading-pr |
+| Base SHA | cb0c40c (tip after test wave) |
+| Mode | Autonomous — gates bypassed; assumptions in §8 |
+
+## 1. Objective & success criteria
+
+1. One source of truth for "supported provider host": `remoteHostsForDirs` moves
+   into `src/bun/git-provider.ts`, implemented over `providerRepoForDir`, and
+   the duplicated `SUPPORTED_PROVIDER_HOSTS` set + inline remote-walk in
+   `src/bun/github.ts` is deleted. Adding a 4th provider then requires editing
+   only `providerForHost`.
+2. Opening Settings no longer spawns an unbounded `2N+` subprocess burst:
+   the scan runs through a small concurrency pool, and repeat calls within a
+   short window (GET followed by PUT save) reuse a cached result.
+
+Success = typecheck green, full `bun test` green (modulo known flakes), the
+moved function behaviorally identical (same sorted raw-host output), existing
+alias-host tests still pass.
+
+## 2. Context & constraints
+
+- `remoteHostsForDirs` currently in `src/bun/github.ts` (added provider-generic
+  in commit 1c4174d) with a local `SUPPORTED_PROVIDER_HOSTS` set duplicating
+  `providerForHost` (`src/bun/git-provider.ts:36-47`); the walk duplicates
+  `providerRepoForDir` (`git-provider.ts:56-78`). The duplication existed only
+  because github.ts cannot import git-provider.ts (git-provider imports
+  github.ts). Moving the function INTO git-provider.ts is cycle-free:
+  `server.ts` already imports both (`server.ts:135` imports it from github.ts
+  today; switch to git-provider.ts).
+- Consumers: only `server.ts` GET/PUT `/github/tokens` handlers
+  (`server.ts:2494`, `:2506`) — the Settings detected-hosts datalist.
+- Test added in the previous wave: github.test.ts has a `remoteHostsForDirs`
+  multi-provider test — move it to `git-provider.test.ts` (or re-import) so
+  coverage follows the function.
+- Perf: each dir costs one `git remote` + up to one `git remote get-url` per
+  remote. Projects list is user-bounded but can be dozens; today it's
+  `Promise.all` over all dirs (unbounded burst). PUT recomputes the identical
+  scan immediately after GET.
+
+## 3. Approach & key decisions
+
+- Move + reimplement over `providerRepoForDir` (returns `ProviderRepoInfo`
+  with `remoteHost`) — behavior identical: distinct raw hosts, sorted, dirs
+  without a supported remote tolerated silently.
+- Concurrency pool of 6 over dirs (plain worker-pool helper local to
+  git-provider.ts; no new deps).
+- TTL cache (10s) keyed on the sorted joined dirs list, storing the promise —
+  GET→PUT within the window reuses it; different dir sets (tests use unique
+  mkdtemp dirs) never collide. Exported `clearRemoteHostsCache()` for tests
+  (or accept `{ fresh: true }`) — pick whichever matches file idiom; tests
+  must be able to bypass staleness deterministically.
+- Keep the exported name `remoteHostsForDirs`; github.ts stops exporting it
+  (delete there) — single-consumer switch in server.ts.
+
+## 4. Work breakdown — implementation tasks
+
+Single task (T1, one sonnet agent — files are small and interdependent, no
+useful partition): owns `src/bun/git-provider.ts`, `src/bun/github.ts`,
+`src/bun/server.ts`, `src/bun/git-provider.test.ts`, `src/bun/github.test.ts`.
+
+## 5. Work breakdown — test tasks
+
+Folded into T1 (move the existing multi-provider test; add a cache-reuse test
+and a concurrency-pool sanity test if cheap). E2e: not applicable — bun-side
+refactor with identical observable behavior; existing network/unit layers
+cover it.
+
+## 6. Execution waves
+
+1. T1 → typecheck + targeted tests → commit.
+2. Opus review of diff vs cb0c40c → fixes if must-fix.
+3. Full suite run (haiku).
+
+## 7. Blast radius & risks
+
+- Settings datalist is the only consumer; identical output shape.
+- Cache staleness: a newly-added project's host may not appear for ≤10s in the
+  detected list — cosmetic, self-heals on next Settings open. Token resolution
+  paths never consume this function.
+- Import cycle risk: git-provider.ts already imports github.ts; the move adds
+  no github.ts → git-provider.ts import. server.ts import switch only.
+
+## 8. Open questions / assumptions
+
+- A1: 10s TTL + pool of 6 chosen without owner input (values are cheap to tune).
+- A2: PUT keeps returning `detectedHosts` (no API-shape change); it just reuses
+  the cached scan.

--- a/docs/plans/fix-bitbucket-alias-host-credentials.md
+++ b/docs/plans/fix-bitbucket-alias-host-credentials.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Date | 2026-08-05 |
-| Source | /implement task: "BitBucket Git integration not loading PRs — 'You may not have access to this repository…'; perhaps custom git host domains (bitbucket-agetor.com)" |
+| Source | /implement task: "BitBucket Git integration not loading PRs — 'You may not have access to this repository…'; perhaps custom git host domains (bitbucket-work.com)" |
 | Config | AGENTS_CONFIG.yml (balanced) |
 | Branch | fix/bitbucket-git-integration-not-loading-pr |
 | Base SHA | 1ac4dc62273745a11dae88a7d11c36828301b15e |
@@ -12,7 +12,7 @@
 ## 1. Objective & success criteria
 
 A user whose Bitbucket repo is reached through an ssh host alias (e.g.
-`git@bitbucket-agetor.com:workspace/repo.git`) can discover, store, and use a
+`git@bitbucket-work.com:workspace/repo.git`) can discover, store, and use a
 Bitbucket credential so PR list / detail / diff / comments / mergeability all
 work; and when auth is missing or wrong, the error shown names the exact host
 and the exact Settings section (with Bitbucket's `email:api_token` format)

--- a/docs/plans/fix-bitbucket-alias-host-credentials.md
+++ b/docs/plans/fix-bitbucket-alias-host-credentials.md
@@ -1,0 +1,179 @@
+# Plan — Bitbucket integration: PRs not loading (alias-host credential UX)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-05 |
+| Source | /implement task: "BitBucket Git integration not loading PRs — 'You may not have access to this repository…'; perhaps custom git host domains (bitbucket-agetor.com)" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/bitbucket-git-integration-not-loading-pr |
+| Base SHA | 1ac4dc62273745a11dae88a7d11c36828301b15e |
+| Mode | Autonomous — Phase 2 grill and Phase 3 approval gates bypassed; assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+A user whose Bitbucket repo is reached through an ssh host alias (e.g.
+`git@bitbucket-agetor.com:workspace/repo.git`) can discover, store, and use a
+Bitbucket credential so PR list / detail / diff / comments / mergeability all
+work; and when auth is missing or wrong, the error shown names the exact host
+and the exact Settings section (with Bitbucket's `email:api_token` format)
+instead of Bitbucket's bare "You may not have access…".
+
+Success = typecheck green, full `bun test` green, new alias-host regression
+tests for Bitbucket pass, all Settings-section references point at a section
+that actually exists.
+
+## 2. Context & constraints (grounded findings)
+
+- **Parsing/canonicalization is NOT the bug.** `canonicalGitHost`
+  (src/bun/github.ts:568) maps any host containing "bitbucket" → bitbucket.org;
+  `parseGitRemote` (github.ts:582) preserves `rawHost`; `providerRepoForDir`
+  (src/bun/git-provider.ts:56) threads it as `remoteHost`; `bitbucketCreds`
+  (git-provider.ts:131) resolves `tokenForHost(remoteHost, "bitbucket.org")`
+  from the shared `<dataDir>/github-tokens.json` store, then
+  `BITBUCKET_TOKEN`/`BITBUCKET_EMAIL` env. Unit-tested (git-provider.test.ts:218-280).
+- **Verified locally:** the user's `~/.agetor/github-tokens.json` holds only
+  GitHub alias hosts — no Bitbucket entry under any host — and no
+  `BITBUCKET_TOKEN` env. So `bitbucketCreds` → null → `authHeader(null)` → `{}`
+  (src/bun/bitbucket.ts:169-176) → **unauthenticated request** → Bitbucket
+  answers its 404-shaped "You may not have access to this repository or it no
+  longer exists in this workspace…" for the private repo. Passed through
+  verbatim (bitbucket.ts:221-231 → git-host.ts:192 → server.ts:678 →
+  mainview api.ts:1258) — exactly the reported symptom.
+- **The gap is the credential UX half, never built for non-GitHub providers**
+  (confirmed by history: PR #104 scoped tokens GitHub-only; PR #107 widened the
+  *plumbing* to Bitbucket/GitLab but promised only "Settings hint text updated",
+  which never landed):
+  1. `remoteHostsForDirs` (github.ts:840) uses `repoForDir` →
+     `parseGitHubRemote`, which hard-rejects non-github hosts (github.ts:597) —
+     Bitbucket/GitLab alias hosts never appear in Settings' detected-hosts list.
+  2. The only credential UI is `GitHubTokensSection.tsx` — branded "GitHub
+     tokens", GitHub-only copy, `ghp_…` placeholder; nothing signals it serves
+     Bitbucket/GitLab or documents Bitbucket's `email:api_token` Basic format.
+  3. Error hints are inconsistent/wrong: bitbucket.ts:228 (401 only) points at
+     "Settings → API tokens" (doesn't exist); gitlab.ts authHint points at
+     "Settings → GitLab tokens" (doesn't exist); Bitbucket 403/404 gets **no
+     hint at all**, unlike GitHub's `privateRepoHint` (github.ts:1291).
+- All ~18 Bitbucket API call sites share `bitbucketCreds` — the whole adapter
+  fails identically ("perhaps not working for other features" confirmed).
+- Constraints: keep `github-tokens.json` filename and `/github/tokens` routes
+  (back-compat with stored tokens); never return raw tokens to the webview;
+  test fixtures must use synthetic alias hosts (e.g. `bitbucket-work.com`),
+  never real ones; `git-provider.ts` imports `github.ts`, so github.ts must not
+  import from git-provider.ts (no circular import) — the generalized
+  `remoteHostsForDirs` must detect "supported provider host" using
+  `parseGitRemote`'s canonical host ∈ {github.com, gitlab.com, bitbucket.org}
+  inline.
+
+## 3. Approach & key decisions
+
+- **Unify the Settings section as "Git host tokens"** (rename of the existing
+  GitHub section, not a new section) — one store, one UI, provider-aware copy.
+  Alternatives: per-provider sections (more surface, same store — rejected);
+  leaving the GitHub name and only fixing hints (still misleading for
+  Bitbucket-only users — rejected).
+- **Generalize host discovery** in `remoteHostsForDirs` to collect the rawHost
+  of any supported provider remote (github/gitlab/bitbucket), implemented
+  inline in github.ts to avoid a circular import. Server route unchanged.
+- **Error-hint parity for Bitbucket**: enrich 401/403/404 at the
+  `apiErrorMessage` choke point with repo/host context (mirror gitlab.ts's
+  `errorFrom(res, body, repo, hadCreds)` shape), naming the alias host, the
+  "Git host tokens" section, and the `email:api_token` format. Bitbucket hides
+  private repos behind 404 (and sometimes 403) — enrich both, plus 401.
+- **Point gitlab.ts / github.ts hints at the renamed section** ("Git host
+  tokens") so every hint references a section that exists.
+- Decisions rest on code-reading + the verified-empty token store; no spikes
+  needed (behavior of Bitbucket's API confirmed by the user's own error text,
+  which is Bitbucket's documented no-access/nonexistent body).
+
+## 4. Work breakdown — implementation tasks
+
+**Wave 1** (parallel, file-disjoint):
+
+- **T1 (bun side)** — files owned: `src/bun/github.ts`, `src/bun/bitbucket.ts`,
+  `src/bun/gitlab.ts`, plus updating any *existing* assertions those wording
+  changes break in `src/bun/*.test.ts`.
+  - Generalize `remoteHostsForDirs` to all supported providers (keep name,
+    location, signature; update doc comment).
+  - bitbucket.ts: add repo/hadCreds-aware access hint for 401/403/404 at the
+    error-message choke point; wording: repo not found / no access on
+    Bitbucket → "add a credential for <remoteHost> in Settings → Git host
+    tokens (Bitbucket Basic auth: email:api_token)"; hadCreds variant → "the
+    configured credential cannot access it…". Thread `repo` + whether creds
+    were present into that choke point (mirror gitlab's errorFrom pattern).
+  - github.ts `privateRepoHint` + gitlab.ts `authHint`: section name → "Git
+    host tokens".
+  - Acceptance: typecheck green; existing bun tests updated & green.
+- **T2 (mainview side)** — files owned:
+  `src/mainview/components/settings/GitHubTokensSection.tsx`,
+  `src/mainview/components/settings/GitHubSetupDialog.tsx`,
+  `src/mainview/components/SettingsDialog.tsx` (only if it renders the section
+  title), `src/mainview/lib/api.ts` (doc comments only).
+  - Rename section label to "Git host tokens"; provider-generic copy: aliases
+    for any git host (git@github-work.com / git@bitbucket-work.com …);
+    defaults github.com / gitlab.com / bitbucket.org; Bitbucket credential
+    format `email:api_token` stated inline; token placeholder no longer
+    GitHub-only (`ghp_… / email:api_token`).
+  - Setup guide dialog: add concise Bitbucket (Atlassian API token +
+    email:api_token) and GitLab (PAT) sections alongside the GitHub one.
+  - Acceptance: typecheck green; no route/store changes.
+
+## 5. Work breakdown — test tasks
+
+**Wave 2** (after Wave 1; one agent — small, related surface):
+
+- **T3** — files owned: `src/bun/bitbucket-network.test.ts`,
+  `src/bun/bitbucket.test.ts`, `src/bun/github.test.ts`,
+  `src/bun/git-host.test.ts` (extend only).
+  - Bitbucket alias-host regression tests using
+    `makeBitbucketRepo(owner, name, "bitbucket-work.com")`: (a) stored
+    alias-host credential → request carries the right auth header; (b) no
+    credential → request unauthenticated and 404 body ("You may not have
+    access…") surfaces *enriched* with host + "Git host tokens" +
+    email:api_token; (c) hadCreds variant wording; (d) 401/403 enrichment.
+  - `remoteHostsForDirs` returns bitbucket/gitlab alias hosts alongside github
+    ones (temp git repos with synthetic alias remotes, per git-host.test.ts
+    conventions).
+  - E2e: **not applicable here** — the fix is bun-side wiring + Settings copy;
+    the repo's Playwright e2e suite is being built on a different branch
+    (feature/implement-e2e-tests) and isn't on main yet. Network-level tests
+    via the existing mockGitHubFetch harness are the right layer.
+- **Run recipe** (Phase 7): `export PATH="$HOME/.bun/bin:/opt/homebrew/bin:$PATH"`,
+  then `bun run typecheck` and `bun test` from the worktree root. Known
+  env-only failures without tmux/bun on PATH (daemon-*, claude-followup-restart).
+
+## 6. Execution waves
+
+1. Wave 1: T1 ∥ T2 (disjoint: src/bun vs src/mainview) → typecheck + commit.
+2. Phase 5 review (opus) of the full diff vs base.
+3. Wave 2: T3 (tests) → commit.
+4. Phase 7 run (haiku): typecheck + full bun test → Phase 8 fixes if needed.
+
+## 7. Blast radius & risks
+
+- `remoteHostsForDirs` feeds only the Settings detected-hosts datalist +
+  "no token yet" rows (server.ts:2494,2506) — new bitbucket/gitlab hosts
+  appearing there is the intended behavior; no auth-resolution path consumes it.
+- Hint-wording changes can break existing test assertions (github.test.ts
+  asserts "Settings → GitHub tokens" strings; bitbucket tests may assert the
+  401 hint) — T1 owns updating them.
+- UI rename is copy-only; routes/api shapes untouched, so no api.ts type churn.
+- The store file stays `github-tokens.json` — slightly misleading name now
+  serving three providers; renaming it would need a migration for zero user
+  value. Accepted.
+- Peers on feature/implement-e2e-tests don't touch these files (verified via
+  fleet list_agents).
+
+## 8. Open questions / assumptions (autonomous mode)
+
+- A1: Section renamed to **"Git host tokens"** without owner sign-off (best
+  generic name; matches "git host" vocabulary already used by git-host.ts).
+- A2: Store filename + `/github/tokens` route names kept for back-compat.
+- A3: The user still must create their Atlassian API token themselves; the fix
+  makes the need discoverable and the format explicit. If their repo *also*
+  lacks access server-side, the enriched message still guides correctly.
+- A4: Bitbucket app-password retirement (2026-06-09) makes stale app passwords
+  another possible cause for *some* users; the enriched error + setup-guide
+  copy (which documents the current API-token flow) covers that path too.
+- A5: GitLab gets discovery + UI copy + hint-name fixes but no new
+  gitlab-specific tests this branch (its enrichment already exists and is
+  tested; scope is Bitbucket).

--- a/src/bun/bitbucket-network.test.ts
+++ b/src/bun/bitbucket-network.test.ts
@@ -145,7 +145,8 @@ test("listBitbucketItems maps a 401 to a friendly error mentioning credential co
     const res = await listBitbucketItems(REPO, { kind: "pulls", state: "open" });
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error("expected failure");
-    expect(res.error).toContain("configure credentials in Settings");
+    expect(res.error).toContain("Settings → Git host tokens");
+    expect(res.error).toContain("configured credential cannot access it");
   } finally {
     mock.restore();
   }

--- a/src/bun/bitbucket-network.test.ts
+++ b/src/bun/bitbucket-network.test.ts
@@ -146,7 +146,7 @@ test("listBitbucketItems maps a 401 to a friendly error mentioning credential co
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error("expected failure");
     expect(res.error).toContain("Settings → Git host tokens");
-    expect(res.error).toContain("configured credential cannot access it");
+    expect(res.error).toContain("was rejected; replace it in");
   } finally {
     mock.restore();
   }

--- a/src/bun/bitbucket-network.test.ts
+++ b/src/bun/bitbucket-network.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { test, expect, beforeAll, afterAll } from "bun:test";
 import { makeBitbucketPrJson, makeBitbucketRepo, mockGitHubFetch } from "./bitbucket-test-util.ts";
 import type { MockRoute } from "./bitbucket-test-util.ts";
+import { setGitHubToken, deleteGitHubToken } from "./github-tokens.ts";
 import {
   closeBitbucketPull,
   createBitbucketComment,
@@ -127,13 +128,49 @@ test("listBitbucketItems resolves the viewer uuid via GET /2.0/user only when cr
   }
 });
 
-test("listBitbucketItems (issues) maps a 404 to the issue-tracker-disabled friendly error", async () => {
+test("listBitbucketItems (issues) maps a 404 to the issue-tracker-disabled friendly error — WITH a credential present (the shortcut only fires once authed)", async () => {
   const mock = mockGitHubFetch([{ match: "/issues", status: 404, json: { error: { message: "Not Found" } } }]);
   try {
+    // REPO carries no per-host stored token, but beforeAll's BITBUCKET_TOKEN
+    // env fallback means a credential IS sent here — this is the authed case.
     const res = await listBitbucketItems(REPO, { kind: "issues", state: "open" });
     expect(res).toEqual({ ok: false, error: "issue tracker is not enabled for this repository" });
   } finally {
     mock.restore();
+  }
+});
+
+test("listBitbucketItems (issues) with NO credential at all surfaces the enriched Settings hint instead of the issue-tracker-disabled shortcut — an unauthed 404 is ambiguous", async () => {
+  const priorToken = process.env.BITBUCKET_TOKEN;
+  const priorEmail = process.env.BITBUCKET_EMAIL;
+  delete process.env.BITBUCKET_TOKEN;
+  delete process.env.BITBUCKET_EMAIL;
+  const aliasRepo = makeBitbucketRepo("acme", "app", "bitbucket-work.com");
+  const mock = mockGitHubFetch([
+    {
+      match: "/issues",
+      status: 404,
+      json: {
+        type: "error",
+        error: { message: "You may not have access to this repository or it no longer exists in this workspace." },
+      },
+    },
+  ]);
+  try {
+    const res = await listBitbucketItems(aliasRepo, { kind: "issues", state: "open" });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).not.toContain("issue tracker is not enabled");
+    expect(res.error).toContain("bitbucket-work.com");
+    expect(res.error).toContain("Settings → Git host tokens");
+    expect(res.error).toContain("email:api_token");
+    expect(mock.calls[0]!.headers.authorization).toBeUndefined();
+  } finally {
+    mock.restore();
+    if (priorToken === undefined) delete process.env.BITBUCKET_TOKEN;
+    else process.env.BITBUCKET_TOKEN = priorToken;
+    if (priorEmail === undefined) delete process.env.BITBUCKET_EMAIL;
+    else process.env.BITBUCKET_EMAIL = priorEmail;
   }
 });
 
@@ -179,6 +216,57 @@ test("email:token credentials send Authorization: Basic base64(email:token)", as
     mock.restore();
     process.env.BITBUCKET_TOKEN = "test-token";
     delete process.env.BITBUCKET_EMAIL;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Alias-host credential resolution (fix-bitbucket-alias-host-credentials.md
+// §5) — a repo reached through an ssh host alias like `bitbucket-work.com`.
+// ---------------------------------------------------------------------------
+
+test("a stored credential for the alias host authenticates the outgoing request with Basic email:api_token", async () => {
+  setGitHubToken("bitbucket-work.com", "user@example.com:storedtoken456");
+  const aliasRepo = makeBitbucketRepo("acme", "app", "bitbucket-work.com");
+  const mock = mockGitHubFetch([{ match: "/2.0/user", json: { nickname: "octo" } }]);
+  try {
+    const res = await getBitbucketViewer(aliasRepo);
+    expect(res).toEqual({ ok: true, login: "octo" });
+    const expected = `Basic ${Buffer.from("user@example.com:storedtoken456").toString("base64")}`;
+    expect(mock.calls[0]!.headers.authorization).toBe(expected);
+  } finally {
+    mock.restore();
+    deleteGitHubToken("bitbucket-work.com");
+  }
+});
+
+test("no credential at all (alias host, no stored entry, no env) sends an unauthenticated request, and Bitbucket's real 404 body surfaces enriched with host + Settings + email:api_token, preserving the original message", async () => {
+  const priorToken = process.env.BITBUCKET_TOKEN;
+  const priorEmail = process.env.BITBUCKET_EMAIL;
+  delete process.env.BITBUCKET_TOKEN;
+  delete process.env.BITBUCKET_EMAIL;
+  const aliasRepo = makeBitbucketRepo("acme", "app", "bitbucket-work.com");
+  const bitbucketBody = {
+    type: "error",
+    error: { message: "You may not have access to this repository or it no longer exists in this workspace." },
+  };
+  const mock = mockGitHubFetch([
+    { match: "/2.0/repositories/acme/app", status: 404, json: bitbucketBody },
+  ]);
+  try {
+    const res = await getBitbucketPullDefaults(aliasRepo);
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(mock.calls[0]!.headers.authorization).toBeUndefined();
+    expect(res.error).toContain("bitbucket-work.com");
+    expect(res.error).toContain("Settings → Git host tokens");
+    expect(res.error).toContain("email:api_token");
+    expect(res.error).toContain(bitbucketBody.error.message);
+  } finally {
+    mock.restore();
+    if (priorToken === undefined) delete process.env.BITBUCKET_TOKEN;
+    else process.env.BITBUCKET_TOKEN = priorToken;
+    if (priorEmail === undefined) delete process.env.BITBUCKET_EMAIL;
+    else process.env.BITBUCKET_EMAIL = priorEmail;
   }
 });
 

--- a/src/bun/bitbucket.test.ts
+++ b/src/bun/bitbucket.test.ts
@@ -61,11 +61,13 @@ test("apiErrorMessage falls back to `status statusText` for a malformed/absent b
   expect(apiErrorMessage({ error: "not an object" }, 400, "Bad Request")).toBe("400 Bad Request");
 });
 
-test("apiErrorMessage gives a 401 an actionable credentials hint, wrapping the underlying message", () => {
+// The 401 actionable-credentials hint moved out of apiErrorMessage (now a
+// pure body/status extractor, matching gitlab.ts's apiError) and into
+// bitbucketAccessHint/errorFrom — see bitbucket-network.test.ts for coverage
+// of the enriched wording end-to-end.
+test("apiErrorMessage extracts the plain body.error.message on a 401, with no enrichment", () => {
   const msg = apiErrorMessage({ error: { message: "Invalid credentials" } }, 401, "Unauthorized");
-  expect(msg).toContain("Invalid credentials");
-  expect(msg).toContain("configure credentials in Settings");
-  expect(msg).toContain("Basic auth: email:api_token");
+  expect(msg).toBe("Invalid credentials");
 });
 
 // ---------------------------------------------------------------------------

--- a/src/bun/bitbucket.test.ts
+++ b/src/bun/bitbucket.test.ts
@@ -10,6 +10,9 @@ const {
   repoBasePath,
   resolveUrl,
   apiErrorMessage,
+  bitbucketAccessHint,
+  bitbucketViewerAccessHint,
+  errorFrom,
   normalizeBitbucketUser,
   normalizeBitbucketPull,
   normalizeBitbucketIssue,
@@ -68,6 +71,105 @@ test("apiErrorMessage falls back to `status statusText` for a malformed/absent b
 test("apiErrorMessage extracts the plain body.error.message on a 401, with no enrichment", () => {
   const msg = apiErrorMessage({ error: { message: "Invalid credentials" } }, 401, "Unauthorized");
   expect(msg).toBe("Invalid credentials");
+});
+
+// ---------------------------------------------------------------------------
+// bitbucketAccessHint — alias-host credential UX (fix-bitbucket-alias-host-
+// credentials.md §3/§5). Repo always carries a synthetic alias remoteHost
+// ("bitbucket-work.com"), never a real one.
+// ---------------------------------------------------------------------------
+
+const ALIAS_REPO = makeBitbucketRepo("acme", "app", "bitbucket-work.com");
+const NOT_FOUND_MSG = "You may not have access to this repository or it no longer exists in this workspace.";
+
+test("bitbucketAccessHint on a 404 with no prior credential names the repo, host, Settings section, and credential format, and preserves the original message", () => {
+  const hint = bitbucketAccessHint(404, NOT_FOUND_MSG, ALIAS_REPO, false);
+  expect(hint).toContain("acme/app");
+  expect(hint).toContain(NOT_FOUND_MSG);
+  expect(hint).toContain("bitbucket-work.com");
+  expect(hint).toContain("Settings → Git host tokens");
+  expect(hint).toContain("email:api_token");
+});
+
+test("bitbucketAccessHint on a 404 with a stored (but ineffective) credential additionally calls out a current API token vs a retired app password", () => {
+  const hint = bitbucketAccessHint(404, NOT_FOUND_MSG, ALIAS_REPO, true);
+  expect(hint).toContain("acme/app");
+  expect(hint).toContain(NOT_FOUND_MSG);
+  expect(hint).toContain("bitbucket-work.com");
+  expect(hint).toContain("Settings → Git host tokens");
+  expect(hint).toContain("email:api_token");
+  expect(hint).toContain("current API token, not a retired app password");
+});
+
+test("bitbucketAccessHint on a 403 with no prior credential is enriched the same way as an unauthenticated 404", () => {
+  const hint = bitbucketAccessHint(403, NOT_FOUND_MSG, ALIAS_REPO, false);
+  expect(hint).toContain("acme/app");
+  expect(hint).toContain(NOT_FOUND_MSG);
+  expect(hint).toContain("bitbucket-work.com");
+  expect(hint).toContain("Settings → Git host tokens");
+  expect(hint).toContain("email:api_token");
+});
+
+test("bitbucketAccessHint on an authenticated 403 passes the real message through UNCHANGED — e.g. a branch-restriction merge error", () => {
+  const branchRestrictionMsg = "Branch restrictions: at least 2 approvals are required to merge this pull request.";
+  expect(bitbucketAccessHint(403, branchRestrictionMsg, ALIAS_REPO, true)).toBe(branchRestrictionMsg);
+});
+
+test("bitbucketAccessHint on a 401 without a stored credential says to add one", () => {
+  const hint = bitbucketAccessHint(401, "Unauthorized", ALIAS_REPO, false);
+  expect(hint).toContain("bitbucket-work.com");
+  expect(hint).toContain("Settings → Git host tokens");
+  expect(hint).toContain("email:api_token");
+  expect(hint).toContain("add a credential");
+  expect(hint).not.toContain("was rejected; replace it");
+});
+
+test("bitbucketAccessHint on a 401 with a stored credential says it was rejected and to replace it", () => {
+  const hint = bitbucketAccessHint(401, "Unauthorized", ALIAS_REPO, true);
+  expect(hint).toContain("bitbucket-work.com");
+  expect(hint).toContain("Settings → Git host tokens");
+  expect(hint).toContain("was rejected; replace it");
+  expect(hint).not.toContain("add a credential for");
+});
+
+test("bitbucketAccessHint leaves a non-auth status (e.g. 500) unchanged, regardless of hadCreds", () => {
+  expect(bitbucketAccessHint(500, "Internal Server Error", ALIAS_REPO, false)).toBe("Internal Server Error");
+  expect(bitbucketAccessHint(500, "Internal Server Error", ALIAS_REPO, true)).toBe("Internal Server Error");
+});
+
+test("errorFrom threads a Response's status/statusText plus the parsed body into bitbucketAccessHint", () => {
+  const res = new Response(null, { status: 404, statusText: "Not Found" });
+  const hint = errorFrom(res, { type: "error", error: { message: NOT_FOUND_MSG } }, ALIAS_REPO, false);
+  expect(hint).toBe(bitbucketAccessHint(404, NOT_FOUND_MSG, ALIAS_REPO, false));
+});
+
+// ---------------------------------------------------------------------------
+// bitbucketViewerAccessHint — account-flavored wording for /2.0/user
+// failures, never owner/repo (fix-bitbucket-alias-host-credentials.md §3).
+// ---------------------------------------------------------------------------
+
+test("bitbucketViewerAccessHint on a 403/404 talks about the account, names the host, and never mentions owner/repo", () => {
+  for (const status of [403, 404]) {
+    const hint = bitbucketViewerAccessHint(status, "Unauthorized", ALIAS_REPO, false);
+    expect(hint).toContain("your Bitbucket account could not be read");
+    expect(hint).toContain("bitbucket-work.com");
+    expect(hint).toContain("Settings → Git host tokens");
+    expect(hint).not.toContain("acme/app");
+    expect(hint).not.toContain("was not found on Bitbucket");
+  }
+});
+
+test("bitbucketViewerAccessHint on a 401 delegates to the same auth wording as bitbucketAccessHint, for both hadCreds values", () => {
+  expect(bitbucketViewerAccessHint(401, "Unauthorized", ALIAS_REPO, false)).toBe(
+    bitbucketAccessHint(401, "Unauthorized", ALIAS_REPO, false),
+  );
+  expect(bitbucketViewerAccessHint(401, "Unauthorized", ALIAS_REPO, true)).toBe(
+    bitbucketAccessHint(401, "Unauthorized", ALIAS_REPO, true),
+  );
+});
+
+test("bitbucketViewerAccessHint leaves a non-auth status unchanged", () => {
+  expect(bitbucketViewerAccessHint(500, "boom", ALIAS_REPO, false)).toBe("boom");
 });
 
 // ---------------------------------------------------------------------------

--- a/src/bun/bitbucket.test.ts
+++ b/src/bun/bitbucket.test.ts
@@ -110,9 +110,18 @@ test("bitbucketAccessHint on a 403 with no prior credential is enriched the same
   expect(hint).toContain("email:api_token");
 });
 
-test("bitbucketAccessHint on an authenticated 403 passes the real message through UNCHANGED — e.g. a branch-restriction merge error", () => {
+test("bitbucketAccessHint on an authenticated 403 preserves the real message first — e.g. a branch-restriction merge error — and appends a scope-check pointer to Settings", () => {
   const branchRestrictionMsg = "Branch restrictions: at least 2 approvals are required to merge this pull request.";
-  expect(bitbucketAccessHint(403, branchRestrictionMsg, ALIAS_REPO, true)).toBe(branchRestrictionMsg);
+  const hint = bitbucketAccessHint(403, branchRestrictionMsg, ALIAS_REPO, true);
+  expect(hint.startsWith(branchRestrictionMsg)).toBe(true);
+  expect(hint).toContain("bitbucket-work.com");
+  expect(hint).toContain("Settings → Git host tokens");
+  expect(hint).toContain("lacks the required Bitbucket scopes");
+});
+
+test("bitbucketAccessHint on an authenticated 403 carries the Settings marker phrase the webview panel detects, unlike the pre-fix pass-through", () => {
+  const hint = bitbucketAccessHint(403, "some other authenticated 403 message", ALIAS_REPO, true);
+  expect(hint).toContain(`Settings → Git host tokens`);
 });
 
 test("bitbucketAccessHint on a 401 without a stored credential says to add one", () => {

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -18,6 +18,7 @@ import type {
   ProviderRepoInfo,
   TaskDiff,
 } from "../shared/types.ts";
+import { GIT_HOST_TOKENS_SECTION } from "../shared/types.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
 import { bitbucketCreds, type BitbucketCreds } from "./git-provider.ts";
 
@@ -253,7 +254,7 @@ function bitbucketAccessHint(status: number, message: string, repo: ProviderRepo
   if (status !== 401 && status !== 403 && status !== 404) return message;
   if (status === 403 && hadCreds) return message;
   const host = repo.remoteHost || "bitbucket.org";
-  const settingsPointer = "Settings → Git host tokens (Bitbucket Basic auth: email:api_token)";
+  const settingsPointer = `Settings → ${GIT_HOST_TOKENS_SECTION} (Bitbucket Basic auth: email:api_token)`;
   if (status === 401) {
     return hadCreds
       ? `Bitbucket authentication failed (${message}) — the credential stored for ${host} was rejected; replace it in ${settingsPointer}. Check it's a current API token, not a retired app password.`
@@ -1367,7 +1368,7 @@ function bitbucketViewerAccessHint(status: number, message: string, repo: Provid
   if (status === 401) return bitbucketAccessHint(status, message, repo, hadCreds);
   if (status !== 403 && status !== 404) return message;
   const host = repo.remoteHost || "bitbucket.org";
-  return `your Bitbucket account could not be read (${message}) — check the credential for ${host} in Settings → Git host tokens`;
+  return `your Bitbucket account could not be read (${message}) — check the credential for ${host} in Settings → ${GIT_HOST_TOKENS_SECTION}`;
 }
 
 /** Matches `getGitHubViewer`'s shape (`{ok:true; login}` only — no token

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -215,19 +215,51 @@ async function fetchBitbucket(
 
 /** Extract a friendly error message from a non-2xx Bitbucket response body
  *  (`{type:"error", error:{message}}`), falling back to `status statusText`.
- *  A 401 gets an actionable hint pointing at where credentials are
- *  configured, mirroring github.ts's `privateRepoHint` — a bare 401 passthrough
- *  otherwise reads as "this doesn't exist" rather than "you're not authed". */
+ *  Pure message extraction only — no status-specific enrichment; that lives
+ *  in `bitbucketAccessHint`/`errorFrom` below, mirroring gitlab.ts's split
+ *  between `apiError` and `authHint`. */
 function apiErrorMessage(body: unknown, status: number, statusText: string): string {
-  const message = body && typeof body === "object" && (body as { error?: unknown }).error
+  return body && typeof body === "object" && (body as { error?: unknown }).error
     && typeof (body as { error?: unknown }).error === "object"
     && typeof ((body as { error: Record<string, unknown> }).error.message) === "string"
     ? (body as { error: { message: string } }).error.message
     : `${status} ${statusText}`;
+}
+
+/** Enriches a 401/403/404 with an actionable pointer to Settings, mirroring
+ *  github.ts's `privateRepoHint` and gitlab.ts's `authHint`. Bitbucket hides a
+ *  private repo behind 404 — and sometimes 403 — rather than answering with a
+ *  clean 401 (its documented "You may not have access to this repository or
+ *  it no longer exists in this workspace…" body), so both get the "was not
+ *  found / add a credential" treatment; a genuine 401 (missing/invalid
+ *  credentials on the request itself) gets an authentication-failed flavor
+ *  instead, but points at the same Settings section and credential format.
+ *  Any other status is returned unchanged. `hadCreds` (was a credential
+ *  configured for this host at all, regardless of whether it worked?) picks
+ *  between "add a credential" and "the configured credential can't access
+ *  it" — the latter also calls out Bitbucket's 2026-06-09 app-password
+ *  retirement, since a stale app password is a common way a previously-working
+ *  credential starts failing. Pure — unit-tested via `__bitbucketInternals`. */
+function bitbucketAccessHint(status: number, message: string, repo: ProviderRepoInfo, hadCreds: boolean): string {
+  if (status !== 401 && status !== 403 && status !== 404) return message;
+  const host = repo.remoteHost || "bitbucket.org";
+  const settingsPointer = "Settings → Git host tokens (Bitbucket Basic auth: email:api_token)";
+  const cantAccess = " (the configured credential cannot access it — check it belongs to the right account and is a current API token, not a retired app password)";
   if (status === 401) {
-    return `Bitbucket authentication failed (${message}) — configure credentials in Settings → API tokens (Basic auth: email:api_token).`;
+    const base = `Bitbucket authentication failed (${message}) — add a credential for ${host} in ${settingsPointer}.`;
+    return hadCreds ? `${base}${cantAccess}` : base;
   }
-  return message;
+  const base = `${repo.owner}/${repo.name} was not found on Bitbucket — if the repo is private, add a credential for ${host} in ${settingsPointer}`;
+  return hadCreds ? `${base}${cantAccess}` : base;
+}
+
+/** Single choke point tying a non-2xx `Response` + parsed body to the enriched
+ *  message, threading the resolved repo and whether creds were sent — mirrors
+ *  gitlab.ts's `errorFrom(res, body, repo, hadToken)`. Nearly every Bitbucket
+ *  call site routes its error branch through this so the whole adapter gets
+ *  hint parity in one place. */
+function errorFrom(res: Response, body: unknown, repo: ProviderRepoInfo, hadCreds: boolean): string {
+  return bitbucketAccessHint(res.status, apiErrorMessage(body, res.status, res.statusText), repo, hadCreds);
 }
 
 function normalizeBitbucketUser(raw: unknown): GitHubUser | null {
@@ -564,7 +596,7 @@ export async function listBitbucketItems(
     if (opts.kind === "issues" && res.status === 404) {
       return { ok: false, error: "issue tracker is not enabled for this repository" };
     }
-    return { ok: false, error: apiErrorMessage(body, res.status, res.statusText) };
+    return { ok: false, error: errorFrom(res, body, repo, !!creds) };
   }
   const values = body && typeof body === "object" && Array.isArray((body as { values?: unknown }).values)
     ? (body as { values: unknown[] }).values
@@ -596,7 +628,7 @@ export async function getBitbucketPullDefaults(repo: ProviderRepoInfo): Promise<
   const res = await fetchBitbucket(repoBasePath(repo), creds, "application/json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   const obj = json && typeof json === "object" ? json as Record<string, unknown> : {};
   const mainbranch = obj.mainbranch && typeof obj.mainbranch === "object" ? obj.mainbranch as Record<string, unknown> : {};
   const base = typeof mainbranch.name === "string" && mainbranch.name ? mainbranch.name : "main";
@@ -641,7 +673,7 @@ export async function createBitbucketPull(
   );
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   const item = normalizeBitbucketPull(json, null);
   if (!item) return { ok: false, error: "Bitbucket returned an unexpected pull request response" };
   return { ok: true, item, message: "Pull request created." };
@@ -673,7 +705,7 @@ export async function getBitbucketPullDiff(repo: ProviderRepoInfo, number: numbe
       const parsed = JSON.parse(body) as { error?: { message?: unknown } };
       if (parsed.error && typeof parsed.error.message === "string") msg = parsed.error.message;
     } catch { /* the diff endpoint returns plain text on success, not JSON */ }
-    return { ok: false, error: msg || `${res.status} ${res.statusText}` };
+    return { ok: false, error: bitbucketAccessHint(res.status, msg || `${res.status} ${res.statusText}`, repo, !!creds) };
   }
   const bodyBytes = Buffer.byteLength(body, "utf8");
   if (bodyBytes > BITBUCKET_DIFF_BODY_CAP_BYTES) {
@@ -723,7 +755,7 @@ export async function listBitbucketComments(
     if (kind === "issues" && res.status === 404) {
       return { ok: false, error: "issue tracker is not enabled for this repository" };
     }
-    return { ok: false, error: apiErrorMessage(body, res.status, res.statusText) };
+    return { ok: false, error: errorFrom(res, body, repo, !!creds) };
   }
   const values = body && typeof body === "object" && Array.isArray((body as { values?: unknown }).values)
     ? (body as { values: unknown[] }).values
@@ -764,7 +796,7 @@ export async function createBitbucketComment(
     if (kind === "issues" && res.status === 404) {
       return { ok: false, error: "issue tracker is not enabled for this repository" };
     }
-    return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+    return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   }
   const comment = normalizeBitbucketComment(json);
   if (!comment) return { ok: false, error: "Bitbucket returned an unexpected comment response" };
@@ -786,7 +818,7 @@ export async function listBitbucketPullReviewComments(
   const res = await fetchBitbucket(url.toString(), creds, "application/json");
   if (!("status" in res)) return res;
   const body = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(body, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, body, repo, !!creds) };
   const values = body && typeof body === "object" && Array.isArray((body as { values?: unknown }).values)
     ? (body as { values: unknown[] }).values
     : null;
@@ -840,7 +872,7 @@ export async function createBitbucketPullLineComment(
   );
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   const comment = normalizeBitbucketLineComment(json);
   if (!comment) return { ok: false, error: "Bitbucket returned an unexpected line comment response" };
   return { ok: true, comment };
@@ -867,7 +899,7 @@ export async function replyBitbucketLineComment(
   );
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   const comment = normalizeBitbucketLineComment(json);
   if (!comment) return { ok: false, error: "Bitbucket returned an unexpected reply response" };
   return { ok: true, comment };
@@ -886,7 +918,7 @@ export async function getBitbucketPullChecks(repo: ProviderRepoInfo, number: num
   const prRes = await fetchBitbucket(`${repoBasePath(repo)}/pullrequests/${number}`, creds, "application/json");
   if (!("status" in prRes)) return prRes;
   const prJson = await prRes.json().catch(() => null);
-  if (!prRes.ok) return { ok: false, error: apiErrorMessage(prJson, prRes.status, prRes.statusText) };
+  if (!prRes.ok) return { ok: false, error: errorFrom(prRes, prJson, repo, !!creds) };
   const prObj = prJson && typeof prJson === "object" ? prJson as Record<string, unknown> : {};
   const source = prObj.source && typeof prObj.source === "object" ? prObj.source as Record<string, unknown> : {};
   const commit = source.commit && typeof source.commit === "object" ? source.commit as Record<string, unknown> : {};
@@ -897,7 +929,7 @@ export async function getBitbucketPullChecks(repo: ProviderRepoInfo, number: num
   const res = await fetchBitbucket(statusesUrl.toString(), creds, "application/json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   const values = json && typeof json === "object" && Array.isArray((json as { values?: unknown }).values)
     ? (json as { values: unknown[] }).values
     : [];
@@ -1058,7 +1090,7 @@ export async function getBitbucketPullMergeability(
   const res = await fetchBitbucket(`${repoBasePath(repo)}/pullrequests/${number}`, creds, "application/json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   if (!json || typeof json !== "object") {
     return { ok: false, error: "Bitbucket returned an unexpected pull request response" };
   }
@@ -1082,7 +1114,7 @@ export async function getBitbucketPullDetail(repo: ProviderRepoInfo, number: num
   const res = await fetchBitbucket(`${repoBasePath(repo)}/pullrequests/${number}`, creds, "application/json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   const item = normalizeBitbucketPull(json, null);
   if (!item) return { ok: false, error: "Bitbucket returned an unexpected pull request response" };
   return { ok: true, item };
@@ -1119,7 +1151,7 @@ export async function mergeBitbucketPull(
   );
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   const obj = json && typeof json === "object" ? json as Record<string, unknown> : {};
   const mergeCommit = obj.merge_commit && typeof obj.merge_commit === "object"
     ? obj.merge_commit as Record<string, unknown>
@@ -1144,7 +1176,7 @@ export async function closeBitbucketPull(repo: ProviderRepoInfo, number: number)
   );
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   const item = normalizeBitbucketPull(json, null);
   return { ok: true, message: "Pull request declined.", ...(item ? { item } : {}) };
 }
@@ -1197,7 +1229,7 @@ export async function reviewBitbucketPull(
   );
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
 
   const verdictLabel = verdict === "APPROVE" ? "Pull request approved" : "Changes requested";
   if (trimmedBody) {
@@ -1243,7 +1275,7 @@ export async function createBitbucketIssue(
   const json = await res.json().catch(() => null);
   if (!res.ok) {
     if (res.status === 404) return { ok: false, error: "issue tracker is not enabled for this repository" };
-    return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+    return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   }
   const item = normalizeBitbucketIssue(json, null);
   if (!item) return { ok: false, error: "Bitbucket returned an unexpected issue response" };
@@ -1296,7 +1328,7 @@ export async function updateBitbucketIssue(
   const json = await res.json().catch(() => null);
   if (!res.ok) {
     if (res.status === 404) return { ok: false, error: "issue tracker is not enabled for this repository" };
-    return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+    return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   }
   const item = normalizeBitbucketIssue(json, null);
   if (!item) return { ok: false, error: "Bitbucket returned an unexpected issue response" };
@@ -1312,7 +1344,7 @@ export async function getBitbucketViewer(repo: ProviderRepoInfo): Promise<Bitbuc
   const res = await fetchBitbucket("/2.0/user", creds, "application/json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: apiErrorMessage(json, res.status, res.statusText) };
+  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
   const obj = json && typeof json === "object" ? json as Record<string, unknown> : {};
   const login = typeof obj.nickname === "string" && obj.nickname
     ? obj.nickname
@@ -1327,6 +1359,8 @@ export const __bitbucketInternals = {
   repoBasePath,
   resolveUrl,
   apiErrorMessage,
+  bitbucketAccessHint,
+  errorFrom,
   normalizeBitbucketUser,
   normalizeBitbucketPull,
   normalizeBitbucketIssue,

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -235,25 +235,34 @@ function apiErrorMessage(body: unknown, status: number, statusText: string): str
  *  not found / add a credential" treatment; a genuine 401 (missing/invalid
  *  credentials on the request itself) gets an authentication-failed flavor
  *  instead, but points at the same Settings section and credential format.
- *  403 is narrower: it's only enriched when `hadCreds === false`, since an
- *  *unauthenticated* 403 is plausibly the same credential-gap signal as an
- *  unauthenticated 404 — but an *authenticated* 403 usually means something
- *  the enrichment would actively mislead about (branch restrictions blocking
- *  a merge, a permission the credential's account genuinely lacks, a rate
- *  limit) and must pass through with its real message intact rather than
- *  being reframed as "add/replace a credential". The underlying `message` is
- *  always preserved in the enriched text so a real, specific API error is
- *  never discarded. `hadCreds` (was a credential configured for this host at
- *  all, regardless of whether it worked?) picks between "add a credential"
- *  and "the configured credential can't access it" for 404 — the latter also
- *  calls out Bitbucket's 2026-06-09 app-password retirement, since a stale
- *  app password is a common way a previously-working credential starts
- *  failing. Any other status is returned unchanged. Pure — exported via
- *  `__bitbucketInternals` for unit testing. */
+ *  403 is narrower: an *unauthenticated* 403 is plausibly the same
+ *  credential-gap signal as an unauthenticated 404, so it gets the full 404
+ *  treatment. An *authenticated* 403 (`hadCreds === true`) usually means
+ *  something the enrichment would actively mislead about (branch restrictions
+ *  blocking a merge, a permission the credential's account genuinely lacks, a
+ *  rate limit) — a real, specific error like that must stay front and center,
+ *  never reframed as a bare "add/replace a credential". But it does get one
+ *  thing appended: a pointer to Settings for the single most common
+ *  authenticated-403 cause since Bitbucket's app-password retirement — a
+ *  token that authenticates fine but lacks the scope the call needs. The
+ *  append keeps the real message first (so it's never discarded or buried)
+ *  and still carries the `Settings → ${GIT_HOST_TOKENS_SECTION}` marker
+ *  phrase so the webview's credential-error panel renders for this case too.
+ *  The underlying `message` is always preserved in the enriched text so a
+ *  real, specific API error is never discarded. `hadCreds` (was a credential
+ *  configured for this host at all, regardless of whether it worked?) picks
+ *  between "add a credential" and "the configured credential can't access
+ *  it" for 404 — the latter also calls out Bitbucket's 2026-06-09
+ *  app-password retirement, since a stale app password is a common way a
+ *  previously-working credential starts failing. Any other status is
+ *  returned unchanged. Pure — exported via `__bitbucketInternals` for unit
+ *  testing. */
 function bitbucketAccessHint(status: number, message: string, repo: ProviderRepoInfo, hadCreds: boolean): string {
   if (status !== 401 && status !== 403 && status !== 404) return message;
-  if (status === 403 && hadCreds) return message;
   const host = repo.remoteHost || "bitbucket.org";
+  if (status === 403 && hadCreds) {
+    return `${message} — if the configured credential for ${host} lacks the required Bitbucket scopes, update it in Settings → ${GIT_HOST_TOKENS_SECTION}.`;
+  }
   const settingsPointer = `Settings → ${GIT_HOST_TOKENS_SECTION} (Bitbucket Basic auth: email:api_token)`;
   if (status === 401) {
     return hadCreds

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -230,27 +230,39 @@ function apiErrorMessage(body: unknown, status: number, statusText: string): str
  *  github.ts's `privateRepoHint` and gitlab.ts's `authHint`. Bitbucket hides a
  *  private repo behind 404 — and sometimes 403 — rather than answering with a
  *  clean 401 (its documented "You may not have access to this repository or
- *  it no longer exists in this workspace…" body), so both get the "was not
- *  found / add a credential" treatment; a genuine 401 (missing/invalid
+ *  it no longer exists in this workspace…" body), so 404 always gets the "was
+ *  not found / add a credential" treatment; a genuine 401 (missing/invalid
  *  credentials on the request itself) gets an authentication-failed flavor
  *  instead, but points at the same Settings section and credential format.
- *  Any other status is returned unchanged. `hadCreds` (was a credential
- *  configured for this host at all, regardless of whether it worked?) picks
- *  between "add a credential" and "the configured credential can't access
- *  it" — the latter also calls out Bitbucket's 2026-06-09 app-password
- *  retirement, since a stale app password is a common way a previously-working
- *  credential starts failing. Pure — unit-tested via `__bitbucketInternals`. */
+ *  403 is narrower: it's only enriched when `hadCreds === false`, since an
+ *  *unauthenticated* 403 is plausibly the same credential-gap signal as an
+ *  unauthenticated 404 — but an *authenticated* 403 usually means something
+ *  the enrichment would actively mislead about (branch restrictions blocking
+ *  a merge, a permission the credential's account genuinely lacks, a rate
+ *  limit) and must pass through with its real message intact rather than
+ *  being reframed as "add/replace a credential". The underlying `message` is
+ *  always preserved in the enriched text so a real, specific API error is
+ *  never discarded. `hadCreds` (was a credential configured for this host at
+ *  all, regardless of whether it worked?) picks between "add a credential"
+ *  and "the configured credential can't access it" for 404 — the latter also
+ *  calls out Bitbucket's 2026-06-09 app-password retirement, since a stale
+ *  app password is a common way a previously-working credential starts
+ *  failing. Any other status is returned unchanged. Pure — exported via
+ *  `__bitbucketInternals` for unit testing. */
 function bitbucketAccessHint(status: number, message: string, repo: ProviderRepoInfo, hadCreds: boolean): string {
   if (status !== 401 && status !== 403 && status !== 404) return message;
+  if (status === 403 && hadCreds) return message;
   const host = repo.remoteHost || "bitbucket.org";
   const settingsPointer = "Settings → Git host tokens (Bitbucket Basic auth: email:api_token)";
-  const cantAccess = " (the configured credential cannot access it — check it belongs to the right account and is a current API token, not a retired app password)";
   if (status === 401) {
-    const base = `Bitbucket authentication failed (${message}) — add a credential for ${host} in ${settingsPointer}.`;
-    return hadCreds ? `${base}${cantAccess}` : base;
+    return hadCreds
+      ? `Bitbucket authentication failed (${message}) — the credential stored for ${host} was rejected; replace it in ${settingsPointer}. Check it's a current API token, not a retired app password.`
+      : `Bitbucket authentication failed (${message}) — add a credential for ${host} in ${settingsPointer}.`;
   }
-  const base = `${repo.owner}/${repo.name} was not found on Bitbucket — if the repo is private, add a credential for ${host} in ${settingsPointer}`;
-  return hadCreds ? `${base}${cantAccess}` : base;
+  const base = `${repo.owner}/${repo.name} was not found on Bitbucket (${message}) — if the repo is private, add a credential for ${host} in ${settingsPointer}`;
+  return hadCreds
+    ? `${base} (the configured credential cannot access it — check it belongs to the right account and is a current API token, not a retired app password).`
+    : base;
 }
 
 /** Single choke point tying a non-2xx `Response` + parsed body to the enriched
@@ -593,7 +605,12 @@ export async function listBitbucketItems(
   if (!("status" in res)) return res;
   const body = await res.json().catch(() => null);
   if (!res.ok) {
-    if (opts.kind === "issues" && res.status === 404) {
+    // Only shortcut to "issue tracker is not enabled" when a credential was
+    // actually sent — an unauthenticated 404 is ambiguous (could just as
+    // easily be a private repo with no credential configured), so it falls
+    // through to `errorFrom`'s enriched hint instead of masking the real
+    // credential-gap signal behind a misleading tracker-disabled message.
+    if (opts.kind === "issues" && res.status === 404 && creds) {
       return { ok: false, error: "issue tracker is not enabled for this repository" };
     }
     return { ok: false, error: errorFrom(res, body, repo, !!creds) };
@@ -752,7 +769,10 @@ export async function listBitbucketComments(
   if (!("status" in res)) return res;
   const body = await res.json().catch(() => null);
   if (!res.ok) {
-    if (kind === "issues" && res.status === 404) {
+    // Same gating as listBitbucketItems above: only shortcut to
+    // "issue tracker is not enabled" once a credential was sent, so an
+    // unauthenticated 404 falls through to the enriched hint instead.
+    if (kind === "issues" && res.status === 404 && creds) {
       return { ok: false, error: "issue tracker is not enabled for this repository" };
     }
     return { ok: false, error: errorFrom(res, body, repo, !!creds) };
@@ -1335,6 +1355,21 @@ export async function updateBitbucketIssue(
   return { ok: true, item, message: "Issue updated." };
 }
 
+/** Account-flavored counterpart to `bitbucketAccessHint`, used only by
+ *  `getBitbucketViewer`. `/2.0/user` has no repo in scope — reusing
+ *  `bitbucketAccessHint`'s 403/404 wording verbatim would render a nonsensical
+ *  "owner/repo was not found on Bitbucket" for what is really an account-level
+ *  read failure. 401 handling (auth flavor: invalid/missing credentials) is
+ *  identical regardless of endpoint, so it's delegated straight to
+ *  `bitbucketAccessHint`; 403/404 instead get account-flavored wording; any
+ *  other status passes the message through unchanged. */
+function bitbucketViewerAccessHint(status: number, message: string, repo: ProviderRepoInfo, hadCreds: boolean): string {
+  if (status === 401) return bitbucketAccessHint(status, message, repo, hadCreds);
+  if (status !== 403 && status !== 404) return message;
+  const host = repo.remoteHost || "bitbucket.org";
+  return `your Bitbucket account could not be read (${message}) — check the credential for ${host} in Settings → Git host tokens`;
+}
+
 /** Matches `getGitHubViewer`'s shape (`{ok:true; login}` only — no token
  *  means an anonymous "" login rather than an error, same no-token behavior
  *  as the GitHub counterpart). */
@@ -1344,7 +1379,12 @@ export async function getBitbucketViewer(repo: ProviderRepoInfo): Promise<Bitbuc
   const res = await fetchBitbucket("/2.0/user", creds, "application/json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
-  if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!creds) };
+  if (!res.ok) {
+    return {
+      ok: false,
+      error: bitbucketViewerAccessHint(res.status, apiErrorMessage(json, res.status, res.statusText), repo, !!creds),
+    };
+  }
   const obj = json && typeof json === "object" ? json as Record<string, unknown> : {};
   const login = typeof obj.nickname === "string" && obj.nickname
     ? obj.nickname
@@ -1360,6 +1400,7 @@ export const __bitbucketInternals = {
   resolveUrl,
   apiErrorMessage,
   bitbucketAccessHint,
+  bitbucketViewerAccessHint,
   errorFrom,
   normalizeBitbucketUser,
   normalizeBitbucketPull,

--- a/src/bun/git-host.test.ts
+++ b/src/bun/git-host.test.ts
@@ -109,6 +109,18 @@ test("providerInfoForDir resolves a bitbucket repo", async () => {
   });
 });
 
+test("providerInfoForDir resolves an ssh host-alias bitbucket remote — provider bitbucket, host canonicalized, remoteHost preserved as the alias", async () => {
+  const dir = await makeRepo("git@bitbucket-work.com:acme/app.git");
+  expect(await providerInfoForDir(dir)).toEqual({
+    ok: true,
+    provider: "bitbucket",
+    owner: "acme",
+    name: "app",
+    host: "bitbucket.org",
+    remoteHost: "bitbucket-work.com",
+  });
+});
+
 test("providerInfoForDir errors on an unsupported git remote", async () => {
   const dir = await makeRepo("git@example.com:acme/app.git");
   expect(await providerInfoForDir(dir)).toEqual({

--- a/src/bun/git-provider.test.ts
+++ b/src/bun/git-provider.test.ts
@@ -6,7 +6,7 @@ import {
   providerForHost,
   providerRepoForDir,
   remoteHostsForDirs,
-  clearRemoteHostsCache,
+  __clearRemoteHostsCacheForTest,
   gitlabToken,
   bitbucketCreds,
 } from "./git-provider.ts";
@@ -38,7 +38,7 @@ beforeEach(() => {
   // fresh mkdtemp dirs so cross-test collisions can't happen in practice, but
   // clearing up front keeps every test's cache behavior self-contained and
   // independent of suite run order.
-  clearRemoteHostsCache();
+  __clearRemoteHostsCacheForTest();
 });
 
 afterEach(() => {
@@ -189,7 +189,7 @@ test("remoteHostsForDirs returns the sorted alias hosts of every supported provi
   expect(hosts).toEqual(["bitbucket-work.com", "github-work.com", "gitlab-work.io"]);
 });
 
-test("remoteHostsForDirs caches within the TTL: a second call for the same dirs reuses the first scan even after the repo's remote changes, and clearRemoteHostsCache() bypasses it", async () => {
+test("remoteHostsForDirs caches within the TTL: a second call for the same dirs reuses the first scan even after the repo's remote changes, and __clearRemoteHostsCacheForTest() bypasses it", async () => {
   const dir = await makeRepoWithRemotes([{ name: "origin", url: "git@github-host-one.example:a/b.git" }]);
 
   const first = await remoteHostsForDirs([dir]);
@@ -204,7 +204,7 @@ test("remoteHostsForDirs caches within the TTL: a second call for the same dirs 
   expect(second).toEqual(["github-host-one.example"]);
 
   // Bypassing the cache observes the mutation immediately.
-  clearRemoteHostsCache();
+  __clearRemoteHostsCacheForTest();
   const third = await remoteHostsForDirs([dir]);
   expect(third).toEqual(["github-host-two.example"]);
 });

--- a/src/bun/git-provider.test.ts
+++ b/src/bun/git-provider.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import {
   providerForHost,
   providerRepoForDir,
+  remoteHostsForDirs,
+  clearRemoteHostsCache,
   gitlabToken,
   bitbucketCreds,
 } from "./git-provider.ts";
@@ -32,6 +34,11 @@ beforeEach(() => {
     savedEnv[key] = process.env[key];
     delete process.env[key];
   }
+  // remoteHostsForDirs caches by sorted-dirs key; each test below uses its own
+  // fresh mkdtemp dirs so cross-test collisions can't happen in practice, but
+  // clearing up front keeps every test's cache behavior self-contained and
+  // independent of suite run order.
+  clearRemoteHostsCache();
 });
 
 afterEach(() => {
@@ -161,6 +168,54 @@ test("providerRepoForDir falls through to another remote when origin is unsuppor
     owner: "acme",
     name: "app",
   });
+});
+
+// ---------------------------------------------------------------------------
+// remoteHostsForDirs (moved from github.ts — reimplemented over
+// providerRepoForDir, docs/plans/consolidate-git-host-discovery.md)
+// ---------------------------------------------------------------------------
+
+test("remoteHostsForDirs returns the sorted alias hosts of every supported provider (github/gitlab/bitbucket), excluding an unsupported host, and tolerates a dir that isn't a repo", async () => {
+  const githubDir = await makeRepoWithRemotes([{ name: "origin", url: "git@github-work.com:a/b.git" }]);
+  const bitbucketDir = await makeRepoWithRemotes([{ name: "origin", url: "git@bitbucket-work.com:w/r.git" }]);
+  const gitlabDir = await makeRepoWithRemotes([{ name: "origin", url: "git@gitlab-work.io:g/p.git" }]);
+  const unsupportedDir = await makeRepoWithRemotes([{ name: "origin", url: "git@example.com:x/y.git" }]);
+  // A dir that isn't a git repo at all (but does exist) — must be tolerated
+  // silently, same as providerRepoForDir returning null for it.
+  const notARepoDir = mkdtempSync(path.join(tmpdir(), "agetor-remote-hosts-plain-"));
+  createdDirs.push(notARepoDir);
+
+  const hosts = await remoteHostsForDirs([githubDir, bitbucketDir, gitlabDir, unsupportedDir, notARepoDir]);
+  expect(hosts).toEqual(["bitbucket-work.com", "github-work.com", "gitlab-work.io"]);
+});
+
+test("remoteHostsForDirs caches within the TTL: a second call for the same dirs reuses the first scan even after the repo's remote changes, and clearRemoteHostsCache() bypasses it", async () => {
+  const dir = await makeRepoWithRemotes([{ name: "origin", url: "git@github-host-one.example:a/b.git" }]);
+
+  const first = await remoteHostsForDirs([dir]);
+  expect(first).toEqual(["github-host-one.example"]);
+
+  // Mutate the remote after the first scan. Within the TTL, a second call for
+  // the exact same dir list must reuse the cached promise/result rather than
+  // re-scanning — this is the GET-then-PUT /github/tokens back-to-back-scan
+  // case the cache exists for.
+  await git(["remote", "set-url", "origin", "git@github-host-two.example:a/b.git"], dir);
+  const second = await remoteHostsForDirs([dir]);
+  expect(second).toEqual(["github-host-one.example"]);
+
+  // Bypassing the cache observes the mutation immediately.
+  clearRemoteHostsCache();
+  const third = await remoteHostsForDirs([dir]);
+  expect(third).toEqual(["github-host-two.example"]);
+});
+
+test("remoteHostsForDirs processes every dir even when the dir count exceeds the concurrency pool size", async () => {
+  const hosts = ["a", "b", "c", "d", "e", "f", "g", "h"];
+  const dirs = await Promise.all(
+    hosts.map((h) => makeRepoWithRemotes([{ name: "origin", url: `git@github-pool-${h}.example:x/y.git` }])),
+  );
+  const result = await remoteHostsForDirs(dirs);
+  expect(result).toEqual(hosts.map((h) => `github-pool-${h}.example`).sort());
 });
 
 // ---------------------------------------------------------------------------

--- a/src/bun/git-provider.ts
+++ b/src/bun/git-provider.ts
@@ -89,29 +89,30 @@ export async function providerRepoForDir(dir: string): Promise<ProviderRepoInfo 
 const REMOTE_HOSTS_POOL_SIZE = 6;
 const REMOTE_HOSTS_CACHE_TTL_MS = 10_000;
 
-/** Promise-cache entry for `remoteHostsForDirs`: `expiresAt` is a wall-clock
- *  deadline (ms since epoch) rather than a timer handle, so a stale entry is
- *  detected lazily on the next call — no cleanup timers to leak or clear. */
-interface RemoteHostsCacheEntry {
-  expiresAt: number;
-  promise: Promise<string[]>;
-}
-
-/** Keyed on the sorted, newline-joined dir list (so caller-side ordering of
- *  `dirs` never causes a spurious cache miss). Distinct project-list
- *  snapshots get distinct entries; the map is small in practice (one entry
- *  per distinct set of registered project paths, effectively one at a time
- *  in production) so it's never proactively swept — a stale entry just sits
- *  until its key is requested again post-expiry and gets overwritten. */
-const remoteHostsCache = new Map<string, RemoteHostsCacheEntry>();
+/** Single-slot promise cache for `remoteHostsForDirs`. Production only ever
+ *  has one live key at a time (the current registered-project list), so a
+ *  one-entry slot replaces what would otherwise be a never-pruned `Map` —
+ *  there's nothing to sweep because a new key simply overwrites the slot.
+ *
+ *  `expiresAt` is anchored at *settle*, not at call start: while `promise` is
+ *  in flight it's set to `Infinity` (always share, never re-scan), and only
+ *  once the scan resolves does it get stamped to `Date.now() + TTL`. This is
+ *  what makes a slow scan always shared — a second caller arriving mid-scan
+ *  reuses the same in-flight promise instead of kicking off a duplicate one —
+ *  and it means freshness is measured from when the data actually landed,
+ *  not from when the scan happened to start. The Settings page's GET-then-PUT
+ *  `/github/tokens` round trip is the motivating case: both handlers call
+ *  `remoteHostsForDirs` with the same project list back-to-back, and this
+ *  design guarantees they share one scan no matter how long that scan takes. */
+let remoteHostsCache: { key: string; expiresAt: number; promise: Promise<string[]> } | null = null;
 
 /** Test-only escape hatch: forces the next `remoteHostsForDirs` call (for any
  *  key) to re-scan instead of reusing a cached promise. Exported rather than
  *  threading a `{ fresh: true }` option through the production signature,
  *  since the only caller that ever needs to bypass the cache is a test
  *  proving the TTL actually expires/cache actually reuses. */
-export function clearRemoteHostsCache(): void {
-  remoteHostsCache.clear();
+export function __clearRemoteHostsCacheForTest(): void {
+  remoteHostsCache = null;
 }
 
 async function scanRemoteHosts(dirs: string[]): Promise<string[]> {
@@ -142,28 +143,51 @@ async function scanRemoteHosts(dirs: string[]): Promise<string[]> {
  * domain for a plain remote) across the given project dirs, sorted — drives
  * the Settings "detected hosts" suggestion list so a user's real aliases are
  * one click away instead of hand-typed. Provider-generic via
- * `providerRepoForDir`: considers every dir whose first origin-first remote
- * resolves to a supported provider (github.com, gitlab.com, or
- * bitbucket.org) — not just GitHub. Dirs with no supported-provider remote
- * (or that aren't a repo at all) are tolerated silently, same as
+ * `providerRepoForDir`: considers every dir whose remotes — walked
+ * origin-first, same order `providerRepoForDir` tries them in — yield a
+ * supported provider (github.com, gitlab.com, or bitbucket.org) anywhere in
+ * that walk, not just via its first remote. Dirs with no supported-provider
+ * remote (or that aren't a repo at all) are tolerated silently, same as
  * `providerRepoForDir` itself returning null.
  *
- * Result is cached (10s TTL) per distinct sorted-dirs key: the Settings
- * "/github/tokens" GET and PUT handlers both call this with the same project
- * list back-to-back (GET on page load, PUT immediately after on every token
- * save), so without a cache a single Settings save always re-runs the whole
- * scan twice. A cache miss beyond the TTL just re-scans; staleness cost is a
- * newly-added project's host not appearing in the detected list for up to
- * 10s, which self-heals on the next Settings open (see
- * docs/plans/consolidate-git-host-discovery.md §7).
+ * `dirs` is normalized (deduped via `Set`, then sorted) before it's used both
+ * as the cache key and as the input to the scan, mirroring the sibling pools
+ * (`listGitHubItemsAcrossRepos` in github.ts, `listItemsAcrossRepos` in
+ * git-host.ts) — this also means a caller passing the same dir twice doesn't
+ * pay for scanning it twice.
+ *
+ * Result is cached (10s TTL, single-slot — see `remoteHostsCache` above) per
+ * distinct normalized-dirs key: the Settings "/github/tokens" GET and PUT
+ * handlers both call this with the same project list back-to-back (GET on
+ * page load, PUT immediately after on every token save), so without a cache
+ * a single Settings save always re-runs the whole scan twice. A cache miss
+ * beyond the TTL just re-scans; staleness cost is a newly-added project's
+ * host not appearing in the detected list for up to 10s, which self-heals on
+ * the next Settings open (see docs/plans/consolidate-git-host-discovery.md
+ * §7).
  */
 export async function remoteHostsForDirs(dirs: string[]): Promise<string[]> {
-  const key = Array.from(dirs).sort().join("\n");
+  const normalizedDirs = Array.from(new Set(dirs.filter((d) => d.trim()))).sort();
+  const key = normalizedDirs.join("\0");
   const now = Date.now();
-  const cached = remoteHostsCache.get(key);
-  if (cached && cached.expiresAt > now) return cached.promise;
-  const promise = scanRemoteHosts(dirs);
-  remoteHostsCache.set(key, { expiresAt: now + REMOTE_HOSTS_CACHE_TTL_MS, promise });
+  if (remoteHostsCache && remoteHostsCache.key === key && remoteHostsCache.expiresAt > now) {
+    return remoteHostsCache.promise;
+  }
+  const promise = scanRemoteHosts(normalizedDirs);
+  const slot = { key, expiresAt: Infinity, promise };
+  remoteHostsCache = slot;
+  // Don't cache rejections: on failure, clear the slot (only if it's still
+  // the one we just set — a later call may have already replaced it) so the
+  // next call retries instead of replaying a stale error. On success, anchor
+  // the TTL here at settle time rather than at call start.
+  promise.then(
+    () => {
+      if (remoteHostsCache === slot) slot.expiresAt = Date.now() + REMOTE_HOSTS_CACHE_TTL_MS;
+    },
+    () => {
+      if (remoteHostsCache === slot) remoteHostsCache = null;
+    },
+  );
   return promise;
 }
 

--- a/src/bun/git-provider.ts
+++ b/src/bun/git-provider.ts
@@ -25,6 +25,15 @@ import { tokenForHost } from "./github-tokens.ts";
  * Leaf module: does not import `db.ts` or `server.ts`. May import from
  * `github-tokens.ts`, `../shared/types.ts`, and `github.ts` (only the
  * provider-agnostic exports: `parseGitRemote`, `canonicalGitHost`, `run`).
+ *
+ * `remoteHostsForDirs` (docs/plans/consolidate-git-host-discovery.md) lives
+ * here rather than in `github.ts` for the same reason the rest of this file
+ * does: it needs to be provider-generic over `providerRepoForDir`, and
+ * `github.ts` can't import this module (this module imports `github.ts` for
+ * `parseGitRemote`/`canonicalGitHost`/`run` — the reverse edge would cycle).
+ * It used to live in github.ts with its own duplicated
+ * supported-provider-hosts set and inline remote-walk for exactly that
+ * reason; moving it here instead of duplicating deletes the duplication.
  */
 
 const GITLAB_FETCH_TIMEOUT_MS = 5_000;
@@ -75,6 +84,87 @@ export async function providerRepoForDir(dir: string): Promise<ProviderRepoInfo 
     };
   }
   return null;
+}
+
+const REMOTE_HOSTS_POOL_SIZE = 6;
+const REMOTE_HOSTS_CACHE_TTL_MS = 10_000;
+
+/** Promise-cache entry for `remoteHostsForDirs`: `expiresAt` is a wall-clock
+ *  deadline (ms since epoch) rather than a timer handle, so a stale entry is
+ *  detected lazily on the next call — no cleanup timers to leak or clear. */
+interface RemoteHostsCacheEntry {
+  expiresAt: number;
+  promise: Promise<string[]>;
+}
+
+/** Keyed on the sorted, newline-joined dir list (so caller-side ordering of
+ *  `dirs` never causes a spurious cache miss). Distinct project-list
+ *  snapshots get distinct entries; the map is small in practice (one entry
+ *  per distinct set of registered project paths, effectively one at a time
+ *  in production) so it's never proactively swept — a stale entry just sits
+ *  until its key is requested again post-expiry and gets overwritten. */
+const remoteHostsCache = new Map<string, RemoteHostsCacheEntry>();
+
+/** Test-only escape hatch: forces the next `remoteHostsForDirs` call (for any
+ *  key) to re-scan instead of reusing a cached promise. Exported rather than
+ *  threading a `{ fresh: true }` option through the production signature,
+ *  since the only caller that ever needs to bypass the cache is a test
+ *  proving the TTL actually expires/cache actually reuses. */
+export function clearRemoteHostsCache(): void {
+  remoteHostsCache.clear();
+}
+
+async function scanRemoteHosts(dirs: string[]): Promise<string[]> {
+  const hosts = new Set<string>();
+  // Bounded concurrency: each dir costs one `git remote` + up to one `git
+  // remote get-url` per remote (via providerRepoForDir), and the Settings
+  // page can list dozens of projects — an unbounded Promise.all over all of
+  // them would burst that many subprocesses at once. Same pool-worker shape
+  // as listGitHubItemsAcrossRepos (github.ts) / listItemsAcrossRepos
+  // (git-host.ts): a shared `next` cursor, workers pull the next index until
+  // exhausted, order doesn't matter since results only feed a Set.
+  let next = 0;
+  const worker = async () => {
+    while (true) {
+      const i = next++;
+      if (i >= dirs.length) return;
+      const dir = dirs[i]!;
+      const info = await providerRepoForDir(dir);
+      if (info) hosts.add(info.remoteHost);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(REMOTE_HOSTS_POOL_SIZE, dirs.length) }, worker));
+  return Array.from(hosts).sort();
+}
+
+/**
+ * Distinct raw remote hosts (the ssh-alias identity, or the provider's own
+ * domain for a plain remote) across the given project dirs, sorted — drives
+ * the Settings "detected hosts" suggestion list so a user's real aliases are
+ * one click away instead of hand-typed. Provider-generic via
+ * `providerRepoForDir`: considers every dir whose first origin-first remote
+ * resolves to a supported provider (github.com, gitlab.com, or
+ * bitbucket.org) — not just GitHub. Dirs with no supported-provider remote
+ * (or that aren't a repo at all) are tolerated silently, same as
+ * `providerRepoForDir` itself returning null.
+ *
+ * Result is cached (10s TTL) per distinct sorted-dirs key: the Settings
+ * "/github/tokens" GET and PUT handlers both call this with the same project
+ * list back-to-back (GET on page load, PUT immediately after on every token
+ * save), so without a cache a single Settings save always re-runs the whole
+ * scan twice. A cache miss beyond the TTL just re-scans; staleness cost is a
+ * newly-added project's host not appearing in the detected list for up to
+ * 10s, which self-heals on the next Settings open (see
+ * docs/plans/consolidate-git-host-discovery.md §7).
+ */
+export async function remoteHostsForDirs(dirs: string[]): Promise<string[]> {
+  const key = Array.from(dirs).sort().join("\n");
+  const now = Date.now();
+  const cached = remoteHostsCache.get(key);
+  if (cached && cached.expiresAt > now) return cached.promise;
+  const promise = scanRemoteHosts(dirs);
+  remoteHostsCache.set(key, { expiresAt: now + REMOTE_HOSTS_CACHE_TTL_MS, promise });
+  return promise;
 }
 
 /**

--- a/src/bun/github-network.test.ts
+++ b/src/bun/github-network.test.ts
@@ -2600,7 +2600,7 @@ test("a 404 on an alias-host repo is enriched with the Settings pointer, naming 
       expect(res.ok).toBe(false);
       if (res.ok) throw new Error("expected getGitHubViewer to fail on a 404");
       expect(res.error).toContain(
-        "add a token for github-testalias-404.com in Settings → GitHub tokens",
+        "add a token for github-testalias-404.com in Settings → Git host tokens",
       );
       expect(res.error).toContain("configured token cannot access it");
     } finally {

--- a/src/bun/github.test.ts
+++ b/src/bun/github.test.ts
@@ -1,8 +1,5 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
 import { expect, test } from "bun:test";
-import { __githubInternals, githubRepoFromRemoteForTest, remoteHostsForDirs } from "./github.ts";
+import { __githubInternals, githubRepoFromRemoteForTest } from "./github.ts";
 import type { GitHubListItem } from "../shared/types.ts";
 
 const {
@@ -1310,45 +1307,6 @@ test("parseGitRemote preserves rawHost for a github ssh host alias while canonic
   });
 });
 
-// ---------------------------------------------------------------------------
-// remoteHostsForDirs — provider-generic alias-host discovery
-// (fix-bitbucket-alias-host-credentials.md §3/§5). Not a pure function (it
-// shells out to `git`), so unlike the rest of this file these tests build
-// throwaway temp git repos, mirroring git-host.test.ts's `makeRepo` convention.
-// ---------------------------------------------------------------------------
-
-async function git(args: string[], cwd: string): Promise<void> {
-  const proc = Bun.spawn(["git", ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
-  await proc.exited;
-}
-
-/** A throwaway git repo whose sole `origin` remote is the given URL. */
-async function makeRemoteHostDir(remoteUrl: string): Promise<string> {
-  const dir = mkdtempSync(path.join(tmpdir(), "agetor-remote-hosts-"));
-  await git(["init", "-b", "main"], dir);
-  await git(["remote", "add", "origin", remoteUrl], dir);
-  return dir;
-}
-
-test("remoteHostsForDirs returns the sorted alias hosts of every supported provider (github/gitlab/bitbucket), excluding an unsupported host, and tolerates a dir that isn't a repo", async () => {
-  const dirs: string[] = [];
-  try {
-    const githubDir = await makeRemoteHostDir("git@github-work.com:a/b.git");
-    dirs.push(githubDir);
-    const bitbucketDir = await makeRemoteHostDir("git@bitbucket-work.com:w/r.git");
-    dirs.push(bitbucketDir);
-    const gitlabDir = await makeRemoteHostDir("git@gitlab-work.io:g/p.git");
-    dirs.push(gitlabDir);
-    const unsupportedDir = await makeRemoteHostDir("git@example.com:x/y.git");
-    dirs.push(unsupportedDir);
-    // A dir that isn't a git repo at all (but does exist) — must be tolerated
-    // silently, same as repoForDir.
-    const notARepoDir = mkdtempSync(path.join(tmpdir(), "agetor-remote-hosts-plain-"));
-    dirs.push(notARepoDir);
-
-    const hosts = await remoteHostsForDirs([githubDir, bitbucketDir, gitlabDir, unsupportedDir, notARepoDir]);
-    expect(hosts).toEqual(["bitbucket-work.com", "github-work.com", "gitlab-work.io"]);
-  } finally {
-    for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
-  }
-});
+// remoteHostsForDirs moved to git-provider.ts, reimplemented over
+// providerRepoForDir (docs/plans/consolidate-git-host-discovery.md) — its
+// test moved with it, to git-provider.test.ts.

--- a/src/bun/github.test.ts
+++ b/src/bun/github.test.ts
@@ -1,5 +1,8 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { expect, test } from "bun:test";
-import { __githubInternals, githubRepoFromRemoteForTest } from "./github.ts";
+import { __githubInternals, githubRepoFromRemoteForTest, remoteHostsForDirs } from "./github.ts";
 import type { GitHubListItem } from "../shared/types.ts";
 
 const {
@@ -1305,4 +1308,47 @@ test("parseGitRemote preserves rawHost for a github ssh host alias while canonic
     owner: "o",
     name: "r",
   });
+});
+
+// ---------------------------------------------------------------------------
+// remoteHostsForDirs — provider-generic alias-host discovery
+// (fix-bitbucket-alias-host-credentials.md §3/§5). Not a pure function (it
+// shells out to `git`), so unlike the rest of this file these tests build
+// throwaway temp git repos, mirroring git-host.test.ts's `makeRepo` convention.
+// ---------------------------------------------------------------------------
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+}
+
+/** A throwaway git repo whose sole `origin` remote is the given URL. */
+async function makeRemoteHostDir(remoteUrl: string): Promise<string> {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-remote-hosts-"));
+  await git(["init", "-b", "main"], dir);
+  await git(["remote", "add", "origin", remoteUrl], dir);
+  return dir;
+}
+
+test("remoteHostsForDirs returns the sorted alias hosts of every supported provider (github/gitlab/bitbucket), excluding an unsupported host, and tolerates a dir that isn't a repo", async () => {
+  const dirs: string[] = [];
+  try {
+    const githubDir = await makeRemoteHostDir("git@github-work.com:a/b.git");
+    dirs.push(githubDir);
+    const bitbucketDir = await makeRemoteHostDir("git@bitbucket-work.com:w/r.git");
+    dirs.push(bitbucketDir);
+    const gitlabDir = await makeRemoteHostDir("git@gitlab-work.io:g/p.git");
+    dirs.push(gitlabDir);
+    const unsupportedDir = await makeRemoteHostDir("git@example.com:x/y.git");
+    dirs.push(unsupportedDir);
+    // A dir that isn't a git repo at all (but does exist) — must be tolerated
+    // silently, same as repoForDir.
+    const notARepoDir = mkdtempSync(path.join(tmpdir(), "agetor-remote-hosts-plain-"));
+    dirs.push(notARepoDir);
+
+    const hosts = await remoteHostsForDirs([githubDir, bitbucketDir, gitlabDir, unsupportedDir, notARepoDir]);
+    expect(hosts).toEqual(["bitbucket-work.com", "github-work.com", "gitlab-work.io"]);
+  } finally {
+    for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -62,6 +62,7 @@ import type {
   GitHubWorkflowsResult,
   TaskDiff,
 } from "../shared/types.ts";
+import { GIT_HOST_TOKENS_SECTION } from "../shared/types.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
 import { tokenForHost } from "./github-tokens.ts";
 
@@ -1277,7 +1278,7 @@ function apiError(body: unknown, status: number, statusText: string): string {
 function privateRepoHint(status: number, message: string, repo: GitHubRepo, hadToken: boolean): string {
   if (status !== 404) return message;
   const host = repo.remoteHost || "github.com";
-  const base = `${repo.owner}/${repo.name} was not found on GitHub — if the repo is private, add a token for ${host} in Settings → Git host tokens`;
+  const base = `${repo.owner}/${repo.name} was not found on GitHub — if the repo is private, add a token for ${host} in Settings → ${GIT_HOST_TOKENS_SECTION}`;
   return hadToken
     ? `${base} (the configured token cannot access it — check it belongs to the right account)`
     : base;

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -832,17 +832,42 @@ export async function repoForDir(dir: string): Promise<GitHubRepo | null> {
   return null;
 }
 
-/** Distinct raw GitHub hosts (the ssh-alias identity, or `github.com` for a
- *  plain remote) across the given project dirs, sorted — drives the Settings
- *  "detected hosts" suggestion list so a user's real aliases are one click
- *  away instead of hand-typed. Dirs with no GitHub remote (or that aren't a
- *  repo at all) are tolerated silently, same as `repoForDir`. */
+/** Canonical hosts recognized by any provider adapter (github.ts, gitlab.ts,
+ *  bitbucket.ts) — the set `remoteHostsForDirs` uses to decide whether a
+ *  remote's host is "supported" at all, independent of which provider it is. */
+const SUPPORTED_PROVIDER_HOSTS = new Set(["github.com", "gitlab.com", "bitbucket.org"]);
+
+/** Distinct raw remote hosts (the ssh-alias identity, or the provider's own
+ *  domain for a plain remote) across the given project dirs, sorted — drives
+ *  the Settings "detected hosts" suggestion list so a user's real aliases are
+ *  one click away instead of hand-typed. Provider-generic: considers every
+ *  remote whose canonical host (via `parseGitRemote`) resolves to a supported
+ *  provider (github.com, gitlab.com, or bitbucket.org) — not just GitHub — so
+ *  a Bitbucket- or GitLab-only repo's alias host still surfaces here. Per dir,
+ *  walks remotes origin-first (same order as `repoForDir`) and stops at the
+ *  first one that resolves to a supported provider. Implemented inline
+ *  (rather than via `git-provider.ts`'s `providerRepoForDir`) to avoid a
+ *  circular import — `git-provider.ts` imports this file. Dirs with no
+ *  supported-provider remote (or that aren't a repo at all) are tolerated
+ *  silently, same as `repoForDir`. */
 export async function remoteHostsForDirs(dirs: string[]): Promise<string[]> {
-  const repos = await Promise.all(dirs.map((dir) => repoForDir(dir)));
   const hosts = new Set<string>();
-  for (const repo of repos) {
-    if (repo) hosts.add(repo.remoteHost);
-  }
+  await Promise.all(dirs.map(async (dir) => {
+    if (!existsSync(dir)) return;
+    const remotes = await run(["git", "remote"], dir);
+    if (!remotes.ok) return;
+    const names = remotes.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+    const ordered = ["origin", ...names.filter((n) => n !== "origin")];
+    for (const name of ordered) {
+      const url = await run(["git", "remote", "get-url", name], dir);
+      if (!url.ok) continue;
+      const parsed = parseGitRemote(url.stdout);
+      if (parsed && SUPPORTED_PROVIDER_HOSTS.has(parsed.host)) {
+        hosts.add(parsed.rawHost);
+        break;
+      }
+    }
+  }));
   return Array.from(hosts).sort();
 }
 
@@ -1291,7 +1316,7 @@ function apiError(body: unknown, status: number, statusText: string): string {
 function privateRepoHint(status: number, message: string, repo: GitHubRepo, hadToken: boolean): string {
   if (status !== 404) return message;
   const host = repo.remoteHost || "github.com";
-  const base = `${repo.owner}/${repo.name} was not found on GitHub — if the repo is private, add a token for ${host} in Settings → GitHub tokens`;
+  const base = `${repo.owner}/${repo.name} was not found on GitHub — if the repo is private, add a token for ${host} in Settings → Git host tokens`;
   return hadToken
     ? `${base} (the configured token cannot access it — check it belongs to the right account)`
     : base;

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -832,45 +832,6 @@ export async function repoForDir(dir: string): Promise<GitHubRepo | null> {
   return null;
 }
 
-/** Canonical hosts recognized by any provider adapter (github.ts, gitlab.ts,
- *  bitbucket.ts) — the set `remoteHostsForDirs` uses to decide whether a
- *  remote's host is "supported" at all, independent of which provider it is. */
-const SUPPORTED_PROVIDER_HOSTS = new Set(["github.com", "gitlab.com", "bitbucket.org"]);
-
-/** Distinct raw remote hosts (the ssh-alias identity, or the provider's own
- *  domain for a plain remote) across the given project dirs, sorted — drives
- *  the Settings "detected hosts" suggestion list so a user's real aliases are
- *  one click away instead of hand-typed. Provider-generic: considers every
- *  remote whose canonical host (via `parseGitRemote`) resolves to a supported
- *  provider (github.com, gitlab.com, or bitbucket.org) — not just GitHub — so
- *  a Bitbucket- or GitLab-only repo's alias host still surfaces here. Per dir,
- *  walks remotes origin-first (same order as `repoForDir`) and stops at the
- *  first one that resolves to a supported provider. Implemented inline
- *  (rather than via `git-provider.ts`'s `providerRepoForDir`) to avoid a
- *  circular import — `git-provider.ts` imports this file. Dirs with no
- *  supported-provider remote (or that aren't a repo at all) are tolerated
- *  silently, same as `repoForDir`. */
-export async function remoteHostsForDirs(dirs: string[]): Promise<string[]> {
-  const hosts = new Set<string>();
-  await Promise.all(dirs.map(async (dir) => {
-    if (!existsSync(dir)) return;
-    const remotes = await run(["git", "remote"], dir);
-    if (!remotes.ok) return;
-    const names = remotes.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
-    const ordered = ["origin", ...names.filter((n) => n !== "origin")];
-    for (const name of ordered) {
-      const url = await run(["git", "remote", "get-url", name], dir);
-      if (!url.ok) continue;
-      const parsed = parseGitRemote(url.stdout);
-      if (parsed && SUPPORTED_PROVIDER_HOSTS.has(parsed.host)) {
-        hosts.add(parsed.rawHost);
-        break;
-      }
-    }
-  }));
-  return Array.from(hosts).sort();
-}
-
 /** Resolve the token to authenticate a GitHub request with, for a repo whose
  *  raw remote host is `host` (null when there's no repo in scope). Order:
  *  (1) a stored token for `host` (or the `github.com` default entry —

--- a/src/bun/gitlab-network.test.ts
+++ b/src/bun/gitlab-network.test.ts
@@ -679,7 +679,7 @@ test("a 401 response surfaces the authHint wording pointing at Settings", async 
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error("expected failure");
     expect(res.error).toContain("Settings");
-    expect(res.error).toContain("GitLab tokens");
+    expect(res.error).toContain("Git host tokens");
   } finally {
     mock.restore();
   }

--- a/src/bun/gitlab.ts
+++ b/src/bun/gitlab.ts
@@ -133,7 +133,7 @@ function apiError(body: unknown, status: number, statusText: string): string {
 function authHint(status: number, message: string, repo: ProviderRepoInfo, hadToken: boolean): string {
   if (status !== 401 && status !== 404) return message;
   const host = repo.remoteHost || "gitlab.com";
-  const base = `${repo.owner}/${repo.name} was not found on GitLab — if the project is private, add a token for ${host} in Settings → GitLab tokens`;
+  const base = `${repo.owner}/${repo.name} was not found on GitLab — if the project is private, add a token for ${host} in Settings → Git host tokens`;
   return hadToken
     ? `${base} (the configured token cannot access it — check it belongs to the right account)`
     : base;

--- a/src/bun/gitlab.ts
+++ b/src/bun/gitlab.ts
@@ -22,6 +22,7 @@ import type {
   ProviderRepoInfo,
   TaskDiff,
 } from "../shared/types.ts";
+import { GIT_HOST_TOKENS_SECTION } from "../shared/types.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
 import { gitlabToken } from "./git-provider.ts";
 
@@ -133,7 +134,7 @@ function apiError(body: unknown, status: number, statusText: string): string {
 function authHint(status: number, message: string, repo: ProviderRepoInfo, hadToken: boolean): string {
   if (status !== 401 && status !== 404) return message;
   const host = repo.remoteHost || "gitlab.com";
-  const base = `${repo.owner}/${repo.name} was not found on GitLab — if the project is private, add a token for ${host} in Settings → Git host tokens`;
+  const base = `${repo.owner}/${repo.name} was not found on GitLab — if the project is private, add a token for ${host} in Settings → ${GIT_HOST_TOKENS_SECTION}`;
   return hadToken
     ? `${base} (the configured token cannot access it — check it belongs to the right account)`
     : base;

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -132,8 +132,8 @@ import {
   updateGitHubMilestone,
   updateGitHubPullBranch,
   updateGitHubRelease,
-  remoteHostsForDirs,
 } from "./github.ts";
+import { remoteHostsForDirs } from "./git-provider.ts";
 import * as gitHost from "./git-host.ts";
 import { getDiscoveredModels, refreshDiscoveredModels } from "./agent-discovery.ts";
 import { getMainWindow } from "./window.ts";

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -894,6 +894,12 @@ export default function App() {
           setGithubPullPrefill(null);
           setGithubPullDetailPrefill(null);
         }}
+        onOpenSettings={() => {
+          setGithubOpen(false);
+          setGithubPullPrefill(null);
+          setGithubPullDetailPrefill(null);
+          setSettingsOpen(true);
+        }}
       />
       <WorktreesDialog
         open={worktreesOpen}

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -673,6 +673,18 @@ export default function App() {
     }
   }, [confirm, refresh, surfaceError]);
 
+  // Shared by GitHubDialog's `onClose` and `onOpenSettings` (the latter also
+  // opens SettingsDialog) so the three-setter teardown can't drift out of
+  // sync between the two call sites — both must clear the dialog's own open
+  // state and both prefill kinds, or a later plain "GitHub" open (no
+  // prefill) could inherit a stale project/task from whichever prefill path
+  // was last used.
+  const closeGithubDialog = useCallback(() => {
+    setGithubOpen(false);
+    setGithubPullPrefill(null);
+    setGithubPullDetailPrefill(null);
+  }, []);
+
   return (
     <div className="flex h-screen w-screen flex-col bg-background text-foreground">
       {/* Top app bar sits on the same row as the macOS traffic lights (see
@@ -889,15 +901,9 @@ export default function App() {
         initialProjectPath={githubPullDetailPrefill?.projectPath ?? githubPullPrefill?.projectPath ?? repoFilter[0] ?? selected?.workdir ?? tasks[0]?.workdir ?? null}
         pullPrefill={githubPullPrefill}
         pullDetailPrefill={githubPullDetailPrefill}
-        onClose={() => {
-          setGithubOpen(false);
-          setGithubPullPrefill(null);
-          setGithubPullDetailPrefill(null);
-        }}
+        onClose={closeGithubDialog}
         onOpenSettings={() => {
-          setGithubOpen(false);
-          setGithubPullPrefill(null);
-          setGithubPullDetailPrefill(null);
+          closeGithubDialog();
           setSettingsOpen(true);
         }}
       />

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -68,6 +68,7 @@ import {
 import { cn } from "@/lib/utils";
 import { toRows, type DiffRow } from "@/lib/diff-rows";
 import { mergeabilityView, type MergeTone } from "@/lib/mergeability";
+import { isCredentialError } from "@/lib/credential-error";
 import { ResolveConflictsDialog, type ResolveConflictsContext } from "./ResolveConflictsDialog";
 import {
   backToList,
@@ -515,6 +516,27 @@ function RateLimitBadge({ rateLimit }: { rateLimit: GitHubRateLimit }) {
       {rateLimit.resource}: {rateLimit.remaining}/{rateLimit.limit}
     </span>
   );
+}
+
+/** First step of the credential-error panel's one-time-setup list (review
+ *  pass on commit 1cb3fa5, finding #1) — names the actual token flavor each
+ *  git host expects, since "create a token on your git host" was true but
+ *  unhelpfully vague for the two most common hosts. `provider` mirrors the
+ *  dialog's own resolved-provider state; "mixed" (aggregate view across
+ *  repos on different hosts) and `null` (not yet resolved, or resolution
+ *  failed) fall back to the original host-neutral wording since we can't say
+ *  which token flavor applies. */
+function credentialSetupStep1(provider: GitProvider | "mixed" | null): string {
+  switch (provider) {
+    case "bitbucket":
+      return "Create an Atlassian API token with scopes at id.atlassian.com — Bitbucket credentials are saved as email:api_token.";
+    case "github":
+      return "Create a personal access token (classic or fine-grained) on github.com.";
+    case "gitlab":
+      return "Create a personal access token with the api scope on gitlab.com (or your self-hosted GitLab instance).";
+    default:
+      return "Create a token on your git host.";
+  }
 }
 
 export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, pullDetailPrefill, onClose, onOpenSettings }: Props) {
@@ -1001,6 +1023,14 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
       setReloadPending(false);
       return;
     }
+    // Clear a stale error immediately (rather than waiting out the debounce
+    // below + the in-flight request) so reopening the dialog on a task that
+    // previously errored shows the loading state, not last time's credential
+    // panel flashing before the fresh load replaces it. `result` is left
+    // alone — every other reload path here (filter/sort changes) already
+    // keeps showing the previous list while the next page loads, and this
+    // shouldn't regress that.
+    setError(null);
     setReloadPending(true);
     const t = setTimeout(() => { setReloadPending(false); void load({ requestId }); }, 250);
     return () => clearTimeout(t);
@@ -3836,23 +3866,28 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
         {/* Credential errors are enriched server-side with the marker phrase
             `Settings → ${GIT_HOST_TOKENS_SECTION}` (github.ts's
             `privateRepoHint`, gitlab.ts's `authHint`, bitbucket.ts's
-            `bitbucketAccessHint`/`bitbucketViewerAccessHint`) — matching it
-            here (rather than a status code we don't have at this layer) is
-            what lets us swap the bare error row for an actionable explainer,
-            while every other list-load failure keeps the plain row below. */}
+            `bitbucketAccessHint`/`bitbucketViewerAccessHint`) — detecting it
+            via the shared `isCredentialError` helper (rather than a status
+            code we don't have at this layer) is what lets us swap the bare
+            error row for an actionable explainer, while every other
+            list-load failure keeps the plain row below. */}
         {!loading && error && (
-          error.includes(`Settings → ${GIT_HOST_TOKENS_SECTION}`) ? (
-            <div className="mx-auto my-6 flex max-w-md flex-col gap-3 rounded-md border border-border/60 bg-card p-4">
+          isCredentialError(error) ? (
+            <div
+              role="alert"
+              className="mx-auto my-6 flex max-w-md flex-col gap-3 rounded-md border border-amber-500/40 bg-amber-500/5 p-4"
+            >
               <div className="flex items-center gap-2 text-sm font-medium text-foreground">
                 <KeyRound className="size-4 text-amber-400" />
-                A credential is needed for this repository
+                Can&apos;t reach this repository
               </div>
+              <p className="text-xs text-muted-foreground">This is usually a missing or invalid credential.</p>
               <p className="text-xs text-muted-foreground">{error}</p>
               <div className="rounded-md border border-border/50 bg-background/40 p-3">
-                <div className="mb-1.5 text-[11px] font-medium text-muted-foreground">One-time setup</div>
+                <div className="mb-1.5 text-[11px] font-medium text-muted-foreground">If the repository is private:</div>
                 <ol className="list-decimal space-y-1 pl-4 text-xs text-muted-foreground">
-                  <li>Create a token on your git host — for Bitbucket that&apos;s an Atlassian API token with scopes at id.atlassian.com.</li>
-                  <li>In Settings → {GIT_HOST_TOKENS_SECTION}, save it for the host named above — Bitbucket credentials are entered as email:api_token.</li>
+                  <li>{credentialSetupStep1(provider)}</li>
+                  <li>In Settings → {GIT_HOST_TOKENS_SECTION}, save it for the host named above.</li>
                   <li>Reopen this dialog. The Setup guide button inside the Settings section walks through each provider step by step.</li>
                 </ol>
               </div>

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -26,6 +26,7 @@ import {
   GitMerge,
   GitPullRequest,
   Kanban,
+  KeyRound,
   ListTree,
   Loader2,
   Lock,
@@ -40,6 +41,7 @@ import {
   Rocket,
   RotateCcw,
   Search,
+  Settings,
   Sparkles,
   Tag,
   Unlock,
@@ -110,7 +112,7 @@ import type {
   ProviderCaps,
   TaskDiff,
 } from "../../../shared/types.ts";
-import { PROVIDER_CAPS } from "../../../shared/types.ts";
+import { GIT_HOST_TOKENS_SECTION, PROVIDER_CAPS } from "../../../shared/types.ts";
 
 // Hoisted ReactMarkdown `components` map for GitHub markdown bodies (PR/issue
 // descriptions, comments, list previews). Module scope keeps the prop identity
@@ -203,6 +205,11 @@ interface Props {
    *  `pendingPullDetailPrefillRef` below. */
   pullDetailPrefill?: GitHubPullDetailPrefill | null;
   onClose: () => void;
+  /** Wired from App.tsx: closes this dialog and opens SettingsDialog. Optional
+   *  so other mounts (tests, storybook-style usages) don't need to supply it —
+   *  when absent, the credential-error panel below simply omits its "Open
+   *  Settings" button rather than rendering a dead one. */
+  onOpenSettings?: () => void;
 }
 
 const basename = (p: string) => {
@@ -510,7 +517,7 @@ function RateLimitBadge({ rateLimit }: { rateLimit: GitHubRateLimit }) {
   );
 }
 
-export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, pullDetailPrefill, onClose }: Props) {
+export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, pullDetailPrefill, onClose, onOpenSettings }: Props) {
   const [projectPath, setProjectPath] = useState("");
   // "All repositories" (G8/F15) — see AGGREGATE_PROJECT_PATH.
   const isAggregate = projectPath === AGGREGATE_PROJECT_PATH;
@@ -3826,10 +3833,43 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
           </div>
         )}
 
+        {/* Credential errors are enriched server-side with the marker phrase
+            `Settings → ${GIT_HOST_TOKENS_SECTION}` (github.ts's
+            `privateRepoHint`, gitlab.ts's `authHint`, bitbucket.ts's
+            `bitbucketAccessHint`/`bitbucketViewerAccessHint`) — matching it
+            here (rather than a status code we don't have at this layer) is
+            what lets us swap the bare error row for an actionable explainer,
+            while every other list-load failure keeps the plain row below. */}
         {!loading && error && (
-          <div className="flex items-center justify-center gap-2 py-12 text-sm text-rose-400">
-            <AlertCircle className="size-4" /> {error}
-          </div>
+          error.includes(`Settings → ${GIT_HOST_TOKENS_SECTION}`) ? (
+            <div className="mx-auto my-6 flex max-w-md flex-col gap-3 rounded-md border border-border/60 bg-card p-4">
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <KeyRound className="size-4 text-amber-400" />
+                A credential is needed for this repository
+              </div>
+              <p className="text-xs text-muted-foreground">{error}</p>
+              <div className="rounded-md border border-border/50 bg-background/40 p-3">
+                <div className="mb-1.5 text-[11px] font-medium text-muted-foreground">One-time setup</div>
+                <ol className="list-decimal space-y-1 pl-4 text-xs text-muted-foreground">
+                  <li>Create a token on your git host — for Bitbucket that&apos;s an Atlassian API token with scopes at id.atlassian.com.</li>
+                  <li>In Settings → {GIT_HOST_TOKENS_SECTION}, save it for the host named above — Bitbucket credentials are entered as email:api_token.</li>
+                  <li>Reopen this dialog. The Setup guide button inside the Settings section walks through each provider step by step.</li>
+                </ol>
+              </div>
+              {onOpenSettings && (
+                <div className="flex justify-end">
+                  <Button size="sm" onClick={onOpenSettings}>
+                    <Settings className="mr-2 size-3.5" />
+                    Open Settings
+                  </Button>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="flex items-center justify-center gap-2 py-12 text-sm text-rose-400">
+              <AlertCircle className="size-4" /> {error}
+            </div>
+          )
         )}
 
         {loading && !result && (

--- a/src/mainview/components/settings/GitHubSetupDialog.tsx
+++ b/src/mainview/components/settings/GitHubSetupDialog.tsx
@@ -16,12 +16,62 @@ import {
   type GuideStep,
 } from "@/lib/github-setup-guide";
 
+/** Click-path to create a Bitbucket Atlassian API token, used in place of
+ *  the retired (2026-06-09) app-password flow. Stored as a single
+ *  `email:api_token` string — Bitbucket's Basic auth format. */
+const BITBUCKET_CREATE_STEPS: GuideStep[] = [
+  {
+    title: "Open id.atlassian.com → Security",
+    detail: "Sign in at id.atlassian.com, then choose \"Security\" in the left sidebar.",
+  },
+  {
+    title: "Create an API token",
+    detail:
+      "Under \"API tokens\", click \"Create API token\", give it a name, and copy the " +
+      "generated token — it's shown only once.",
+  },
+  {
+    title: "Save it as email:api_token",
+    detail:
+      "Back in the Git host tokens section, enter the host (bitbucket.org, or your ssh " +
+      "alias host) and put your Atlassian account email, a colon, then the API token in " +
+      "the token field — e.g. \"jane@example.com:ATATT3x…\". Bitbucket app passwords were " +
+      "retired on 2026-06-09; replace any saved app password with a token in this format.",
+  },
+];
+
+/** Click-path to create a GitLab personal access token. */
+const GITLAB_CREATE_STEPS: GuideStep[] = [
+  {
+    title: "Open GitLab → Edit profile → Access tokens",
+    detail:
+      "From your GitLab avatar, go to \"Edit profile\", then \"Access tokens\" in the left " +
+      "sidebar.",
+  },
+  {
+    title: "Name, expiration, and scope",
+    detail: "Give the token a name and expiration, then select the \"api\" scope.",
+  },
+  {
+    title: "Create and save it in Agetor",
+    detail:
+      "Click \"Create personal access token\" and copy it — it's shown only once. Back in " +
+      "the Git host tokens section, enter the host (gitlab.com, or your ssh alias host) and " +
+      "the token itself.",
+  },
+];
+
+const BITBUCKET_TOKENS_URL = "https://id.atlassian.com/manage-profile/security/api-tokens";
+const GITLAB_TOKENS_URL = "https://gitlab.com/-/user_settings/personal_access_tokens";
+
 /**
- * "Connect Agetor to GitHub" instructions modal, opened from
+ * "Connect Agetor to a git host" instructions modal, opened from
  * `GitHubTokensSection` (the header button and the empty-state link). Purely
  * informational — it does not embed the token form itself, which lives
- * directly behind it in the same Settings section. All copy is sourced from
- * `lib/github-setup-guide.ts`; this component only supplies section
+ * directly behind it in the same Settings section. GitHub copy is sourced
+ * from `lib/github-setup-guide.ts`; Bitbucket and GitLab copy is local to
+ * this component (smaller, single-consumer guides that don't warrant a
+ * shared data module yet). This component supplies section
  * headings/intro sentences and layout.
  */
 export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
@@ -35,7 +85,7 @@ export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: (
     >
       <div className="flex items-center justify-between border-b border-border/60 pb-3">
         <h2 id="github-setup-dialog-title" className="text-base font-semibold">
-          Connect Agetor to GitHub
+          Connect Agetor to a git host
         </h2>
         <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
           <X className="size-4" />
@@ -45,19 +95,20 @@ export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: (
       <div className="max-h-[70vh] space-y-5 overflow-y-auto pt-3 text-sm">
         <section className="space-y-1">
           <p id="github-setup-dialog-desc" className="text-[11px] leading-snug text-muted-foreground">
-            Agetor talks to GitHub using a personal access token (PAT) that you create and
-            paste into this Settings section. The integration covers pull requests, issues,
-            reviews, checks, Actions, releases, Projects, Discussions, and notifications —
-            how much of that works depends on which permissions the token you save actually
-            has.
+            Agetor talks to GitHub, GitLab, and Bitbucket using a token or credential that you
+            create and paste into the Git host tokens Settings section. For GitHub, the
+            integration covers pull requests, issues, reviews, checks, Actions, releases,
+            Projects, Discussions, and notifications — how much of that works depends on which
+            permissions the token you save actually has. Set up whichever host(s) apply to you
+            below.
           </p>
         </section>
 
-        <GuideSection heading="How Agetor finds a token">
+        <GuideSection heading="GitHub: how Agetor finds a token">
           <StepList steps={AUTH_RESOLUTION_STEPS} />
         </GuideSection>
 
-        <GuideSection heading="Recommended: classic token (full access)">
+        <GuideSection heading="GitHub — recommended: classic token (full access)">
           <StepList steps={CLASSIC_CREATE_STEPS} />
           <div className="space-y-1.5">
             {CLASSIC_SCOPES.map((row) => (
@@ -74,7 +125,7 @@ export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: (
           </div>
         </GuideSection>
 
-        <GuideSection heading="Alternative: fine-grained token (least privilege)">
+        <GuideSection heading="GitHub — alternative: fine-grained token (least privilege)">
           <StepList steps={FINE_GRAINED_CREATE_STEPS} />
           <div className="space-y-1.5">
             {FINE_GRAINED_PERMISSIONS.map((row) => (
@@ -108,7 +159,7 @@ export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: (
           </div>
         </GuideSection>
 
-        <GuideSection heading="Working with organizations">
+        <GuideSection heading="GitHub — working with organizations">
           <ul className="list-disc space-y-1 pl-4 text-[11px] leading-snug text-muted-foreground">
             {ORG_CAVEATS.map((item) => (
               <li key={item}>{item}</li>
@@ -116,15 +167,42 @@ export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: (
           </ul>
         </GuideSection>
 
-        <GuideSection heading="Multiple GitHub accounts">
+        <GuideSection heading="GitHub — multiple accounts">
           <p className="text-[11px] leading-snug text-muted-foreground">{MULTI_ACCOUNT_NOTE}</p>
         </GuideSection>
 
-        <GuideSection heading="Save the token in Agetor">
+        <GuideSection heading="Bitbucket: Atlassian API token">
+          <StepList steps={BITBUCKET_CREATE_STEPS} />
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void api.openExternal(BITBUCKET_TOKENS_URL)}
+            >
+              Open Atlassian → API tokens
+            </Button>
+          </div>
+        </GuideSection>
+
+        <GuideSection heading="GitLab: personal access token">
+          <StepList steps={GITLAB_CREATE_STEPS} />
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void api.openExternal(GITLAB_TOKENS_URL)}
+            >
+              Open GitLab → Access tokens
+            </Button>
+          </div>
+        </GuideSection>
+
+        <GuideSection heading="Save the credential in Agetor">
           <p className="text-[11px] leading-snug text-muted-foreground">
-            Back in this Settings section, paste the host (github.com, or your ssh alias host),
-            an optional label, and the token itself into the fields below, then click Save
-            token.
+            Back in this Settings section, paste the host (github.com, gitlab.com,
+            bitbucket.org, or your ssh alias host), an optional label, and the token — or, for
+            Bitbucket, the <code className="font-mono">email:api_token</code> string — into the
+            fields below, then click Save token.
           </p>
           <div className="flex justify-end">
             <Button

--- a/src/mainview/components/settings/GitHubSetupDialog.tsx
+++ b/src/mainview/components/settings/GitHubSetupDialog.tsx
@@ -13,22 +13,31 @@ import {
   GITHUB_URLS,
   MULTI_ACCOUNT_NOTE,
   ORG_CAVEATS,
+  type GuideScopeRow,
   type GuideStep,
 } from "@/lib/github-setup-guide";
 
 /** Click-path to create a Bitbucket Atlassian API token, used in place of
  *  the retired (2026-06-09) app-password flow. Stored as a single
- *  `email:api_token` string — Bitbucket's Basic auth format. */
+ *  `email:api_token` string — Bitbucket's Basic auth format. A *scopeless*
+ *  Atlassian API token (the default the Atlassian account UI offers, aimed at
+ *  Jira/Confluence) is rejected by api.bitbucket.org — the token must be
+ *  created "with scopes" and have the Bitbucket scopes below selected. */
 const BITBUCKET_CREATE_STEPS: GuideStep[] = [
   {
     title: "Open id.atlassian.com → Security",
     detail: "Sign in at id.atlassian.com, then choose \"Security\" in the left sidebar.",
   },
   {
-    title: "Create an API token",
+    title: "Create an API token with scopes",
     detail:
-      "Under \"API tokens\", click \"Create API token\", give it a name, and copy the " +
-      "generated token — it's shown only once.",
+      "Under \"API tokens\", click \"Create API token with scopes\" (NOT the plain, scopeless " +
+      "\"Create API token\" — a scopeless token works for Jira/Confluence but api.bitbucket.org " +
+      "rejects it). Give it a name, then select \"Bitbucket\" and tick the scopes listed below.",
+  },
+  {
+    title: "Copy the token",
+    detail: "Click \"Create\" and copy the generated token — it's shown only once.",
   },
   {
     title: "Save it as email:api_token",
@@ -37,6 +46,32 @@ const BITBUCKET_CREATE_STEPS: GuideStep[] = [
       "alias host) and put your Atlassian account email, a colon, then the API token in " +
       "the token field — e.g. \"jane@example.com:ATATT3x…\". Bitbucket app passwords were " +
       "retired on 2026-06-09; replace any saved app password with a token in this format.",
+  },
+];
+
+/** Bitbucket scopes to select when creating the scoped API token above — the
+ *  minimum set covering everything this adapter's ~18 call sites touch
+ *  (src/bun/bitbucket.ts): repository read/write for PR diffs, statuses, and
+ *  merges; pull request and issue read/write; account read to resolve the
+ *  viewer (`getBitbucketViewer`, used for the "me"-scoped BBQL filters). */
+const BITBUCKET_SCOPES: GuideScopeRow[] = [
+  {
+    scope: "Repositories: Read, Write",
+    usedFor: "Listing repos, reading diffs/commit statuses, and merging pull requests.",
+  },
+  {
+    scope: "Pull requests: Read, Write",
+    usedFor:
+      "Listing, creating, merging, declining, and reviewing PRs; PR and line comments; " +
+      "merge-conflict detection.",
+  },
+  {
+    scope: "Issues: Read, Write",
+    usedFor: "The repository issue tracker — listing, creating, updating, and commenting.",
+  },
+  {
+    scope: "Account: Read",
+    usedFor: "Resolving the signed-in account, used for \"assigned to me\"/\"created by me\" filters.",
   },
 ];
 
@@ -106,6 +141,14 @@ export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: (
 
         <GuideSection heading="GitHub: how Agetor finds a token">
           <StepList steps={AUTH_RESOLUTION_STEPS} />
+          <p className="text-[11px] leading-snug text-muted-foreground">
+            Bitbucket and GitLab resolve the same way minus the CLI-login step: Bitbucket tries a
+            stored host entry, then the bitbucket.org entry, then the{" "}
+            <code className="font-mono">BITBUCKET_TOKEN</code>/
+            <code className="font-mono">BITBUCKET_EMAIL</code> environment variables; GitLab tries a
+            stored entry, then <code className="font-mono">GITLAB_TOKEN</code>, then a stored{" "}
+            <code className="font-mono">glab</code> CLI login.
+          </p>
         </GuideSection>
 
         <GuideSection heading="GitHub — recommended: classic token (full access)">
@@ -173,6 +216,14 @@ export function GitHubSetupDialog({ open, onClose }: { open: boolean; onClose: (
 
         <GuideSection heading="Bitbucket: Atlassian API token">
           <StepList steps={BITBUCKET_CREATE_STEPS} />
+          <div className="space-y-1.5">
+            {BITBUCKET_SCOPES.map((row) => (
+              <div key={row.scope} className="rounded-md border border-border/60 px-3 py-2">
+                <div className="font-mono text-xs">{row.scope}</div>
+                <div className="text-[11px] leading-snug text-muted-foreground">{row.usedFor}</div>
+              </div>
+            ))}
+          </div>
           <div className="flex justify-end">
             <Button
               size="sm"

--- a/src/mainview/components/settings/GitHubTokensSection.tsx
+++ b/src/mainview/components/settings/GitHubTokensSection.tsx
@@ -4,6 +4,7 @@ import { api, type GitHubTokensResult } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { GitHubSetupDialog } from "@/components/settings/GitHubSetupDialog";
+import { GIT_HOST_TOKENS_SECTION } from "../../../shared/types.ts";
 
 const DATALIST_ID = "github-token-hosts";
 
@@ -105,7 +106,7 @@ export function GitHubTokensSection() {
     <section className="space-y-2">
       <div className="flex items-center justify-between gap-2">
         <div>
-          <label className="text-xs text-muted-foreground">Git host tokens</label>
+          <label className="text-xs text-muted-foreground">{GIT_HOST_TOKENS_SECTION}</label>
           <p className="text-[11px] leading-snug text-muted-foreground">
             Repos reached through an ssh host alias (git@github-work.com:…, git@gitlab-work.com:…,
             git@bitbucket-work.com:…) authenticate with the token stored for that alias; github.com,

--- a/src/mainview/components/settings/GitHubTokensSection.tsx
+++ b/src/mainview/components/settings/GitHubTokensSection.tsx
@@ -107,10 +107,10 @@ export function GitHubTokensSection() {
         <div>
           <label className="text-xs text-muted-foreground">Git host tokens</label>
           <p className="text-[11px] leading-snug text-muted-foreground">
-            Repos reached through an ssh host alias (git@github-work.com:…, git@bitbucket-work.com:…)
-            authenticate with the token stored for that alias; github.com, gitlab.com, and
-            bitbucket.org act as the per-provider defaults. Bitbucket credentials are entered as{" "}
-            <code className="font-mono">email:api_token</code>.
+            Repos reached through an ssh host alias (git@github-work.com:…, git@gitlab-work.com:…,
+            git@bitbucket-work.com:…) authenticate with the token stored for that alias; github.com,
+            gitlab.com, and bitbucket.org act as the per-provider defaults. Bitbucket credentials are
+            entered as <code className="font-mono">email:api_token</code>.
           </p>
         </div>
         <Button
@@ -194,7 +194,7 @@ export function GitHubTokensSection() {
           <Input
             value={host}
             onChange={(e) => setHost(e.target.value)}
-            placeholder="github.com / bitbucket.org"
+            placeholder="github.com / gitlab.com / bitbucket.org"
             list={DATALIST_ID}
             spellCheck={false}
           />

--- a/src/mainview/components/settings/GitHubTokensSection.tsx
+++ b/src/mainview/components/settings/GitHubTokensSection.tsx
@@ -10,12 +10,18 @@ const DATALIST_ID = "github-token-hosts";
 const EMPTY: GitHubTokensResult = { tokens: [], detectedHosts: [] };
 
 /**
- * "GitHub tokens" Settings section — lists stored per-host PATs and lets the
- * user add/replace or delete one. Tokens are keyed by the raw ssh remote host
- * (e.g. `github-work.com`); `github.com` acts as the default entry used when
- * no alias-specific token exists. The raw token is never returned by the API
- * — only a redacted `tokenPreview` — so the add-form input is always cleared
- * (never re-populated) after a successful save.
+ * "Git host tokens" Settings section — lists stored per-host credentials and
+ * lets the user add/replace or delete one. One shared store serves GitHub,
+ * GitLab, and Bitbucket: entries are keyed by the raw remote host, which may
+ * be a plain provider domain (github.com, gitlab.com, bitbucket.org) or an
+ * ssh alias host (e.g. `github-work.com`, `bitbucket-work.com`) — the
+ * provider domains act as the default entry used when no alias-specific
+ * credential exists for that provider. GitHub and GitLab use a plain PAT;
+ * Bitbucket expects Basic auth entered as a single `email:api_token` string
+ * (an Atlassian API token, not the retired app-password format). The raw
+ * credential is never returned by the API — only a redacted `tokenPreview`
+ * — so the add-form input is always cleared (never re-populated) after a
+ * successful save.
  */
 export function GitHubTokensSection() {
   const [data, setData] = useState<GitHubTokensResult>(EMPTY);
@@ -99,10 +105,12 @@ export function GitHubTokensSection() {
     <section className="space-y-2">
       <div className="flex items-center justify-between gap-2">
         <div>
-          <label className="text-xs text-muted-foreground">GitHub tokens</label>
+          <label className="text-xs text-muted-foreground">Git host tokens</label>
           <p className="text-[11px] leading-snug text-muted-foreground">
-            Repos reached through an ssh host alias (git@github-work.com:…) authenticate with the
-            token stored for that alias; github.com acts as the default.
+            Repos reached through an ssh host alias (git@github-work.com:…, git@bitbucket-work.com:…)
+            authenticate with the token stored for that alias; github.com, gitlab.com, and
+            bitbucket.org act as the per-provider defaults. Bitbucket credentials are entered as{" "}
+            <code className="font-mono">email:api_token</code>.
           </p>
         </div>
         <Button
@@ -186,7 +194,7 @@ export function GitHubTokensSection() {
           <Input
             value={host}
             onChange={(e) => setHost(e.target.value)}
-            placeholder="github.com"
+            placeholder="github.com / bitbucket.org"
             list={DATALIST_ID}
             spellCheck={false}
           />
@@ -211,7 +219,7 @@ export function GitHubTokensSection() {
           type="password"
           value={token}
           onChange={(e) => setToken(e.target.value)}
-          placeholder="ghp_…"
+          placeholder="ghp_… / glpat-… / email:api_token"
           autoComplete="off"
         />
       </div>

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -218,17 +218,26 @@ export type PendingInteraction =
   | PendingAskQuestions
   | PendingTmuxPrompt;
 
-/** One stored per-host GitHub PAT, as surfaced to the webview. The raw token
- *  is never returned — `tokenPreview` is a redacted tail (e.g. "…abcd"). */
+/** One stored per-host git credential, as surfaced to the webview. The store
+ *  is shared across GitHub/GitLab/Bitbucket — `host` may be a plain provider
+ *  domain (github.com, gitlab.com, bitbucket.org) or a raw ssh alias host
+ *  (e.g. github-work.com, bitbucket-work.com). The raw credential is never
+ *  returned — `tokenPreview` is a redacted tail (e.g. "…abcd"). Routes keep
+ *  the `/github/tokens` path and the `GitHub` type-name prefix for
+ *  backwards compatibility with existing stored tokens; the type name is
+ *  legacy naming only, not a GitHub-only shape. */
 export interface GitHubTokenInfo {
   host: string;
   label: string | null;
   tokenPreview: string;
 }
 
-/** Response shape for the GitHub tokens routes. `detectedHosts` are the
- *  distinct raw remote hosts (including ssh aliases) seen across registered
- *  project dirs — used to suggest hosts that don't have a token yet. */
+/** Response shape for the (misleadingly-named, back-compat) `/github/tokens`
+ *  routes, which actually serve credentials for any supported git host —
+ *  GitHub, GitLab, and Bitbucket. `detectedHosts` are the distinct raw
+ *  remote hosts (including ssh aliases, across all three providers) seen
+ *  across registered project dirs — used to suggest hosts that don't have a
+ *  token yet. */
 export interface GitHubTokensResult {
   tokens: GitHubTokenInfo[];
   detectedHosts: string[];
@@ -984,11 +993,13 @@ export const api = {
       method: "POST",
       body: JSON.stringify(input),
     }),
-  /** Stored per-host GitHub tokens + hosts detected across registered
-   *  projects (drives the "GitHub tokens" Settings section). */
+  /** Stored per-host git credentials (GitHub, GitLab, and Bitbucket all
+   *  share this store) + hosts detected across registered projects — drives
+   *  the "Git host tokens" Settings section. Route path kept as
+   *  `/github/tokens` for back-compat with existing stored credentials. */
   listGitHubTokens: () => j<GitHubTokensResult>("/github/tokens"),
-  /** Upsert the token for `input.host`. Returns the refreshed list — never
-   *  the raw token. */
+  /** Upsert the credential for `input.host`. Returns the refreshed list —
+   *  never the raw token. */
   setGitHubToken: (input: { host: string; token: string; label?: string | null }) =>
     j<GitHubTokensResult>("/github/tokens", {
       method: "PUT",

--- a/src/mainview/lib/credential-error.test.ts
+++ b/src/mainview/lib/credential-error.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { isCredentialError } from "./credential-error.ts";
+
+describe("isCredentialError", () => {
+  test("detects the marker phrase github.ts's privateRepoHint appends", () => {
+    const err = "acme/app was not found on GitHub — if the repo is private, add a token for github.com in Settings → Git host tokens";
+    expect(isCredentialError(err)).toBe(true);
+  });
+
+  test("detects the marker phrase gitlab.ts's authHint appends", () => {
+    const err = "acme/app was not found on GitLab — if the project is private, add a token for gitlab.com in Settings → Git host tokens";
+    expect(isCredentialError(err)).toBe(true);
+  });
+
+  test("detects the marker phrase bitbucket.ts's bitbucketAccessHint appends, including the authenticated-403 scope-check append", () => {
+    const notFound = "acme/app was not found on Bitbucket (…) — if the repo is private, add a credential for bitbucket.org in Settings → Git host tokens (Bitbucket Basic auth: email:api_token)";
+    expect(isCredentialError(notFound)).toBe(true);
+
+    const scopeAppend = "Branch restrictions: at least 2 approvals are required to merge this pull request. — if the configured credential for bitbucket.org lacks the required Bitbucket scopes, update it in Settings → Git host tokens.";
+    expect(isCredentialError(scopeAppend)).toBe(true);
+  });
+
+  test("returns false for a plain error with no Settings pointer", () => {
+    expect(isCredentialError("500 Internal Server Error")).toBe(false);
+    expect(isCredentialError("Branch restrictions: at least 2 approvals are required to merge this pull request.")).toBe(false);
+  });
+
+  test("returns false for null", () => {
+    expect(isCredentialError(null)).toBe(false);
+  });
+});

--- a/src/mainview/lib/credential-error.ts
+++ b/src/mainview/lib/credential-error.ts
@@ -1,0 +1,17 @@
+import { GIT_HOST_TOKENS_SECTION } from "../../shared/types.ts";
+
+/**
+ * Detects whether a git-provider error string is a credential error — i.e.
+ * one of the enriched hints built server-side by `bitbucketAccessHint` /
+ * `bitbucketViewerAccessHint` (src/bun/bitbucket.ts), `privateRepoHint`
+ * (src/bun/github.ts), or `authHint` (src/bun/gitlab.ts). All three append
+ * the same marker phrase, `Settings → ${GIT_HOST_TOKENS_SECTION}`, so
+ * matching it here (rather than a status code we don't have at this layer)
+ * is what lets `GitHubDialog` swap the bare error row for an actionable
+ * explainer panel while every other list-load failure keeps the plain row.
+ * `null` (no error) is not a credential error. This is a heuristic, not a
+ * structured signal — a false negative just degrades to the plain error row.
+ */
+export function isCredentialError(error: string | null): boolean {
+  return !!error && error.includes(`Settings → ${GIT_HOST_TOKENS_SECTION}`);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -21,10 +21,14 @@ export const SESSION_DIED_STATUS_PREFIX = "session ended: ";
  * The Settings section name where per-host git credentials live, interpolated
  * into the server-side credential-error hints (github.ts `privateRepoHint`,
  * gitlab.ts `authHint`, bitbucket.ts `bitbucketAccessHint` and friends) as
- * `Settings → ${GIT_HOST_TOKENS_SECTION}`. The webview pattern-matches that
- * same phrase to recognize a credential error and swap the bare error row for
- * an actionable explainer panel (GitHubDialog.tsx). Renaming the Settings
- * section requires changing only this constant. */
+ * `Settings → ${GIT_HOST_TOKENS_SECTION}`, and reused as the section's own
+ * label (GitHubTokensSection.tsx). The webview pattern-matches that same
+ * phrase to recognize a credential error and swap the bare error row for an
+ * actionable explainer panel (GitHubDialog.tsx / credential-error.ts). This
+ * constant keeps those three — server hints, the section label, and the
+ * webview's detection — in sync; it does NOT guarantee a full rename, since
+ * the setup guide (GitHubSetupDialog) still names the section in informal
+ * prose that won't follow a change here. */
 export const GIT_HOST_TOKENS_SECTION = "Git host tokens";
 
 export const COLUMNS: { id: ColumnId; label: string }[] = [

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,6 +17,16 @@ export const TMUX_MISSING_REASON = "tmux is required to drive claude-code intera
  * claude and codex drivers emit it and the orchestrator consumes it. */
 export const SESSION_DIED_STATUS_PREFIX = "session ended: ";
 
+/**
+ * The Settings section name where per-host git credentials live, interpolated
+ * into the server-side credential-error hints (github.ts `privateRepoHint`,
+ * gitlab.ts `authHint`, bitbucket.ts `bitbucketAccessHint` and friends) as
+ * `Settings → ${GIT_HOST_TOKENS_SECTION}`. The webview pattern-matches that
+ * same phrase to recognize a credential error and swap the bare error row for
+ * an actionable explainer panel (GitHubDialog.tsx). Renaming the Settings
+ * section requires changing only this constant. */
+export const GIT_HOST_TOKENS_SECTION = "Git host tokens";
+
 export const COLUMNS: { id: ColumnId; label: string }[] = [
   { id: "backlog", label: "Backlog" },
   { id: "ready", label: "Ready" },


### PR DESCRIPTION
## Problem

Opening the Git dialog on a Bitbucket repo failed with Bitbucket's raw API error:

> You may not have access to this repository or it no longer exists in this workspace. If you think this repository exists and you have access, make sure you are authenticated.

This affected **every** Bitbucket feature (PR list/detail/diff, comments, checks, mergeability, merge/decline, issues), and was worst for repos reached through ssh host aliases (`git@bitbucket-work.com:workspace/repo.git`).

**Root cause:** not a parsing bug — alias-host canonicalization and per-host credential resolution already worked. The credential *UX* half was never built for non-GitHub providers, so requests went out **unauthenticated** and Bitbucket answered with its generic no-access 404:

- Settings host discovery (`remoteHostsForDirs`) was hard-wired to GitHub remotes, so Bitbucket/GitLab alias hosts never appeared in the detected-hosts list.
- The only credential UI was branded **"GitHub tokens"** with GitHub-only copy — nothing signaled it serves Bitbucket/GitLab or documented Bitbucket's `email:api_token` format.
- Error hints pointed at Settings sections that don't exist ("API tokens", "GitLab tokens"), and Bitbucket 403/404 got no hint at all.

## What changed

**Credential UX (the fix)**
- Settings section renamed to **"Git host tokens"** with provider-generic copy; host discovery now surfaces Bitbucket/GitLab alias hosts alongside GitHub ones.
- Setup guide covers all three providers — including Bitbucket's Atlassian **API token with scopes** flow (scopes table: repositories/PRs/issues read-write + account read), the `email:api_token` format, the app-password retirement (2026-06-09), and each provider's credential fallback order.

**Error enrichment (Bitbucket parity with GitHub/GitLab)**
- Bitbucket 401/403/404 responses are enriched with the repo's exact host, the real Settings section, and the credential format — preserving Bitbucket's original message. Authenticated 403s keep the real cause first (merge/branch-restriction errors don't masquerade as credential problems) with a scope hint appended; the issues "tracker not enabled" shortcut no longer masks the missing-credential case; `/2.0/user` errors get account-flavored wording.
- All three providers' hints, the Settings label, and the webview detection share one constant (`GIT_HOST_TOKENS_SECTION` in `shared/types.ts`).

**In-app explainer at the failure point**
- When loading fails on a credential error, the Git dialog shows an explainer panel ("Can't reach this repository") with provider-aware one-time setup steps and an **Open Settings** button — instead of a bare red error row. `role="alert"` + amber styling; stale errors clear on reopen.

**Consolidation / perf**
- `remoteHostsForDirs` moved into `git-provider.ts` over `providerRepoForDir` — supported-host knowledge lives in one place (a 4th provider now only needs `providerForHost`).
- The Settings host scan runs through a 6-wide worker pool with a single-slot, settle-anchored 10s promise-cache: GET+PUT `/github/tokens` share one scan, in-flight scans are never duplicated, failures aren't cached.

**Back-compat:** the token store file (`github-tokens.json`) and `/github/tokens` routes keep their names — existing stored tokens keep working unchanged.

## Tests

- 20+ new tests: Bitbucket alias-host regression coverage (credential resolution by alias, unauthenticated-404 enrichment with Bitbucket's real error body, hint variants, issues-404 both credential states), multi-provider host discovery, cache/pool behavior, and webview credential-error detection.
- Two review passes addressed all must-fix findings.
- `bun run typecheck` green; full `bun test`: **2171 pass / 1 skip / 0 fail** (140 files).

## Note for users

A one-time setup is still required: create an Atlassian **API token with scopes** at id.atlassian.com and save it as `email:api_token` under Settings → Git host tokens for your Bitbucket host (or `bitbucket.org` as the default). The in-app setup guide walks through it — and the error panel now points there when a credential is missing.