### PR TITLE
fix: uppercase the "Task details" section header in the run panel

### DIFF
--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -4889,7 +4889,9 @@ function TaskDetails({
 
   return (
     <details className="border-b border-border/60 px-3 py-2 text-xs">
-      <summary className="cursor-pointer text-muted-foreground">Task details</summary>
+      <summary className="cursor-pointer text-muted-foreground">
+        <span className="text-[10px] uppercase tracking-wide">Task details</span>
+      </summary>
       <div className="mt-2 space-y-2">
         <div>
           <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Prompt</div>


### PR DESCRIPTION
## What

The run panel's three top-level collapsible sections rendered their headers inconsistently — `FILES MENTIONED (20)` and `TERMINAL` in caps, but `Task details` in sentence case at a larger size.

This wraps the `TaskDetails` label in the same span the other two use, in `src/mainview/components/kanban/RunPanel.tsx`:

```tsx
<summary className="cursor-pointer text-muted-foreground">
  <span className="text-[10px] uppercase tracking-wide">Task details</span>
</summary>
```

## Why

The caps and letter-spacing come from an inner `<span className="text-[10px] uppercase tracking-wide">`, not from the `<summary>` itself. That indirection is deliberate — it's what lets a count chip opt back out with `font-mono normal-case` (`Files mentioned (20)`, `Terminal (2)`). `TaskDetails` put bare text directly in the summary, so it picked up neither the size nor the casing.

## Scope

Every `<summary>` in `src/mainview/components/` was checked. The only remaining sentence-case label is the nested `(N) files / folders` disclosure inside the Task-details field list — that's an inline disclosure within a section body, not a section header, so it stays as is.

No logic changes. `bun run typecheck` is green.