### PR TITLE
fix: heal stuck tmux window-size pin that rendered the agent "minimized" on attach

### DIFF
--- a/docs/plans/fix-minimized-agent-tmux-attach.md
+++ b/docs/plans/fix-minimized-agent-tmux-attach.md
@@ -1,0 +1,79 @@
+# Plan — Fix "minimized" agent rendering on tmux attach (heal stuck window-size)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-05 |
+| Source | Task "the agent runs in a minimized way — Agetor not identifying the task is still running" + screenshot (tmux status line `[agetor-eb0:…`, claude TUI squashed to a small strip) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/recognize-agent-and-shell (agetor-managed worktree, pre-existing) |
+| Base SHA | 7d28f2a071bcbdcd474887f956a030992983a6b0 |
+| Mode | **Autonomous** — Phase 2 grill and Phase 3 approval gates bypassed; all assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+When the user clicks **Attach** on a claude-code task (Terminal.app + `tmux attach`), the agent's TUI must fill the terminal window — never render pinned to a small region with the rest blank — regardless of whether an agetor crash/kill previously interrupted the AskUserQuestion pane-grow cycle.
+
+Success:
+- A session whose tmux `window-size` option was left stuck on `manual` (small) is healed to `latest` before the user's client attaches, and on boot reattach.
+- The crash window that produces the stuck state in the first place is closed (atomic resize/restore).
+- `bun test` and `bun run typecheck` green; no behavior change to the pane scraper's normal 80-col regime.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- Two terminal surfaces exist; the bug is in the **Attach** flow, not the sidebar PTY tabs: `RunPanel.tsx:4816-4839` → `POST /tasks/:id/open-tmux` (`server.ts:3294`) → osascript opens Terminal.app running `tmux attach -t agetor-<taskId12>`. The screenshot's `[agetor-eb0:` session name proves this path (`sessionNameFor`, `claude-tmux.ts:361`).
+- The "auto mode on · 1 shell · 1 agent" bar in the screenshot is **claude-code's own TUI status line** (its background-shell / Task-subagent counts), not agetor UI. Agetor has **no** code path that varies attach behavior by run state — the user's "Agetor doesn't see it running" hypothesis has no matching code path and is explained by the rendering bug.
+- `spawnClaudeViaTmux` creates sessions detached with no `-x/-y` → tmux `default-size` 80×24, `window-size latest`. Verified empirically (PTY harness): with `latest`, a real client attach **does** renegotiate the window to the client size — so a plain small session self-heals on attach.
+- The **only** code that sets `window-size manual` is the AskUserQuestion pane-grow scraper: `resizePane`/`restorePaneSize` (`claude-tmux.ts:2385-2399`), driven by `collectAskQuestionsFromPane` (`:2471+`) to grow the pane to ≥120×100 and restore in a `finally`. Each helper issues **two separate tmux invocations**; a Bun-process crash/kill between them leaves the session **permanently pinned `manual`** (potentially at 80×24 — e.g. death between `restorePaneSize`'s shrink and its `latest` flip). Sessions survive agetor restarts by design, so the pin persists.
+- Verified empirically: attaching a real 200×49 client to a session pinned `manual` at 80×24 keeps the window at 80×24 — content confined to a small strip, remainder blank. **Exact match for the screenshot.**
+- **Width constraint (fleet knowledge):** claude's modal TUI renders a side-by-side preview column at wide widths, and the parser bleed-fix for that layout was never merged to main; the modal parser's proven regime is the 80-col default. Therefore we must **not** change the default session size (rejects the "copy codex's `-x 200 -y 50`" option).
+- `tmux()` helper (sync, argv array) at `claude-tmux.ts:1098`. tmux supports chaining multiple commands in one client invocation with a literal `;` argv element — the whole batch reaches the tmux server in one process, immune to our process dying between commands.
+- Env gotchas: `bun`/`tmux` not on non-interactive PATH (`~/.bun/bin`, `/opt/homebrew/bin`); this worktree needs `bun install` before `bun run typecheck`; tests must use isolated tmux sockets (`AGETOR_TMUX_SOCKET`, see `tmux-resolution.ts:73-85`) — never the user's default socket.
+
+## 3. Approach & key decisions
+
+1. **Heal at attach (primary, evidence-backed):** before spawning the Terminal.app attach, reset the session's `window-size` to `latest` so any stuck `manual` pin self-heals and tmux renegotiates to the real client size. Implemented as an exported `healWindowSize(taskId)` in `claude-tmux.ts` (the module owns session state), called from the `open-tmux` route. **Skipped while a pane-grow is in flight** (new per-session flag set/cleared around the grow cycle) so we never fight the scraper; the scraper's own `finally` restores `latest` in that case.
+2. **Heal at boot reattach:** `reattachSession` also resets `window-size latest` — a crashed previous process is exactly when the pin strands.
+3. **Close the race:** make `resizePane` and `restorePaneSize` each a **single** tmux invocation using `;`-chained commands, so process death can no longer strand the session between `set-window-option` and `resize-window`.
+4. **Not changing default session size** — rejected due to the wide-width modal-parser hazard (§2). Decision rests on fleet knowledge + spike-verified tmux behavior (`latest` self-heals on attach, so a small-but-unpinned session is fine).
+5. No UI changes. No change to codex (`-x 200 -y 50`, never sets `manual`, one-shot sessions).
+
+## 4. Work breakdown — implementation tasks
+
+- **I1** — Heal + atomicity in the tmux driver and route.
+  Owns: `src/bun/claude-tmux.ts`, `src/bun/server.ts`.
+  - Rewrite `resizePane`/`restorePaneSize` as single chained tmux invocations.
+  - Add per-session `paneGrowInFlight` guard set/cleared (try/finally) around the grow cycle in `collectAskQuestionsFromPane`.
+  - Export `healWindowSize(taskId)`: no-op if session missing or grow in flight; else `set-window-option -t <session> window-size latest` (best-effort, never throws).
+  - Call it from `reattachSession` and from the `open-tmux` route (before osascript).
+  Acceptance: typecheck green; existing claude-tmux tests green; no scraper behavior change at default size.
+
+## 5. Work breakdown — test tasks
+
+- **T1** — Unit + integration tests. Owns: `src/bun/claude-tmux.test.ts` (extend), optionally a new `src/bun/window-size-heal.test.ts`, `src/bun/codex-tmux.test.ts` (one assertion).
+  - Unit (fake `PaneIo` / recorded tmux argv): resize/restore each issue exactly one tmux invocation with the chained command shape; heal no-ops during an in-flight grow.
+  - Integration (real tmux on an **isolated socket**, temp `AGETOR_DATA_DIR`): create a session, pin `window-size manual` small, call `healWindowSize`, assert `show-options` reports `latest`. Skip gracefully if tmux is unavailable.
+  - Codex regression guard: assert `-x`/`-y` present in codex `new-session` argv (currently untested).
+- **E2E: not applicable as automation** — the full symptom needs Terminal.app + a real claude REPL attach; recorded here as a manual runbook instead: start a claude task, run `tmux set-window-option -t agetor-<id12> window-size manual; tmux resize-window -t agetor-<id12> -x 80 -y 24`, click Attach → TUI must fill the window.
+
+## 6. Execution waves
+
+- Wave 1: I1 (single agent — changes concentrate in two files with one owner).
+- Review (opus) on the diff.
+- Wave 2: T1 (single agent).
+- Test run (haiku): `bun test` + `bun run typecheck` (after `bun install`; export PATH with `~/.bun/bin` and `/opt/homebrew/bin`).
+
+## 7. Blast radius & risks
+
+- `open-tmux` route: heal adds one best-effort tmux call; failure must not block the attach.
+- Scraper: guard flag must be cleared in `finally`, else heal is permanently disabled for that session.
+- Chained tmux commands: `;` must be its own argv element (not shell-quoted `\;` — no shell involved).
+- Reattach: heal runs once at boot per reattached session; harmless if already `latest`.
+- Tests: real-tmux tests must use `AGETOR_TMUX_SOCKET` isolation (prior incident: a test killed the user's shared tmux server).
+
+## 8. Open questions / assumptions (autonomous mode log)
+
+- **A1:** The screenshot's symptom is the `window-size manual` pin (empirically reproduced) and/or small-session attach; the user's "not identifying running" phrasing is the perception, not a distinct state bug — no such code path exists.
+- **A2:** Chose heal-on-attach + atomicity over enlarging default session size, to protect the width-sensitive modal parser (preview-column bleed fix never merged).
+- **A3:** Branch `fix/recognize-agent-and-shell` (agetor's task worktree) is used as-is; no new branch.
+- **A4:** Phase 2/3 human gates bypassed — user unavailable mid-task; this plan is self-approved.
+- **A5:** Whether claude's Ink TUI fully repaints newly exposed area after a large post-attach resize is unverified against a real binary; with `latest` restored, an actively-streaming agent repaints continuously, so residual blank scrollback (old 80-col history) is cosmetic and out of scope.

--- a/src/bun/claude-tmux.test.ts
+++ b/src/bun/claude-tmux.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "bun:test";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
 
 // cycleToMode's tmux send-keys call runs `Bun.spawnSync` on the tmux
 // binary; point it at /bin/echo so the per-press spawn is fast and the
@@ -19,6 +21,7 @@ import {
   cycleOrderFor,
   cycleToMode,
   encodeProjectPath,
+  healWindowSize,
   jsonlPathFor,
   mapJsonlEventToChunks,
   parseSessionActivityLine,
@@ -1926,4 +1929,179 @@ test("collectAskQuestionsFromPane: flat no-preview question takes the fast path 
   } finally {
     __forTest.uninstallSession("ask-nopreview");
   }
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * paneGrowInFlight — the flag `collectAskQuestionsFromPane` brackets around
+ * the ONLY window a stuck `window-size manual` pin is legitimate (docs/plans/
+ * fix-minimized-agent-tmux-attach.md §3 I1). `healWindowSize` refuses to heal
+ * while this is true, so the flag must be set for the actual duration of the
+ * grow and reliably cleared afterward — including when the grow is aborted
+ * mid-flight (the session was disposed/respawned out from under it).
+ * ────────────────────────────────────────────────────────────────────────── */
+
+test("collectAskQuestionsFromPane: paneGrowInFlight is set for the duration of a grow and cleared once it completes", async () => {
+  const { __forTest } = await import("./claude-tmux.ts");
+  const tabs: FakeTab[] = [{
+    header: "Pick", question: "Which option?", multiSelect: false,
+    options: [{ label: "Alpha", preview: ["a-1"] }],
+  }];
+  const { io: baseIo } = makeFakePane(tabs);
+  const state = __forTest.installSession("ask-flag-live", "/tmp/never-read.jsonl");
+  let sawInFlightDuringResize = false;
+  // Peek at the flag from inside the reflow sleep that follows `io.resize` —
+  // this is the one moment production code guarantees it's already true.
+  const io = {
+    ...baseIo,
+    sleep: async (_ms: number) => {
+      if (state.paneGrowInFlight) sawInFlightDuringResize = true;
+      await baseIo.sleep();
+    },
+  };
+  try {
+    expect(state.paneGrowInFlight).toBe(false);
+    const res = await __forTest.collectAskQuestionsFromPane(state, renderFakeModal(tabs, 0, 0), io);
+    expect(res).not.toBeNull();
+    expect(sawInFlightDuringResize).toBe(true);
+    // Cleared by the `finally` in the collector once the grow settles.
+    expect(state.paneGrowInFlight).toBe(false);
+  } finally {
+    __forTest.uninstallSession("ask-flag-live");
+  }
+});
+
+test("collectAskQuestionsFromPane: paneGrowInFlight clears via the early-abort path when the session identity changes mid-grow", async () => {
+  const { __forTest } = await import("./claude-tmux.ts");
+  const tabs: FakeTab[] = [{
+    header: "Pick", question: "Which option?", multiSelect: false,
+    options: [
+      { label: "Alpha", preview: ["a-1"] },
+      { label: "Beta", preview: ["b-1"] },
+    ],
+  }];
+  const { io: baseIo, log } = makeFakePane(tabs);
+  const state = __forTest.installSession("ask-flag-abort", "/tmp/never-read.jsonl");
+  let swapped = false;
+  // Simulate the session being disposed + respawned mid-grow (e.g. a
+  // concurrent dropSession/reattach racing the scraper). `queueTmuxOp`'s
+  // `stillCurrent()` gate is `sessions.get(taskId) === state` (captured at
+  // schedule time) — replacing the map entry mid-await flips it to false
+  // right after this sleep resolves, driving the collector's early-return
+  // branch (`if (!stillCurrent()) { io.restore(...); paneGrowInFlight =
+  // false; return; }`).
+  const io = {
+    ...baseIo,
+    sleep: async (_ms: number) => {
+      await baseIo.sleep();
+      if (!swapped) {
+        swapped = true;
+        __forTest.installSession("ask-flag-abort", "/tmp/never-read.jsonl");
+      }
+    },
+  };
+  try {
+    const res = await __forTest.collectAskQuestionsFromPane(state, renderFakeModal(tabs, 0, 0), io);
+    // Aborted before any tab was collected.
+    expect(res).toBeNull();
+    expect(state.paneGrowInFlight).toBe(false);
+    // The pane was still restored on the abort path...
+    expect(log.some((l) => l.startsWith("restore:"))).toBe(true);
+    // ...but we bailed before ever touching the option cursor.
+    expect(log.filter((l) => l === "Down" || l === "Up")).toEqual([]);
+  } finally {
+    __forTest.uninstallSession("ask-flag-abort");
+  }
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * healWindowSize — best-effort heal of a stuck `window-size manual` pin,
+ * called before an `open-tmux` attach and on boot reattach (docs/plans/
+ * fix-minimized-agent-tmux-attach.md §3 I1). Real tmux isn't used here — a
+ * small fake `tmux` (sh script) logs every invocation's argv and answers
+ * `has-session` with a scripted verdict, mirroring the `fakeTmux` helper in
+ * reconcile.test.ts and the `fakeRoutingTmuxBin` helper in
+ * claude-turn-routing.test.ts.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** Write an executable fake `tmux` that appends every invocation's argv
+ *  (space-joined, one line per call) to `logPath`, and answers `has-session`
+ *  with `hasSessionExitCode` (0 = "exists", 1 = "doesn't") — anything else
+ *  exits 0. Returns the bin path; caller points AGETOR_TMUX_BIN at it. */
+function fakeHealTmuxBin(hasSessionExitCode: number, logPath: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-heal-faketmux-"));
+  const bin = path.join(dir, "tmux");
+  writeFileSync(
+    bin,
+    "#!/bin/sh\n" +
+      `printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}\n` +
+      'case "$*" in\n' +
+      `  *has-session*) exit ${hasSessionExitCode} ;;\n` +
+      "  *) exit 0 ;;\n" +
+      "esac\n",
+  );
+  chmodSync(bin, 0o755);
+  return bin;
+}
+
+/** Swap AGETOR_TMUX_BIN (module-pinned to /bin/echo at the top of this file,
+ *  which would make `has-session` always "succeed" and defeat the
+ *  missing-session case) for the duration of `fn`, restoring afterward. */
+async function withFakeTmuxBin<T>(bin: string, fn: () => T | Promise<T>): Promise<T> {
+  const prev = process.env.AGETOR_TMUX_BIN;
+  process.env.AGETOR_TMUX_BIN = bin;
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) delete process.env.AGETOR_TMUX_BIN;
+    else process.env.AGETOR_TMUX_BIN = prev;
+  }
+}
+
+test("healWindowSize issues no tmux call at all when a pane-grow is in flight for the session", async () => {
+  const { __forTest } = await import("./claude-tmux.ts");
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-heal-log-"));
+  const logPath = path.join(dir, "log.txt");
+  // Even a "session exists" verdict must never be reached — the in-flight
+  // check short-circuits before healWindowSize ever calls sessionExists.
+  const bin = fakeHealTmuxBin(0, logPath);
+  const state = __forTest.installSession("heal-inflight", "/tmp/never-read.jsonl");
+  state.paneGrowInFlight = true;
+  try {
+    await withFakeTmuxBin(bin, () => {
+      healWindowSize("heal-inflight");
+    });
+    const log = existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
+    expect(log).toBe("");
+  } finally {
+    __forTest.uninstallSession("heal-inflight");
+  }
+});
+
+test("healWindowSize probes has-session but issues no set-window-option when the session doesn't exist", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-heal-log-"));
+  const logPath = path.join(dir, "log.txt");
+  const bin = fakeHealTmuxBin(1, logPath); // has-session always "fails"
+  await withFakeTmuxBin(bin, () => {
+    // No installed SessionState for this taskId at all — mirrors the boot
+    // path where a session outlived the process with no state rebuilt yet.
+    healWindowSize("heal-missing-task-id");
+  });
+  const log = readFileSync(logPath, "utf8");
+  expect(log).toContain("has-session");
+  expect(log).not.toContain("set-window-option");
+});
+
+test("healWindowSize resets window-size to latest with a single call when the session exists and no grow is in flight", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-heal-log-"));
+  const logPath = path.join(dir, "log.txt");
+  const bin = fakeHealTmuxBin(0, logPath); // has-session always "succeeds"
+  await withFakeTmuxBin(bin, () => {
+    healWindowSize("heal-live-task-id");
+  });
+  const lines = readFileSync(logPath, "utf8").trim().split("\n");
+  expect(lines.length).toBe(2);
+  expect(lines[0]).toContain("has-session");
+  expect(lines[1]).toContain("set-window-option");
+  expect(lines[1]).toContain("window-size");
+  expect(lines[1]).toContain("latest");
 });

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -1926,6 +1926,13 @@ interface SessionState {
    * places. Content-triggered adoption arms nothing — real content already
    * arrived, so there's nothing to wait for. Null when not armed. */
   continuationWatchdog: { timer: ReturnType<typeof setTimeout>; slot: TurnSlot } | null;
+  /** True while `collectAskQuestionsFromPane` has grown the detached pane and
+   *  `window-size` is legitimately `manual` for this session — set right before
+   *  the grow, cleared in the same `finally` that restores `latest`. Brackets
+   *  the ONLY period a stuck `manual` pin is expected; `healWindowSize` checks
+   *  this so it never races the scraper's own restore (which would fight over
+   *  window-size mid-grow and could strand the pane at the wrong size). */
+  paneGrowInFlight: boolean;
 }
 
 interface TurnSlot {
@@ -2036,6 +2043,7 @@ function makeSessionState(o: MakeSessionStateOpts): SessionState {
     pendingSlashToken: null,
     subagentWatcher: null,
     continuationWatchdog: null,
+    paneGrowInFlight: false,
   };
 }
 
@@ -2383,19 +2391,56 @@ function paneSize(state: SessionState): { w: number; h: number } | null {
 }
 
 /** Force a detached window to a fixed size (`window-size manual` is required for
- *  `resize-window` to stick on a session no client is attached to). */
+ *  `resize-window` to stick on a session no client is attached to). Chained as a
+ *  SINGLE tmux invocation (`;` as its own argv element — no shell involved, so
+ *  it's a literal semicolon, not a shell-escaped `\;`) so the two commands reach
+ *  the tmux server atomically: if agetor dies mid-call there's no window where
+ *  `window-size` is `manual` but the resize hasn't landed yet. */
 function resizePane(state: SessionState, w: number, h: number): void {
-  tmux(["set-window-option", "-t", state.sessionName, "window-size", "manual"]);
-  tmux(["resize-window", "-t", state.sessionName, "-x", String(w), "-y", String(h)]);
+  tmux([
+    "set-window-option", "-t", state.sessionName, "window-size", "manual", ";",
+    "resize-window", "-t", state.sessionName, "-x", String(w), "-y", String(h),
+  ]);
 }
 
-/** Restore the original size and hand sizing back to tmux (`latest`). Best-effort
- *  — if the process dies between the grow and this call the pane is just left
- *  larger, which is harmless (claude's TUI reflows to any size and the next
- *  attach/resize corrects it). */
+/** Restore the original size and hand sizing back to tmux (`latest`). Chained as
+ *  a single invocation for the same reason as `resizePane`: two separate tmux
+ *  calls left a window where a crash between them stranded the session pinned
+ *  `window-size manual` (potentially at the small grown-then-half-restored
+ *  size) — a client attaching later gets confined to that fixed size instead of
+ *  renegotiating to its own, which is exactly the "minimized" rendering bug.
+ *  Chaining closes that window; `healWindowSize` below is the backstop for any
+ *  pin that predates this fix. */
 function restorePaneSize(state: SessionState, w: number, h: number): void {
-  tmux(["resize-window", "-t", state.sessionName, "-x", String(w), "-y", String(h)]);
-  tmux(["set-window-option", "-t", state.sessionName, "window-size", "latest"]);
+  tmux([
+    "resize-window", "-t", state.sessionName, "-x", String(w), "-y", String(h), ";",
+    "set-window-option", "-t", state.sessionName, "window-size", "latest",
+  ]);
+}
+
+/**
+ * Heal a session's `window-size` back to `latest` if a prior crash left it
+ * stuck `manual` (chaining above closes the race going forward, but a pin
+ * from before this fix — or from any other interruption — can still be
+ * sitting on a session that outlived an agetor restart). A `manual` pin
+ * confines every future attach to whatever size it was left at instead of
+ * letting the attaching client's own size win, which is exactly the
+ * "minimized" rendering bug. Best-effort and never throws — called right
+ * before an attach (where failing shouldn't block the user from getting a
+ * terminal) and on reattach (where there's no one to report a failure to).
+ *
+ * No-ops when the session doesn't exist, or when a pane-grow is legitimately
+ * in flight for it (`paneGrowInFlight`) — healing mid-grow would fight the
+ * scraper's own resize/restore. A taskId with no in-memory `SessionState`
+ * (boot before reattach, or a session that survived a crash with no state
+ * rebuilt yet) can't have a grow in flight — there's no code path that could
+ * be running one without state — so it's safe to heal in that case too.
+ */
+export function healWindowSize(taskId: string): void {
+  const state = sessions.get(taskId);
+  if (state?.paneGrowInFlight) return;
+  if (!sessionExists(taskId)) return;
+  tmux(["set-window-option", "-t", sessionNameFor(taskId), "window-size", "latest"]);
 }
 
 /** Full pane capture (NOT the 40-line tail) — a grown preview panel can be much
@@ -2492,9 +2537,14 @@ async function collectAskQuestionsFromPane(
   await queueTmuxOp(state.taskId, async (stillCurrent) => {
     const orig = io.size();
     if (orig) {
+      // Brackets the ONLY window where `window-size manual` is expected on
+      // this session — cleared right after each `io.restore` below (both the
+      // early-return path and the `finally`) so `healWindowSize` never fights
+      // a grow that's still in progress.
+      state.paneGrowInFlight = true;
       io.resize(Math.max(orig.w, PREVIEW_PANE_MIN_COLS), PREVIEW_PANE_ROWS);
       await io.sleep(PREVIEW_REFLOW_MS);
-      if (!stillCurrent()) { io.restore(orig.w, orig.h); return; }
+      if (!stillCurrent()) { io.restore(orig.w, orig.h); state.paneGrowInFlight = false; return; }
     }
     try {
       for (let t = 0; t < n; t++) {
@@ -2528,7 +2578,7 @@ async function collectAskQuestionsFromPane(
         if (!stillCurrent()) break;
       }
     } finally {
-      if (orig) io.restore(orig.w, orig.h);
+      if (orig) { io.restore(orig.w, orig.h); state.paneGrowInFlight = false; }
     }
   }, state);
 
@@ -4702,6 +4752,10 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
   disposeSessionState(sessions.get(opts.taskId));
   sessions.set(opts.taskId, state);
   attachTailer(state);
+  // A crashed previous process is exactly when a stuck `window-size manual`
+  // pin (see `healWindowSize`) would have been left behind — heal it now so
+  // a subsequent attach isn't confined to whatever size the pin left.
+  healWindowSize(opts.taskId);
 
   return {
     kill: () => {

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -1928,8 +1928,9 @@ interface SessionState {
   continuationWatchdog: { timer: ReturnType<typeof setTimeout>; slot: TurnSlot } | null;
   /** True while `collectAskQuestionsFromPane` has grown the detached pane and
    *  `window-size` is legitimately `manual` for this session — set right before
-   *  the grow, cleared in the same `finally` that restores `latest`. Brackets
-   *  the ONLY period a stuck `manual` pin is expected; `healWindowSize` checks
+   *  the grow, cleared by the SAME `finally` (nested inside it) that restores
+   *  the pane, so a throwing `restore` still clears the flag. Brackets the
+   *  ONLY period a stuck `manual` pin is expected; `healWindowSize` checks
    *  this so it never races the scraper's own restore (which would fight over
    *  window-size mid-grow and could strand the pane at the wrong size). */
   paneGrowInFlight: boolean;
@@ -2398,24 +2399,42 @@ function paneSize(state: SessionState): { w: number; h: number } | null {
  *  `window-size` is `manual` but the resize hasn't landed yet. */
 function resizePane(state: SessionState, w: number, h: number): void {
   tmux([
-    "set-window-option", "-t", state.sessionName, "window-size", "manual", ";",
-    "resize-window", "-t", state.sessionName, "-x", String(w), "-y", String(h),
+    "set-window-option", "-t", "=" + state.sessionName, "window-size", "manual", ";",
+    "resize-window", "-t", "=" + state.sessionName, "-x", String(w), "-y", String(h),
   ]);
 }
 
-/** Restore the original size and hand sizing back to tmux (`latest`). Chained as
- *  a single invocation for the same reason as `resizePane`: two separate tmux
- *  calls left a window where a crash between them stranded the session pinned
+/** Restore the original size and hand sizing back to tmux. Chained as a single
+ *  invocation for the same reason as `resizePane`: two separate tmux calls
+ *  left a window where a crash between them stranded the session pinned
  *  `window-size manual` (potentially at the small grown-then-half-restored
  *  size) — a client attaching later gets confined to that fixed size instead of
  *  renegotiating to its own, which is exactly the "minimized" rendering bug.
- *  Chaining closes that window; `healWindowSize` below is the backstop for any
- *  pin that predates this fix. */
+ *  Chaining closes that window going forward.
+ *
+ *  BUT tmux aborts a `;`-chain at the first failing command (empirically
+ *  verified) — if `resize-window` fails (bad dims, session gone mid-chain,
+ *  etc.) the trailing `set-window-option … latest` never runs, and the
+ *  session is left pinned `manual`: the exact bug this file fixes, just
+ *  triggered by a failed command instead of a crash. The old two-invocation
+ *  form ran the unpin unconditionally, so a failed resize alone couldn't
+ *  strand the pin. Restore that guarantee: if the chain didn't report ok,
+ *  issue a standalone unpin as a fallback. `-u` (unset) reverts to the
+ *  inherited value rather than forcing `latest` — see the comment on
+ *  `healWindowSize` for why that heal path, unlike this one, deliberately
+ *  forces `latest` instead. */
 function restorePaneSize(state: SessionState, w: number, h: number): void {
-  tmux([
-    "resize-window", "-t", state.sessionName, "-x", String(w), "-y", String(h), ";",
-    "set-window-option", "-t", state.sessionName, "window-size", "latest",
+  const r = tmux([
+    "resize-window", "-t", "=" + state.sessionName, "-x", String(w), "-y", String(h), ";",
+    "set-window-option", "-u", "-t", "=" + state.sessionName, "window-size",
   ]);
+  if (!r.ok) {
+    console.warn(
+      `[claude-tmux] restorePaneSize chain failed for session ${state.sessionName} — ` +
+        `falling back to a standalone unpin: ${r.stderr}`,
+    );
+    tmux(["set-window-option", "-u", "-t", "=" + state.sessionName, "window-size"]);
+  }
 }
 
 /**
@@ -2429,18 +2448,31 @@ function restorePaneSize(state: SessionState, w: number, h: number): void {
  * before an attach (where failing shouldn't block the user from getting a
  * terminal) and on reattach (where there's no one to report a failure to).
  *
+ * Forces the explicit `latest` value rather than `-u` (unset): unlike
+ * `restorePaneSize`'s revert-to-inherited, a stuck-`manual` session's
+ * inherited/global `window-size` setting is exactly what could be `manual`
+ * on the user's tmux (deliberate override) — reverting to it would re-expose
+ * the bug this function exists to heal. This is the one place in the file
+ * that deliberately overrides a user global; don't "simplify" it to `-u`.
+ *
  * No-ops when the session doesn't exist, or when a pane-grow is legitimately
  * in flight for it (`paneGrowInFlight`) — healing mid-grow would fight the
  * scraper's own resize/restore. A taskId with no in-memory `SessionState`
  * (boot before reattach, or a session that survived a crash with no state
  * rebuilt yet) can't have a grow in flight — there's no code path that could
  * be running one without state — so it's safe to heal in that case too.
+ *
+ * `opts.assumeAlive` skips the internal `sessionExists` probe when the
+ * caller already knows the session is live (a duplicate round-trip
+ * otherwise): the `open-tmux` route just checked existence itself, and
+ * `reattachSession` only runs for sessions `reconcileOrphans` already
+ * verified alive.
  */
-export function healWindowSize(taskId: string): void {
+export function healWindowSize(taskId: string, opts: { assumeAlive?: boolean } = {}): void {
   const state = sessions.get(taskId);
   if (state?.paneGrowInFlight) return;
-  if (!sessionExists(taskId)) return;
-  tmux(["set-window-option", "-t", sessionNameFor(taskId), "window-size", "latest"]);
+  if (!opts.assumeAlive && !sessionExists(taskId)) return;
+  tmux(["set-window-option", "-t", "=" + sessionNameFor(taskId), "window-size", "latest"]);
 }
 
 /** Full pane capture (NOT the 40-line tail) — a grown preview panel can be much
@@ -2536,17 +2568,19 @@ async function collectAskQuestionsFromPane(
   const collected: Array<ParsedQuestionPane | null> = [];
   await queueTmuxOp(state.taskId, async (stillCurrent) => {
     const orig = io.size();
-    if (orig) {
-      // Brackets the ONLY window where `window-size manual` is expected on
-      // this session — cleared right after each `io.restore` below (both the
-      // early-return path and the `finally`) so `healWindowSize` never fights
-      // a grow that's still in progress.
-      state.paneGrowInFlight = true;
-      io.resize(Math.max(orig.w, PREVIEW_PANE_MIN_COLS), PREVIEW_PANE_ROWS);
-      await io.sleep(PREVIEW_REFLOW_MS);
-      if (!stillCurrent()) { io.restore(orig.w, orig.h); state.paneGrowInFlight = false; return; }
-    }
+    // Brackets the ONLY window where `window-size manual` is expected on this
+    // session. ONE `finally` below owns both the restore and the clear (the
+    // clear nested inside it) so a throwing `io.restore` — the injected
+    // `PaneIo` can throw even though the production tmux-backed one can't —
+    // still clears the flag instead of stranding it true forever, which
+    // would permanently disable `healWindowSize` for this session.
+    if (orig) state.paneGrowInFlight = true;
     try {
+      if (orig) {
+        io.resize(Math.max(orig.w, PREVIEW_PANE_MIN_COLS), PREVIEW_PANE_ROWS);
+        await io.sleep(PREVIEW_REFLOW_MS);
+        if (!stillCurrent()) return; // finally below restores + clears
+      }
       for (let t = 0; t < n; t++) {
         if (t > 0) {
           if (!io.send("Right")) return; // entering a tab resets the cursor to option 0
@@ -2578,7 +2612,13 @@ async function collectAskQuestionsFromPane(
         if (!stillCurrent()) break;
       }
     } finally {
-      if (orig) { io.restore(orig.w, orig.h); state.paneGrowInFlight = false; }
+      if (orig) {
+        try {
+          io.restore(orig.w, orig.h);
+        } finally {
+          state.paneGrowInFlight = false;
+        }
+      }
     }
   }, state);
 
@@ -4755,7 +4795,10 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
   // A crashed previous process is exactly when a stuck `window-size manual`
   // pin (see `healWindowSize`) would have been left behind — heal it now so
   // a subsequent attach isn't confined to whatever size the pin left.
-  healWindowSize(opts.taskId);
+  // `assumeAlive`: `reattachSession` only runs for sessions `reconcileOrphans`
+  // already verified alive, so the internal `sessionExists` probe would be a
+  // duplicate round-trip.
+  healWindowSize(opts.taskId, { assumeAlive: true });
 
   return {
     kill: () => {

--- a/src/bun/codex-tmux.test.ts
+++ b/src/bun/codex-tmux.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -7,7 +8,7 @@ import path from "node:path";
 // from it. Set a temp dir before importing.
 process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-codex-tmux-"));
 
-const { mapCodexEvent, codexLogPath } = await import("./codex-tmux.ts");
+const { mapCodexEvent, codexLogPath, spawnCodexViaTmux } = await import("./codex-tmux.ts");
 import type { RunEventStream } from "../shared/types.ts";
 
 type Chunk = { stream: RunEventStream; data: string; lineUuid?: string };
@@ -157,4 +158,74 @@ test("unknown item type without text falls back to a generic tool_use", () => {
 test("codexLogPath is derivable from runId alone (so reattach can recompute it)", () => {
   const p = codexLogPath("run-xyz");
   expect(p.endsWith(path.join("codex-logs", "run-xyz.jsonl"))).toBe(true);
+});
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * spawnCodexViaTmux's `new-session` argv — regression guard for the fixed
+ * `-x 200 -y 50` pin (docs/plans/fix-minimized-agent-tmux-attach.md §2: codex
+ * never sets `window-size manual`, so it was never subject to the stuck-pin
+ * bug claude-code's pane-grow scraper could leave behind; this just locks in
+ * that the fixed size itself never regresses). No real tmux involved — a fake
+ * `tmux` (Bun/Node script under a `#!` shebang) logs the full argv of every
+ * invocation and always fails `new-session`, which makes
+ * `spawnCodexViaTmux` bail out synchronously right after logging (no tailer,
+ * no timers to clean up) — same "fail the spawn to keep the observation
+ * synchronous" trick `claude-turn-routing.test.ts` uses for its fake tmux.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function fakeFailingTmuxBin(): { bin: string; logPath: string } {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-codex-faketmux-"));
+  const bin = path.join(dir, "tmux");
+  const logPath = path.join(dir, "log.jsonl");
+  writeFileSync(
+    bin,
+    `#!${process.execPath}\n` +
+      `import { appendFileSync } from "node:fs";\n` +
+      `const argv = process.argv.slice(2);\n` +
+      `appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ argv }) + "\\n");\n` +
+      `process.exit(1);\n`,
+  );
+  chmodSync(bin, 0o755);
+  return { bin, logPath };
+}
+
+function readArgvLog(logPath: string): Array<{ argv: string[] }> {
+  return readFileSync(logPath, "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l));
+}
+
+test("spawnCodexViaTmux's new-session argv pins -x 200 -y 50 (fixed size, never window-size manual)", () => {
+  const { bin, logPath } = fakeFailingTmuxBin();
+  const prevBin = process.env.AGETOR_TMUX_BIN;
+  process.env.AGETOR_TMUX_BIN = bin;
+  try {
+    const { chunks, onChunk } = collect();
+    const taskId = `task-codexsize-${randomUUID()}`;
+    const runId = `run-codexsize-${randomUUID()}`;
+    spawnCodexViaTmux({
+      taskId,
+      runId,
+      argv: ["codex", "exec", "-"],
+      env: {},
+      cwd: "/tmp",
+      promptText: "hello",
+      onChunk,
+    });
+    // Sanity: the deliberately-failing new-session surfaced as a stderr chunk
+    // (proves we exercised the real spawn path, not a short-circuit).
+    expect(chunks.some((c) => c.stream === "stderr")).toBe(true);
+
+    const entries = readArgvLog(logPath);
+    const newSession = entries.find((e) => e.argv.includes("new-session"));
+    expect(newSession).toBeDefined();
+    const argv = newSession!.argv;
+    const xIdx = argv.indexOf("-x");
+    const yIdx = argv.indexOf("-y");
+    expect(xIdx).toBeGreaterThan(-1);
+    expect(yIdx).toBeGreaterThan(-1);
+    expect(argv[xIdx + 1]).toBe("200");
+    expect(argv[yIdx + 1]).toBe("50");
+  } finally {
+    if (prevBin === undefined) delete process.env.AGETOR_TMUX_BIN;
+    else process.env.AGETOR_TMUX_BIN = prevBin;
+  }
 });

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -3339,7 +3339,9 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           // before attaching, so the client's own size wins instead of being
           // confined to whatever the pin left behind — see `healWindowSize`.
           // Best-effort: must not block or delay the attach below.
-          healWindowSize(task.id);
+          // `assumeAlive`: `sessionExists(task.id)` was just checked above, so
+          // skip the internal probe's duplicate round-trip.
+          healWindowSize(task.id, { assumeAlive: true });
           // AppleScript `do script` runs the string through `/bin/bash`, so
           // we escape anything bash would interpret inside double-quotes:
           // backslash, dollar, backtick, and the double-quote itself. Without

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -41,6 +41,7 @@ import {
 import {
   dismissTmuxPrompt,
   driveAskAnswers,
+  healWindowSize,
   jsonlPathFor,
   rebuildEventsFromJsonl,
   markTmuxPromptAnswered,
@@ -3334,6 +3335,11 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
               { status: 404, headers: corsHeaders(req) },
             );
           }
+          // Heal a stuck `window-size manual` pin (a prior crash mid pane-grow)
+          // before attaching, so the client's own size wins instead of being
+          // confined to whatever the pin left behind — see `healWindowSize`.
+          // Best-effort: must not block or delay the attach below.
+          healWindowSize(task.id);
           // AppleScript `do script` runs the string through `/bin/bash`, so
           // we escape anything bash would interpret inside double-quotes:
           // backslash, dollar, backtick, and the double-quote itself. Without

--- a/src/bun/window-size-heal.test.ts
+++ b/src/bun/window-size-heal.test.ts
@@ -1,0 +1,138 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Real-tmux integration test for `healWindowSize` (docs/plans/fix-minimized-
+// agent-tmux-attach.md §5 T1). The unit tests in claude-tmux.test.ts fake
+// tmux entirely (recorded argv); this one exercises the real binary end to
+// end: pin a live session's window-size to `manual` at a small fixed size —
+// exactly what a crash between the OLD two-call resizePane/restorePaneSize
+// used to leave stranded — call the exported heal function, and assert tmux
+// itself now reports `latest`.
+//
+// db.ts opens (and migrates) SQLite on module load, so AGETOR_DATA_DIR must
+// be a throwaway dir set BEFORE any import that reaches it (same idiom as
+// every other real-tmux test file in this suite).
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-window-heal-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+
+// Isolated tmux socket — a name of our OWN, distinct from the generic
+// "agetor-test" default other files fall back to, and NEVER the user's real
+// default socket. See the incident note in tmux-resolution.ts:73-85: a test
+// that once ran on the shared default socket killed the user's live agent
+// sessions. `tmuxSocketName()`/`tmuxSocketArgs()` read AGETOR_TMUX_SOCKET at
+// CALL time (no module-level caching), so setting it here before any tmux
+// call is enough — no need to touch AGETOR_TMUX_BIN, since this file
+// deliberately needs the REAL tmux binary (there's nothing to heal against a
+// fake one).
+const TEST_SOCKET = "agetor-test-window-heal";
+process.env.AGETOR_TMUX_SOCKET = TEST_SOCKET;
+
+/** Real tmux resolvable on THIS process's PATH? An agent's non-interactive
+ *  shell often lacks /opt/homebrew/bin, and `Bun.spawnSync` then throws
+ *  ENOENT mid-test — a false hard failure. Skip (visibly) instead: on any
+ *  machine that can actually run agetor, tmux is present and the test runs.
+ *  Same idiom as claude-followup-restart.test.ts. */
+const HAVE_TMUX = (() => {
+  try {
+    return Bun.spawnSync(["tmux", "-V"]).exitCode === 0;
+  } catch {
+    return false;
+  }
+})();
+if (!HAVE_TMUX) {
+  console.warn("[window-size-heal.test] tmux not on PATH — skipping real-tmux test");
+}
+
+// This file needs the REAL tmux binary — but a sibling file sharing this
+// process in a combined `bun test` run can leave AGETOR_TMUX_BIN pinned to a
+// stub (claude-tmux.test.ts sets it to `/bin/echo` at module top level and
+// never restores it, since every test in that file wants the fast fake).
+// `resolveTmuxBin()` reads the env at call time with no caching, so clearing
+// the override here (and restoring whatever was there afterward) is enough
+// to make sure this file always talks to real tmux regardless of run order.
+let savedTmuxBin: string | undefined;
+beforeAll(() => {
+  savedTmuxBin = process.env.AGETOR_TMUX_BIN;
+  delete process.env.AGETOR_TMUX_BIN;
+});
+
+afterAll(async () => {
+  if (HAVE_TMUX) {
+    // Best-effort: tear down the whole isolated socket's server so no
+    // session lingers past the suite. Guarded to ONLY ever target our own
+    // dedicated socket name — this must never reach the user's default
+    // socket, which is exactly the incident socket isolation exists to
+    // prevent.
+    try {
+      const { resolveTmuxBin, tmuxSocketName, tmuxSocketArgs } = await import("./tmux-resolution.ts");
+      if (tmuxSocketName() === TEST_SOCKET) {
+        Bun.spawnSync([resolveTmuxBin(), ...tmuxSocketArgs(), "kill-server"]);
+      }
+    } catch {
+      // best-effort only — a missing tmux bin or already-dead server is fine.
+    }
+  }
+  if (savedTmuxBin === undefined) delete process.env.AGETOR_TMUX_BIN;
+  else process.env.AGETOR_TMUX_BIN = savedTmuxBin;
+});
+
+test.skipIf(!HAVE_TMUX)(
+  "healWindowSize resets a real session stuck at window-size manual back to latest",
+  async () => {
+    await import("./db.ts");
+    const { healWindowSize, sessionNameFor } = await import("./claude-tmux.ts");
+    const { resolveTmuxBin, tmuxSocketArgs, tmuxSocketName } = await import("./tmux-resolution.ts");
+
+    // Guard rail: if AGETOR_TMUX_SOCKET somehow didn't take (e.g. a sibling
+    // file cleared it after this one's top-level ran, in a combined `bun
+    // test` run sharing one process), refuse to touch a session on the
+    // default socket rather than silently running against it.
+    expect(tmuxSocketName()).toBe(TEST_SOCKET);
+
+    const taskId = `task-windowheal-${randomUUID()}`;
+    const sessionName = sessionNameFor(taskId);
+    const tmuxBin = resolveTmuxBin();
+    const sockArgs = tmuxSocketArgs();
+
+    const create = Bun.spawnSync([
+      tmuxBin, ...sockArgs, "new-session", "-d", "-s", sessionName, "--", "sleep", "30",
+    ]);
+    expect(create.exitCode).toBe(0);
+
+    try {
+      // Reproduce the stuck-pin bug: pin window-size manual at a small,
+      // fixed size — exactly what a crash between the old two separate
+      // resizePane/restorePaneSize tmux calls could leave a session in.
+      const pin = Bun.spawnSync([
+        tmuxBin, ...sockArgs,
+        "set-window-option", "-t", sessionName, "window-size", "manual", ";",
+        "resize-window", "-t", sessionName, "-x", "80", "-y", "24",
+      ]);
+      expect(pin.exitCode).toBe(0);
+
+      const before = Bun.spawnSync([
+        tmuxBin, ...sockArgs, "show-window-options", "-t", sessionName, "window-size",
+      ]);
+      expect(before.exitCode).toBe(0);
+      expect(before.stdout.toString().trim()).toBe("window-size manual");
+
+      // No in-memory SessionState is installed for this taskId — mirrors the
+      // production case healWindowSize is mainly for (a session that
+      // outlived the process, or a fresh boot before reattach rebuilds
+      // state): `paneGrowInFlight` is only checked on a state that exists,
+      // so healing must still proceed via the plain sessionExists() path.
+      healWindowSize(taskId);
+
+      const after = Bun.spawnSync([
+        tmuxBin, ...sockArgs, "show-window-options", "-t", sessionName, "window-size",
+      ]);
+      expect(after.exitCode).toBe(0);
+      expect(after.stdout.toString().trim()).toBe("window-size latest");
+    } finally {
+      Bun.spawnSync([tmuxBin, ...sockArgs, "kill-session", "-t", "=" + sessionName]);
+    }
+  },
+);

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -59,6 +59,15 @@ export async function cmdAttach(args: string[], flags: Flags): Promise<void> {
     );
   }
 
+  // Best-effort unpin of a stuck `window-size manual` pin before attaching —
+  // this CLI surface can't import claude-tmux.ts's `healWindowSize` (see the
+  // module comment above), so it duplicates the minimal fix inline. See
+  // `healWindowSize` in ../../bun/claude-tmux.ts for the full rationale.
+  Bun.spawnSync(
+    [tmuxBin, ...socketArgs, "set-window-option", "-t", "=" + session, "window-size", "latest"],
+    { stdout: "ignore", stderr: "ignore" },
+  );
+
   out(c.dim(`attaching to ${session} — detach with Ctrl-b d`));
   const proc = Bun.spawn([tmuxBin, ...socketArgs, "attach", "-t", session], {
     stdin: "inherit",


### PR DESCRIPTION
## Problem

Attaching to a running claude-code task (Task Details → **Attach**, or `agetor attach`) could render the agent's TUI squashed into a tiny strip at the top of the terminal, with the rest of the window blank — looking like the agent was "minimized" and making it seem like Agetor had lost track of the running task.

## Root cause

The AskUserQuestion pane-scraper temporarily grows the detached tmux window to read option previews, pinning it with `window-size manual` and restoring it afterwards. Both the pin and the restore were **two separate tmux invocations** — if Agetor crashed or was killed between them, the session was left permanently pinned `manual` at a small size (tmux sessions deliberately survive restarts). Any later `tmux attach` then confined the claude TUI to that pinned region instead of renegotiating to the client's real size. Reproduced empirically: a session pinned `manual` at 80×24 stays 80×24 for a 200×49 client; with `window-size latest` it resizes correctly.

Notably, this was *not* a run-state detection bug: the "1 shell · 1 agent" bar visible in the report screenshot is Claude Code's own status line, and no Agetor code path varies attach behavior by run state.

## Fix

- **Atomic pin/restore** — `resizePane`/`restorePaneSize` now chain their two commands into a single tmux invocation (literal `;` argv element), so process death can no longer strand the session between them.
- **Chain-abort fallback** — tmux aborts a `;`-chain at the first failing command (empirically verified), so a failed `resize-window` would have skipped the unpin; the restore now checks the result and issues a standalone unpin (`set-window-option -u`, reverting to the inherited value) on failure.
- **Heal on attach** — new `healWindowSize(taskId)` resets `window-size` to `latest` before the `open-tmux` attach and on boot reattach, clearing any pin left by a pre-fix crash. Guarded by a `SessionState.paneGrowInFlight` flag (single `try/finally`, strand-proof against a throwing `PaneIo`) so it never races the scraper's own restore. The heal deliberately forces `latest` rather than `-u` — a user's global could itself be `manual` — and this is documented inline.
- **CLI parity** — `agetor attach` performs the same best-effort unpin before attaching (it can't import `claude-tmux.ts`, which opens SQLite on module load).
- **Hardening** — `=` exact-match anchors on all mutating `-t` targets (shared-socket safety, matching `sessionExists`/kill paths); `assumeAlive` option skips duplicate liveness probes at call sites that just checked.

Deliberately **not** changed: claude sessions still spawn without `-x`/`-y` (unlike codex's 200×50) — the modal parser is width-sensitive (claude renders a side-by-side preview column at ≥~100 cols), so widening the default would risk breaking AskUserQuestion parsing.

## Tests

- `healWindowSize` guard behavior (no-op mid-grow / missing session; single `set-window-option … latest` otherwise) via a recording fake tmux binary.
- `paneGrowInFlight` lifecycle (normal + early-abort paths) via the injectable fake `PaneIo`.
- Real-tmux integration test on an isolated socket: pin `manual` → heal → asserts `latest`. Skips cleanly when tmux is unavailable.
- Regression guard for codex's `-x 200 -y 50` session sizing (previously unasserted).

`bun test`: 2178 pass, 1 skip, 0 fail. `bun run typecheck`: clean.

Manual verification (needs Terminal.app + a real claude REPL): start a claude task, run `tmux set-window-option -t =agetor-<id12> window-size manual ; tmux resize-window -t =agetor-<id12> -x 80 -y 24`, click **Attach** — the TUI fills the window.

Plan/notes: `docs/plans/fix-minimized-agent-tmux-attach.md`.