### PR TITLE
feature: saved prompts — manage reusable prompts in Settings, insert from the composer picker and slash menu

### DIFF
--- a/docs/plans/saved-prompts.md
+++ b/docs/plans/saved-prompts.md
@@ -1,0 +1,94 @@
+# Plan — Saved Prompts
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-08 |
+| Source | /implement conversation (saved prompts in Settings + picker category) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/saved-prompts (fast-forwarded to origin/main @ ce9a842 before planning) |
+| Base SHA | ce9a842 (clean tree at Phase 4 start; only this plan file untracked) |
+
+## 1. Objective & success criteria
+
+Users can manage reusable prompt snippets ("saved prompts": name + content) in the Settings modal — add, edit, delete (delete gated by a confirmation dialog) — and use them from both composers:
+
+- The MCP · Skills · Plugins picker (`ExtensionPicker`) gains a **Saved Prompts** category in the new-task panel's prompt field and the task-details (RunPanel) message input.
+- The `/` slash autocomplete also matches saved prompt names in both composers.
+- Selecting a prompt **inserts its content at the caret** (preserving existing text), mirroring the existing insertion UX.
+- Prompts are **global** (not per-project/workdir).
+
+Done = typecheck green, `bun test` green including new db + endpoint tests, and the flows above work in the UI.
+
+## 2. Context & constraints (Phase 1 findings, re-verified after fast-forward to ce9a842)
+
+- **Settings modal (post-#157 sidebar split)**: `src/mainview/components/settings/SettingsDialog.tsx` renders a left sidebar from `SETTINGS_SECTIONS` in `src/mainview/lib/settings-dialog-view.ts` (pure, unit-tested lib: `settings-dialog-view.test.ts`). View state is the `SettingsView` union (`section` | `templates` | `editor`); the content pane switches on `view.section` (SettingsDialog.tsx:417–463). A new section = one entry in `SETTINGS_SECTIONS`, one `case` in the switch, one new section component. Peer branch `fix/light-auto-theme` is concurrently adding a Theme row inside `GeneralSection` and app-wide semantic color tokens (`--success`/`--warning`/`--info`/`--danger`) — those tokens do **not exist yet**; do not use them (Tailwind silently emits no CSS for undefined tokens). Stick to existing tokens (`text-muted-foreground`, `text-destructive`, `bg-card`, …) and avoid raw palette classes that assume a dark background.
+- Persistence analog: **harnesses** — table → `db.ts` CRUD module (`export const harnesses`) → `authed()` routes in `server.ts` → `api.ts` wrappers → Settings section. Wire types live in `src/shared/types.ts`; DB insert/patch input shapes stay local to `db.ts`.
+- Migrations: **highest is now `039_run_events_user_history.sql`** → new migration is **`040_saved_prompts.sql`**, registered in `src/bun/migrations/index.ts` (text import; append, never reorder).
+- Confirmation: `useConfirm()` from `@/components/ui/confirm` — promise-based, `variant: "destructive"` paints confirm red and defaults focus to Cancel.
+- Picker: `ExtensionPicker` (`src/mainview/components/kanban/ExtensionPicker.tsx`) — hardcoded `KINDS` const (mcp/skill/plugin) grouping a flat `extensions: AvailableExtension[]` prop; `insert()` splices `ext.insert` at the caret and restores it via `requestAnimationFrame` + `setSelectionRange`. Used at NewTaskForm.tsx:648 and RunPanel.tsx:2663.
+- Slash menu: `SlashAutocomplete` — `/`-typeahead over `AvailableCommand[]`; `insert()` replaces the `/query` slice (`findActiveQuery`). Native keydown listener with `preventDefault()`; RunPanel's Enter-to-send checks `e.defaultPrevented`. Used at NewTaskForm.tsx:668 and RunPanel.tsx:2824.
+- **New precedent — `MessageHistoryPicker`** (#158, `src/mainview/components/kanban/MessageHistoryPicker.tsx`): a composer dropdown that takes `onPick: (text: string) => void`; RunPanel's handler (RunPanel.tsx:2841–2854) sets the input then re-focuses and **pins the caret to the end inside `requestAnimationFrame`** — with an explicit comment that a stale caret can land inside a `/command` token and pop SlashAutocomplete. Saved-prompt insertion must preserve the same caret discipline.
+- Composers: `NewTaskForm.tsx` (`prompt`/`setPrompt`/`promptRef`) and `RunPanel.tsx` (`input`/`setInput`/`sendRef`). Both pass the same `value`/`onChange`/`textareaRef` triple to the picker components — designed to stack over one textarea. RunPanel's composer trigger row already hosts ExtensionPicker + MessageHistoryPicker; disabled conditions differ per composer (`!workdir.trim()` vs `sending || backlogBusy`).
+- Saved prompts are workdir/agent-independent — they do **not** ride `/agent-discovery` (keyed on agent+workdir+branch); they get their own list fetch.
+- Caret-splice helpers exist in `src/mainview/lib/textarea-insert.ts` (`spliceAtSelection`, `readCaret`, `restoreCaret`).
+- Tests: `bun:test` only. DB-module tests set `AGETOR_DATA_DIR` to a mkdtemp dir at module top-level then dynamically import `db.ts` (harnesses.test.ts idiom). Endpoint tests additionally set `AGETOR_API_PORT`, start the real server via `startApiServer()` and authenticate with `API_TOKEN` (backlog-endpoint.test.ts idiom). Flat `test()` calls, no `describe`. No UI/e2e harness exists anywhere in the repo.
+
+## 3. Approach & key decisions
+
+- **Dedicated table** `saved_prompts` (not a JSON column) — prompts are user-global; harnesses-style CRUD is the house pattern. Columns: `id TEXT PRIMARY KEY, name TEXT NOT NULL, content TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL`. Ids are `crypto.randomUUID()`. List order: `created_at ASC`.
+- **REST**: `GET/POST /saved-prompts`, `PATCH/DELETE /saved-prompts/:id`, all `authed()`. Validation: `name` and `content` required non-empty after trim; unknown ids → 404 `{ error }`. No usage probe on delete — nothing references a prompt by id (content is copied into the field on insert).
+- **Settings UI**: a **fourth sidebar section** — add `{ id: "prompts", label: "Saved Prompts" }` to `SETTINGS_SECTIONS`, a `case "prompts"` in the content switch, and a new self-contained `SavedPromptsSection.tsx` (list + inline add/edit form: name input + content textarea; Delete via `useConfirm({ variant: "destructive" })`). Update `settings-dialog-view.test.ts` only if the added section breaks its exhaustiveness expectations (that lib's tests live with the lib, not in Phase 6).
+- **Picker category**: extend `ExtensionPicker` with a `savedPrompts?: SavedPrompt[]` prop and a fourth group ("Saved Prompts", lucide `BookText`-style icon) rendered from that prop rather than widening `AvailableExtension` — the insert semantic differs (full multi-line content vs short token). Selection inserts `prompt.content` at the caret (user decision: **insert at cursor, not replace**), then restores focus/caret per the MessageHistoryPicker discipline. Group hidden when empty; search matches prompt name + content.
+- **Slash menu**: extend `SlashAutocomplete` with the same `savedPrompts?: SavedPrompt[]` prop; `/query` matches prompt names, shown as a distinct group; selection replaces the `/query` slice with `prompt.content + " "` (user decision: **slash access requested**), caret pinned after the inserted content.
+- **Fetch**: one `api.listSavedPrompts()` per composer mount (NewTaskForm opens per use; RunPanel remounts per task via `key={task.id}`), plus a refetch when the picker popover opens so Settings edits are picked up mid-session. No SSE/push.
+- **Not in scope** (recorded non-goals): the backlog draft inline editor keeps no picker; no per-project scoping (user decision: **global**); no import/export; no template variables (plain text v1); no MessageHistoryPicker changes.
+
+## 4. Work breakdown — implementation tasks
+
+**Wave 1**
+- **T1 — Backend vertical slice.** Files owned: `src/bun/migrations/040_saved_prompts.sql` (new), `src/bun/migrations/index.ts`, `src/bun/db.ts`, `src/bun/server.ts`, `src/shared/types.ts`, `src/mainview/lib/api.ts`.
+  Add `SavedPrompt { id, name, content, createdAt, updatedAt }` to shared types; migration + registration; `db.ts` `export const savedPrompts = { list, get, insert, update, delete }` following the harnesses module shape (row mapper, timestamps); routes with validation per §3; `api.ts` wrappers (`listSavedPrompts`, `createSavedPrompt`, `updateSavedPrompt`, `deleteSavedPrompt`).
+  Acceptance: `bun run typecheck` green; routes return full `SavedPrompt` objects.
+
+**Wave 2** (after T1 — both depend on `SavedPrompt` + api wrappers; disjoint files)
+- **T2 — Settings UI.** Files owned: `src/mainview/components/settings/SavedPromptsSection.tsx` (new), `src/mainview/components/settings/SettingsDialog.tsx` (sidebar case + render only — no restructuring), `src/mainview/lib/settings-dialog-view.ts` (add the section entry), `src/mainview/lib/settings-dialog-view.test.ts` (keep green after the entry is added).
+  Section per §3: list, add, edit, delete-with-confirm, empty state; loading/error handling consistent with sibling sections; **use only existing color tokens** (see §2 theme-peer note).
+  Acceptance: typecheck green; existing settings-dialog-view tests green; add/edit/delete flows work against the running API.
+- **T3 — Composer integration.** Files owned: `src/mainview/components/kanban/ExtensionPicker.tsx`, `src/mainview/components/kanban/SlashAutocomplete.tsx`, `src/mainview/components/kanban/NewTaskForm.tsx`, `src/mainview/components/kanban/RunPanel.tsx`, `src/mainview/lib/prompt-picker.ts` (new pure helper: filter/match saved prompts for a query, shared by both picker components — factored out for unit testing).
+  Wire `savedPrompts` through both picker components in both composers; fetch per §3; insertion per §3 with the MessageHistoryPicker caret discipline; preserve the `preventDefault()`/`defaultPrevented` Enter convention.
+  Acceptance: typecheck green; category appears in both composers; picker inserts content at caret; slash matches prompt names.
+
+## 5. Work breakdown — test tasks
+
+E2e: **not applicable** — the repo has no UI/e2e harness (no playwright/cypress/testing-library anywhere); house convention is `bun:test` on the bun side plus unit tests for pure `src/mainview/lib/*` helpers. Recorded as a decision; no new e2e infrastructure.
+
+**Wave T** (after Wave 2 + review fixes)
+- **TT1 — Backend tests.** Files owned: `src/bun/saved-prompts.test.ts` (new), `src/bun/saved-prompts-endpoint.test.ts` (new).
+  DB-module tests per harnesses.test.ts idiom (mkdtemp `AGETOR_DATA_DIR` before dynamic import; CRUD, ordering, not-found, empty name/content rejection). Endpoint tests per backlog-endpoint.test.ts idiom (real server + bearer token; 200s, 400 validation, 404 unknown id, 401 without token).
+- **TT2 — UI helper tests.** Files owned: `src/mainview/lib/prompt-picker.test.ts` (new).
+  Cover the query-matching helper: empty query, name match, case-insensitivity, content match (picker search), non-match — per the contract T3 gave the helper.
+
+Run recipe (Phase 7): `export PATH="$HOME/.bun/bin:$PATH"`, then `bun run typecheck` and `bun test` from the repo root.
+
+## 6. Execution waves
+
+1. Wave 1: T1 (single agent).
+2. Wave 2: T2 ∥ T3 (two agents, file-disjoint).
+3. Phase 5 code review over the full diff.
+4. Wave T: TT1 ∥ TT2 (two agents, file-disjoint).
+5. Phase 7 full-suite run; Phase 8 fixes if needed.
+
+## 7. Blast radius & risks
+
+- `SettingsDialog.tsx` / `settings-dialog-view.ts`: peer branch `fix/light-auto-theme` edits `GeneralSection` + color classes in the same file; our edits (new sidebar entry + case) are structurally disjoint but same-file — merge order coordinated with the peer (they confirmed no restructuring).
+- `RunPanel.tsx` / `NewTaskForm.tsx` are churn hotspots (#158 just rewrote composer areas); our changes are confined to picker props + one fetch effect each.
+- `ExtensionPicker`/`SlashAutocomplete` are shared by both composers — a regression affects both; helper extraction + unit tests mitigate.
+- Migration 040: additive `CREATE TABLE` — no rebuild, no data risk. Dev DB is `~/.agetor-dev`; tests use mkdtemp dirs.
+- No security surface change: routes sit behind the existing bearer-token `authed()` gate; prompt content stays local.
+
+## 8. Open questions / assumptions
+
+- Name uniqueness not enforced (ids are UUIDs). Assumed acceptable for v1.
+- Content is plain text; no variable/placeholder expansion in v1.
+- The backlog inline draft editor intentionally keeps no picker (matches today).
+- Prompt list refetches on picker open + composer mount; no live push. Assumed acceptable staleness window.

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { homedir, tmpdir } from "node:os";
 import { mkdirSync, mkdtempSync } from "node:fs";
 import path from "node:path";
-import type { AgentKind, BacklogMessage, BranchNamingConfig, Harness, HarnessUsage, Project, Task, TaskDraft, TaskReference, TaskType, Run, RunEventStream, Subagent, SubagentStatus } from "../shared/types.ts";
+import type { AgentKind, BacklogMessage, BranchNamingConfig, Harness, HarnessUsage, Project, SavedPrompt, Task, TaskDraft, TaskReference, TaskType, Run, RunEventStream, Subagent, SubagentStatus } from "../shared/types.ts";
 import { migrate } from "./migrate.ts";
 import { migrations } from "./migrations/index.ts";
 import { coreCredsPath } from "./core-creds.ts";
@@ -687,6 +687,75 @@ export const harnesses = {
       runningTaskIds: running.map((r) => r.id),
       totalTaskCount: total?.n ?? 0,
     };
+  },
+};
+
+type SavedPromptRow = {
+  id: string; name: string; content: string;
+  created_at: number; updated_at: number;
+};
+
+const toSavedPrompt = (r: SavedPromptRow): SavedPrompt => ({
+  id: r.id,
+  name: r.name,
+  content: r.content,
+  createdAt: r.created_at,
+  updatedAt: r.updated_at,
+});
+
+export interface SavedPromptInsertInput {
+  name: string;
+  content: string;
+}
+
+export interface SavedPromptPatch {
+  name?: string;
+  content?: string;
+}
+
+export const savedPrompts = {
+  list(): SavedPrompt[] {
+    return db
+      .query<SavedPromptRow, []>(
+        `SELECT * FROM saved_prompts ORDER BY created_at ASC, id ASC`,
+      )
+      .all()
+      .map(toSavedPrompt);
+  },
+  get(id: string): SavedPrompt | null {
+    const row = db
+      .query<SavedPromptRow, [string]>(`SELECT * FROM saved_prompts WHERE id = ?`)
+      .get(id);
+    return row ? toSavedPrompt(row) : null;
+  },
+  insert(input: SavedPromptInsertInput): SavedPrompt {
+    const id = randomUUID();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO saved_prompts (id, name, content, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      [id, input.name, input.content, now, now],
+    );
+    return this.get(id) as SavedPrompt;
+  },
+  update(id: string, patch: SavedPromptPatch): SavedPrompt | null {
+    const current = this.get(id);
+    if (!current) return null;
+    const next = {
+      name: patch.name ?? current.name,
+      content: patch.content ?? current.content,
+    };
+    db.run(
+      `UPDATE saved_prompts SET name = ?, content = ?, updated_at = ? WHERE id = ?`,
+      [next.name, next.content, Date.now(), id],
+    );
+    return this.get(id);
+  },
+  delete(id: string): boolean {
+    const current = this.get(id);
+    if (!current) return false;
+    db.run(`DELETE FROM saved_prompts WHERE id = ?`, [id]);
+    return true;
   },
 };
 

--- a/src/bun/migrations/040_saved_prompts.sql
+++ b/src/bun/migrations/040_saved_prompts.sql
@@ -1,0 +1,10 @@
+-- Saved prompts: user-global reusable snippets ({ name, content }), unrelated
+-- to any single task — distinct from `tasks.draft` (per-task composer state)
+-- and `tasks.backlog` (per-task queued messages).
+CREATE TABLE saved_prompts (
+  id         TEXT PRIMARY KEY,
+  name       TEXT NOT NULL,
+  content    TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);

--- a/src/bun/migrations/index.ts
+++ b/src/bun/migrations/index.ts
@@ -54,6 +54,7 @@ import m038 from "./038_reseed_harness_builtins_2.sql" with { type: "text" };
 // main-merges (max-mode took 035, gemini took 036); renumbered to 039 with
 // both prior ids as aliases (same renumber-with-alias pattern).
 import m039 from "./039_run_events_user_history.sql" with { type: "text" };
+import m040 from "./040_saved_prompts.sql" with { type: "text" };
 
 import type { Migration } from "../migrate.ts";
 
@@ -97,4 +98,5 @@ export const migrations: Migration[] = [
   { id: "037_harness_kind_gemini", sql: m037, aliases: ["033_harness_kind_gemini"] },
   { id: "038_reseed_harness_builtins_2", sql: m038, aliases: ["034_reseed_harness_builtins_2"] },
   { id: "039_run_events_user_history", sql: m039, aliases: ["035_run_events_user_history", "036_run_events_user_history"] },
+  { id: "040_saved_prompts", sql: m040 },
 ];

--- a/src/bun/saved-prompts-endpoint.test.ts
+++ b/src/bun/saved-prompts-endpoint.test.ts
@@ -1,0 +1,247 @@
+import { test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { SavedPrompt } from "../shared/types.ts";
+
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-saved-prompts-endpoint-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+// Unique port, distinct from every other *.test.ts file's AGETOR_API_PORT.
+process.env.AGETOR_API_PORT = "4451";
+
+const BASE = "http://127.0.0.1:4451";
+
+let server: { stop: () => void };
+let token: string;
+let db: typeof import("./db.ts").db;
+
+beforeAll(async () => {
+  ({ db } = await import("./db.ts"));
+  const { startApiServer, API_TOKEN } = await import("./server.ts");
+  server = startApiServer() as unknown as { stop: () => void };
+  token = API_TOKEN;
+});
+
+afterAll(() => {
+  server?.stop?.();
+});
+
+beforeEach(() => {
+  db.run(`DELETE FROM saved_prompts`);
+});
+
+const call = (p: string, init: RequestInit = {}) =>
+  fetch(`${BASE}${p}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+
+const callNoAuth = (p: string, init: RequestInit = {}) =>
+  fetch(`${BASE}${p}`, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+
+test("GET /saved-prompts on an empty table returns []", async () => {
+  const res = await call("/saved-prompts");
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual([]);
+});
+
+test("POST /saved-prompts happy path creates and returns the prompt", async () => {
+  const res = await call("/saved-prompts", {
+    method: "POST",
+    body: JSON.stringify({ name: "Greeting", content: "Say hello" }),
+  });
+  expect(res.status).toBe(200);
+  const created = (await res.json()) as SavedPrompt;
+  expect(created.name).toBe("Greeting");
+  expect(created.content).toBe("Say hello");
+  expect(typeof created.id).toBe("string");
+
+  const list = await (await call("/saved-prompts")).json();
+  expect(list).toEqual([created]);
+});
+
+test("POST /saved-prompts trims name and content", async () => {
+  const res = await call("/saved-prompts", {
+    method: "POST",
+    body: JSON.stringify({ name: "  Padded  ", content: "  padded content  " }),
+  });
+  expect(res.status).toBe(200);
+  const created = (await res.json()) as SavedPrompt;
+  expect(created.name).toBe("Padded");
+  expect(created.content).toBe("padded content");
+});
+
+test.each([
+  ["missing name", { content: "has content" }],
+  ["blank name", { name: "", content: "has content" }],
+  ["whitespace-only name", { name: "   ", content: "has content" }],
+])("POST /saved-prompts with %s → 400", async (_label, body) => {
+  const res = await call("/saved-prompts", { method: "POST", body: JSON.stringify(body) });
+  expect(res.status).toBe(400);
+  const parsed = (await res.json()) as { error: string };
+  expect(parsed.error).toBeTruthy();
+});
+
+test.each([
+  ["missing content", { name: "Has name" }],
+  ["blank content", { name: "Has name", content: "" }],
+  ["whitespace-only content", { name: "Has name", content: "   " }],
+])("POST /saved-prompts with %s → 400", async (_label, body) => {
+  const res = await call("/saved-prompts", { method: "POST", body: JSON.stringify(body) });
+  expect(res.status).toBe(400);
+  const parsed = (await res.json()) as { error: string };
+  expect(parsed.error).toBeTruthy();
+});
+
+test.each([
+  ["null", "null"],
+  ["array", "[]"],
+  ["string", '"x"'],
+])("POST /saved-prompts with a non-object JSON body (%s) → 400, not 500", async (_label, raw) => {
+  const res = await call("/saved-prompts", { method: "POST", body: raw });
+  expect(res.status).toBe(400);
+  const parsed = (await res.json()) as { error: string };
+  expect(parsed.error).toBeTruthy();
+});
+
+test("PATCH /saved-prompts/:id updates name only", async () => {
+  const created = (await (
+    await call("/saved-prompts", {
+      method: "POST",
+      body: JSON.stringify({ name: "Before", content: "unchanged" }),
+    })
+  ).json()) as SavedPrompt;
+
+  const res = await call(`/saved-prompts/${created.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ name: "After" }),
+  });
+  expect(res.status).toBe(200);
+  const updated = (await res.json()) as SavedPrompt;
+  expect(updated.name).toBe("After");
+  expect(updated.content).toBe("unchanged");
+});
+
+test("PATCH /saved-prompts/:id updates content only", async () => {
+  const created = (await (
+    await call("/saved-prompts", {
+      method: "POST",
+      body: JSON.stringify({ name: "Stays", content: "before content" }),
+    })
+  ).json()) as SavedPrompt;
+
+  const res = await call(`/saved-prompts/${created.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ content: "after content" }),
+  });
+  expect(res.status).toBe(200);
+  const updated = (await res.json()) as SavedPrompt;
+  expect(updated.name).toBe("Stays");
+  expect(updated.content).toBe("after content");
+});
+
+test.each([
+  ["blank name", { name: "   " }],
+  ["blank content", { content: "   " }],
+])("PATCH /saved-prompts/:id with %s → 400 and leaves the row untouched", async (_label, patch) => {
+  const created = (await (
+    await call("/saved-prompts", {
+      method: "POST",
+      body: JSON.stringify({ name: "Keep", content: "keep content" }),
+    })
+  ).json()) as SavedPrompt;
+
+  const res = await call(`/saved-prompts/${created.id}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+  expect(res.status).toBe(400);
+  const parsed = (await res.json()) as { error: string };
+  expect(parsed.error).toBeTruthy();
+
+  const stillThere = (await (await call(`/saved-prompts`)).json()) as SavedPrompt[];
+  const row = stillThere.find((p) => p.id === created.id)!;
+  expect(row.name).toBe("Keep");
+  expect(row.content).toBe("keep content");
+});
+
+test("PATCH /saved-prompts/:id on an unknown id → 404", async () => {
+  const res = await call("/saved-prompts/does-not-exist", {
+    method: "PATCH",
+    body: JSON.stringify({ name: "x" }),
+  });
+  expect(res.status).toBe(404);
+  const parsed = (await res.json()) as { error: string };
+  expect(parsed.error).toBeTruthy();
+});
+
+test.each([
+  ["null", "null"],
+  ["array", "[]"],
+  ["string", '"x"'],
+])("PATCH /saved-prompts/:id with a non-object JSON body (%s) → not 500", async (_label, raw) => {
+  // No fields present in the normalized-to-{} body → patch is a no-op, so
+  // this exercises the "unknown id" 404 path rather than a 400; either way
+  // it must not be a 500.
+  const res = await call("/saved-prompts/does-not-exist", { method: "PATCH", body: raw });
+  expect(res.status).not.toBe(500);
+  expect([400, 404]).toContain(res.status);
+});
+
+test("PATCH /saved-prompts/:id with a non-object JSON body on a real id is a no-op 200", async () => {
+  const created = (await (
+    await call("/saved-prompts", {
+      method: "POST",
+      body: JSON.stringify({ name: "Untouched", content: "untouched content" }),
+    })
+  ).json()) as SavedPrompt;
+
+  const res = await call(`/saved-prompts/${created.id}`, { method: "PATCH", body: "null" });
+  expect(res.status).toBe(200);
+  const updated = (await res.json()) as SavedPrompt;
+  expect(updated.name).toBe("Untouched");
+  expect(updated.content).toBe("untouched content");
+});
+
+test("DELETE /saved-prompts/:id happy path returns { ok: true } and the list omits it", async () => {
+  const created = (await (
+    await call("/saved-prompts", {
+      method: "POST",
+      body: JSON.stringify({ name: "Doomed", content: "doomed content" }),
+    })
+  ).json()) as SavedPrompt;
+
+  const res = await call(`/saved-prompts/${created.id}`, { method: "DELETE" });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+
+  const list = (await (await call("/saved-prompts")).json()) as SavedPrompt[];
+  expect(list.find((p) => p.id === created.id)).toBeUndefined();
+});
+
+test("DELETE /saved-prompts/:id on an unknown id → 404", async () => {
+  const res = await call("/saved-prompts/does-not-exist", { method: "DELETE" });
+  expect(res.status).toBe(404);
+  const parsed = (await res.json()) as { error: string };
+  expect(parsed.error).toBeTruthy();
+});
+
+test.each([
+  ["GET /saved-prompts", "/saved-prompts", "GET"],
+  ["POST /saved-prompts", "/saved-prompts", "POST"],
+  ["PATCH /saved-prompts/:id", "/saved-prompts/some-id", "PATCH"],
+  ["DELETE /saved-prompts/:id", "/saved-prompts/some-id", "DELETE"],
+])("%s without a bearer token → 401", async (_label, p, method) => {
+  const res = await callNoAuth(p, { method });
+  expect(res.status).toBe(401);
+});

--- a/src/bun/saved-prompts.test.ts
+++ b/src/bun/saved-prompts.test.ts
@@ -1,0 +1,76 @@
+import { test, expect, beforeEach } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Set AGETOR_DATA_DIR before any import that pulls in db.ts. ES imports
+// hoist before top-level code, so we use dynamic `await import()` below
+// instead of a top-level `import { db } from "./db.ts"`.
+process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-saved-prompts-"));
+const { db, savedPrompts } = await import("./db.ts");
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+beforeEach(() => {
+  db.run(`DELETE FROM saved_prompts`);
+});
+
+test("insert returns the full object with a UUID id and equal created/updated timestamps", () => {
+  const created = savedPrompts.insert({ name: "Greeting", content: "Say hello" });
+  expect(created.id).toMatch(UUID_RE);
+  expect(created.name).toBe("Greeting");
+  expect(created.content).toBe("Say hello");
+  expect(created.createdAt).toBe(created.updatedAt);
+  expect(typeof created.createdAt).toBe("number");
+});
+
+test("list orders by created_at ASC, id ASC and is stable across calls", async () => {
+  const first = savedPrompts.insert({ name: "First", content: "one" });
+  await new Promise((r) => setTimeout(r, 5));
+  const second = savedPrompts.insert({ name: "Second", content: "two" });
+  await new Promise((r) => setTimeout(r, 5));
+  const third = savedPrompts.insert({ name: "Third", content: "three" });
+
+  // Distinct millisecond timestamps (guaranteed by the sleeps above) fully
+  // order the rows, so list() must return them in insertion order.
+  const expectedOrder = [first.id, second.id, third.id];
+  expect(savedPrompts.list().map((p) => p.id)).toEqual(expectedOrder);
+  // Calling again returns the same order — deterministic, not incidental.
+  expect(savedPrompts.list().map((p) => p.id)).toEqual(expectedOrder);
+});
+
+test("get on a missing id returns null", () => {
+  expect(savedPrompts.get("does-not-exist")).toBeNull();
+});
+
+test("update patches only the provided fields and bumps updated_at", async () => {
+  const created = savedPrompts.insert({ name: "Original", content: "orig content" });
+  await new Promise((r) => setTimeout(r, 5));
+
+  const nameOnly = savedPrompts.update(created.id, { name: "Renamed" });
+  expect(nameOnly).not.toBeNull();
+  expect(nameOnly!.name).toBe("Renamed");
+  expect(nameOnly!.content).toBe("orig content"); // untouched
+  expect(nameOnly!.updatedAt).toBeGreaterThanOrEqual(created.updatedAt);
+  expect(nameOnly!.createdAt).toBe(created.createdAt); // created_at never changes
+
+  await new Promise((r) => setTimeout(r, 5));
+
+  const contentOnly = savedPrompts.update(created.id, { content: "new content" });
+  expect(contentOnly).not.toBeNull();
+  expect(contentOnly!.name).toBe("Renamed"); // untouched from previous patch
+  expect(contentOnly!.content).toBe("new content");
+  expect(contentOnly!.updatedAt).toBeGreaterThanOrEqual(nameOnly!.updatedAt);
+});
+
+test("update on a missing id returns null", () => {
+  expect(savedPrompts.update("does-not-exist", { name: "x" })).toBeNull();
+});
+
+test("delete removes the row; delete on a missing id returns false", () => {
+  const created = savedPrompts.insert({ name: "Temp", content: "temp content" });
+  expect(savedPrompts.delete(created.id)).toBe(true);
+  expect(savedPrompts.get(created.id)).toBeNull();
+  expect(savedPrompts.delete(created.id)).toBe(false);
+  expect(savedPrompts.delete("never-existed")).toBe(false);
+});

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -16,6 +16,7 @@ import {
   harnesses,
   HarnessBuiltinError,
   HarnessInUseError,
+  savedPrompts,
   dataDir,
 } from "./db.ts";
 import { archiveTask, createTask, deleteOrphanWorktree, deleteTask, listWorktrees, startTask, cancelRun, reconcileTaskSession, sendInput, subscribe, subscribeGlobal, unarchiveTask, worktreeGitStatus } from "./orchestrator.ts";
@@ -2857,6 +2858,57 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             }
             return json({ error: (e as Error).message }, { status: 400, headers: corsHeaders(req) });
           }
+        }),
+      },
+
+      // User-global reusable prompt snippets — not tied to any task/project.
+      "/saved-prompts": {
+        GET: authed((req) => json(savedPrompts.list(), { headers: corsHeaders(req) })),
+        POST: authed(async (req) => {
+          const body = (await req.json().catch(() => ({}))) as {
+            name?: unknown;
+            content?: unknown;
+          };
+          const name = typeof body.name === "string" ? body.name.trim() : "";
+          const content = typeof body.content === "string" ? body.content.trim() : "";
+          if (!name) return json({ error: "name required" }, { status: 400, headers: corsHeaders(req) });
+          if (!content) return json({ error: "content required" }, { status: 400, headers: corsHeaders(req) });
+          const created = savedPrompts.insert({ name, content });
+          return json(created, { headers: corsHeaders(req) });
+        }),
+      },
+
+      "/saved-prompts/:id": {
+        PATCH: authed(async (req) => {
+          const current = savedPrompts.get(req.params.id);
+          if (!current) {
+            return json({ error: "not found" }, { status: 404, headers: corsHeaders(req) });
+          }
+          const body = (await req.json().catch(() => ({}))) as {
+            name?: unknown;
+            content?: unknown;
+          };
+          const patch: Parameters<typeof savedPrompts.update>[1] = {};
+          if ("name" in body) {
+            const name = typeof body.name === "string" ? body.name.trim() : "";
+            if (!name) return json({ error: "name required" }, { status: 400, headers: corsHeaders(req) });
+            patch.name = name;
+          }
+          if ("content" in body) {
+            const content = typeof body.content === "string" ? body.content.trim() : "";
+            if (!content) return json({ error: "content required" }, { status: 400, headers: corsHeaders(req) });
+            patch.content = content;
+          }
+          const updated = savedPrompts.update(req.params.id, patch);
+          return updated
+            ? json(updated, { headers: corsHeaders(req) })
+            : json({ error: "not found" }, { status: 404, headers: corsHeaders(req) });
+        }),
+        DELETE: authed((req) => {
+          const removed = savedPrompts.delete(req.params.id);
+          return removed
+            ? json({ ok: true }, { headers: corsHeaders(req) })
+            : json({ error: "not found" }, { status: 404, headers: corsHeaders(req) });
         }),
       },
 

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -2865,7 +2865,8 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       "/saved-prompts": {
         GET: authed((req) => json(savedPrompts.list(), { headers: corsHeaders(req) })),
         POST: authed(async (req) => {
-          const body = (await req.json().catch(() => ({}))) as {
+          const raw = await req.json().catch(() => null);
+          const body = (raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {}) as {
             name?: unknown;
             content?: unknown;
           };
@@ -2884,7 +2885,8 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           if (!current) {
             return json({ error: "not found" }, { status: 404, headers: corsHeaders(req) });
           }
-          const body = (await req.json().catch(() => ({}))) as {
+          const raw = await req.json().catch(() => null);
+          const body = (raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {}) as {
             name?: unknown;
             content?: unknown;
           };

--- a/src/mainview/components/kanban/ExtensionPicker.tsx
+++ b/src/mainview/components/kanban/ExtensionPicker.tsx
@@ -151,8 +151,12 @@ export function ExtensionPicker({
     requestAnimationFrame(() => {
       const t = textareaRef.current;
       if (!t) return;
-      t.focus();
+      // Set the caret BEFORE focusing — SlashAutocomplete syncs its tracked
+      // caret on the native `focus` event, so focusing first would make it
+      // read the stale pre-insert offset (which can land inside a `/token`,
+      // pop the slash menu, and swallow the next Enter via preventDefault).
       t.setSelectionRange(newCaret, newCaret);
+      t.focus();
     });
   };
 
@@ -164,7 +168,7 @@ export function ExtensionPicker({
         type="button"
         disabled={disabled}
         onClick={() => setOpen((o) => !o)}
-        title="Insert an MCP server, skill, or plugin reference"
+        title="Insert an MCP server, skill, plugin reference, or saved prompt"
         className={cn(
           "inline-flex items-center gap-1 rounded-md border border-border/60 bg-card/40 px-2 py-1 text-[11px] text-muted-foreground",
           "hover:bg-accent/40 hover:text-foreground disabled:opacity-50 disabled:hover:bg-card/40 disabled:hover:text-muted-foreground",
@@ -172,7 +176,7 @@ export function ExtensionPicker({
         )}
       >
         <Blocks className="size-3" />
-        <span>MCP · Skills · Plugins</span>
+        <span>MCP · Skills · Plugins · Prompts</span>
         <ChevronDown className={cn("size-3 transition-transform", open && "rotate-180")} />
       </button>
 
@@ -203,7 +207,7 @@ export function ExtensionPicker({
                   if (choice) insert(choice);
                 }
               }}
-              placeholder="Search extensions…"
+              placeholder="Search…"
               className="w-full rounded bg-muted/40 px-2 py-1 text-[11px] outline-none placeholder:text-muted-foreground"
             />
           </div>
@@ -211,7 +215,7 @@ export function ExtensionPicker({
             {grouped.length === 0 ? (
               <p className="px-3 py-2 text-[11px] text-muted-foreground">
                 {extensions.length === 0 && (savedPrompts?.length ?? 0) === 0
-                  ? "No MCP servers, skills, plugins, or saved prompts found for this project."
+                  ? "No MCP servers, skills, or plugins found for this project, and no saved prompts."
                   : "No matches."}
               </p>
             ) : (

--- a/src/mainview/components/kanban/ExtensionPicker.tsx
+++ b/src/mainview/components/kanban/ExtensionPicker.tsx
@@ -1,12 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Blocks, ChevronDown, Plug, Puzzle, Sparkles } from "lucide-react";
+import { Blocks, BookText, ChevronDown, Plug, Puzzle, Sparkles } from "lucide-react";
 import type { AvailableExtension } from "@/lib/api";
+import type { SavedPrompt } from "../../../shared/types.ts";
+import { filterPromptsForPicker } from "@/lib/prompt-picker";
 import { cn } from "@/lib/utils";
 
 interface Props {
   /** Available MCP / skill / plugin entries. Empty disables selection but the
    *  trigger still renders (with an empty-state hint inside the popover). */
   extensions: AvailableExtension[];
+  /** User-global reusable prompt snippets, rendered as a fourth "Saved
+   *  Prompts" group below MCP/skills/plugins. Omitted/empty just hides the
+   *  group — the trigger and the other groups are unaffected. */
+  savedPrompts?: SavedPrompt[];
   /** Current textarea value. */
   value: string;
   /** Setter for the textarea value. */
@@ -23,6 +29,9 @@ interface Props {
   align?: "left" | "right";
   /** Disables the trigger (e.g. before a workdir is picked / no live session). */
   disabled?: boolean;
+  /** Fired when the popover opens — lets a caller refetch `savedPrompts` so
+   *  edits made in Settings mid-session show up without a remount. */
+  onPromptsOpen?: () => void;
 }
 
 const KINDS = [
@@ -31,11 +40,17 @@ const KINDS = [
   { kind: "plugin", label: "Plugins", Icon: Puzzle },
 ] as const;
 
+/** A group row is either an MCP/skill/plugin entry or a saved prompt — the
+ *  tag lets the flattened keyboard-nav list and the row renderer dispatch
+ *  without conflating the two shapes. */
+type Row = { tag: "ext"; ext: AvailableExtension } | { tag: "prompt"; prompt: SavedPrompt };
+
 /**
  * "Extensions" picker that sits above the prompt / message textarea. A single
- * button opens a searchable, grouped popover of the MCP servers, skills, and
- * plugins reachable for the current agent + workdir. Selecting one inserts its
- * `insert` token (`/skill` or `@mcp` / `@plugin`) at the caret.
+ * button opens a searchable, grouped popover of the MCP servers, skills,
+ * plugins, and saved prompts reachable for the current agent + workdir.
+ * Selecting an MCP/skill/plugin inserts its `insert` token (`/skill` or
+ * `@mcp` / `@plugin`); selecting a saved prompt inserts its content.
  *
  * Complements — doesn't replace — the `/` SlashAutocomplete: that one is a
  * typeahead for slash-invokable commands; this is an always-available browse
@@ -43,12 +58,14 @@ const KINDS = [
  */
 export function ExtensionPicker({
   extensions,
+  savedPrompts,
   value,
   onChange,
   textareaRef,
   placement = "below",
   align = "left",
   disabled,
+  onPromptsOpen,
 }: Props) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -72,27 +89,38 @@ export function ExtensionPicker({
     };
   }, [open]);
 
-  // Focus the search box when the popover opens; reset the query when it closes.
+  // Focus the search box when the popover opens (and let the caller refetch
+  // saved prompts so mid-session Settings edits show up); reset the query
+  // when it closes.
   useEffect(() => {
-    if (open) requestAnimationFrame(() => searchRef.current?.focus());
-    else setQuery("");
+    if (open) {
+      requestAnimationFrame(() => searchRef.current?.focus());
+      onPromptsOpen?.();
+    } else {
+      setQuery("");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const grouped = useMemo(() => {
     const q = query.trim().toLowerCase();
     const match = (e: AvailableExtension) =>
       !q || (e.name + " " + e.description).toLowerCase().includes(q);
-    return KINDS.map(({ kind, label, Icon }) => ({
-      kind,
+    const extGroups = KINDS.map(({ kind, label, Icon }) => ({
+      key: kind as string,
       label,
       Icon,
-      items: extensions.filter((e) => e.kind === kind && match(e)),
-    })).filter((g) => g.items.length > 0);
-  }, [extensions, query]);
+      rows: extensions.filter((e) => e.kind === kind && match(e)).map((ext): Row => ({ tag: "ext", ext })),
+    }));
+    const promptRows = filterPromptsForPicker(savedPrompts ?? [], query).map((prompt): Row => ({ tag: "prompt", prompt }));
+    // Saved Prompts always renders last, after mcp/skill/plugin.
+    return [...extGroups, { key: "prompt", label: "Saved Prompts", Icon: BookText, rows: promptRows }]
+      .filter((g) => g.rows.length > 0);
+  }, [extensions, savedPrompts, query]);
 
   // Flattened, display-order list so ↑/↓ can move a single highlight across
   // group boundaries; the render derives each row's global index from this.
-  const flat = useMemo(() => grouped.flatMap((g) => g.items), [grouped]);
+  const flat = useMemo(() => grouped.flatMap((g) => g.rows), [grouped]);
 
   // Reset the highlight whenever the filtered list changes so it never points
   // past the end.
@@ -105,7 +133,9 @@ export function ExtensionPicker({
     row?.scrollIntoView({ block: "nearest" });
   }, [active, open]);
 
-  const insert = (ext: AvailableExtension) => {
+  // Splice `text` into the textarea at the caret — shared by both `ext.insert`
+  // tokens and saved-prompt content so the two selection paths never diverge.
+  const insertText = (text: string) => {
     const el = textareaRef.current;
     const caret = el?.selectionStart ?? value.length;
     const before = value.slice(0, caret);
@@ -113,7 +143,7 @@ export function ExtensionPicker({
     // Pad with a leading space when the caret isn't already at a boundary, and
     // a trailing space so the user keeps typing after the token.
     const needLead = before.length > 0 && !/\s$/.test(before);
-    const piece = (needLead ? " " : "") + ext.insert + " ";
+    const piece = (needLead ? " " : "") + text + " ";
     const next = before + piece + after;
     onChange(next);
     const newCaret = before.length + piece.length;
@@ -125,6 +155,8 @@ export function ExtensionPicker({
       t.setSelectionRange(newCaret, newCaret);
     });
   };
+
+  const insert = (row: Row) => insertText(row.tag === "ext" ? row.ext.insert : row.prompt.content);
 
   return (
     <div ref={rootRef} className="relative">
@@ -178,57 +210,66 @@ export function ExtensionPicker({
           <div ref={listRef} className="max-h-64 overflow-y-auto py-1">
             {grouped.length === 0 ? (
               <p className="px-3 py-2 text-[11px] text-muted-foreground">
-                {extensions.length === 0
-                  ? "No MCP servers, skills, or plugins found for this project."
+                {extensions.length === 0 && (savedPrompts?.length ?? 0) === 0
+                  ? "No MCP servers, skills, plugins, or saved prompts found for this project."
                   : "No matches."}
               </p>
             ) : (
               grouped.map((g, gi) => {
                 // Global index of this group's first item in the flat list, so
                 // the ↑/↓ highlight lines up with keyboard navigation.
-                const base = grouped.slice(0, gi).reduce((n, x) => n + x.items.length, 0);
+                const base = grouped.slice(0, gi).reduce((n, x) => n + x.rows.length, 0);
                 return (
-                <div key={g.kind}>
+                <div key={g.key}>
                   <div className="flex items-center gap-1.5 px-3 pb-0.5 pt-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
                     <g.Icon className="size-3 opacity-70" />
                     {g.label}
                   </div>
                   <ul>
-                    {g.items.map((e, i) => {
+                    {g.rows.map((row, i) => {
                       const idx = base + i;
                       return (
-                      <li key={`${e.kind}:${e.name}`}>
+                      <li key={row.tag === "ext" ? `${row.ext.kind}:${row.ext.name}` : `prompt:${row.prompt.id}`}>
                         <button
                           type="button"
                           data-idx={idx}
                           // mousedown so the textarea doesn't blur before insert.
-                          onMouseDown={(ev) => { ev.preventDefault(); insert(e); }}
+                          onMouseDown={(ev) => { ev.preventDefault(); insert(row); }}
                           onMouseEnter={() => setActive(idx)}
                           className={cn(
                             "flex w-full items-start gap-2 px-3 py-1.5 text-left text-[11px]",
                             idx === active ? "bg-accent text-accent-foreground" : "hover:bg-accent/40",
                           )}
                         >
-                          <span className="min-w-0 flex-1">
-                            <span className="flex items-center gap-1.5">
-                              <span className="font-mono">{e.insert}</span>
-                              <span
-                                className={cn(
-                                  "rounded px-1 py-px text-[10px] uppercase tracking-wide",
-                                  e.source === "project"
-                                    ? "bg-primary/20 text-primary"
-                                    : "bg-muted text-muted-foreground",
-                                )}
-                              >
-                                {e.source}
+                          {row.tag === "ext" ? (
+                            <span className="min-w-0 flex-1">
+                              <span className="flex items-center gap-1.5">
+                                <span className="font-mono">{row.ext.insert}</span>
+                                <span
+                                  className={cn(
+                                    "rounded px-1 py-px text-[10px] uppercase tracking-wide",
+                                    row.ext.source === "project"
+                                      ? "bg-primary/20 text-primary"
+                                      : "bg-muted text-muted-foreground",
+                                  )}
+                                >
+                                  {row.ext.source}
+                                </span>
+                              </span>
+                              {row.ext.description && (
+                                <span className="mt-0.5 block truncate text-muted-foreground">
+                                  {row.ext.description}
+                                </span>
+                              )}
+                            </span>
+                          ) : (
+                            <span className="min-w-0 flex-1">
+                              <span className="font-medium">{row.prompt.name}</span>
+                              <span className="mt-0.5 block truncate text-muted-foreground">
+                                {row.prompt.content}
                               </span>
                             </span>
-                            {e.description && (
-                              <span className="mt-0.5 block truncate text-muted-foreground">
-                                {e.description}
-                              </span>
-                            )}
-                          </span>
+                          )}
                         </button>
                       </li>
                       );

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -673,6 +673,11 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
                     value={prompt}
                     onChange={(e) => { setPrompt(e.target.value); if (dropHint) setDropHint(null); }}
                     onPaste={onPromptPaste}
+                    // Refetch saved prompts on focus (in addition to the
+                    // popover-open refetch) so a deleted/edited prompt made in
+                    // Settings mid-session doesn't linger in the `/`
+                    // autocomplete indefinitely.
+                    onFocus={loadSavedPrompts}
                     rows={6}
                     className="resize-none"
                   />

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -31,6 +31,7 @@ import {
   type AgentStatus,
   type Harness,
   type Isolation,
+  type SavedPrompt,
   type TaskReference,
   type TaskType,
 } from "../../../shared/types.ts";
@@ -243,6 +244,14 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
   const [dropHint, setDropHint] = useState<string | null>(null);
   const [agentCommands, setAgentCommands] = useState<AvailableCommand[]>([]);
   const [agentExtensions, setAgentExtensions] = useState<AvailableExtension[]>([]);
+  // User-global saved prompts — not keyed on agent/workdir, unlike the two
+  // lists above. Loaded once on mount; refetched when the Extensions popover
+  // opens so an edit made in Settings mid-session shows up.
+  const [savedPrompts, setSavedPrompts] = useState<SavedPrompt[]>([]);
+  const loadSavedPrompts = () => {
+    void api.listSavedPrompts().then(setSavedPrompts).catch(() => setSavedPrompts([]));
+  };
+  useEffect(() => { loadSavedPrompts(); }, []);
   const promptRef = useRef<HTMLTextAreaElement>(null);
 
   // Refresh both the `/…` autocomplete (commands/skills) and the Extensions
@@ -647,6 +656,8 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
                   <label className="text-muted-foreground">Prompt</label>
                   <ExtensionPicker
                     extensions={agentExtensions}
+                    savedPrompts={savedPrompts}
+                    onPromptsOpen={loadSavedPrompts}
                     value={prompt}
                     onChange={setPrompt}
                     textareaRef={promptRef}
@@ -667,6 +678,7 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
                   />
                   <SlashAutocomplete
                     commands={agentCommands}
+                    savedPrompts={savedPrompts}
                     value={prompt}
                     onChange={setPrompt}
                     textareaRef={promptRef}

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -2668,23 +2668,21 @@ function RunPanelBody({
             // Picker on the left; "Save for later" / "Commit & push" pushed to
             // the right so they aren't stacked directly on top of the picker.
             <div className="flex items-center justify-between gap-2">
-              {canSend ? (
-                <ExtensionPicker
-                  extensions={sendExtensions}
-                  savedPrompts={savedPrompts}
-                  onPromptsOpen={loadSavedPrompts}
-                  value={input}
-                  onChange={setInput}
-                  textareaRef={sendRef}
-                  placement="above"
-                  // Only the in-flight send needs to disable the trigger here.
-                  disabled={sending}
-                />
-              ) : (
-                // Keep `justify-between` pushing the buttons right when the
-                // picker isn't offered (pre-run).
-                <span />
-              )}
+              <ExtensionPicker
+                extensions={sendExtensions}
+                savedPrompts={savedPrompts}
+                onPromptsOpen={loadSavedPrompts}
+                value={input}
+                onChange={setInput}
+                textareaRef={sendRef}
+                placement="above"
+                // Deliberately mirrors MessageHistoryPicker's disabled
+                // condition below (not `!canSend`/`modalPending`) — composing
+                // is decoupled from sending, so the picker stays usable
+                // before the task's first run and while a native prompt is
+                // pending.
+                disabled={sending || backlogBusy}
+              />
               <div className="flex items-center gap-2">
                 {/* Backlog mutations are frozen server-side while archived
                     (`backlogGuard`) — only Send (which auto-unarchives) is
@@ -2782,6 +2780,11 @@ function RunPanelBody({
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onPaste={onSendPaste}
+                // Refetch saved prompts on focus (in addition to the
+                // popover-open refetch) so a deleted/edited prompt made in
+                // Settings mid-session doesn't linger in the `/` autocomplete
+                // indefinitely.
+                onFocus={loadSavedPrompts}
                 onKeyDown={(e) => {
                   // Enter to send; Shift+Enter for a newline. SlashAutocomplete
                   // attaches a native keydown listener that calls preventDefault

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -41,6 +41,7 @@ import {
   type GitHubPullMergeability,
   type Run,
   type RunEvent,
+  type SavedPrompt,
   type Subagent,
   type SubagentEvent,
   type Task,
@@ -1715,6 +1716,14 @@ function RunPanelBody({
   const [sendCommands, setSendCommands] = useState<AvailableCommand[]>([]);
   // MCP / skill / plugin entries for the Extensions picker above the send box.
   const [sendExtensions, setSendExtensions] = useState<AvailableExtension[]>([]);
+  // User-global saved prompts — not keyed on agent/workdir like the two lists
+  // above. Loaded once on mount; refetched when the Extensions popover opens
+  // so an edit made in Settings mid-session shows up.
+  const [savedPrompts, setSavedPrompts] = useState<SavedPrompt[]>([]);
+  const loadSavedPrompts = () => {
+    void api.listSavedPrompts().then(setSavedPrompts).catch(() => setSavedPrompts([]));
+  };
+  useEffect(() => { loadSavedPrompts(); }, []);
   const sendRef = useRef<HTMLTextAreaElement>(null);
   useEffect(() => {
     if (!task.workdir.trim()) { setSendCommands([]); setSendExtensions([]); return; }
@@ -2662,6 +2671,8 @@ function RunPanelBody({
               {canSend ? (
                 <ExtensionPicker
                   extensions={sendExtensions}
+                  savedPrompts={savedPrompts}
+                  onPromptsOpen={loadSavedPrompts}
                   value={input}
                   onChange={setInput}
                   textareaRef={sendRef}
@@ -2823,6 +2834,7 @@ function RunPanelBody({
               />
               <SlashAutocomplete
                 commands={sendCommands}
+                savedPrompts={savedPrompts}
                 value={input}
                 onChange={setInput}
                 textareaRef={sendRef}

--- a/src/mainview/components/kanban/SlashAutocomplete.tsx
+++ b/src/mainview/components/kanban/SlashAutocomplete.tsx
@@ -1,11 +1,16 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Sparkles, Terminal } from "lucide-react";
+import { BookText, Sparkles, Terminal } from "lucide-react";
 import type { AvailableCommand } from "@/lib/api";
+import type { SavedPrompt } from "../../../shared/types.ts";
+import { filterPromptsForSlash } from "@/lib/prompt-picker";
 import { cn } from "@/lib/utils";
 
 interface Props {
   /** Available `/…` entries to suggest. Empty list disables the popover. */
   commands: AvailableCommand[];
+  /** User-global reusable prompt snippets, matched by name and shown as a
+   *  distinct "Saved Prompts" group below the command/skill results. */
+  savedPrompts?: SavedPrompt[];
   /** Current textarea value. */
   value: string;
   /** Setter for the textarea value. */
@@ -18,6 +23,9 @@ interface Props {
    *  the popover renders off-screen and the user never sees it. */
   placement?: "above" | "below";
 }
+
+/** A row in the combined popover: a command/skill, or a saved prompt. */
+type Row = { tag: "cmd"; cmd: AvailableCommand } | { tag: "prompt"; prompt: SavedPrompt };
 
 /**
  * The slice of text we treat as the active query: everything from a `/` that
@@ -56,13 +64,15 @@ function findActiveQuery(text: string, caret: number): {
 
 /**
  * Lightweight slash-command picker for the new-task prompt textarea. Opens when
- * the caret is in a `/<query>` slice, filters by fuzzy substring match, and
- * inserts the selected command back into the textarea on Enter / Tab / click.
+ * the caret is in a `/<query>` slice, filters commands/skills by substring
+ * match and saved prompts by name, and inserts the selection back into the
+ * textarea on Enter / Tab / click — command names insert as-is, saved
+ * prompts insert their content.
  *
  * Designed to live next to the textarea — it doesn't render the textarea
  * itself, so the form keeps full control over styling, placeholder, etc.
  */
-export function SlashAutocomplete({ commands, value, onChange, textareaRef, placement = "below" }: Props) {
+export function SlashAutocomplete({ commands, savedPrompts, value, onChange, textareaRef, placement = "below" }: Props) {
   const [caret, setCaret] = useState<number>(0);
   const [active, setActive] = useState(0);
   const listRef = useRef<HTMLUListElement>(null);
@@ -84,40 +94,44 @@ export function SlashAutocomplete({ commands, value, onChange, textareaRef, plac
   }, [textareaRef]);
 
   const slice = useMemo(() => findActiveQuery(value, caret), [value, caret]);
-  const open = slice !== null && commands.length > 0;
+  const open = slice !== null && (commands.length > 0 || (savedPrompts?.length ?? 0) > 0);
 
-  const filtered = useMemo(() => {
+  // Commands first, saved prompts second — the render groups them under a
+  // "Saved Prompts" label so the combined list stays visually distinct while
+  // ↑/↓/Enter treat it as one flat sequence.
+  const filtered = useMemo<Row[]>(() => {
     if (!slice) return [];
     const q = slice.query.toLowerCase();
-    if (!q) return commands;
-    return commands.filter((c) => {
+    const cmdRows: Row[] = (q ? commands.filter((c) => {
       const hay = (c.name.slice(1) + " " + c.description).toLowerCase();
       return hay.includes(q);
-    });
-  }, [commands, slice]);
+    }) : commands).map((cmd) => ({ tag: "cmd", cmd }));
+    const promptRows: Row[] = filterPromptsForSlash(savedPrompts ?? [], slice.query).map((prompt) => ({ tag: "prompt", prompt }));
+    return [...cmdRows, ...promptRows];
+  }, [commands, savedPrompts, slice]);
 
   // Reset highlight when the filtered list changes (avoid a stale index that
   // points past the new list's length).
   useEffect(() => { setActive(0); }, [slice?.query, filtered.length]);
 
-  // Keep the highlighted row scrolled into view.
+  // Keep the highlighted row scrolled into view. `data-idx` (not positional
+  // children) since the "Saved Prompts" group label is itself a list child.
   useEffect(() => {
     if (!open) return;
-    const list = listRef.current;
-    if (!list) return;
-    const item = list.children[active] as HTMLElement | undefined;
-    item?.scrollIntoView({ block: "nearest" });
+    const row = listRef.current?.querySelector<HTMLElement>(`[data-idx="${active}"]`);
+    row?.scrollIntoView({ block: "nearest" });
   }, [active, open]);
 
-  const insert = (cmd: AvailableCommand) => {
+  const insert = (row: Row) => {
     if (!slice) return;
     const before = value.slice(0, slice.start);
     const after = value.slice(slice.end);
-    // Trailing space so the user can immediately type arguments after `/cmd`.
-    const next = before + cmd.name + " " + after;
+    const text = row.tag === "cmd" ? row.cmd.name : row.prompt.content;
+    // Trailing space so the user can immediately type arguments / keep typing.
+    const next = before + text + " " + after;
     onChange(next);
-    // Restore caret right after the inserted command + space.
-    const newCaret = before.length + cmd.name.length + 1;
+    // Restore caret right after the inserted text + space.
+    const newCaret = before.length + text.length + 1;
     requestAnimationFrame(() => {
       const el = textareaRef.current;
       if (!el) return;
@@ -174,48 +188,74 @@ export function SlashAutocomplete({ commands, value, onChange, textareaRef, plac
       )}
     >
       <ul ref={listRef} className="py-1">
-        {filtered.map((c, i) => (
-          <li key={`${c.kind}:${c.name}`}>
+        {filtered.map((row, i) => {
+          // Group label right before the first prompt row — commands (if any)
+          // always come first, so this fires at most once.
+          const showPromptLabel = row.tag === "prompt" && filtered[i - 1]?.tag !== "prompt";
+          return (
+          <li key={row.tag === "cmd" ? `${row.cmd.kind}:${row.cmd.name}` : `prompt:${row.prompt.id}`}>
+            {showPromptLabel && (
+              <div className="flex items-center gap-1.5 px-3 pb-0.5 pt-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                <BookText className="size-3 opacity-70" />
+                Saved Prompts
+              </div>
+            )}
             <button
               type="button"
+              data-idx={i}
               // `onMouseDown` instead of `onClick` so the textarea doesn't lose
               // focus before the insertion runs (the popover handles its own
               // focus internally).
-              onMouseDown={(e) => { e.preventDefault(); insert(c); }}
+              onMouseDown={(e) => { e.preventDefault(); insert(row); }}
               onMouseEnter={() => setActive(i)}
               className={cn(
                 "flex w-full items-start gap-2 px-3 py-1.5 text-left text-[11px]",
                 i === active ? "bg-accent text-accent-foreground" : "hover:bg-accent/40",
               )}
             >
-              {c.kind === "skill" ? (
-                <Sparkles className="mt-0.5 size-3 shrink-0 opacity-70" />
-              ) : (
-                <Terminal className="mt-0.5 size-3 shrink-0 opacity-70" />
-              )}
-              <span className="min-w-0 flex-1">
-                <span className="flex items-center gap-1.5">
-                  <span className="font-mono">{c.name}</span>
-                  <span
-                    className={cn(
-                      "rounded px-1 py-px text-[10px] uppercase tracking-wide",
-                      c.source === "project"
-                        ? "bg-primary/20 text-primary"
-                        : "bg-muted text-muted-foreground",
+              {row.tag === "cmd" ? (
+                <>
+                  {row.cmd.kind === "skill" ? (
+                    <Sparkles className="mt-0.5 size-3 shrink-0 opacity-70" />
+                  ) : (
+                    <Terminal className="mt-0.5 size-3 shrink-0 opacity-70" />
+                  )}
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-1.5">
+                      <span className="font-mono">{row.cmd.name}</span>
+                      <span
+                        className={cn(
+                          "rounded px-1 py-px text-[10px] uppercase tracking-wide",
+                          row.cmd.source === "project"
+                            ? "bg-primary/20 text-primary"
+                            : "bg-muted text-muted-foreground",
+                        )}
+                      >
+                        {row.cmd.source}
+                      </span>
+                    </span>
+                    {row.cmd.description && (
+                      <span className="mt-0.5 block truncate text-muted-foreground">
+                        {row.cmd.description}
+                      </span>
                     )}
-                  >
-                    {c.source}
                   </span>
-                </span>
-                {c.description && (
-                  <span className="mt-0.5 block truncate text-muted-foreground">
-                    {c.description}
+                </>
+              ) : (
+                <>
+                  <BookText className="mt-0.5 size-3 shrink-0 opacity-70" />
+                  <span className="min-w-0 flex-1">
+                    <span className="font-medium">{row.prompt.name}</span>
+                    <span className="mt-0.5 block truncate text-muted-foreground">
+                      {row.prompt.content}
+                    </span>
                   </span>
-                )}
-              </span>
+                </>
+              )}
             </button>
           </li>
-        ))}
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/mainview/components/settings/SavedPromptsSection.tsx
+++ b/src/mainview/components/settings/SavedPromptsSection.tsx
@@ -126,6 +126,7 @@ export function SavedPromptsSection() {
                 size="sm"
                 variant="ghost"
                 onClick={() => setForm({ id: p.id, name: p.name, content: p.content })}
+                disabled={form !== null}
               >
                 Edit
               </Button>

--- a/src/mainview/components/settings/SavedPromptsSection.tsx
+++ b/src/mainview/components/settings/SavedPromptsSection.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from "react";
+import { Plus } from "lucide-react";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useConfirm } from "@/components/ui/confirm";
+import type { SavedPrompt } from "../../../shared/types.ts";
+
+type FormState = { id: string | null; name: string; content: string };
+
+/**
+ * "Saved Prompts" Settings section — a flat CRUD list of reusable prompt
+ * snippets, not tied to any task or project. Mirrors GitHubTokensSection's
+ * load/save/delete shape; the add/edit form is a single inline component
+ * (`PromptForm`) shared by both flows rather than a separate create vs.
+ * edit path, since the fields are identical.
+ */
+export function SavedPromptsSection() {
+  const [prompts, setPrompts] = useState<SavedPrompt[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const confirm = useConfirm();
+
+  const refresh = async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const result = await api.listSavedPrompts();
+      setPrompts(result);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const save = async () => {
+    if (!form) return;
+    const name = form.name.trim();
+    const content = form.content.trim();
+    if (!name || !content) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const saved = form.id
+        ? await api.updateSavedPrompt(form.id, { name, content })
+        : await api.createSavedPrompt({ name, content });
+      setPrompts((prev) => {
+        const idx = prev.findIndex((p) => p.id === saved.id);
+        if (idx === -1) return [...prev, saved];
+        const next = [...prev];
+        next[idx] = saved;
+        return next;
+      });
+      setForm(null);
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (p: SavedPrompt) => {
+    const ok = await confirm({
+      title: `Delete "${p.name}"?`,
+      description: "The prompt will be removed permanently.",
+      confirmLabel: "Delete",
+      variant: "destructive",
+    });
+    if (!ok) return;
+    setDeletingId(p.id);
+    setDeleteError(null);
+    try {
+      await api.deleteSavedPrompt(p.id);
+      setPrompts((prev) => prev.filter((x) => x.id !== p.id));
+    } catch (e) {
+      setDeleteError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4 pt-3 text-sm">
+      <div className="flex items-center justify-between">
+        <label className="text-xs text-muted-foreground">Saved Prompts</label>
+        {!form && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setForm({ id: null, name: "", content: "" })}
+          >
+            <Plus className="mr-1 size-3.5" /> Add prompt
+          </Button>
+        )}
+      </div>
+
+      {loadError && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
+          {loadError}
+        </div>
+      )}
+
+      {!loading && (
+        <div className="space-y-1.5">
+          {prompts.map((p) => (
+            <div
+              key={p.id}
+              className="flex items-center gap-2 rounded-md border border-border/60 px-3 py-2"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-medium">{p.name}</div>
+                <div className="truncate text-[11px] text-muted-foreground">{p.content}</div>
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setForm({ id: p.id, name: p.name, content: p.content })}
+              >
+                Edit
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => void remove(p)}
+                disabled={deletingId === p.id}
+              >
+                Delete
+              </Button>
+            </div>
+          ))}
+          {prompts.length === 0 && (
+            <p className="text-xs text-muted-foreground">No saved prompts yet.</p>
+          )}
+        </div>
+      )}
+
+      {deleteError && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
+          {deleteError}
+        </div>
+      )}
+
+      {form && (
+        <PromptForm
+          form={form}
+          saving={saving}
+          error={saveError}
+          onChange={setForm}
+          onSave={() => void save()}
+          onCancel={() => {
+            setForm(null);
+            setSaveError(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function PromptForm({
+  form,
+  saving,
+  error,
+  onChange,
+  onSave,
+  onCancel,
+}: {
+  form: FormState;
+  saving: boolean;
+  error: string | null;
+  onChange: (next: FormState) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  const disabled = saving || !form.name.trim() || !form.content.trim();
+  return (
+    <div className="space-y-2 rounded-md border border-border/60 p-3">
+      <div className="space-y-1">
+        <label className="text-xs text-muted-foreground">Name</label>
+        <Input
+          value={form.name}
+          onChange={(e) => onChange({ ...form, name: e.target.value })}
+          placeholder="Bug repro checklist"
+        />
+      </div>
+      <div className="space-y-1">
+        <label className="text-xs text-muted-foreground">Content</label>
+        <Textarea
+          value={form.content}
+          onChange={(e) => onChange({ ...form, content: e.target.value })}
+          rows={5}
+        />
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
+          {error}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" size="sm" onClick={onCancel} disabled={saving}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={onSave} disabled={disabled}>
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -461,7 +461,8 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
                   // Rendered by the always-mounted div below instead.
                   return null;
                 case "prompts":
-                  return <SavedPromptsSection />;
+                  // Rendered by the always-mounted div below instead.
+                  return null;
                 default: {
                   const _exhaustive: never = view.section;
                   void _exhaustive;
@@ -482,6 +483,17 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
             )}
           >
             <GitHubTokensSection />
+          </div>
+
+          {/* Same treatment as GitHubTokensSection above — kept mounted
+              regardless of the active section so an in-progress
+              name/content draft in SavedPromptsSection survives switching
+              sections instead of being destroyed on unmount. No wrapper
+              spacing classes here (unlike the GitHubTokensSection div
+              above) since SavedPromptsSection's own root already applies
+              "space-y-4 pt-3 text-sm". */}
+          <div className={cn(!(view.kind === "section" && view.section === "prompts") && "hidden")}>
+            <SavedPromptsSection />
           </div>
 
           {view.kind === "templates" && (

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -11,6 +11,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useConfirm } from "@/components/ui/confirm";
 import { AgentIcon } from "@/components/kanban/AgentIcon";
 import { GitHubTokensSection } from "@/components/settings/GitHubTokensSection";
+import { SavedPromptsSection } from "@/components/settings/SavedPromptsSection";
 import { abbreviateHome, cn } from "@/lib/utils";
 import {
   SETTINGS_SECTIONS,
@@ -459,6 +460,8 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
                 case "git":
                   // Rendered by the always-mounted div below instead.
                   return null;
+                case "prompts":
+                  return <SavedPromptsSection />;
                 default: {
                   const _exhaustive: never = view.section;
                   void _exhaustive;

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -68,6 +68,7 @@ import type {
   Project,
   Run,
   RunEvent,
+  SavedPrompt,
   Subagent,
   Task,
   TaskDiff,
@@ -390,6 +391,16 @@ export const api = {
     j<{ ok: true }>(`/harnesses/${encodeURIComponent(id)}/open-terminal`, {
       method: "POST",
     }),
+  listSavedPrompts: () => j<SavedPrompt[]>("/saved-prompts"),
+  createSavedPrompt: (input: { name: string; content: string }) =>
+    j<SavedPrompt>("/saved-prompts", { method: "POST", body: JSON.stringify(input) }),
+  updateSavedPrompt: (id: string, patch: { name?: string; content?: string }) =>
+    j<SavedPrompt>(`/saved-prompts/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      body: JSON.stringify(patch),
+    }),
+  deleteSavedPrompt: (id: string) =>
+    j<{ ok: true }>(`/saved-prompts/${encodeURIComponent(id)}`, { method: "DELETE" }),
   listAgentModels: () => j<AgentModelMap>("/agent-models"),
   refreshAgentModels: () => j<AgentModelMap>("/agent-models", { method: "POST" }),
   listProjects: () => j<Project[]>("/projects"),

--- a/src/mainview/lib/prompt-picker.test.ts
+++ b/src/mainview/lib/prompt-picker.test.ts
@@ -1,0 +1,128 @@
+import { test, expect } from "bun:test";
+import type { SavedPrompt } from "../../shared/types.ts";
+import { filterPromptsForPicker, filterPromptsForSlash } from "./prompt-picker.ts";
+
+function prompt(id: string, name: string, content: string): SavedPrompt {
+  return { id, name, content, createdAt: 0, updatedAt: 0 };
+}
+
+// ── empty prompts array ─────────────────────────────────────────────────────
+
+test("filterPromptsForPicker: empty prompts array returns empty", () => {
+  expect(filterPromptsForPicker([], "anything")).toEqual([]);
+});
+
+test("filterPromptsForSlash: empty prompts array returns empty", () => {
+  expect(filterPromptsForSlash([], "anything")).toEqual([]);
+});
+
+// ── empty / whitespace-only query returns all ──────────────────────────────
+
+test("filterPromptsForPicker: empty query returns all prompts, in order", () => {
+  const prompts = [prompt("1", "Alpha", "one"), prompt("2", "Beta", "two")];
+  expect(filterPromptsForPicker(prompts, "")).toEqual(prompts);
+});
+
+test("filterPromptsForPicker: whitespace-only query returns all prompts", () => {
+  const prompts = [prompt("1", "Alpha", "one"), prompt("2", "Beta", "two")];
+  expect(filterPromptsForPicker(prompts, "   ")).toEqual(prompts);
+});
+
+test("filterPromptsForSlash: empty query returns all prompts, in order", () => {
+  const prompts = [prompt("1", "Alpha", "one"), prompt("2", "Beta", "two")];
+  expect(filterPromptsForSlash(prompts, "")).toEqual(prompts);
+});
+
+test("filterPromptsForSlash: whitespace-only query returns all prompts", () => {
+  const prompts = [prompt("1", "Alpha", "one"), prompt("2", "Beta", "two")];
+  expect(filterPromptsForSlash(prompts, "   ")).toEqual(prompts);
+});
+
+// ── case-insensitive name match ────────────────────────────────────────────
+
+test("filterPromptsForPicker: case-insensitive name match", () => {
+  const prompts = [prompt("1", "Code Review", "body")];
+  expect(filterPromptsForPicker(prompts, "CODE review")).toEqual(prompts);
+});
+
+test("filterPromptsForSlash: case-insensitive name match", () => {
+  const prompts = [prompt("1", "Code Review", "body")];
+  expect(filterPromptsForSlash(prompts, "CODE review")).toEqual(prompts);
+});
+
+// ── content match: included for picker, excluded for slash ────────────────
+
+test("filterPromptsForPicker: matches on content when name doesn't match", () => {
+  const p = prompt("1", "Greeting", "Please review the repo carefully");
+  expect(filterPromptsForPicker([p], "review the repo")).toEqual([p]);
+});
+
+test("filterPromptsForSlash: does NOT match on content, only name", () => {
+  const p = prompt("1", "Greeting", "Please review the repo carefully");
+  expect(filterPromptsForSlash([p], "review the repo")).toEqual([]);
+});
+
+// ── no cross-field seam match for picker (per-field substring only) ───────
+
+test("filterPromptsForPicker: no cross-field seam match spanning end-of-name + start-of-content", () => {
+  // "end start" appears nowhere in "alphaend" nor in "startbeta" individually,
+  // even though concatenating name+content would produce "...end start...".
+  const p = prompt("1", "AlphaEnd", "StartBeta");
+  expect(filterPromptsForPicker([p], "end start")).toEqual([]);
+});
+
+test("filterPromptsForSlash: seam text also does not match via name alone", () => {
+  const p = prompt("1", "AlphaEnd", "StartBeta");
+  expect(filterPromptsForSlash([p], "end start")).toEqual([]);
+});
+
+// ── non-matching query returns empty ───────────────────────────────────────
+
+test("filterPromptsForPicker: non-matching query returns empty", () => {
+  const prompts = [prompt("1", "Alpha", "one"), prompt("2", "Beta", "two")];
+  expect(filterPromptsForPicker(prompts, "zzz")).toEqual([]);
+});
+
+test("filterPromptsForSlash: non-matching query returns empty", () => {
+  const prompts = [prompt("1", "Alpha", "one"), prompt("2", "Beta", "two")];
+  expect(filterPromptsForSlash(prompts, "zzz")).toEqual([]);
+});
+
+// ── multiple matches preserve input order ──────────────────────────────────
+
+test("filterPromptsForPicker: multiple matches preserve input order", () => {
+  const prompts = [
+    prompt("1", "Zeta Review", "x"),
+    prompt("2", "Alpha", "review body"),
+    prompt("3", "Middle", "no match here"),
+    prompt("4", "Beta Review", "y"),
+  ];
+  const result = filterPromptsForPicker(prompts, "review");
+  expect(result.map((p) => p.id)).toEqual(["1", "2", "4"]);
+});
+
+test("filterPromptsForSlash: multiple matches preserve input order", () => {
+  const prompts = [
+    prompt("1", "Zeta Review", "x"),
+    prompt("2", "Alpha", "review body"), // content-only match, excluded from slash
+    prompt("3", "Middle", "no match here"),
+    prompt("4", "Beta Review", "y"),
+  ];
+  const result = filterPromptsForSlash(prompts, "review");
+  expect(result.map((p) => p.id)).toEqual(["1", "4"]);
+});
+
+// ── query with surrounding whitespace ──────────────────────────────────────
+// Implementation calls query.trim().toLowerCase(), so surrounding whitespace
+// is stripped before matching — a query of " review " behaves identically to
+// "review" (not as a literal substring search including the spaces).
+
+test("filterPromptsForPicker: surrounding whitespace in query is trimmed away", () => {
+  const p = prompt("1", "Review", "body");
+  expect(filterPromptsForPicker([p], "  review  ")).toEqual([p]);
+});
+
+test("filterPromptsForSlash: surrounding whitespace in query is trimmed away", () => {
+  const p = prompt("1", "Review", "body");
+  expect(filterPromptsForSlash([p], "  review  ")).toEqual([p]);
+});

--- a/src/mainview/lib/prompt-picker.ts
+++ b/src/mainview/lib/prompt-picker.ts
@@ -4,7 +4,7 @@ import type { SavedPrompt } from "../../shared/types.ts";
 export function filterPromptsForPicker(prompts: SavedPrompt[], query: string): SavedPrompt[] {
   const q = query.trim().toLowerCase();
   if (!q) return prompts;
-  return prompts.filter((p) => (p.name + " " + p.content).toLowerCase().includes(q));
+  return prompts.filter((p) => p.name.toLowerCase().includes(q) || p.content.toLowerCase().includes(q));
 }
 
 /** Case-insensitive name match, mirroring SlashAutocomplete's command filter (a prefix match is a subset of substring, so `includes` covers both); blank query returns all. */

--- a/src/mainview/lib/prompt-picker.ts
+++ b/src/mainview/lib/prompt-picker.ts
@@ -1,0 +1,15 @@
+import type { SavedPrompt } from "../../shared/types.ts";
+
+/** Case-insensitive substring match on name OR content; blank query returns all. */
+export function filterPromptsForPicker(prompts: SavedPrompt[], query: string): SavedPrompt[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return prompts;
+  return prompts.filter((p) => (p.name + " " + p.content).toLowerCase().includes(q));
+}
+
+/** Case-insensitive name match, mirroring SlashAutocomplete's command filter (a prefix match is a subset of substring, so `includes` covers both); blank query returns all. */
+export function filterPromptsForSlash(prompts: SavedPrompt[], query: string): SavedPrompt[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return prompts;
+  return prompts.filter((p) => p.name.toLowerCase().includes(q));
+}

--- a/src/mainview/lib/settings-dialog-view.test.ts
+++ b/src/mainview/lib/settings-dialog-view.test.ts
@@ -27,13 +27,14 @@ function template(overrides: Partial<HarnessTemplate> = {}): HarnessTemplate {
   };
 }
 
-const SECTION_IDS: SettingsSectionId[] = ["general", "harnesses", "git"];
+const SECTION_IDS: SettingsSectionId[] = ["general", "harnesses", "git", "prompts"];
 
-test("SETTINGS_SECTIONS lists the three sidebar sections in order", () => {
+test("SETTINGS_SECTIONS lists the four sidebar sections in order", () => {
   expect(SETTINGS_SECTIONS).toEqual([
     { id: "general", label: "General" },
     { id: "harnesses", label: "Harnesses" },
     { id: "git", label: "Git Integration" },
+    { id: "prompts", label: "Saved Prompts" },
   ]);
 });
 

--- a/src/mainview/lib/settings-dialog-view.ts
+++ b/src/mainview/lib/settings-dialog-view.ts
@@ -5,6 +5,7 @@ export const SETTINGS_SECTIONS = [
   { id: "general", label: "General" },
   { id: "harnesses", label: "Harnesses" },
   { id: "git", label: "Git Integration" },
+  { id: "prompts", label: "Saved Prompts" },
 ] as const;
 
 export type SettingsSectionId = (typeof SETTINGS_SECTIONS)[number]["id"];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -119,6 +119,15 @@ export interface Harness {
   enabled: boolean;
 }
 
+/** A user-global reusable prompt snippet — not tied to any task or project. */
+export interface SavedPrompt {
+  id: string;
+  name: string;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
 export interface HarnessUsage {
   /** Harness id this usage report is for. */
   harnessId: string;


### PR DESCRIPTION
## What

Adds a **saved prompts** system: reusable prompt snippets (name + content) managed in the Settings modal and insertable from both composers.

### Settings
- New **Saved Prompts** sidebar section (`SETTINGS_SECTIONS` entry + `SavedPromptsSection.tsx`): list, inline add/edit form, delete gated by a destructive confirmation dialog (`useConfirm`).
- The section stays mounted while switching sidebar sections (same treatment as the Git section), so an in-progress draft is never lost.

### Composers (new-task panel + task-details message input)
- The **MCP · Skills · Plugins** picker gains a fourth **Saved Prompts** category; selecting a prompt inserts its **content at the caret**, preserving what was already typed.
- The **`/` slash autocomplete** also matches saved prompt names and inserts their content.
- The prompt list refetches on picker open and textarea focus, so edits made in Settings apply immediately.
- In the task-details composer the picker now follows the "composing is decoupled from sending" rule (enabled before the first run and while a native prompt is pending, like the message-history dropdown).

### Backend
- Migration `040_saved_prompts.sql` (`saved_prompts` table: id, name, content, timestamps).
- `savedPrompts` CRUD module in `db.ts` (UUID ids, `created_at ASC` ordering), mirroring the harnesses module shape.
- Token-authed routes: `GET/POST /saved-prompts`, `PATCH/DELETE /saved-prompts/:id` — trim validation → 400, unknown id → 404, non-object JSON bodies safely normalized.
- `api.ts` client wrappers + `SavedPrompt` shared type.

## Why

Re-typing recurring prompts (review checklists, task templates, house instructions) into every task is wasteful. Saved prompts make them one click (or one `/name`) away in both places where prompts are written, while keeping management centralized in Settings.

## Notes for review
- Prompts are **global** (not per-project) by design; insertion is **at-caret**, not replace.
- Insertion follows the caret discipline established by `MessageHistoryPicker`: `setSelectionRange` **before** `focus()`, otherwise `SlashAutocomplete`'s focus-event caret sync reads a stale offset that can pop the slash menu and swallow the next Enter.
- `ExtensionPicker`/`SlashAutocomplete` keep their existing keyboard-nav and `preventDefault()` contracts; prompts ride a separate `savedPrompts` prop rather than widening `AvailableExtension` (different insert semantics: full content vs `/name` token).
- Structurally disjoint from the concurrent `fix/light-auto-theme` work in `SettingsDialog.tsx` (that branch edits `GeneralSection`); only existing color tokens are used, so the section is ready for the light theme.
- `updatedAt` is persisted and returned but not yet surfaced in the UI — candidate follow-up ("edited 2d ago" on Settings rows).

## Testing
- 51 new tests: `saved-prompts.test.ts` (db module), `saved-prompts-endpoint.test.ts` (real-server HTTP: validation 400s, 404s, 401 without token, non-object bodies), `prompt-picker.test.ts` (filter helper).
- Full suite: **2381 pass / 3 skip / 0 fail**; `tsc --noEmit` clean.