### PR TITLE
feature: split Settings into left-sidebar sections (General / Harnesses / Git Integration)

### DIFF
--- a/docs/plans/settings-dialog-section-sidebar.md
+++ b/docs/plans/settings-dialog-section-sidebar.md
@@ -1,0 +1,172 @@
+# Plan — Settings dialog left-side section sidebar
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-08 |
+| Source | /implement — "add a left side menu for the settings page, so we can break up the config there" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/left-side-manu-options-for-settings-moda |
+| Base SHA | 7a50d75ccb2aa8232a50c2b8f06262c3311bdc15 |
+
+> Known-broken baseline: `bun run typecheck` at this SHA already fails with 8
+> pre-existing "Property 'fast' is missing" errors in
+> `src/bun/claude-followup-restart.test.ts` and `src/bun/claude-turn-routing.test.ts`
+> (PR #152 fixtures; peer-reported). "Typecheck green" for this feature means
+> *no new errors beyond those 8*.
+
+## 1. Objective & success criteria
+
+Replace the Settings dialog's single flat scrolling page with a left sidebar that
+splits the config into three sections, each shown one at a time in the content pane:
+
+- **General** — default-harness picker + tmux source picker
+- **Harnesses** — harness list (enable/disable, terminal, edit, delete) + the
+  existing Add-harness flow (template picker → editor)
+- **Git Integration** — the existing `GitHubTokensSection`
+
+Success criteria:
+1. Opening Settings lands on **General** every time (owner decision — no persistence).
+2. Clicking a sidebar item swaps the content pane; the active item is visually
+   selected (`secondary` vs `ghost` Button variants — the repo's selected-state idiom).
+3. The Add/Edit harness flows still work end-to-end and now return to the
+   **Harnesses** section (not a generic "list") on cancel/save/back.
+4. **Escape inside templates/editor pops back to Harnesses instead of closing the
+   whole modal** (fixes an existing gap; the header X still always closes).
+5. Dialog widens to `max-w-4xl`; PR #150's overflow contract is preserved — header
+   stays fixed, only the content pane scrolls, nothing overflows at small viewport heights.
+6. `bun run typecheck` green; new pure-logic unit tests pass under `bun test`.
+
+## 2. Context & constraints (grounded)
+
+- `src/mainview/components/settings/SettingsDialog.tsx` is the whole surface.
+  Current `View` union at L35–38: `list | templates | editor`. Root component
+  L164–464; `ListView` L466–639 contains the four flat groups (default harness
+  L512–522, tmux L524–541, `<GitHubTokensSection />` L543, harness list L545–637);
+  `TemplatePicker` L641–676; `Editor` L678–873.
+- **PR #150 layout contract** (`5661761`, docs/plans/settings-dialog-max-height-scroll.md):
+  Dialog panel `flex max-h-[85vh] w-full max-w-2xl flex-col p-0` (L344), header
+  `shrink-0` (L347), body `min-h-0 flex-1 overflow-y-auto p-4 pt-0` (L378). The
+  sidebar must be introduced as a **flex-row inside** that body slot — the outer
+  flex-col + shrink-0 header must not change shape.
+- **Canonical navigation pattern**: `src/mainview/lib/github-dialog-view.ts` — a
+  pure discriminated-union module with navigation helpers and
+  `resolveEscape(view): "pop" | "close"`, wired in `GitHubDialog.tsx` ~L3049–3062
+  (Dialog `onClose` checks resolveEscape; only the root view actually closes).
+  Unit-tested in `github-dialog-view.test.ts` (bun:test). Settings currently
+  **lacks** resolveEscape — Escape from the editor closes the modal.
+- Back-chevron idiom: `ChevronLeft`, `size="icon" variant="ghost"`,
+  `aria-label="Back"` (SettingsDialog.tsx L349–358).
+- Styling: semantic HSL tokens only (`border-border/60`, `bg-muted`, `text-muted-foreground`,
+  `secondary`/`ghost`/`outline` Button variants); `cn()` from `@/lib/utils`. No literal
+  palette classes. There is **no existing sidebar component** anywhere to reuse — net-new markup.
+- Save model is save-per-action (no dirty state, no Save button) — the section
+  split moves JSX, it must not change any handler logic. Failure toasts via
+  `sonner` with `duration: Infinity`, no success toasts.
+- Tests: repo convention is pure-logic `.ts` modules tested with `bun:test`; there
+  is no React component-test harness and **no e2e harness** (recorded in the PR
+  #150 plan). `bun test` at repo root discovers everything; typecheck is `tsc --noEmit`.
+- Gotcha for sandboxed test shells: `bun` may be missing from PATH — prepend
+  `$HOME/.bun/bin` and `/opt/homebrew/bin`.
+
+## 3. Approach & key decisions
+
+1. **Extract navigation into `src/mainview/lib/settings-dialog-view.ts`** (new file),
+   mirroring `github-dialog-view.ts`:
+   ```ts
+   export const SETTINGS_SECTIONS = [
+     { id: "general", label: "General" },
+     { id: "harnesses", label: "Harnesses" },
+     { id: "git", label: "Git Integration" },
+   ] as const;
+   export type SettingsSectionId = (typeof SETTINGS_SECTIONS)[number]["id"];
+
+   export type SettingsView =
+     | { kind: "section"; section: SettingsSectionId }
+     | { kind: "templates" }
+     | { kind: "editor"; harnessId: string | null; template: HarnessTemplate };
+   ```
+   Helpers (all pure): `initialView()` → General; `openSection(id)`;
+   `openTemplates()`; `openEditor(harnessId, template)`; `backFromSubview()` →
+   Harnesses section; `activeSection(view)` → which sidebar item highlights
+   (templates/editor → `"harnesses"`); `resolveEscape(view)` → `"pop"` for
+   templates/editor, `"close"` for any section. Type-only import of
+   `HarnessTemplate` from `shared/types.ts` keeps it runtime-pure.
+   *Rationale:* this is the exact shape the repo's own prior plan
+   (github-modal-pr-detail-subpage) canonized; it replaces the old hardcoded
+   `{ kind: "list" }` back-target, which has no section memory.
+2. **Sidebar stays visible during templates/editor**, with Harnesses highlighted
+   (unlike GitHubDialog's full-panel replacement). Clicking another section while
+   mid-editor navigates away and discards the draft — identical to today's
+   Cancel-then-navigate behavior, and the editor is short-lived CRUD, not precious state.
+3. **Layout**: Dialog className → `flex max-h-[85vh] w-full max-w-4xl flex-col p-0`
+   (width is the only change). Body slot becomes:
+   `<div class="flex min-h-0 flex-1">` wrapping
+   `<nav class="w-44 shrink-0 overflow-y-auto border-r border-border/60 p-2">`
+   (full-width `justify-start` Buttons, `secondary` when active, `ghost` otherwise)
+   and `<div class="min-h-0 flex-1 overflow-y-auto p-4 pt-0">` (the existing
+   scroll container, unchanged classes, now scoped to content only).
+4. **ListView splits** into `GeneralSection` (default harness + tmux pickers) and
+   `HarnessesSection` (list + Add button); Git section renders `<GitHubTokensSection />`
+   directly. All stay inside `SettingsDialog.tsx` (repo keeps dialog subcomponents
+   in-file). Handler logic, props, and copy move verbatim — zero behavior change.
+5. **Escape wiring**: Dialog gets `onClose={() => resolveEscape(view) === "pop"
+   ? setView(backFromSubview()) : onClose()}`; the header X keeps calling the raw
+   `onClose`. Header title stays "Settings" on section views ("Add/Edit harness"
+   on subviews as today); back-chevron shows only on templates/editor and goes to
+   `backFromSubview()`. The on-open reset (L228) becomes `setView(initialView())`.
+6. **Out of scope** (owner decisions): no Environment section (unmerged
+   `feat/env-settings-panel` stays shelved), no last-section persistence, no
+   React component-test harness, no e2e harness.
+
+## 4. Work breakdown — implementation tasks
+
+| ID | Goal | Files owned | Depends on | Acceptance |
+| --- | --- | --- | --- | --- |
+| IMPL-1 | Create the view lib, then refactor SettingsDialog to the sidebar layout per §3 | `src/mainview/lib/settings-dialog-view.ts` (new), `src/mainview/components/settings/SettingsDialog.tsx` | — | Criteria 1–5 of §1; `bun run typecheck` green; no other files touched |
+
+One task, one agent: the two files are one coherent change (the component imports
+the lib), and nothing else in the repo is touched. No parallel fan-out needed.
+
+## 5. Work breakdown — test tasks
+
+| ID | Goal | Files owned | Covers | Acceptance |
+| --- | --- | --- | --- | --- |
+| TEST-1 | Unit-test every helper in the new view lib (initialView, openSection, openTemplates, openEditor, backFromSubview, activeSection, resolveEscape — incl. the templates/editor→harnesses highlight and pop-vs-close for every view kind) | `src/mainview/lib/settings-dialog-view.test.ts` (new) | IMPL-1 | Mirrors `github-dialog-view.test.ts` style; `bun test src/mainview/lib/settings-dialog-view.test.ts` green |
+
+**E2e: not applicable.** No e2e harness exists (recorded decision, matching the
+PR #150 precedent), and the rendered sidebar is markup + CSS over unchanged
+handlers. Verification of the visual layout is manual: `bun run dev:hmr`
+(AGETOR_DATA_DIR=~/.agetor-dev), open Settings, click through the three sections
+and the add/edit flow.
+
+## 6. Execution waves
+
+- Wave 1: IMPL-1 (single agent, `sonnet`)
+- Review barrier: Phase 5 review of the diff (`opus`)
+- Wave 2: TEST-1 (single agent, `sonnet`)
+- Phase 7: `bun run typecheck` + `bun test` (haiku runner; PATH fix per §2)
+
+## 7. Blast radius & risks
+
+- `App.tsx` passes `onClose={() => setSettingsOpen(false)}` — untouched; the
+  pop-vs-close logic lives entirely inside SettingsDialog.
+- `GitHubTokensSection` and its nested `GitHubSetupDialog` (stacked modal) are
+  rendered unchanged; the dialog primitive's `openDialogStack` already handles
+  stacked-Escape correctly, and our onClose wrapper only runs when Settings is topmost.
+- Risk: regressing PR #150's overflow fix. Mitigated by keeping the outer
+  flex-col/header untouched and reusing the exact scroll-container classes on the
+  content pane; review explicitly checks this.
+- Risk: `refresh()`/handler logic accidentally altered during the JSX split.
+  Mitigated by verbatim-move instruction + review.
+- Parallel-branch risk: history shows duplicate agents racing on this file
+  (`fix/settings-no-max-height`); fleet peers were notified via echo_current_task.
+
+## 8. Open questions / assumptions
+
+- Assumption: sidebar labels "General" / "Harnesses" / "Git Integration" (owner
+  approved the 3-way split; exact strings are mine).
+- Assumption: `w-44` sidebar width and keeping `85vh` height (only width changes
+  to `max-w-4xl`, per owner).
+- Assumption: sidebar remains visible (Harnesses highlighted) during
+  templates/editor subviews — chosen over GitHubDialog's full-panel replacement
+  because a settings modal with a persistent rail is the more conventional UX.

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -18,6 +18,17 @@ import {
   type Harness,
   type HarnessTemplate,
 } from "../../../shared/types.ts";
+import {
+  SETTINGS_SECTIONS,
+  activeSection,
+  backFromSubview,
+  initialView,
+  openEditor,
+  openSection,
+  openTemplates,
+  resolveEscape,
+  type SettingsView,
+} from "@/lib/settings-dialog-view";
 
 interface Props {
   open: boolean;
@@ -31,11 +42,6 @@ interface Props {
    *  (~/.agetor for the .app, ~/.agetor-dev for `bun run dev`). */
   dataDir: string;
 }
-
-type View =
-  | { kind: "list" }
-  | { kind: "templates" }
-  | { kind: "editor"; harnessId: string | null; template: HarnessTemplate };
 
 /**
  * Parse a textarea of `KEY=value` lines into a record. Blank lines and
@@ -167,7 +173,7 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
   const [defaultHarness, setDefaultHarness] = useState<string>("claude-code");
   const [tmuxSource, setTmuxSource] = useState<"system" | "bundled">("system");
   const [bundledTmuxAvailable, setBundledTmuxAvailable] = useState(false);
-  const [view, setView] = useState<View>({ kind: "list" });
+  const [view, setView] = useState<SettingsView>(initialView());
   const [busy, setBusy] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   // Optimistic toggle map: harness id → the value the user *clicked toward*.
@@ -223,9 +229,9 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
   useEffect(() => {
     if (!open) return;
     void refresh();
-    // Reset to list view on every open so a half-filled editor doesn't
-    // greet the user next time.
-    setView({ kind: "list" });
+    // Reset to the General section on every open so a half-filled editor
+    // doesn't greet the user next time.
+    setView(initialView());
     setFormError(null);
   }, [open]);
 
@@ -258,8 +264,8 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
       await refresh();
       onChange?.();
     } catch (e) {
-      // ListView doesn't render `formError` (only the Editor does), so a
-      // failed delete would otherwise be invisible. Surface it as a toast.
+      // HarnessesSection doesn't render `formError` (only the Editor does),
+      // so a failed delete would otherwise be invisible. Surface it as a toast.
       const message = e instanceof Error ? e.message : String(e);
       const description = await describeHarnessInUse(e) ?? message;
       toast.error(`Couldn't delete "${h.label}"`, {
@@ -337,27 +343,35 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
     }
   };
 
+  const currentSection = activeSection(view);
+
   return (
     <Dialog
       open={open}
-      onClose={onClose}
-      className="flex max-h-[85vh] w-full max-w-2xl flex-col p-0"
+      onClose={() => {
+        if (resolveEscape(view) === "pop") {
+          setView(backFromSubview());
+          return;
+        }
+        onClose();
+      }}
+      className="flex max-h-[85vh] w-full max-w-4xl flex-col p-0"
       labelledBy="settings-dialog-title"
     >
       <div className="flex shrink-0 items-center justify-between border-b border-border/60 p-4 pb-3">
         <div className="flex items-center gap-2">
-          {view.kind !== "list" && (
+          {view.kind !== "section" && (
             <Button
               variant="ghost"
               size="icon"
-              onClick={() => setView({ kind: "list" })}
+              onClick={() => setView(backFromSubview())}
               aria-label="Back"
             >
               <ChevronLeft className="size-4" />
             </Button>
           )}
           <h2 id="settings-dialog-title" className="text-base font-semibold">
-            {view.kind === "list" && "Settings"}
+            {view.kind === "section" && "Settings"}
             {view.kind === "templates" && "Add harness"}
             {view.kind === "editor" && (view.harnessId ? "Edit harness" : "Add harness")}
           </h2>
@@ -375,134 +389,125 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-4 pt-0">
-        {view.kind === "list" && (
-          <ListView
-            payload={payload}
-            statusByHarness={statusByHarness}
-            defaultHarness={defaultHarness}
-            homeDir={homeDir}
-            onPickDefault={onPickDefault}
-            tmuxSource={tmuxSource}
-            bundledTmuxAvailable={bundledTmuxAvailable}
-            onPickTmuxSource={onPickTmuxSource}
-            canAdd={!!dataDir}
-            onAdd={() => setView({ kind: "templates" })}
-            onEdit={(h) =>
-              setView({
-                kind: "editor",
-                harnessId: h.id,
-                template: {
-                  id: "__edit",
-                  label: h.label,
-                  description: "",
-                  kind: h.kind,
-                  suggestedHarnessId: h.id,
-                  home: h.home,
-                  bin: h.bin,
-                  env: h.env,
-                },
-              })
-            }
-            onDelete={onDeleteHarness}
-            onToggleEnabled={onToggleEnabled}
-            onOpenTerminal={onOpenTerminal}
-            pendingToggle={pendingToggle}
-          />
-        )}
+      <div className="flex min-h-0 flex-1">
+        <nav className="w-44 shrink-0 overflow-y-auto border-r border-border/60 p-2">
+          {SETTINGS_SECTIONS.map((s) => (
+            <Button
+              key={s.id}
+              size="sm"
+              variant={currentSection === s.id ? "secondary" : "ghost"}
+              className="w-full justify-start"
+              aria-current={currentSection === s.id ? "true" : undefined}
+              onClick={() => setView(openSection(s.id))}
+            >
+              {s.label}
+            </Button>
+          ))}
+        </nav>
 
-        {view.kind === "templates" && (
-          <TemplatePicker
-            onPick={(t) =>
-              setView({
-                kind: "editor",
-                harnessId: null,
-                template: resolveTemplate(t, dataDir),
-              })
-            }
-          />
-        )}
+        <div className="min-h-0 flex-1 overflow-y-auto p-4 pt-0">
+          {view.kind === "section" && view.section === "general" && (
+            <GeneralSection
+              defaultHarness={defaultHarness}
+              payload={payload}
+              onPickDefault={onPickDefault}
+              tmuxSource={tmuxSource}
+              bundledTmuxAvailable={bundledTmuxAvailable}
+              onPickTmuxSource={onPickTmuxSource}
+            />
+          )}
 
-        {view.kind === "editor" && (
-          <Editor
-            template={view.template}
-            isEdit={view.harnessId !== null}
-            homeDir={homeDir}
-            dataDir={dataDir}
-            existingIds={new Set(payload.harnesses.map((h) => h.id))}
-            busy={busy}
-            error={formError}
-            onCancel={() => setView({ kind: "list" })}
-            onSubmit={async (input) => {
-              setBusy(true);
-              setFormError(null);
-              try {
-                if (view.harnessId) {
-                  await api.updateHarness(view.harnessId, {
-                    label: input.label,
-                    home: input.home,
-                    bin: input.bin,
-                    env: input.env,
-                  });
-                } else {
-                  await api.createHarness(input);
-                }
-                await refresh();
-                onChange?.();
-                setView({ kind: "list" });
-              } catch (e) {
-                setFormError(e instanceof Error ? e.message : String(e));
-              } finally {
-                setBusy(false);
+          {view.kind === "section" && view.section === "harnesses" && (
+            <HarnessesSection
+              payload={payload}
+              statusByHarness={statusByHarness}
+              homeDir={homeDir}
+              canAdd={!!dataDir}
+              onAdd={() => setView(openTemplates())}
+              onEdit={(h) =>
+                setView(
+                  openEditor(h.id, {
+                    id: "__edit",
+                    label: h.label,
+                    description: "",
+                    kind: h.kind,
+                    suggestedHarnessId: h.id,
+                    home: h.home,
+                    bin: h.bin,
+                    env: h.env,
+                  }),
+                )
               }
-            }}
-          />
-        )}
+              onDelete={onDeleteHarness}
+              onToggleEnabled={onToggleEnabled}
+              onOpenTerminal={onOpenTerminal}
+              pendingToggle={pendingToggle}
+            />
+          )}
+
+          {view.kind === "section" && view.section === "git" && <GitHubTokensSection />}
+
+          {view.kind === "templates" && (
+            <TemplatePicker
+              onPick={(t) => setView(openEditor(null, resolveTemplate(t, dataDir)))}
+            />
+          )}
+
+          {view.kind === "editor" && (
+            <Editor
+              template={view.template}
+              isEdit={view.harnessId !== null}
+              homeDir={homeDir}
+              dataDir={dataDir}
+              existingIds={new Set(payload.harnesses.map((h) => h.id))}
+              busy={busy}
+              error={formError}
+              onCancel={() => setView(backFromSubview())}
+              onSubmit={async (input) => {
+                setBusy(true);
+                setFormError(null);
+                try {
+                  if (view.harnessId) {
+                    await api.updateHarness(view.harnessId, {
+                      label: input.label,
+                      home: input.home,
+                      bin: input.bin,
+                      env: input.env,
+                    });
+                  } else {
+                    await api.createHarness(input);
+                  }
+                  await refresh();
+                  onChange?.();
+                  setView(backFromSubview());
+                } catch (e) {
+                  setFormError(e instanceof Error ? e.message : String(e));
+                } finally {
+                  setBusy(false);
+                }
+              }}
+            />
+          )}
+        </div>
       </div>
     </Dialog>
   );
 }
 
-function ListView({
+function GeneralSection({
   payload,
-  statusByHarness,
   defaultHarness,
-  homeDir,
   onPickDefault,
   tmuxSource,
   bundledTmuxAvailable,
   onPickTmuxSource,
-  canAdd,
-  onAdd,
-  onEdit,
-  onDelete,
-  onToggleEnabled,
-  onOpenTerminal,
-  pendingToggle,
 }: {
   payload: HarnessesPayload;
-  statusByHarness: Map<string, HarnessesPayload["statuses"][number]>;
   defaultHarness: string;
-  homeDir: string;
   onPickDefault: (id: string) => void;
   tmuxSource: "system" | "bundled";
   bundledTmuxAvailable: boolean;
   onPickTmuxSource: (source: "system" | "bundled") => void;
-  /** False while `dataDir` is still loading from `GET /defaults`. Adding a
-   *  harness with an unresolved data dir would persist a broken HOME path
-   *  (`/harnesses/claude-2` instead of `<dataDir>/harnesses/claude-2`). */
-  canAdd: boolean;
-  onAdd: () => void;
-  onEdit: (h: Harness) => void;
-  onDelete: (h: Harness) => void;
-  onToggleEnabled: (h: Harness) => void;
-  /** Open a new Terminal.app window with this harness's env loaded so the
-   *  user can authenticate or inspect it (e.g. `claude /login`). */
-  onOpenTerminal: (h: Harness) => void;
-  /** Optimistic toggle state — keyed by harness id, value is what the user
-   *  clicked toward. Lets the Switch animate before the confirm/round-trip
-   *  resolves. Missing keys mean "use the server's `h.enabled`". */
-  pendingToggle: Record<string, boolean>;
 }) {
   // Disabled harnesses are excluded from the default-harness picker so a
   // soft-deleted harness can't silently become the default for new tasks.
@@ -539,9 +544,43 @@ function ListView({
           binary if you don't want to install tmux system-wide.
         </p>
       </section>
+    </div>
+  );
+}
 
-      <GitHubTokensSection />
-
+function HarnessesSection({
+  payload,
+  statusByHarness,
+  homeDir,
+  canAdd,
+  onAdd,
+  onEdit,
+  onDelete,
+  onToggleEnabled,
+  onOpenTerminal,
+  pendingToggle,
+}: {
+  payload: HarnessesPayload;
+  statusByHarness: Map<string, HarnessesPayload["statuses"][number]>;
+  homeDir: string;
+  /** False while `dataDir` is still loading from `GET /defaults`. Adding a
+   *  harness with an unresolved data dir would persist a broken HOME path
+   *  (`/harnesses/claude-2` instead of `<dataDir>/harnesses/claude-2`). */
+  canAdd: boolean;
+  onAdd: () => void;
+  onEdit: (h: Harness) => void;
+  onDelete: (h: Harness) => void;
+  onToggleEnabled: (h: Harness) => void;
+  /** Open a new Terminal.app window with this harness's env loaded so the
+   *  user can authenticate or inspect it (e.g. `claude /login`). */
+  onOpenTerminal: (h: Harness) => void;
+  /** Optimistic toggle state — keyed by harness id, value is what the user
+   *  clicked toward. Lets the Switch animate before the confirm/round-trip
+   *  resolves. Missing keys mean "use the server's `h.enabled`". */
+  pendingToggle: Record<string, boolean>;
+}) {
+  return (
+    <div className="space-y-4 pt-3 text-sm">
       <section className="space-y-2">
         <div className="flex items-center justify-between">
           <label className="text-xs text-muted-foreground">Harnesses</label>

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronLeft, Plus, Terminal, Trash2, X } from "lucide-react";
 import { toast } from "sonner";
 import { ApiError, api, type HarnessesPayload, type HarnessInput } from "@/lib/api";
@@ -13,12 +13,6 @@ import { AgentIcon } from "@/components/kanban/AgentIcon";
 import { GitHubTokensSection } from "@/components/settings/GitHubTokensSection";
 import { abbreviateHome, cn } from "@/lib/utils";
 import {
-  HARNESS_TEMPLATES,
-  type AgentKind,
-  type Harness,
-  type HarnessTemplate,
-} from "../../../shared/types.ts";
-import {
   SETTINGS_SECTIONS,
   activeSection,
   backFromSubview,
@@ -29,6 +23,12 @@ import {
   resolveEscape,
   type SettingsView,
 } from "@/lib/settings-dialog-view";
+import {
+  HARNESS_TEMPLATES,
+  type AgentKind,
+  type Harness,
+  type HarnessTemplate,
+} from "../../../shared/types.ts";
 
 interface Props {
   open: boolean;
@@ -174,6 +174,11 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
   const [tmuxSource, setTmuxSource] = useState<"system" | "bundled">("system");
   const [bundledTmuxAvailable, setBundledTmuxAvailable] = useState(false);
   const [view, setView] = useState<SettingsView>(initialView());
+  // Mirrors `view` for use inside async callbacks (e.g. the Editor's
+  // onSubmit) so they can tell, after an await, whether the user navigated
+  // away in the meantime — see Fix 3 in the settings-sidebar review.
+  const viewRef = useRef(view);
+  viewRef.current = view;
   const [busy, setBusy] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   // Optimistic toggle map: harness id → the value the user *clicked toward*.
@@ -390,62 +395,94 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
       </div>
 
       <div className="flex min-h-0 flex-1">
-        <nav className="w-44 shrink-0 overflow-y-auto border-r border-border/60 p-2">
-          {SETTINGS_SECTIONS.map((s) => (
-            <Button
-              key={s.id}
-              size="sm"
-              variant={currentSection === s.id ? "secondary" : "ghost"}
-              className="w-full justify-start"
-              aria-current={currentSection === s.id ? "true" : undefined}
-              onClick={() => setView(openSection(s.id))}
-            >
-              {s.label}
-            </Button>
-          ))}
+        <nav
+          aria-label="Settings sections"
+          className="flex w-44 shrink-0 flex-col gap-1 overflow-y-auto border-r border-border/60 p-2"
+        >
+          {SETTINGS_SECTIONS.map((s) => {
+            const active = currentSection === s.id;
+            return (
+              <Button
+                key={s.id}
+                size="sm"
+                variant={active ? "secondary" : "ghost"}
+                className="w-full justify-start"
+                aria-current={active ? "page" : undefined}
+                onClick={() => setView(openSection(s.id))}
+              >
+                {s.label}
+              </Button>
+            );
+          })}
         </nav>
 
         <div className="min-h-0 flex-1 overflow-y-auto p-4 pt-0">
-          {view.kind === "section" && view.section === "general" && (
-            <GeneralSection
-              defaultHarness={defaultHarness}
-              payload={payload}
-              onPickDefault={onPickDefault}
-              tmuxSource={tmuxSource}
-              bundledTmuxAvailable={bundledTmuxAvailable}
-              onPickTmuxSource={onPickTmuxSource}
-            />
-          )}
-
-          {view.kind === "section" && view.section === "harnesses" && (
-            <HarnessesSection
-              payload={payload}
-              statusByHarness={statusByHarness}
-              homeDir={homeDir}
-              canAdd={!!dataDir}
-              onAdd={() => setView(openTemplates())}
-              onEdit={(h) =>
-                setView(
-                  openEditor(h.id, {
-                    id: "__edit",
-                    label: h.label,
-                    description: "",
-                    kind: h.kind,
-                    suggestedHarnessId: h.id,
-                    home: h.home,
-                    bin: h.bin,
-                    env: h.env,
-                  }),
-                )
+          {view.kind === "section" &&
+            (() => {
+              switch (view.section) {
+                case "general":
+                  return (
+                    <GeneralSection
+                      defaultHarness={defaultHarness}
+                      payload={payload}
+                      onPickDefault={onPickDefault}
+                      tmuxSource={tmuxSource}
+                      bundledTmuxAvailable={bundledTmuxAvailable}
+                      onPickTmuxSource={onPickTmuxSource}
+                    />
+                  );
+                case "harnesses":
+                  return (
+                    <HarnessesSection
+                      payload={payload}
+                      statusByHarness={statusByHarness}
+                      homeDir={homeDir}
+                      canAdd={!!dataDir}
+                      onAdd={() => setView(openTemplates())}
+                      onEdit={(h) =>
+                        setView(
+                          openEditor(h.id, {
+                            id: "__edit",
+                            label: h.label,
+                            description: "",
+                            kind: h.kind,
+                            suggestedHarnessId: h.id,
+                            home: h.home,
+                            bin: h.bin,
+                            env: h.env,
+                          }),
+                        )
+                      }
+                      onDelete={onDeleteHarness}
+                      onToggleEnabled={onToggleEnabled}
+                      onOpenTerminal={onOpenTerminal}
+                      pendingToggle={pendingToggle}
+                    />
+                  );
+                case "git":
+                  // Rendered by the always-mounted div below instead.
+                  return null;
+                default: {
+                  const _exhaustive: never = view.section;
+                  void _exhaustive;
+                  return null;
+                }
               }
-              onDelete={onDeleteHarness}
-              onToggleEnabled={onToggleEnabled}
-              onOpenTerminal={onOpenTerminal}
-              pendingToggle={pendingToggle}
-            />
-          )}
+            })()}
 
-          {view.kind === "section" && view.section === "git" && <GitHubTokensSection />}
+          {/* Kept mounted regardless of the active section (unlike the
+              switch above) so an unsaved host/label/token draft in
+              GitHubTokensSection survives switching sections — matches the
+              pre-sidebar flat-layout lifetime, where this pane never
+              unmounted while the dialog was open. */}
+          <div
+            className={cn(
+              "space-y-4 pt-3 text-sm",
+              !(view.kind === "section" && view.section === "git") && "hidden",
+            )}
+          >
+            <GitHubTokensSection />
+          </div>
 
           {view.kind === "templates" && (
             <TemplatePicker
@@ -479,9 +516,23 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
                   }
                   await refresh();
                   onChange?.();
-                  setView(backFromSubview());
+                  // The user may have navigated away (rail click, Escape-pop)
+                  // while this round-trip was in flight — only pop the view
+                  // if the Editor is still the one showing.
+                  if (viewRef.current.kind === "editor") setView(backFromSubview());
                 } catch (e) {
-                  setFormError(e instanceof Error ? e.message : String(e));
+                  const message = e instanceof Error ? e.message : String(e);
+                  if (viewRef.current.kind === "editor") {
+                    setFormError(message);
+                  } else {
+                    // Editor is unmounted — setFormError would target nothing
+                    // and the failure would be silent. Surface it as a toast
+                    // instead, mirroring the delete-failure toast above.
+                    toast.error("Couldn't save harness", {
+                      description: message,
+                      duration: Infinity,
+                    });
+                  }
                 } finally {
                   setBusy(false);
                 }

--- a/src/mainview/lib/settings-dialog-view.test.ts
+++ b/src/mainview/lib/settings-dialog-view.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import {
+  activeSection,
+  backFromSubview,
+  initialView,
+  openEditor,
+  openSection,
+  openTemplates,
+  resolveEscape,
+  SETTINGS_SECTIONS,
+  type SettingsSectionId,
+  type SettingsView,
+} from "./settings-dialog-view.ts";
+import type { HarnessTemplate } from "../../shared/types.ts";
+
+function template(overrides: Partial<HarnessTemplate> = {}): HarnessTemplate {
+  return {
+    id: "claude-code-additional",
+    label: "Additional Claude Code",
+    description: "Another claude-code harness with its own CLAUDE_CONFIG_DIR.",
+    kind: "claude-code",
+    suggestedHarnessId: "claude-2",
+    home: "{dataDir}/harnesses/claude-2",
+    bin: null,
+    env: {},
+    ...overrides,
+  };
+}
+
+const SECTION_IDS: SettingsSectionId[] = ["general", "harnesses", "git"];
+
+test("SETTINGS_SECTIONS lists the three sidebar sections in order", () => {
+  expect(SETTINGS_SECTIONS).toEqual([
+    { id: "general", label: "General" },
+    { id: "harnesses", label: "Harnesses" },
+    { id: "git", label: "Git Integration" },
+  ]);
+});
+
+test("initialView opens on the General section", () => {
+  expect(initialView()).toEqual({ kind: "section", section: "general" });
+});
+
+describe("openSection", () => {
+  for (const id of SECTION_IDS) {
+    test(`opens the ${id} section`, () => {
+      expect(openSection(id)).toEqual({ kind: "section", section: id });
+    });
+  }
+});
+
+describe("openTemplates", () => {
+  test("opens the templates picker view", () => {
+    expect(openTemplates()).toEqual({ kind: "templates" });
+  });
+});
+
+describe("openEditor", () => {
+  test("opens the editor for a new harness (null id) with the template payload", () => {
+    const tpl = template();
+    expect(openEditor(null, tpl)).toEqual({ kind: "editor", harnessId: null, template: tpl });
+  });
+
+  test("opens the editor for an existing harness id with the template payload", () => {
+    const tpl = template({ id: "codex-additional", kind: "codex", suggestedHarnessId: "codex-2" });
+    expect(openEditor("codex-2", tpl)).toEqual({
+      kind: "editor",
+      harnessId: "codex-2",
+      template: tpl,
+    });
+  });
+});
+
+test("backFromSubview returns the Harnesses section", () => {
+  expect(backFromSubview()).toEqual({ kind: "section", section: "harnesses" });
+});
+
+describe("activeSection", () => {
+  for (const id of SECTION_IDS) {
+    test(`a ${id} section view highlights itself`, () => {
+      expect(activeSection(openSection(id))).toBe(id);
+    });
+  }
+
+  test("the templates view highlights Harnesses", () => {
+    expect(activeSection(openTemplates())).toBe("harnesses");
+  });
+
+  test("the editor view highlights Harnesses", () => {
+    expect(activeSection(openEditor(null, template()))).toBe("harnesses");
+  });
+});
+
+describe("resolveEscape", () => {
+  for (const id of SECTION_IDS) {
+    test(`closes the modal from the ${id} section view`, () => {
+      expect(resolveEscape(openSection(id))).toBe("close");
+    });
+  }
+
+  test("pops to Harnesses from the templates view", () => {
+    expect(resolveEscape(openTemplates())).toBe("pop");
+  });
+
+  test("pops to Harnesses from the editor view", () => {
+    expect(resolveEscape(openEditor("claude-2", template()))).toBe("pop");
+  });
+});
+
+describe("round-trip conventions", () => {
+  test("openSection(activeSection(v)) is idempotent for a section view", () => {
+    const view = openSection("git");
+    expect(openSection(activeSection(view))).toEqual(view);
+  });
+
+  test("openSection(activeSection(v)) lands back on Harnesses from templates", () => {
+    const view: SettingsView = openTemplates();
+    expect(openSection(activeSection(view))).toEqual(backFromSubview());
+  });
+
+  test("openSection(activeSection(v)) lands back on Harnesses from the editor", () => {
+    const view: SettingsView = openEditor(null, template());
+    expect(openSection(activeSection(view))).toEqual(backFromSubview());
+  });
+});

--- a/src/mainview/lib/settings-dialog-view.ts
+++ b/src/mainview/lib/settings-dialog-view.ts
@@ -57,7 +57,17 @@ export function backFromSubview(): SettingsView {
  * entry of their own, so they highlight Harnesses.
  */
 export function activeSection(view: SettingsView): SettingsSectionId {
-  return view.kind === "section" ? view.section : "harnesses";
+  switch (view.kind) {
+    case "section":
+      return view.section;
+    case "templates":
+    case "editor":
+      return "harnesses";
+    default: {
+      const _exhaustive: never = view;
+      return _exhaustive;
+    }
+  }
 }
 
 /**
@@ -66,5 +76,15 @@ export function activeSection(view: SettingsView): SettingsSectionId {
  * a section view closes the modal — templates/editor pop first.
  */
 export function resolveEscape(view: SettingsView): "pop" | "close" {
-  return view.kind === "section" ? "close" : "pop";
+  switch (view.kind) {
+    case "section":
+      return "close";
+    case "templates":
+    case "editor":
+      return "pop";
+    default: {
+      const _exhaustive: never = view;
+      return _exhaustive;
+    }
+  }
 }

--- a/src/mainview/lib/settings-dialog-view.ts
+++ b/src/mainview/lib/settings-dialog-view.ts
@@ -1,0 +1,70 @@
+import type { HarnessTemplate } from "../../shared/types.ts";
+
+/** The three left-sidebar sections in the Settings dialog. */
+export const SETTINGS_SECTIONS = [
+  { id: "general", label: "General" },
+  { id: "harnesses", label: "Harnesses" },
+  { id: "git", label: "Git Integration" },
+] as const;
+
+export type SettingsSectionId = (typeof SETTINGS_SECTIONS)[number]["id"];
+
+/**
+ * Discriminated-union view state for the Settings dialog's content pane,
+ * mirroring `GitHubDialogView` in `github-dialog-view.ts` — "section" is one
+ * of the three sidebar sections (General/Harnesses/Git Integration),
+ * "templates" is the Add-harness template picker, and "editor" is the
+ * harness create/edit form. The sidebar itself stays visible across all
+ * three kinds (see `activeSection`), unlike the GitHub modal's full-panel
+ * subpage replacement.
+ */
+export type SettingsView =
+  | { kind: "section"; section: SettingsSectionId }
+  | { kind: "templates" }
+  | { kind: "editor"; harnessId: string | null; template: HarnessTemplate };
+
+/** The view shown every time the dialog opens — always General, no persistence. */
+export function initialView(): SettingsView {
+  return { kind: "section", section: "general" };
+}
+
+/** Navigate to a sidebar section. */
+export function openSection(section: SettingsSectionId): SettingsView {
+  return { kind: "section", section };
+}
+
+/** Navigate to the Add-harness template picker. */
+export function openTemplates(): SettingsView {
+  return { kind: "templates" };
+}
+
+/** Navigate to the harness editor — `harnessId` is null when creating. */
+export function openEditor(harnessId: string | null, template: HarnessTemplate): SettingsView {
+  return { kind: "editor", harnessId, template };
+}
+
+/**
+ * Navigate back from a subview (templates or editor). Both flows are reached
+ * from the Harnesses section, so back always lands there.
+ */
+export function backFromSubview(): SettingsView {
+  return { kind: "section", section: "harnesses" };
+}
+
+/**
+ * Which sidebar item should render as active for the current view. The
+ * templates/editor subviews are reached from Harnesses and have no sidebar
+ * entry of their own, so they highlight Harnesses.
+ */
+export function activeSection(view: SettingsView): SettingsSectionId {
+  return view.kind === "section" ? view.section : "harnesses";
+}
+
+/**
+ * Resolve what Escape (or a backdrop click) should do given the current
+ * view: pop the subpage back to Harnesses, or close the modal outright. Only
+ * a section view closes the modal — templates/editor pop first.
+ */
+export function resolveEscape(view: SettingsView): "pop" | "close" {
+  return view.kind === "section" ? "close" : "pop";
+}


### PR DESCRIPTION
## What

Replaces the Settings dialog's single flat scrolling page with a left sidebar that breaks the config into three sections, shown one at a time:

- **General** — default-harness picker + tmux source picker
- **Harnesses** — harness list (enable/disable, terminal, edit, delete) plus the existing Add-harness flow (template picker → editor)
- **Git Integration** — the existing `GitHubTokensSection`

The dialog widens from `max-w-2xl` to `max-w-4xl` to fit the `w-44` nav rail; it always opens on General.

## How

- New pure lib `src/mainview/lib/settings-dialog-view.ts` (mirroring `github-dialog-view.ts`): `SETTINGS_SECTIONS`, the `SettingsView` discriminated union (`section | templates | editor`), and pure navigation helpers including `resolveEscape` — covered by 22 unit tests in `settings-dialog-view.test.ts`.
- `SettingsDialog.tsx`: the sidebar is a flex-row nested **inside** the body slot from #150, so the overflow contract is untouched (fixed header, only the content pane scrolls). The old `ListView` is split into `GeneralSection` / `HarnessesSection` with all handler logic moved verbatim — no behavior changes to save/toggle/confirm/toast flows.

## Behavior changes beyond the layout

- **Escape (and backdrop click) from the harness editor/template picker now returns to the Harnesses section instead of closing the whole modal** (same `resolveEscape` semantics as GitHubDialog; the header X still always closes). Previously Escape from the editor dismissed all of Settings.
- The Add/Edit harness flows return to the Harnesses section on cancel/save/back; the sidebar stays visible during them with Harnesses highlighted.

## Review hardening (opus review, all should-fixes applied)

- Git pane keeps `GitHubTokensSection` mounted behind a `hidden` toggle so an unsaved token draft survives an accidental section switch (also restores the pre-refactor mount lifetime and its `text-sm`/`pt-3` styling context).
- Exhaustive `switch` + `never` guards in the pane renderer and the view lib, so adding a fourth section can't silently render a blank pane.
- An in-flight harness save no longer yanks the user back from another section on success, and its error surfaces as a toast (instead of being swallowed by the unmounted editor form).
- a11y: `<nav aria-label="Settings sections">`, `aria-current="page"` on the active rail item.

## Testing

- Full suite: 2258 pass / 1 skip / 0 fail (`bun test`).
- `bun run typecheck`: no new errors (the 7 pre-existing `Task.fast` fixture errors from #152 remain and are untouched here).
- No component/e2e harness exists in the repo, so the visual layout was scoped for a manual pass: `bun run dev:hmr` → Settings → click through the three sections and the add/edit flow.

Plan: `docs/plans/settings-dialog-section-sidebar.md`. Out of scope by decision: no Environment section (the unmerged `feat/env-settings-panel` work stays shelved — the sidebar makes adding it later trivial), no last-section persistence.