### PR TITLE
fix: 'ask' mode silently inherits user-level defaultMode — pass --permission-mode default explicitly

### DIFF
--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -250,9 +250,14 @@ test("claude-code 'plan' mode emits --permission-mode plan", () => {
   expect(cmd).not.toContain("--print");
 });
 
-test("claude-code 'ask' mode emits no permission flag", () => {
+test("claude-code 'ask' mode emits an EXPLICIT --permission-mode default", () => {
+  // Omitting the flag would inherit the user-level `defaultMode` from
+  // ~/.claude/settings.json (e.g. `auto`), silently running the task in a
+  // looser mode than the one stored on it.
   const { cmd } = buildCommand(builtin("claude-code"), "p", { ...claudeDefaults, mode: "ask" });
-  expect(cmd).not.toContain("--permission-mode");
+  const i = cmd.indexOf("--permission-mode");
+  expect(i).toBeGreaterThan(-1);
+  expect(cmd[i + 1]).toBe("default");
   expect(cmd).not.toContain("--dangerously-skip-permissions");
   expect(cmd).not.toContain("--print");
 });

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -359,7 +359,10 @@ export function buildCommand(
     const mode = opts.mode ?? "auto";
     if (mode === "bypass") {
       args.push("--dangerously-skip-permissions");
-    } else if (mode !== "ask") {
+    } else {
+      // `ask` must be EXPLICIT: omitting the flag inherits the user-level
+      // `defaultMode` (e.g. `auto` in ~/.claude/settings.json), silently
+      // running the task in a looser mode than the one stored on it.
       args.push("--permission-mode", toClaudeModeString(mode));
     }
 


### PR DESCRIPTION
## Problem

For `mode: ask`, `buildCommand` deliberately emits no `--permission-mode` flag, expecting claude to land in its built-in `default` mode (the comment says *"omitting it matches the prior behavior"*).

That assumption breaks when the user has a `defaultMode` in `~/.claude/settings.json`. With e.g. `"defaultMode": "auto"` there, a task stored as **ask** silently launches in **auto**: safe-looking commands run without ever surfacing an approval card, contradicting the mode shown on the task.

## Repro

1. Set `"defaultMode": "auto"` in `~/.claude/settings.json`.
2. Create a claude-code task with `--mode ask` whose prompt runs any non-allowlisted command (e.g. `curl -s https://example.com`).
3. Session JSONL reports `permission-mode: auto`; the command executes with `pendingInteractionCount = 0` — no card ever appears.

After this change the same task hits claude's native approval prompt, and the scraper surfaces it as a card (verified end-to-end: answered via `POST /tmux-prompts/<id>/answer`, command then executed).

## Change

- `agents.ts`: always pass `--permission-mode` explicitly; `ask` → `default` via the existing `toClaudeModeString`.
- `agents.test.ts`: the `'ask' mode emits no permission flag` test codified the omission — it now asserts the explicit flag.

`bun test src/bun/agents.test.ts`: 80 pass / 0 fail.