### PR TITLE
fix: move the New Task panel collapse toggle to the header row

### DIFF
--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -571,14 +571,15 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
       {/* VS Code-style collapse control: straddles the border between the
           sidebar and the board (half of it overhangs into the board's p-4
           gutter, so it never covers a card). z-20 keeps it above the board
-          and below dialogs/overlays (z-50). */}
+          and below dialogs/overlays (z-50). top-3 centers it on the 44px
+          header row ("New task" title) so it's found where users look. */}
       <button
         type="button"
         onClick={() => setCollapsed((c) => !c)}
         aria-expanded={!collapsed}
         aria-label={collapsed ? "Expand new task panel" : "Collapse new task panel"}
         title={collapsed ? "Expand new task panel" : "Collapse new task panel"}
-        className="absolute -right-2.5 top-1/2 z-20 flex size-5 -translate-y-1/2 items-center justify-center rounded-full border border-border/60 bg-card text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground"
+        className="absolute -right-2.5 top-3 z-20 flex size-5 items-center justify-center rounded-full border border-border/60 bg-card text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground"
       >
         {collapsed
           ? <ChevronRight className="size-3.5" />


### PR DESCRIPTION
## What

Moves the New Task panel's collapse chevron from the sidebar's vertical center (`top-1/2 -translate-y-1/2`) to the top (`top-3`), centering it on the 44px "New task" header row.

## Why

The collapse feature itself (shipped in #153) works correctly, but the toggle sat halfway down the panel's border — not where users look for a collapse control, so it read as missing. Anchored at the header row it's discoverable in both states:

- **Expanded:** the chevron sits beside the "New task" title, straddling the panel/board border (VS Code-style, unchanged horizontally).
- **Collapsed:** the chevron sits at the top of the icon rail, right above the vertical "New task" label.

## Verification

- Drove the real UI (headless backend + Vite + Playwright/Chromium): toggle renders at the header line, panel animates 320px ⇄ 44px, `localStorage` persistence and reload behavior unchanged, expand/collapse both green.
- `bun run typecheck` clean; 12/12 `panel-collapse` unit tests pass.

## Note

The last packaged release (v0.0.18) predates the collapse feature entirely — it lands in the app on the next release cut, along with this placement fix.