### PR TITLE
feature: move the Theme picker below tmux config in Settings → General

### DIFF
--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -589,30 +589,6 @@ function GeneralSection({
   return (
     <div className="space-y-4 pt-3 text-sm">
       <section className="space-y-1">
-        <label className="text-xs text-muted-foreground">Theme</label>
-        <div className="grid grid-cols-3 gap-1">
-          {THEME_PREFERENCES.map((t) => {
-            const Icon = THEME_PREFERENCE_ICON[t.id];
-            return (
-              <Button
-                key={t.id}
-                size="sm"
-                variant={themePreference === t.id ? "default" : "outline"}
-                onClick={() => setThemePreference(t.id)}
-                className="justify-start"
-              >
-                <Icon className="mr-1.5 size-3.5" />
-                {t.label}
-              </Button>
-            );
-          })}
-        </div>
-        <p className="text-[11px] text-muted-foreground">
-          Auto follows your system's appearance and switches live if it changes.
-        </p>
-      </section>
-
-      <section className="space-y-1">
         <label className="text-xs text-muted-foreground">Default harness for new tasks</label>
         <Select value={defaultHarness} onChange={(e) => onPickDefault(e.target.value)}>
           {enabledHarnesses.map((h) => (
@@ -640,6 +616,30 @@ function GeneralSection({
         <p className="text-[11px] text-muted-foreground">
           Claude Code runs through a tmux session per task. Switch to the bundled
           binary if you don't want to install tmux system-wide.
+        </p>
+      </section>
+
+      <section className="space-y-1">
+        <label className="text-xs text-muted-foreground">Theme</label>
+        <div className="grid grid-cols-3 gap-1">
+          {THEME_PREFERENCES.map((t) => {
+            const Icon = THEME_PREFERENCE_ICON[t.id];
+            return (
+              <Button
+                key={t.id}
+                size="sm"
+                variant={themePreference === t.id ? "default" : "outline"}
+                onClick={() => setThemePreference(t.id)}
+                className="justify-start"
+              >
+                <Icon className="mr-1.5 size-3.5" />
+                {t.label}
+              </Button>
+            );
+          })}
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          Auto follows your system's appearance and switches live if it changes.
         </p>
       </section>
     </div>


### PR DESCRIPTION
## What changed

Reordered the sections in **Settings → General** (`GeneralSection` in `src/mainview/components/settings/SettingsDialog.tsx`): the **Theme** picker (Auto / Dark / Light) moved from the top of the page to the bottom, below the "tmux for Claude Code" selector.

New section order:

1. Default harness for new tasks
2. tmux for Claude Code
3. Theme

## Why

The theme picker was sitting above the settings that actually affect how tasks run (default harness, tmux source). Moving the cosmetic preference to the bottom puts the operational settings first.

## Notes

- Pure JSX reorder — no logic, state, or styling changes.
- Verified: `bun run typecheck` clean, `bun test src/mainview/lib/settings-dialog-view.test.ts` 25/25 passing.