### PR TITLE
feature: collapsible tool-call blocks in the task-details stream (default collapsed)

### DIFF
--- a/docs/plans/collapsible-tool-call-blocks.md
+++ b/docs/plans/collapsible-tool-call-blocks.md
@@ -1,0 +1,80 @@
+# Plan — Collapsible tool-call blocks in the task-details message stream
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-08 |
+| Source | /implement — "tool calls are being very noisy in the messages, let's make them collapsible, default to collapsed/closed" + screenshot |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/make-tools-collapisable-in-task-details |
+| Base SHA | ce9a842b093219cdb278fdc540cc1a47c25596a9 |
+
+## 1. Objective & success criteria
+
+Tool-call cards (`tool_use` + folded `tool_result`) in the RunPanel message stream currently render their full args JSON and result body inline, which drowns the conversation. Make each tool-call card collapsible, **collapsed by default**: only the compact header row (icon, tool name, badges, `· summary`) is visible until the user clicks to expand.
+
+Success criteria:
+- A tool-call card renders only its header row by default; clicking the header toggles the args body (+ result section) open/closed.
+- Interactive tool calls (`AskUserQuestion`, `ExitPlanMode`) **stay expanded while unresolved** (their call-to-action banner must remain visible); once resolved they behave like any other collapsed card. (Owner-confirmed.)
+- A card whose result `isError` still defaults to collapsed but shows a visible error flag in the collapsed header. (Owner-confirmed.)
+- Search-jump (Cmd+F) onto a match inside a collapsed card **auto-expands** it so the matched text is visible. (Owner-confirmed.)
+- No behavior change for other event kinds (user / assistant / thinking / status / stderr / interaction cards).
+- No perf regression: the `sections` memo (`RunPanel.tsx:3591`) gains **no new deps**; expand state is component-local and survives 2s polls and event appends.
+
+## 2. Context & constraints (Phase 1 findings)
+
+All relevant code is in `src/mainview/components/kanban/RunPanel.tsx` (file-local components, one call site):
+
+- `renderEvent` (`RunPanel.tsx:3624-3672`) renders `tool_use` as `<ToolUseBlock call result>`; a well-formed `tool_result` renders **nothing** of its own — it's folded into the owning block via the `resultByToolId` map (`:3544`). Orphan results render `<ToolResultBlock>` (`:4201`).
+- `ToolUseBlock` (`:4157-4199`, `memo`'d): header row div (`:4173-4187`) → `ToolInputBody` (always visible today) → optional `ToolResultBody` (has its own `▶ result` fold, default closed, `:4545`) → interactive-pending banner (`:4190-4196`).
+- Collapse idiom in this file is hand-rolled: `useState(false)` + full-width `<button>` with unicode `▶`/`▼` glyphs (`ThinkingBlock` `:4132`, `ToolResultBody` `:4545`). No shared Collapsible primitive exists; icon library is lucide but these toggles use text glyphs.
+- **Perf trap (fleet knowledge, verified):** the `sections` memo must not take per-interaction state as a dep — search's active-match highlight is applied *imperatively* via `classList` on the `[data-evid]` wrapper (`:1296-1323`) precisely to avoid rebuilding the section tree. Auto-expand must use the same imperative channel, not props.
+- React reconciles blocks by array position + stable key (`${e.ts}-${i}`), so `useState` inside `ToolUseBlock` survives polls/appends — local state is safe.
+- Subagent (background-agent) tabs feed the same `<RunEventList>`; the change applies there automatically. `DiffDialog` is unrelated.
+- Mainview test convention: pure-logic `.ts` modules under `src/mainview/lib/` with `bun test` (no React render testing exists; no jsdom/@testing-library in deps).
+
+## 3. Approach & key decisions
+
+1. **Local `useState(false)` in `ToolUseBlock`; effective expansion = `open || (isInteractive && !result)`.** Forced-open while an interactive call is pending (banner stays visible); when the result lands, the forced term drops and the card collapses like the rest. No persistence (matches `ThinkingBlock`/`ToolResultBody` precedent; per-block localStorage keying would be overkill — decision).
+2. **Header row becomes the toggle button.** Convert the header div to a full-width `<button type="button">` prepending the `▶`/`▼` glyph (matching the file's idiom), keeping icon, MCP badge, name, `server` badge, and summary exactly as-is. `border-b` on the header renders only when the card is expanded (no dangling divider on a collapsed card).
+3. **Error flag:** when `result?.isError` and the card is collapsed, append a `<span className="text-destructive">· error</span>` to the header (expanded cards already show the `error result` section label).
+4. **Search auto-expand via a bubbling CustomEvent — the imperative channel.** New pure module `src/mainview/lib/expand-on-jump.ts`: exports `EXPAND_EVENT` name constant and `isExpandTargetFor(target: unknown, root: Element | null): boolean` (target is a Node that contains root). The active-match highlight effect (`RunPanel.tsx:1305-1323`) additionally dispatches `new CustomEvent(EXPAND_EVENT, { bubbles: true })` on the matched `[data-evid]` element. A tiny hook `useExpandOnJump(rootRef, onExpand)` (defined in `RunPanel.tsx`, next to the blocks) registers a document-level listener and calls `onExpand()` when `isExpandTargetFor(evt.target, rootRef.current)`. Wired into:
+   - `ToolUseBlock` → opens the card;
+   - `ToolResultBody` → opens the result fold (search folds result text into the owning tool_use, so the outer card alone isn't enough);
+   - `ThinkingBlock` → fixes the same preexisting gap for thinking matches at near-zero cost.
+   This keeps `sections`-memo deps untouched and adds no props to memo'd components (rests on the verified imperative-highlight design at `:1296`).
+5. **Out of scope:** expand-all/collapse-all control; persistence of expand state; any change to `ExpandableBlock`, orphan `ToolResultBlock` chrome, or other event kinds.
+
+## 4. Work breakdown — implementation tasks
+
+| ID | Goal | Files owned | Deps | Acceptance |
+| --- | --- | --- | --- | --- |
+| I1 | Collapsible ToolUseBlock + header toggle + error flag + expand-on-jump wiring (incl. ToolResultBody & ThinkingBlock listeners) + new `expand-on-jump.ts` helper | `src/mainview/components/kanban/RunPanel.tsx`, `src/mainview/lib/expand-on-jump.ts` | — | Criteria §1; `bun run typecheck` green |
+
+Single task — the components are file-local and interdependent; splitting would force two agents into one file.
+
+## 5. Work breakdown — test tasks
+
+| ID | Goal | Files owned | Covers | 
+| --- | --- | --- | --- |
+| T1 | Unit tests for `isExpandTargetFor` (node containing root, node === root wrapper, unrelated node, null root, non-Node target) | `src/mainview/lib/expand-on-jump.test.ts` | I1 |
+
+**E2e: not applicable.** The mainview has no render/e2e harness (no jsdom, no @testing-library, no browser test runner) — repo convention is pure-logic extraction + `bun test`, with visual QA via `bun run dev:hmr`. The JSX changes get manual visual verification; standing up a render harness for one toggle is out of proportion (recorded decision).
+
+## 6. Execution waves
+
+- Wave 1: I1 (one implementation agent, sonnet).
+- Review: full diff vs base (opus).
+- Wave 2: T1 (one test agent, sonnet) → run `bun test` + `bun run typecheck` (haiku).
+
+## 7. Blast radius & risks
+
+- `ToolUseBlock` is file-local with a single render path; subagent tabs inherit the change (intended).
+- Header→button conversion: keep inner elements non-interactive (no nested buttons — the header currently has none) to avoid invalid DOM.
+- Collapsed-by-default shrinks stream height; bottom-pin uses a ResizeObserver (prior fix) so auto-scroll is unaffected.
+- Forced-open interactive cards: `isInteractive && !result` is the existing banner condition (`:4190`) — reuse it verbatim so the two can't drift.
+- Document-level listeners: one per mounted block; removed on unmount via the hook's cleanup. Long streams mount hundreds of blocks — listener work is O(blocks) only on a jump (rare, user-initiated), negligible.
+
+## 8. Open questions / assumptions
+
+- Assumption: no persistence of per-block expand state across reloads (session-local only). Not raised by owner; matches all sibling toggles.
+- Assumption: unicode `▶`/`▼` glyphs (file idiom) rather than lucide chevrons.

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -18,7 +18,7 @@ import { buildResolveConflictsPrompt } from "@/lib/resolve-conflicts-prompt";
 import { eventWindowKeepCount } from "@/lib/event-window";
 import type { GitHubPullPrefill } from "./GitHubDialog";
 import { Button, buttonVariants } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { Badge, badgeVariants } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
@@ -376,6 +376,14 @@ function RunPanelBody({
   // (imperatively toggled, not driven by a React prop/memo dep — see the
   // effect below). `null` when nothing is highlighted.
   const highlightedElRef = useRef<HTMLElement | null>(null);
+  // Set by explicit match navigation (Enter / Shift+Enter / the ↑↓ nav
+  // buttons — see `stepSearch`) and consumed by the highlight effect below.
+  // Typing re-resolves the active match on every keystroke too (the resolve
+  // effect above), which would otherwise dispatch `EXPAND_EVENT` on every
+  // character typed and leave a trail of force-expanded cards behind as the
+  // query narrows — gating the dispatch on "the user actually asked to jump"
+  // keeps auto-expand tied to intentional navigation only.
+  const jumpIntentRef = useRef(false);
   // Tracks whether the log was scrolled near the bottom at the last user
   // interaction. Auto-scroll-to-bottom on new events only fires when this is
   // true, so a user who scrolls up to read history isn't yanked back down on
@@ -1310,18 +1318,39 @@ function RunPanelBody({
       prev.classList.remove(...HIGHLIGHT_CLASSES);
       highlightedElRef.current = null;
     }
-    if (activeMatchId === null) return;
+    if (activeMatchId === null) {
+      jumpIntentRef.current = false;
+      return;
+    }
     const el = logRef.current?.querySelector<HTMLElement>(`[data-evid="${activeMatchId}"]`);
-    if (!el) return;
+    if (!el) {
+      jumpIntentRef.current = false;
+      return;
+    }
     el.classList.add(...HIGHLIGHT_CLASSES);
     highlightedElRef.current = el;
-    el.scrollIntoView({ block: "center" });
-    // The scrollIntoView above can land the log outside the "near bottom"
+    // The scrollIntoView below can land the log outside the "near bottom"
     // band (or an SSE flush landing in the same tick could otherwise yank
     // the view back to the bottom before the browser paints the scroll) —
     // clear it immediately so neither auto-scroll path fights the jump.
     nearBottomRef.current = false;
-    el.dispatchEvent(new CustomEvent(EXPAND_EVENT, { bubbles: true }));
+    // Only an explicit jump (Enter / Shift+Enter / the ↑↓ nav buttons — see
+    // `jumpIntentRef`) auto-expands a collapsed tool-call card; a keystroke
+    // re-resolving the active match while typing gets the highlight + scroll
+    // below but not the dispatch, so narrowing a query doesn't leave a trail
+    // of force-expanded cards.
+    const isExplicitJump = jumpIntentRef.current;
+    jumpIntentRef.current = false;
+    if (isExplicitJump) el.dispatchEvent(new CustomEvent(EXPAND_EVENT, { bubbles: true }));
+    el.scrollIntoView({ block: "center" });
+    if (isExplicitJump) {
+      // The dispatch above can expand a collapsed card AFTER this
+      // scrollIntoView already centered it at its collapsed height — the
+      // newly revealed body then pushes the matched text below the fold.
+      // Re-center on the next frame, once the expand's re-render has
+      // committed and the browser has laid out the taller card.
+      requestAnimationFrame(() => el.scrollIntoView({ block: "center" }));
+    }
   }, [activeMatchId]);
 
   const closeSearch = useCallback(() => {
@@ -1331,6 +1360,7 @@ function RunPanelBody({
   }, []);
 
   const stepSearch = useCallback((dir: 1 | -1) => {
+    jumpIntentRef.current = true;
     setActiveMatchId((cur) => {
       const idx = matches.indexOf(cur ?? -1);
       const next = stepMatchIndex(matches.length, idx, dir);
@@ -4170,6 +4200,11 @@ const ThinkingBlock = memo(function ThinkingBlock({ text }: { text: string }) {
   );
 });
 
+// `<Badge>` renders a `<div>`, invalid inside the `<button>` header below
+// (button only permits phrasing content) — these two spots use a plain
+// `<span>` styled via `badgeVariants` instead.
+const SECONDARY_BADGE_CLASS = badgeVariants({ variant: "secondary" });
+
 /** Tool-call card with input rendered per-tool, plus the matched result
  *  collapsed underneath (expand to read full output). Special-cases:
  *  AskUserQuestion + ExitPlanMode get prominent styling because the user
@@ -4186,7 +4221,17 @@ const ToolUseBlock = memo(function ToolUseBlock({ call, result }: { call: Parsed
     setResultOpenSignal((s) => s + 1);
   }, []);
   useExpandOnJump(rootRef, expand);
-  const expanded = open || (isInteractive && !result);
+  // `resultOpenSignal` only means anything for the ONE `ToolResultBody` mount
+  // that follows the jump that set it — since it's conditionally mounted
+  // (only while `expanded`), a stale signal ≥1 would force-open the result
+  // fold on every future expand of this same card (collapse → re-expand)
+  // even without a fresh jump. Clearing it back to 0 on collapse makes it
+  // one-shot per jump.
+  useEffect(() => {
+    if (!open) setResultOpenSignal(0);
+  }, [open]);
+  const forcedOpen = isInteractive && !result;
+  const expanded = open || forcedOpen;
   // MCP convention: `mcp__<server>__<tool>`. The server name is always the
   // first segment after the `mcp__` prefix; everything after the next `__`
   // is the literal tool name (which itself may contain `__`). We rebuild
@@ -4203,25 +4248,31 @@ const ToolUseBlock = memo(function ToolUseBlock({ call, result }: { call: Parsed
     >
       <button
         type="button"
-        onClick={() => setOpen((o) => !o)}
+        disabled={forcedOpen}
+        onClick={() => {
+          if (window.getSelection()?.toString()) return;
+          setOpen((o) => !o);
+        }}
         aria-expanded={expanded}
         className={cn(
-          "flex w-full items-center gap-2 px-2 py-1.5 text-left text-[11px]",
+          "flex w-full select-text items-center gap-2 px-2 py-1.5 text-left text-[11px] hover:bg-muted/30",
           expanded && "border-b border-border/40",
         )}
       >
-        <span className="shrink-0 text-muted-foreground">{expanded ? "▼" : "▶"}</span>
+        {!forcedOpen && (
+          <span className="shrink-0 text-muted-foreground" aria-hidden>{expanded ? "▼" : "▶"}</span>
+        )}
         <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
         {mcpParts && mcpParts.length >= 2 ? (
           <span className="flex items-center gap-1 font-mono">
-            <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">mcp · {mcpParts[0]}</Badge>
+            <span className={cn(SECONDARY_BADGE_CLASS, "px-1.5 py-0 text-[10px]")}>mcp · {mcpParts[0]}</span>
             <span className="font-medium">{mcpParts.slice(1).join("__")}</span>
           </span>
         ) : (
           <span className="font-mono font-medium">{call.name}</span>
         )}
         {call.serverSide && (
-          <Badge variant="secondary" className="px-1 py-0 text-[9px] uppercase">server</Badge>
+          <span className={cn(SECONDARY_BADGE_CLASS, "px-1 py-0 text-[9px] uppercase")}>server</span>
         )}
         {summary && <span className="truncate text-muted-foreground">· {summary}</span>}
         {!expanded && result?.isError && <span className="shrink-0 text-destructive">· error</span>}

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -11,6 +11,7 @@ import { api, commitPushPrompt, type AgentModelMap, type AvailableCommand, type 
 import { shouldShowSubagentTabs, resolveActiveStream, splitTabsForOverflow, sortSubagentTabs } from "@/lib/subagent-tabs";
 import { shouldOfferCommitPush, shouldOfferOpenPr, type TaskGitStatus } from "@/lib/commit-push";
 import { findMatchingEventIds, resolveActiveMatchIndex, stepMatchIndex } from "@/lib/event-search";
+import { EXPAND_EVENT, isExpandTargetFor } from "@/lib/expand-on-jump";
 import { latestPrProposal } from "@/lib/pr-proposal";
 import { parsePrUrl, parsePullNumber, canOfferResolveConflicts } from "@/lib/pr-url";
 import { buildResolveConflictsPrompt } from "@/lib/resolve-conflicts-prompt";
@@ -1320,6 +1321,7 @@ function RunPanelBody({
     // the view back to the bottom before the browser paints the scroll) —
     // clear it immediately so neither auto-scroll path fights the jump.
     nearBottomRef.current = false;
+    el.dispatchEvent(new CustomEvent(EXPAND_EVENT, { bubbles: true }));
   }, [activeMatchId]);
 
   const closeSearch = useCallback(() => {
@@ -4129,11 +4131,30 @@ const StatusDivider = memo(function StatusDivider({ text }: { text: string }) {
   );
 });
 
+/** Listens for the search-jump `EXPAND_EVENT` bubbling up from the matched
+ *  `[data-evid]` element (see the highlight effect above) and calls
+ *  `onExpand` when `root` is (or contains) the element that dispatched it —
+ *  the imperative counterpart to that effect, so a jump onto a match inside
+ *  a collapsed tool-call card / result fold / thinking block reveals it
+ *  without threading new props through the `sections` memo. */
+function useExpandOnJump(rootRef: React.RefObject<HTMLDivElement | null>, onExpand: () => void) {
+  useEffect(() => {
+    const handler = (evt: Event) => {
+      if (isExpandTargetFor(evt.target, rootRef.current)) onExpand();
+    };
+    document.addEventListener(EXPAND_EVENT, handler);
+    return () => document.removeEventListener(EXPAND_EVENT, handler);
+  }, [rootRef, onExpand]);
+}
+
 const ThinkingBlock = memo(function ThinkingBlock({ text }: { text: string }) {
   const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const expand = useCallback(() => setOpen(true), []);
+  useExpandOnJump(rootRef, expand);
   const preview = text.length > 120 ? text.slice(0, 120) + "…" : text;
   return (
-    <div className="rounded-md border border-border/40 bg-muted/30 px-2 py-1.5">
+    <div ref={rootRef} className="rounded-md border border-border/40 bg-muted/30 px-2 py-1.5">
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
@@ -4157,6 +4178,15 @@ const ThinkingBlock = memo(function ThinkingBlock({ text }: { text: string }) {
 const ToolUseBlock = memo(function ToolUseBlock({ call, result }: { call: ParsedToolUse; result?: ParsedToolResult }) {
   const summary = formatToolInputSummary(call.name, call.input);
   const isInteractive = call.name === "AskUserQuestion" || call.name === "ExitPlanMode";
+  const [open, setOpen] = useState(false);
+  const [resultOpenSignal, setResultOpenSignal] = useState(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const expand = useCallback(() => {
+    setOpen(true);
+    setResultOpenSignal((s) => s + 1);
+  }, []);
+  useExpandOnJump(rootRef, expand);
+  const expanded = open || (isInteractive && !result);
   // MCP convention: `mcp__<server>__<tool>`. The server name is always the
   // first segment after the `mcp__` prefix; everything after the next `__`
   // is the literal tool name (which itself may contain `__`). We rebuild
@@ -4165,12 +4195,22 @@ const ToolUseBlock = memo(function ToolUseBlock({ call, result }: { call: Parsed
   const Icon = toolIcon(call.name);
   return (
     <div
+      ref={rootRef}
       className={cn(
         "rounded-md border bg-card",
         isInteractive ? "border-primary/60 ring-1 ring-primary/40" : "border-border/60",
       )}
     >
-      <div className="flex items-center gap-2 border-b border-border/40 px-2 py-1.5 text-[11px]">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={expanded}
+        className={cn(
+          "flex w-full items-center gap-2 px-2 py-1.5 text-left text-[11px]",
+          expanded && "border-b border-border/40",
+        )}
+      >
+        <span className="shrink-0 text-muted-foreground">{expanded ? "▼" : "▶"}</span>
         <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
         {mcpParts && mcpParts.length >= 2 ? (
           <span className="flex items-center gap-1 font-mono">
@@ -4184,9 +4224,14 @@ const ToolUseBlock = memo(function ToolUseBlock({ call, result }: { call: Parsed
           <Badge variant="secondary" className="px-1 py-0 text-[9px] uppercase">server</Badge>
         )}
         {summary && <span className="truncate text-muted-foreground">· {summary}</span>}
-      </div>
-      <ToolInputBody name={call.name} input={call.input} />
-      {result && <ToolResultBody result={result} />}
+        {!expanded && result?.isError && <span className="shrink-0 text-destructive">· error</span>}
+      </button>
+      {expanded && (
+        <>
+          <ToolInputBody name={call.name} input={call.input} />
+          {result && <ToolResultBody result={result} openSignal={resultOpenSignal} />}
+        </>
+      )}
       {isInteractive && !result && (
         <div className="border-t border-primary/40 bg-primary/10 px-2 py-1.5 text-[11px] text-foreground">
           {call.name === "AskUserQuestion"
@@ -4542,13 +4587,28 @@ function RawJsonBody({ input }: { input: unknown }) {
   );
 }
 
-function ToolResultBody({ result }: { result: ParsedToolResult }) {
+function ToolResultBody({ result, openSignal = 0 }: { result: ParsedToolResult; openSignal?: number }) {
   const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const expand = useCallback(() => setOpen(true), []);
+  useExpandOnJump(rootRef, expand);
+  // `openSignal` covers the mount-order gap the document-level listener above
+  // can't: when a jump expands a collapsed `ToolUseBlock`, this component
+  // doesn't exist yet to catch the bubbling `EXPAND_EVENT`, so `ToolUseBlock`
+  // also bumps this counter (in its own jump-expand callback) and hands it
+  // down as a prop — safe for the memo'd tree since it originates from
+  // `ToolUseBlock`'s own local state, not from the `sections` memo. A mount
+  // with `openSignal > 0` opens the fold immediately; incrementing (rather
+  // than a boolean) means a repeat jump to the same block re-opens it even
+  // if the user had since collapsed it manually.
+  useEffect(() => {
+    if (openSignal) setOpen(true);
+  }, [openSignal]);
   const text = stringifyResult(result.content);
   const isLong = text.length > 280;
   const preview = isLong ? text.slice(0, 280) + "…" : text;
   return (
-    <div className={cn("border-t border-border/40", result.isError && "bg-destructive/10")}>
+    <div ref={rootRef} className={cn("border-t border-border/40", result.isError && "bg-destructive/10")}>
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}

--- a/src/mainview/components/ui/badge.tsx
+++ b/src/mainview/components/ui/badge.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
-const badgeVariants = cva(
+export const badgeVariants = cva(
   "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors",
   {
     variants: {

--- a/src/mainview/lib/expand-on-jump.test.ts
+++ b/src/mainview/lib/expand-on-jump.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { EXPAND_EVENT, isExpandTargetFor } from "./expand-on-jump.ts";
+
+// `isExpandTargetFor` guards with `target instanceof Node` before trusting
+// `.contains()`. bun:test runs with no DOM, so `Node` is not a global here —
+// confirmed empirically (`typeof Node === "undefined"` under `bun -e`) — and
+// `x instanceof Node` throws ("right-hand side of 'instanceof' is not
+// callable") rather than returning false when `Node` is undefined. To
+// exercise the `contains`-calling branches honestly (not just the early
+// `!root` / non-object bailouts), we install a minimal `FakeNode` as the
+// global `Node` for the duration of this file and restore whatever was there
+// before (nothing, on bun) afterward.
+class FakeNode {
+  private readonly containsImpl: (other: unknown) => boolean;
+  constructor(containsImpl: (other: unknown) => boolean = () => false) {
+    this.containsImpl = containsImpl;
+  }
+  contains(other: unknown): boolean {
+    return this.containsImpl(other);
+  }
+}
+
+const hadOwnNode = Object.prototype.hasOwnProperty.call(globalThis, "Node");
+const originalNode = (globalThis as Record<string, unknown>).Node;
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).Node = FakeNode;
+});
+
+afterEach(() => {
+  if (hadOwnNode) {
+    (globalThis as Record<string, unknown>).Node = originalNode;
+  } else {
+    delete (globalThis as Record<string, unknown>).Node;
+  }
+});
+
+test("isExpandTargetFor: null root is always false, regardless of target", () => {
+  expect(isExpandTargetFor(null, null)).toBe(false);
+  expect(isExpandTargetFor(new FakeNode(() => true), null)).toBe(false);
+  expect(isExpandTargetFor("anything", null)).toBe(false);
+});
+
+test("isExpandTargetFor: undefined target is false", () => {
+  const root = new FakeNode() as unknown as Element;
+  expect(isExpandTargetFor(undefined, root)).toBe(false);
+});
+
+test("isExpandTargetFor: primitive targets are false", () => {
+  const root = new FakeNode() as unknown as Element;
+  for (const primitive of [0, 1, "", "str", true, false, Symbol("x")]) {
+    expect(isExpandTargetFor(primitive, root)).toBe(false);
+  }
+});
+
+test("isExpandTargetFor: a plain object shaped like a Node (duck-typed contains) is still false", () => {
+  // Not `instanceof Node` even though it structurally looks like one — the
+  // guard rejects it before ever calling `.contains()`.
+  const root = new FakeNode() as unknown as Element;
+  const duckTyped = { contains: () => true };
+  expect(isExpandTargetFor(duckTyped, root)).toBe(false);
+});
+
+test("isExpandTargetFor: a real Node whose contains() returns false is false", () => {
+  const root = new FakeNode() as unknown as Element;
+  const target = new FakeNode(() => false);
+  expect(isExpandTargetFor(target, root)).toBe(false);
+});
+
+test("isExpandTargetFor: a real Node whose contains(root) returns true is true", () => {
+  const root = new FakeNode() as unknown as Element;
+  const target = new FakeNode((other) => other === root);
+  expect(isExpandTargetFor(target, root)).toBe(true);
+});
+
+test("isExpandTargetFor: target === root (self-containment) is true", () => {
+  // `node.contains(node)` is true for a real DOM node, and the implementation
+  // relies on that: a block whose own root dispatched the event should still
+  // expand. Model that self-containment explicitly in the fake.
+  let node!: FakeNode;
+  node = new FakeNode((other) => other === node);
+  const root = node as unknown as Element;
+  expect(isExpandTargetFor(node, root)).toBe(true);
+});
+
+test("EXPAND_EVENT is a non-empty, stable event-name string", () => {
+  expect(typeof EXPAND_EVENT).toBe("string");
+  expect(EXPAND_EVENT.length).toBeGreaterThan(0);
+  expect(EXPAND_EVENT).toBe("agetor:expand-on-jump");
+});

--- a/src/mainview/lib/expand-on-jump.ts
+++ b/src/mainview/lib/expand-on-jump.ts
@@ -1,0 +1,19 @@
+// DOM-free helper for the search-jump auto-expand behavior in RunPanel: a
+// tool-call card (or its folded result / thinking block) collapses by
+// default, but jumping search onto a match inside a collapsed block should
+// still reveal it. RunPanel's active-match highlight effect is imperative
+// (classList + scrollIntoView on the matched `[data-evid]` element) rather
+// than a prop threaded through the `sections` memo, to avoid re-deriving the
+// whole section tree on every match navigation — this module rides the same
+// imperative channel via a bubbling CustomEvent instead of new props.
+export const EXPAND_EVENT = "agetor:expand-on-jump";
+
+/** True iff `root` is the highlighted element (or an ancestor of it) that
+ *  dispatched `EXPAND_EVENT` — i.e. `target` (the event's bubbling origin)
+ *  contains `root`. `node.contains(node)` is true, which is intentional: a
+ *  block whose own root IS the matched element should still expand. */
+export function isExpandTargetFor(target: unknown, root: Element | null): boolean {
+  if (!root) return false;
+  if (!(target instanceof Node)) return false;
+  return target.contains(root);
+}


### PR DESCRIPTION
## What

Tool-call cards (`tool_use` + folded `tool_result`) in the task-details message stream now render collapsed by default — just a compact header row (▶ glyph, tool icon, name, MCP/server badges, `· summary`). Clicking the header expands the args body and result section. Subagent tabs inherit the behavior automatically since they render through the same `RunEventList`.

Behavior details:

- **Interactive calls stay visible**: `AskUserQuestion` / `ExitPlanMode` cards are force-expanded while unresolved (toggle disabled, no glyph) so the call-to-action banner can't be hidden; once the result lands they collapse like any other card. A stray click during the pending window can no longer latch them open.
- **Errors aren't silently hidden**: a collapsed card whose result `isError` shows a `· error` flag in the header.
- **Search still works**: explicit search navigation (Enter / arrow buttons in Cmd+F) auto-expands the matched card — including its inner result fold and `ThinkingBlock` — and re-centers the scroll after expansion. Keystroke-driven match resolution only highlights, so typing a query doesn't leave a trail of expanded cards.

## Why

Tool calls dominate the stream visually (full args JSON + result bodies inline), drowning the actual conversation. Collapsing them to header rows makes the stream scannable while keeping every detail one click away.

## How

- Expansion state is component-local `useState` inside the memo'd `ToolUseBlock` — the perf-critical `sections` memo gained **no new deps**, and no new props thread through it. State survives the 2s poll and event appends because React keys blocks by position + stable key.
- The search-jump → expand channel is imperative, matching the existing highlight design: the highlight effect dispatches a bubbling `CustomEvent` on the matched `[data-evid]` wrapper; blocks self-match via a document-level listener (`isExpandTargetFor` in the new `src/mainview/lib/expand-on-jump.ts`, unit-tested).
- The inner result fold opens via a one-shot counter signal from the parent (reset on collapse), since `ToolResultBody` isn't mounted at dispatch time.
- Header div → `<button>` conversion keeps text selectable (`select-text` + `getSelection()` guard, mirroring the existing `GitHubDialog` precedent) and swaps `<Badge>` (a `div`, invalid inside a button) for `badgeVariants`-styled spans — `badgeVariants` is now exported from `ui/badge.tsx`.

## Verification

- `bun run typecheck` clean; `bun test` 2335 pass / 0 fail (3 pre-existing environment skips: tmux not on PATH ×2, missing sample transcripts ×1).
- Reviewed against the full diff: 0 must-fix; all 4 should-fix findings and 4 nits addressed (scroll-before-expand ordering, header selectability, sticky result-open signal, forced-open latch, badge content model, hover affordance, glyph a11y, keystroke-trail dispatch).
- Known tradeoff: collapsing a card unmounts its body, so an inner "show more" resets on the next expand — intentional, it's what keeps hundreds of collapsed cards cheap.

Plan: `docs/plans/collapsible-tool-call-blocks.md`.