### PR TITLE
Fix Settings dialog overflow

### DIFF
--- a/docs/plans/settings-dialog-max-height-scroll.md
+++ b/docs/plans/settings-dialog-max-height-scroll.md
@@ -1,0 +1,47 @@
+# Plan - Settings Dialog Max Height And Scroll
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-06 |
+| Source | `/implement It's missing a max height and a scroll for the Settings screen` |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/settings-no-max-height |
+| Base SHA | 4b9328fb64dfdc70e7208ceed89fa26807d82240 |
+
+## 1. Objective & success criteria
+Bound the Settings dialog to the viewport and make its content scroll vertically when it exceeds the available height.
+
+Success criteria:
+- Settings dialog panel has a viewport-relative max height.
+- Header remains visible while list/template/editor content scrolls.
+- Existing Settings subviews keep their current behavior and styling.
+
+## 2. Context & constraints
+- `src/mainview/components/ui/dialog.tsx` supplies a centered modal panel but does not impose a max height or internal body scroller on consumers.
+- Similar larger dialogs use `flex max-h-[85vh] ... flex-col p-0` on `Dialog` and wrap body content in `min-h-0 flex-1 overflow-y-auto`.
+- `src/mainview/components/settings/SettingsDialog.tsx` currently passes only `max-w-2xl`, then renders the header and active view directly in the panel.
+
+## 3. Approach & key decisions
+- Convert Settings dialog panel to a flex column with `max-h-[85vh]`, `w-full`, `max-w-2xl`, and `p-0`.
+- Move the header padding onto the header container so it remains visually unchanged.
+- Wrap the active view switch in a `min-h-0 flex-1 overflow-y-auto p-4 pt-0` body.
+- Leave child view components unchanged to keep this a layout-only fix.
+
+## 4. Work breakdown - implementation tasks
+I1 - Bound and scroll Settings dialog
+Files owned: `src/mainview/components/settings/SettingsDialog.tsx`
+Acceptance: Settings content scrolls inside the modal instead of expanding past the viewport.
+
+## 5. Work breakdown - test tasks
+No automated test will be added for this CSS-only modal sizing change. Verification is typecheck/build-level validation.
+
+E2E is not added because the repository does not have an existing webview E2E harness for modal visual layout, and adding one is outside this narrow bug fix.
+
+## 6. Execution waves
+- Wave 1: I1.
+- Wave 2: Typecheck.
+
+## 7. Blast radius & risks
+Blast radius is limited to the Settings modal. The main risk is losing panel padding or making nested Settings subviews double-pad; the wrapper uses existing child `pt-3` spacing and keeps horizontal padding at the body level.
+
+## 8. Open questions / assumptions
+- Assumption: `85vh` is acceptable because sibling dialogs already use `85vh` or `86vh`.

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -341,10 +341,10 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
     <Dialog
       open={open}
       onClose={onClose}
-      className="max-w-2xl"
+      className="flex max-h-[85vh] w-full max-w-2xl flex-col p-0"
       labelledBy="settings-dialog-title"
     >
-      <div className="flex items-center justify-between border-b border-border/60 pb-3">
+      <div className="flex shrink-0 items-center justify-between border-b border-border/60 p-4 pb-3">
         <div className="flex items-center gap-2">
           {view.kind !== "list" && (
             <Button
@@ -375,88 +375,90 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
         </div>
       </div>
 
-      {view.kind === "list" && (
-        <ListView
-          payload={payload}
-          statusByHarness={statusByHarness}
-          defaultHarness={defaultHarness}
-          homeDir={homeDir}
-          onPickDefault={onPickDefault}
-          tmuxSource={tmuxSource}
-          bundledTmuxAvailable={bundledTmuxAvailable}
-          onPickTmuxSource={onPickTmuxSource}
-          canAdd={!!dataDir}
-          onAdd={() => setView({ kind: "templates" })}
-          onEdit={(h) =>
-            setView({
-              kind: "editor",
-              harnessId: h.id,
-              template: {
-                id: "__edit",
-                label: h.label,
-                description: "",
-                kind: h.kind,
-                suggestedHarnessId: h.id,
-                home: h.home,
-                bin: h.bin,
-                env: h.env,
-              },
-            })
-          }
-          onDelete={onDeleteHarness}
-          onToggleEnabled={onToggleEnabled}
-          onOpenTerminal={onOpenTerminal}
-          pendingToggle={pendingToggle}
-        />
-      )}
-
-      {view.kind === "templates" && (
-        <TemplatePicker
-          onPick={(t) =>
-            setView({
-              kind: "editor",
-              harnessId: null,
-              template: resolveTemplate(t, dataDir),
-            })
-          }
-        />
-      )}
-
-      {view.kind === "editor" && (
-        <Editor
-          template={view.template}
-          isEdit={view.harnessId !== null}
-          homeDir={homeDir}
-          dataDir={dataDir}
-          existingIds={new Set(payload.harnesses.map((h) => h.id))}
-          busy={busy}
-          error={formError}
-          onCancel={() => setView({ kind: "list" })}
-          onSubmit={async (input) => {
-            setBusy(true);
-            setFormError(null);
-            try {
-              if (view.harnessId) {
-                await api.updateHarness(view.harnessId, {
-                  label: input.label,
-                  home: input.home,
-                  bin: input.bin,
-                  env: input.env,
-                });
-              } else {
-                await api.createHarness(input);
-              }
-              await refresh();
-              onChange?.();
-              setView({ kind: "list" });
-            } catch (e) {
-              setFormError(e instanceof Error ? e.message : String(e));
-            } finally {
-              setBusy(false);
+      <div className="min-h-0 flex-1 overflow-y-auto p-4 pt-0">
+        {view.kind === "list" && (
+          <ListView
+            payload={payload}
+            statusByHarness={statusByHarness}
+            defaultHarness={defaultHarness}
+            homeDir={homeDir}
+            onPickDefault={onPickDefault}
+            tmuxSource={tmuxSource}
+            bundledTmuxAvailable={bundledTmuxAvailable}
+            onPickTmuxSource={onPickTmuxSource}
+            canAdd={!!dataDir}
+            onAdd={() => setView({ kind: "templates" })}
+            onEdit={(h) =>
+              setView({
+                kind: "editor",
+                harnessId: h.id,
+                template: {
+                  id: "__edit",
+                  label: h.label,
+                  description: "",
+                  kind: h.kind,
+                  suggestedHarnessId: h.id,
+                  home: h.home,
+                  bin: h.bin,
+                  env: h.env,
+                },
+              })
             }
-          }}
-        />
-      )}
+            onDelete={onDeleteHarness}
+            onToggleEnabled={onToggleEnabled}
+            onOpenTerminal={onOpenTerminal}
+            pendingToggle={pendingToggle}
+          />
+        )}
+
+        {view.kind === "templates" && (
+          <TemplatePicker
+            onPick={(t) =>
+              setView({
+                kind: "editor",
+                harnessId: null,
+                template: resolveTemplate(t, dataDir),
+              })
+            }
+          />
+        )}
+
+        {view.kind === "editor" && (
+          <Editor
+            template={view.template}
+            isEdit={view.harnessId !== null}
+            homeDir={homeDir}
+            dataDir={dataDir}
+            existingIds={new Set(payload.harnesses.map((h) => h.id))}
+            busy={busy}
+            error={formError}
+            onCancel={() => setView({ kind: "list" })}
+            onSubmit={async (input) => {
+              setBusy(true);
+              setFormError(null);
+              try {
+                if (view.harnessId) {
+                  await api.updateHarness(view.harnessId, {
+                    label: input.label,
+                    home: input.home,
+                    bin: input.bin,
+                    env: input.env,
+                  });
+                } else {
+                  await api.createHarness(input);
+                }
+                await refresh();
+                onChange?.();
+                setView({ kind: "list" });
+              } catch (e) {
+                setFormError(e instanceof Error ? e.message : String(e));
+              } finally {
+                setBusy(false);
+              }
+            }}
+          />
+        )}
+      </div>
     </Dialog>
   );
 }


### PR DESCRIPTION
## Summary
- Bound the Settings dialog to the viewport with a max height.
- Added an internal scroll container so long Settings content stays usable.
- Kept the dialog header fixed while the body scrolls.

## Verification
- `bun run typecheck`
- `bun test`