### PR TITLE
Add GPT-5.6 Codex models

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Add a harness from **Settings → Harnesses**. Templates pre-fill common pattern
 Each task picks:
 
 - a **mode** — how much permission the agent has (`auto`, `ask`, `acceptEdits`, `plan`, `bypass` — exposed per agent),
-- a **model** — Opus / Sonnet / Haiku for Claude, GPT-5 / GPT-5 Codex for Codex,
+- a **model** — Opus / Sonnet / Haiku for Claude, GPT-5.6 Sol / Terra / Luna and earlier GPT-5 options for Codex,
 - an **effort** level — reasoning depth, where the model supports it.
 
 The picker filters incompatible combinations (e.g. effort is hidden on Haiku 4.5 because Anthropic's API doesn't accept it there).

--- a/docs/plans/add-gpt-5-6-codex-models.md
+++ b/docs/plans/add-gpt-5-6-codex-models.md
@@ -1,0 +1,66 @@
+# Plan - Add GPT-5.6 Codex Models
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-06 |
+| Source | `/implement OpenAI release GPT 5.6 Sol, Terra and Luna` |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/add-gpt-5-6 |
+| Base SHA | 4b9328fb64dfdc70e7208ceed89fa26807d82240 |
+
+## 1. Objective & success criteria
+
+Add `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to Agetor's Codex model picker, and make `gpt-5.6-sol` the default Codex model for new tasks.
+
+Success means the UI/CLI default model path resolves Codex to `gpt-5.6-sol`, the picker exposes all three GPT-5.6 variants, supported effort filtering matches official GPT-5.6 guidance, and Codex command construction passes the selected GPT-5.6 model ID through unchanged.
+
+## 2. Context & constraints
+
+Official OpenAI documentation says `gpt-5.6` routes to `gpt-5.6-sol`, and names `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` as the GPT-5.6 family. The same guidance lists GPT-5.6 reasoning efforts from `none` through `max`.
+
+Local findings:
+
+- `src/shared/types.ts` owns `DEFAULT_MODEL`, `MODEL_EFFORT_SUPPORT`, and `AGENT_OPTIONS`.
+- `src/bun/agents.ts` passes Codex model IDs through as `--model <id>` and maps effort to `-c model_reasoning_effort=<id>`.
+- `src/bun/effort-support.test.ts` covers effort filtering and default-model fallback.
+- `src/bun/agents.test.ts` covers Codex command construction.
+
+## 3. Approach & key decisions
+
+Use the exact model IDs rather than the `gpt-5.6` alias so the user-visible default is explicitly Sol. Keep legacy GPT-5.5/GPT-5/GPT-5 Codex options available rather than removing historical choices.
+
+Add `none` and `max` effort support only for the GPT-5.6 family, leaving older Codex models on their existing `low` to `xhigh` range.
+
+## 4. Work breakdown - implementation tasks
+
+Task 1: Update Codex model registry.
+
+- Owns: `src/shared/types.ts`
+- Acceptance: Codex default is `gpt-5.6-sol`; all three GPT-5.6 model options are present; GPT-5.6 efforts include `max` and `none`.
+
+Task 2: Update docs copy.
+
+- Owns: `README.md`
+- Acceptance: model examples mention GPT-5.6 Sol/Terra/Luna for Codex.
+
+## 5. Work breakdown - test tasks
+
+Task 3: Update focused unit tests.
+
+- Owns: `src/bun/effort-support.test.ts`, `src/bun/agents.test.ts`
+- Acceptance: tests cover Codex default, GPT-5.6 effort support, unknown-model fallback to Sol support, and command pass-through for `gpt-5.6-sol`.
+
+E2E does not apply: this is a shared registry/default change with no new user flow or process boundary beyond already-tested command construction.
+
+## 6. Execution waves
+
+One local wave: update registry/docs/tests together because the change is small and centered on one shared file.
+
+## 7. Blast radius & risks
+
+New tasks default to `gpt-5.6-sol` for Codex. Existing tasks keep their persisted model unless edited. Legacy null model rows are backfilled by current default paths, so Codex legacy rows will move to Sol when the app applies defaulting behavior.
+
+Risk: if a user's installed Codex CLI predates GPT-5.6 support, launching the new default may fail at the CLI. The existing app already supports discovered models and direct model pass-through; this change follows that established pattern.
+
+## 8. Open questions / assumptions
+
+No open product questions. Assumption: Agetor should expose all three new Codex choices while preserving older Codex models for compatibility.

--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -54,7 +54,7 @@ function alias(kind: AgentKind, opts: { home?: string; bin?: string; env?: Recor
 // missing-model / missing-effort guards. Mirrors what the UI + orchestrator
 // will now always pass at runtime.
 const claudeDefaults = { mode: "auto", model: "opus-4.7", effort: "high" } as const;
-const codexDefaults = { mode: "auto", model: "gpt-5-codex", effort: "high" } as const;
+const codexDefaults = { mode: "auto", model: "gpt-5.6-sol", effort: "high" } as const;
 // Cursor has no effort knob — omitted from the defaults object entirely
 // (unlike claude/codex, `buildCommand`'s cursor branch never inspects
 // `opts.effort`, so leaving it unset is the realistic runtime shape).
@@ -409,7 +409,7 @@ test("codex with defaults emits --model + reasoning effort + structured-stream f
   const { cmd } = buildCommand(builtin("codex"), "hi", { ...codexDefaults });
   expect(cmd).toEqual([
     "codex", "exec",
-    "--model", "gpt-5-codex",
+    "--model", "gpt-5.6-sol",
     "-c", "model_reasoning_effort=high",
     "--json", "--color", "never", "--skip-git-repo-check",
     "--sandbox", "workspace-write",
@@ -422,7 +422,7 @@ test("codex 'ask' mode uses --sandbox read-only so codex can't change anything",
   expect(cmd).not.toContain("workspace-write");
   expect(cmd).toEqual([
     "codex", "exec",
-    "--model", "gpt-5-codex",
+    "--model", "gpt-5.6-sol",
     "-c", "model_reasoning_effort=high",
     "--json", "--color", "never", "--skip-git-repo-check",
     "--sandbox", "read-only",
@@ -435,6 +435,18 @@ test("codex model 'gpt-5.5' passes through verbatim as --model", () => {
   expect(cmd).toEqual([
     "codex", "exec",
     "--model", "gpt-5.5",
+    "-c", "model_reasoning_effort=high",
+    "--json", "--color", "never", "--skip-git-repo-check",
+    "--sandbox", "workspace-write",
+    "-",
+  ]);
+});
+
+test("codex model 'gpt-5.6-sol' passes through verbatim as --model", () => {
+  const { cmd } = buildCommand(builtin("codex"), "hi", { ...codexDefaults, model: "gpt-5.6-sol", mode: "auto" });
+  expect(cmd).toEqual([
+    "codex", "exec",
+    "--model", "gpt-5.6-sol",
     "-c", "model_reasoning_effort=high",
     "--json", "--color", "never", "--skip-git-repo-check",
     "--sandbox", "workspace-write",

--- a/src/bun/effort-support.test.ts
+++ b/src/bun/effort-support.test.ts
@@ -67,6 +67,22 @@ test("claude fable-5 supports xhigh + max", () => {
   expect(ids).toContain("max");
 });
 
+test("codex DEFAULT_MODEL is GPT-5.6 Sol", () => {
+  expect(DEFAULT_MODEL.codex).toBe("gpt-5.6-sol");
+});
+
+test("codex GPT-5.6 family supports none through max", () => {
+  for (const model of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+    const ids = supportedEfforts("codex", model).map((o) => o.id);
+    expect(ids).toEqual(["max", "xhigh", "high", "medium", "low", "none"]);
+  }
+});
+
+test("codex model picker includes the GPT-5.6 family", () => {
+  const ids = AGENT_OPTIONS.codex.models.map((m) => m.id);
+  expect(ids.slice(0, 3)).toEqual(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
+});
+
 test("codex gpt-5.5 supports xhigh but not max", () => {
   const ids = supportedEfforts("codex", "gpt-5.5").map((o) => o.id);
   expect(ids).toContain("xhigh");
@@ -83,10 +99,9 @@ test("codex gpt-5 supports xhigh but not max", () => {
 });
 
 test("unknown model falls back to the agent's DEFAULT_MODEL support set", () => {
-  // codex's default is gpt-5.5 which has the same set as gpt-5.
+  // codex's default is gpt-5.6-sol, so pasted future ids inherit its range.
   const ids = supportedEfforts("codex", "future-codex-9000").map((o) => o.id);
-  expect(ids).toContain("xhigh");
-  expect(ids).not.toContain("max");
+  expect(ids).toEqual(["max", "xhigh", "high", "medium", "low", "none"]);
 });
 
 test("ordered highest → lowest (no placeholder at the top)", () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -912,7 +912,7 @@ export const DEFAULT_MODEL: Record<AgentKind, string> = {
   // ($5/$25 per MTok). Fable 5 sits above it in the picker but costs 2x the
   // usage, so the default stays on the most-capable non-premium tier.
   "claude-code": "opus-5",
-  "codex": "gpt-5.5",
+  "codex": "gpt-5.6-sol",
   // Cursor's own "let cursor-agent pick" model — matches its CLI default.
   "cursor": "auto",
 };
@@ -969,8 +969,7 @@ export const CODE_PLAN_MODE: Record<AgentKind, { code: string; plan: string }> =
  *                   high → "think harder" xhigh → "think very hard"
  *                   max → "ultrathink"
  *
- * `none` is kept in the canonical list for future codex-only "reasoning-off"
- * models — currently no model in our list opts into it, so it never renders.
+ * `none` is currently used only by GPT-5.6-family Codex models.
  */
 export const EFFORT_OPTIONS: AgentOption[] = [
   { id: "max", label: "Max", hint: "Absolute maximum effort. Slowest, most thorough." },
@@ -990,8 +989,8 @@ export const EFFORT_OPTIONS: AgentOption[] = [
  *     Haiku 4.5 → effort parameter NOT supported
  *   - Codex `model_reasoning_effort`:
  *       https://developers.openai.com/codex/config-advanced
+ *     GPT-5.6 family → none/low/medium/high/xhigh/max
  *     gpt-5.5 / gpt-5 / gpt-5-codex → low/medium/high/xhigh
- *     (minimal kept out of UI)
  *
  * An empty list means "this model does not accept the effort flag at all"
  * (e.g. Haiku 4.5) — the UI collapses the dropdown and `buildCommand` emits
@@ -1021,6 +1020,9 @@ export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> =
     "haiku-4.5": [],
   },
   codex: {
+    "gpt-5.6-sol": ["max", "xhigh", "high", "medium", "low", "none"],
+    "gpt-5.6-terra": ["max", "xhigh", "high", "medium", "low", "none"],
+    "gpt-5.6-luna": ["max", "xhigh", "high", "medium", "low", "none"],
     "gpt-5.5": ["xhigh", "high", "medium", "low"],
     "gpt-5": ["xhigh", "high", "medium", "low"],
     "gpt-5-codex": ["xhigh", "high", "medium", "low"],
@@ -1117,7 +1119,10 @@ export const AGENT_OPTIONS: Record<AgentKind, AgentOptions> = {
   },
   codex: {
     models: [
-      { id: "gpt-5.5", label: "GPT-5.5", hint: "Recommended default — works on ChatGPT plans." },
+      { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", hint: "Recommended default — flagship GPT-5.6 capability." },
+      { id: "gpt-5.6-terra", label: "GPT-5.6 Terra", hint: "Balanced GPT-5.6 model for strong performance at lower cost." },
+      { id: "gpt-5.6-luna", label: "GPT-5.6 Luna", hint: "Efficient GPT-5.6 model for high-volume workloads." },
+      { id: "gpt-5.5", label: "GPT-5.5", hint: "Previous recommended default — works on ChatGPT plans." },
       { id: "gpt-5-codex", label: "GPT-5 Codex", hint: "Requires an API-key account; rejected on ChatGPT plans." },
       { id: "gpt-5", label: "GPT-5", hint: "Requires an API-key account; rejected on ChatGPT plans." },
     ],


### PR DESCRIPTION
## Summary

- Add GPT-5.6 Sol, Terra, and Luna to the Codex model picker.
- Make GPT-5.6 Sol the default Codex model for new tasks.
- Add effort-support and command-construction test coverage for the GPT-5.6 family.
- Update README model copy and save the implementation plan.

## Verification

- `bun test src/bun/effort-support.test.ts src/bun/agents.test.ts`
- `bun run typecheck`
- `git diff --check`
- `bun test src/bun/claude-tmux-queue.test.ts`