### PR TITLE
feature: quote selected message text into the composer

### DIFF
--- a/docs/plans/quote-messages-list.md
+++ b/docs/plans/quote-messages-list.md
@@ -1,0 +1,78 @@
+# Plan — Quote-on-select in the messages list
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-10 |
+| Source | /implement task: "quote system when the user selects text from the messages list" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/quote-messages-list |
+| Base SHA | f241c9d0d61e641046301ef65dd13e4b85080e72 |
+| Mode | Autonomous (agetor worktree; owner unreachable mid-task — both human gates self-approved, assumptions logged in §8) |
+
+## 1. Objective & success criteria
+
+Selecting any text in the run panel's messages list (user, assistant, thinking, tool_use, tool_result, status — any rendered event) surfaces a floating **Quote** button (quote icon + "Quote" label) near the selection. It stays visible while the selection is live. Clicking it appends the selected text to the composer as a markdown blockquote (`> ` per line), separated from any existing composer text by one blank line, and focuses the composer with the caret on the line below the inserted quote so the user can keep typing. Repeatable any number of times on the same message draft.
+
+Success = the flow above works in `bun run dev:hmr`, `bun run typecheck` green, unit tests green, e2e spec (or documented fallback, §5) green.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- Messages scroll viewport: `logRef` div in `RunPanel.tsx` (~:2553), content in `logContentRef`; every event block is wrapped in `<div data-evid={…}>` by `wrap()` (~:3746) — usable to scope "selection is inside the stream".
+- Nothing in the stream blocks native selection (no `user-select:none` in the render path). `ToolUseBlock`'s header button already guards click-vs-selection via `window.getSelection()?.toString()` (~:4270).
+- Composer: controlled `input` state (`RunPanel.tsx:1535`), textarea `sendRef` (`:1791`). Draft autosave keys off `input` state — a plain `setInput(...)` is all persistence needs.
+- **Caret-before-focus is load-bearing**: `setSelectionRange(...)` must run *before* `.focus()` (proven bug fix `bcf0d07` — `SlashAutocomplete` syncs caret on the native `focus` event; wrong order can pop the slash menu and eat the next Enter).
+- Blank-line join convention: `appendReferences` (`src/shared/refs.ts:24`) and `composeDiffMessage` (`lib/diff-selection.ts:125`) both use `text ? `${text}\n\n${block}` : block` — same contract as this feature's "one line below".
+- Floating UI convention: hand-rolled popovers carry `data-popover-open`; RunPanel's Escape listeners check `[role="dialog"][aria-modal="true"], [data-popover-open], [data-search-open]` before closing the panel. The Quote button must carry `data-popover-open` while visible, or Escape will close the panel underneath the user.
+- Perf trap: `RunEventList`'s `sections` memo and hoisted `ReactMarkdown` component maps must not receive selection state — selection handling stays imperative (listeners + `getSelection()`), fully outside the message render path.
+- "Composing is decoupled from sending": pickers (`ExtensionPicker`, `MessageHistoryPicker`) render whenever the composer renders, gated only on `sending || backlogBusy`, not `canSend`/`modalPending`. Quote follows the same rule.
+- Tests: pure logic lives in `src/mainview/lib/*.ts` with colocated `bun:test` `*.test.ts`; **no component test harness** — JSX wiring is verified by typecheck + e2e/manual. E2E: Playwright (`playwright.config.ts`, `e2e/theme.spec.ts`) drives Chromium against `scripts/dev-headless.sh` (real Bun API, dedicated `~/.agetor-dev-e2e` data dir, pinned token). Fake agent drivers exist (`AGETOR_CLAUDE_DRIVER=fake`) to produce run events without tmux/CLI.
+- No existing selection-toolbar precedent anywhere in the repo; `position:fixed` + `Range.getBoundingClientRect()` placement is new territory (existing popovers are absolute-in-relative-wrapper).
+
+## 3. Approach & key decisions
+
+- **Pure formatter module** `src/mainview/lib/quote-selection.ts` (no React imports), mirroring `diff-selection.ts` structure:
+  - `formatQuote(selected: string): string` — normalize CRLF→LF, strip leading/trailing blank lines, prefix every line with `> ` (bare `>` for empty inner lines). Whitespace-only input → `""`.
+  - `appendQuote(existing: string, quoted: string): { text: string; caret: number }` — `""` existing → `quoted + "\n\n"`; else `existing trimmed of trailing whitespace + "\n\n" + quoted + "\n\n"`. `caret = text.length`. The trailing blank line is deliberate: caret lands on a line *below* the quote **and** outside markdown lazy-continuation, so typed text isn't swallowed into the blockquote. Repeat calls naturally stack quotes with single blank lines.
+- **Floating button component** `src/mainview/components/kanban/QuoteSelectionButton.tsx`: props `{ containerRef, disabled?, onQuote(quoted: string) }`. Imperative listeners (`selectionchange` on document + scroll/resize repositioning via rAF); shows a `position:fixed` pill (lucide `TextQuote` icon + "Quote" label, `Button` primitive styling, semantic tokens only) near the selection's end rect, clamped to the viewport; visible only while a non-collapsed, non-whitespace selection lives inside `containerRef.current`. `onMouseDown={e => e.preventDefault()}` so clicking doesn't collapse the selection before `onClick` reads it. Carries `data-popover-open` while visible; Escape hides it (and only it). After quoting: `removeAllRanges()` + hide.
+- **RunPanel wiring**: mount `<QuoteSelectionButton containerRef={logRef} …/>` only when the editable composer surface exists (not on background-agent tabs, not on archived tasks). Handler: `const { text, caret } = appendQuote(input, quoted); setInput(text); requestAnimationFrame(() => { el.setSelectionRange(caret, caret); el.focus(); })` — caret set **before** focus.
+- Rejected alternative: rendering selection state through React props into the stream (breaks the `sections` memo — the search plan explicitly rejected this shape) and a `<mark>`-based highlight (same trap). Rejected `absolute` positioning inside the scroll container (would be clipped by `overflow-y-auto` and complicates coordinates); `fixed` + viewport rect is simpler and scroll-repositioning is cheap.
+
+## 4. Work breakdown — implementation tasks
+
+Single wave, single agent (small, context-sharing feature; splitting risks contract drift for no wall-clock win).
+
+- **T1 — feature (one agent)**
+  - Files owned: `src/mainview/lib/quote-selection.ts` (new), `src/mainview/components/kanban/QuoteSelectionButton.tsx` (new), `src/mainview/components/kanban/RunPanel.tsx` (wiring only).
+  - Acceptance: behavior in §1; conventions in §2/§3 honored (data-popover-open, caret-before-focus, decoupled-from-sending gating, semantic tokens, no changes to `sections` memo or markdown component maps); `bun run typecheck` green.
+
+## 5. Work breakdown — test tasks
+
+- **TT1 — unit tests** `src/mainview/lib/quote-selection.test.ts` (`bun:test`): multi-line, CRLF, embedded blank lines, whitespace-only → `""`, already-quoted text (gets double-prefixed `> > ` — accepted, it's how quoting quoted text reads in MD), empty/non-empty existing draft joins, caret position, repeated appends stacking.
+- **TT2 — e2e** `e2e/quote.spec.ts`: **applies** — the feature is a pure UI flow. Recipe: existing harness (`playwright.config.ts` webServer → `scripts/dev-headless.sh`, data dir `~/.agetor-dev-e2e`, token pinned). Seed a task via `POST /tasks` (isolation `none`), produce stream events via the fake claude driver (`AGETOR_CLAUDE_DRIVER=fake` added to webServer env — inert for the theme spec, which never starts runs) or, if the fake driver can't yield a rendered assistant message, fall back to asserting on the task's *user* message event. In-page: `page.evaluate` builds a `Range` over rendered message text + dispatches `mouseup`/selectionchange, then assert the Quote button appears, click it, assert composer value is the blockquote + trailing blank line and `selectionStart === value.length`. Quote twice → stacked quotes. No pixel assertions (WKWebView ≠ Chromium). If event seeding proves genuinely infeasible in the harness, TT2 downgrades to a documented manual runbook in the final report — recorded, not silent.
+- Run commands: `bun test src/mainview/lib/quote-selection.test.ts`, full `bun test`, `bunx playwright test` (no package.json script — invoked directly), `bun run typecheck`.
+
+## 6. Execution waves
+
+- Wave 1: T1 (Phase 4) → checkpoint commit.
+- Phase 5: code review (opus) on `git diff f241c9d…HEAD`.
+- Wave 2: TT1 + TT2 in parallel (disjoint files: `lib/*.test.ts` vs `e2e/*` + `playwright.config.ts`).
+- Phase 7: run unit + typecheck + e2e; Phase 8 fixes if needed.
+
+## 7. Blast radius & risks
+
+- `RunPanel.tsx` is a convergence point for many features — wiring kept minimal (one mount + one handler) to limit merge risk.
+- Escape layering: forgetting `data-popover-open` closes the whole panel when the user dismisses the button — covered in acceptance.
+- Selection collapse on button mousedown — covered by `preventDefault`.
+- Draft autosave picks up programmatic inserts automatically (keyed off `input` state); no server surface touched — zero backend blast radius.
+- `selectionchange` fires at high frequency — handler must be cheap (bail fast when no selection / not in container) and reposition via rAF.
+- Selections spanning multiple event blocks: `Selection.toString()` inserts newlines between block elements in Chromium/WebKit; each visual line gets its own `> `. Acceptable per A2.
+
+## 8. Open questions / assumptions (autonomous mode — logged, not asked)
+
+- **A1**: Quote is hidden on read-only surfaces (background-agent tabs, archived tasks) — there is no editable composer to insert into there.
+- **A2**: Cross-block selections are allowed; the quote is the selection's rendered plain text (markdown syntax stripped by rendering), one `> ` per visual line. Rendered-text (not raw-source) quoting is expected behavior.
+- **A3**: Append always goes to the end of the draft (not at caret), per the stated "one line below the previous inputted text".
+- **A4**: A trailing blank line follows the quote so the caret sits below it *outside* the blockquote (markdown lazy continuation would otherwise absorb typed text into the quote).
+- **A5**: No size cap on quoted text (consistent with diff-selection's A6) and no dedup of identical repeated quotes.
+- **A6**: Whitespace-only selections never show the button.
+- **A7**: Both human gates (grill, plan approval) self-approved under autonomous mode.

--- a/e2e/quote.spec.ts
+++ b/e2e/quote.spec.ts
@@ -1,0 +1,215 @@
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
+import { E2E_API_PORT, E2E_API_TOKEN, E2E_BASE_URL } from "../playwright.config";
+
+/**
+ * E2E coverage for quote-on-select in the run panel's messages list
+ * (docs/plans/quote-messages-list.md, §5 TT2). Runs Chromium against the
+ * real webview + real Bun API/orchestrator (both started by
+ * `playwright.config.ts`'s `webServer`) — no mocked fetches, no component
+ * harness standing in for the actual DOM.
+ *
+ * Producing a rendered message without a real `claude` CLI or tmux: the
+ * config's `webServer.env` sets `AGETOR_CLAUDE_DRIVER=fake` (see the comment
+ * there), which makes `spawnAgent`'s claude-code branch return an in-process
+ * fake agent (`makeFakeAgent` in `src/bun/agents.ts`) instead of shelling out
+ * to tmux. That fake emits a plain `stdout` chunk — `"fake response to:
+ * <prompt>"` — ~5ms after start, which the run panel renders through the
+ * generic `RawText` block (`RunPanel.tsx`'s `case "stdout"`), i.e. plain
+ * selectable text inside a `[data-evid]` wrapper. `AGETOR_CLAUDE_BIN` /
+ * `AGETOR_TMUX_BIN` point at `/bin/echo` only to satisfy `checkHarness`'s
+ * start-task pre-flight probe (which is a separate code path from the driver
+ * override and always resolves a claude-shaped + tmux binary) — the fake
+ * driver never actually spawns either.
+ *
+ * Selection is simulated by building a `Range` over the rendered text node
+ * via `page.evaluate` and adding it to `window.getSelection()`, rather than
+ * a pixel-level drag — `selectionchange` fires automatically on `addRange`
+ * in Chromium, which is all `QuoteSelectionButton` listens for. No pixel or
+ * screenshot assertions (WKWebView, the app's real target, renders
+ * differently from Chromium) — everything here asserts DOM state: the
+ * pill's `data-quote-open` marker + accessible name, and the composer
+ * textarea's value/caret.
+ *
+ * Serial within this file since both tests below would otherwise race the
+ * one task/composer they share; `theme.spec.ts` runs as a separate file
+ * (separate worker/browser context) and never starts a run, so the two
+ * specs don't observe each other's state.
+ */
+
+const API_BASE = `http://127.0.0.1:${E2E_API_PORT}`;
+const BOOT_URL = `${E2E_BASE_URL}/#api=${E2E_API_PORT}&token=${E2E_API_TOKEN}`;
+const AUTH = { authorization: `Bearer ${E2E_API_TOKEN}` };
+
+test.describe.configure({ mode: "serial" });
+
+interface TaskRow {
+  id: string;
+  title: string;
+}
+
+/** Create a task (isolation "none", a plain non-git temp dir as workdir —
+ *  the fake driver never touches the filesystem, so it doesn't need to be a
+ *  real repo) and start it. Returns the created task row. Fails loudly (via
+ *  `expect`) rather than leaving a silent 400 for a later step to trip on. */
+async function createAndStartFakeClaudeTask(
+  request: APIRequestContext,
+  prompt: string,
+): Promise<TaskRow> {
+  const createRes = await request.post(`${API_BASE}/tasks`, {
+    headers: AUTH,
+    data: { title: prompt, prompt, isolation: "none", workdir: tmpdir() },
+  });
+  expect(createRes.ok(), `POST /tasks -> ${createRes.status()}: ${await createRes.text()}`).toBeTruthy();
+  const task = (await createRes.json()) as TaskRow;
+
+  const startRes = await request.post(`${API_BASE}/tasks/${task.id}/start`, { headers: AUTH });
+  expect(
+    startRes.ok(),
+    `POST /tasks/${task.id}/start -> ${startRes.status()}: ${await startRes.text()}`,
+  ).toBeTruthy();
+
+  return task;
+}
+
+/** Navigate to the app boot URL and wait for real rendered content — same
+ *  pattern as theme.spec.ts's `gotoApp`. */
+async function gotoApp(page: Page): Promise<void> {
+  await page.goto(BOOT_URL);
+  await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
+}
+
+/** The run panel's slide-over `<aside>`. `RunPanel` is mounted after
+ *  `NewTaskForm` (whose own `<aside>` sidebar is always present) in
+ *  `App.tsx`'s JSX, so once a task is open there are exactly two `<aside>`
+ *  elements and the run panel is the later one in DOM order. */
+function runPanel(page: Page) {
+  return page.locator("aside").last();
+}
+
+/** Click a task card by its exact title (cards render `task.title` verbatim,
+ *  and the card's `onClick` opens the run panel) and wait for the composer
+ *  textarea to mount as proof the panel is open.
+ *
+ *  `.first()`: `TaskCard` also shows `task.prompt` as a preview line below
+ *  the title (`line-clamp-2`), and this test uses the same string for both
+ *  title and prompt — so the exact-text match resolves two elements. Either
+ *  one bubbles the click up to the same `Card`'s `onClick`, so picking the
+ *  first (the `CardTitle`, which renders first in DOM order) is enough. */
+async function openTask(page: Page, title: string) {
+  await page.getByText(title, { exact: true }).first().click();
+  const panel = runPanel(page);
+  await expect(panel.locator("textarea")).toBeVisible();
+  return panel;
+}
+
+function quotePill(page: Page) {
+  return page.locator("[data-quote-open]");
+}
+
+/** Build a native `Range` over the first text node anywhere in the document
+ *  whose content includes `needle`, and install it as the window's live
+ *  selection — the DOM end-state of a real text-drag, without simulating
+ *  pixel-level mouse movement. Returns whether a match was found. */
+async function selectTextContaining(page: Page, needle: string): Promise<boolean> {
+  return page.evaluate((marker) => {
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+      if (node.textContent && node.textContent.includes(marker)) {
+        const range = document.createRange();
+        range.selectNodeContents(node);
+        const sel = window.getSelection();
+        if (!sel) return false;
+        sel.removeAllRanges();
+        sel.addRange(range);
+        return true;
+      }
+    }
+    return false;
+  }, needle);
+}
+
+test.describe("quote-on-select", () => {
+  test("selecting a rendered message shows the Quote pill; quoting it twice stacks blockquotes in the composer", async ({
+    page,
+    request,
+  }) => {
+    const prompt = `quote-e2e ${randomUUID()}`;
+    await createAndStartFakeClaudeTask(request, prompt);
+    // The fake driver's canned reply — see the fake-response comment atop
+    // this file. Unique per test run via the prompt's uuid, so the
+    // tree-walking text search below can never match stale content from a
+    // prior run sharing the disposable e2e data dir.
+    const responseMarker = `fake response to: ${prompt}`;
+
+    await gotoApp(page);
+    const panel = await openTask(page, prompt);
+
+    // Replayed over the task's unified SSE event stream regardless of
+    // whether the (very fast, ~20ms) fake turn already finished before we
+    // navigated here.
+    await expect(page.getByText(responseMarker)).toBeVisible();
+
+    const textarea = panel.locator("textarea");
+    await expect(textarea).toHaveValue("");
+
+    // --- (1) selecting the message text shows the floating Quote pill ----
+    const found1 = await selectTextContaining(page, responseMarker);
+    expect(found1, `no text node containing "${responseMarker}" to select`).toBeTruthy();
+
+    const pill = quotePill(page);
+    await expect(pill).toBeVisible();
+    await expect(pill).toHaveAttribute("data-quote-open", "");
+    // Portaled to document.body (not left under RunPanel's transformed
+    // `<aside>`) — see QuoteSelectionButton's doc comment on why that
+    // matters for `position: fixed` to be viewport-relative.
+    expect(await pill.evaluate((el) => el.parentElement === document.body)).toBe(true);
+
+    const pillButton = page.getByRole("button", { name: /Quote/ });
+    await expect(pillButton).toBeVisible();
+
+    // --- (2) clicking it inserts a markdown blockquote into the composer -
+    await pillButton.click();
+    await expect(quotePill(page)).toHaveCount(0);
+
+    const quotedLine = `> ${responseMarker}`;
+    const afterFirst = `${quotedLine}\n\n`;
+    await expect(textarea).toHaveValue(afterFirst);
+
+    // Caret-before-focus (RunPanel.tsx's handleQuote) both happen inside a
+    // requestAnimationFrame callback scheduled the moment the click handler
+    // runs — after `toHaveValue` above resolves, `setInput` has definitely
+    // committed, but the rAF callback isn't guaranteed to have fired yet
+    // (headless Chromium can delay a frame relative to Playwright's own
+    // polling cadence). Poll for focus rather than reading state exactly
+    // once right after the value settles.
+    await expect
+      .poll(() => textarea.evaluate((el: HTMLTextAreaElement) => document.activeElement === el))
+      .toBe(true);
+
+    const first = await textarea.evaluate((el: HTMLTextAreaElement) => ({
+      value: el.value,
+      selectionStart: el.selectionStart,
+    }));
+    expect(first.selectionStart).toBe(first.value.length);
+
+    // --- (3) quoting a second time stacks a second `> ` block below it ---
+    const found2 = await selectTextContaining(page, responseMarker);
+    expect(found2, `no text node containing "${responseMarker}" to select (second pass)`).toBeTruthy();
+    await expect(quotePill(page)).toBeVisible();
+
+    await page.getByRole("button", { name: /Quote/ }).click();
+    await expect(quotePill(page)).toHaveCount(0);
+
+    const afterSecond = `${quotedLine}\n\n${quotedLine}\n\n`;
+    await expect(textarea).toHaveValue(afterSecond);
+
+    const second = await textarea.evaluate((el: HTMLTextAreaElement) => ({
+      value: el.value,
+      selectionStart: el.selectionStart,
+    }));
+    expect(second.selectionStart).toBe(second.value.length);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,6 +62,23 @@ export default defineConfig({
       AGETOR_DATA_DIR: E2E_DATA_DIR,
       AGETOR_API_PORT: String(E2E_API_PORT),
       AGETOR_API_TOKEN: E2E_API_TOKEN,
+      // Added for e2e/quote.spec.ts (docs/plans/quote-messages-list.md §5
+      // TT2). Same fake-driver combo `orchestrator.test.ts` uses: with
+      // AGETOR_CLAUDE_DRIVER=fake, spawnAgent's claude-code branch returns an
+      // in-process fake agent instead of shelling out to tmux, so a run can
+      // be driven end to end without a real `claude` CLI or tmux session.
+      // `checkHarness` (the start-task pre-flight) is a separate code path
+      // that doesn't know about the driver override — it still resolves a
+      // `claude`-shaped binary AND a tmux binary regardless — so
+      // AGETOR_CLAUDE_BIN/AGETOR_TMUX_BIN point both at `/bin/echo` (always
+      // present) purely to satisfy that probe; AGETOR_CLAUDE_ARGS is cleared
+      // so buildCommand's argv (recorded by the fake but never executed)
+      // isn't polluted by an inherited shell override. Inert for
+      // theme.spec.ts, which never starts a run.
+      AGETOR_CLAUDE_DRIVER: "fake",
+      AGETOR_CLAUDE_BIN: "/bin/echo",
+      AGETOR_TMUX_BIN: "/bin/echo",
+      AGETOR_CLAUDE_ARGS: "",
     },
   },
 });

--- a/src/mainview/components/kanban/QuoteSelectionButton.tsx
+++ b/src/mainview/components/kanban/QuoteSelectionButton.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { TextQuote } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { formatQuote } from "@/lib/quote-selection";
+
+/** Margin kept between the pill and the viewport edge when clamping. */
+const VIEWPORT_MARGIN = 8;
+/** Vertical gap between the pill and the selection rect it's anchored to. */
+const SELECTION_GAP = 8;
+/** Rough footprint used to clamp the pill before it's actually measured —
+ *  cheap and good enough since the pill's real size only differs by a few
+ *  px, well inside VIEWPORT_MARGIN. */
+const PILL_WIDTH = 84;
+const PILL_HEIGHT = 32;
+
+interface Position {
+  top: number;
+  left: number;
+}
+
+interface Props {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  /** When true, the pill never shows — used to gate the pill closed while a
+   *  send is in flight or the backlog is busy, matching how
+   *  ExtensionPicker/MessageHistoryPicker/Save-for-later gate themselves in
+   *  RunPanel. Without this, a quote clicked mid-send gets wiped by the
+   *  resolving `setInput("")` + `clearTaskDraft`. */
+  disabled?: boolean;
+  onQuote: (quoted: string) => void;
+}
+
+/** Whether `node` lives inside `container` — Range.commonAncestorContainer
+ *  can be a text node, so this walks up through `parentNode` rather than
+ *  relying on `Element.contains`. */
+function isNodeInside(node: Node | null, container: HTMLElement): boolean {
+  let el: Node | null = node;
+  while (el) {
+    if (el === container) return true;
+    el = el.parentNode;
+  }
+  return false;
+}
+
+/** The single source of truth for "is there a selection worth quoting, and
+ *  what is it" — shared by the recompute/positioning path and the button's
+ *  own `onClick` so what the pill shows-for and what it actually quotes can
+ *  never drift apart. Valid means: a selection exists, has at least one
+ *  range, isn't collapsed, has non-whitespace text, and both its anchor and
+ *  focus nodes live inside `container`. */
+function readValidSelection(container: HTMLElement): Selection | null {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return null;
+  if (sel.toString().trim() === "") return null;
+  if (!isNodeInside(sel.anchorNode, container) || !isNodeInside(sel.focusNode, container)) return null;
+  return sel;
+}
+
+/** Compute the pill's `position: fixed` coordinates from a selection rect:
+ *  centered above the selection, falling back to below it when there isn't
+ *  room, then clamped to the viewport with a small margin. */
+function computePosition(rect: DOMRect): Position {
+  const left = Math.min(
+    Math.max(rect.left + rect.width / 2 - PILL_WIDTH / 2, VIEWPORT_MARGIN),
+    window.innerWidth - PILL_WIDTH - VIEWPORT_MARGIN,
+  );
+
+  const above = rect.top - PILL_HEIGHT - SELECTION_GAP;
+  const top = above >= VIEWPORT_MARGIN ? above : rect.bottom + SELECTION_GAP;
+  const clampedTop = Math.min(Math.max(top, VIEWPORT_MARGIN), window.innerHeight - PILL_HEIGHT - VIEWPORT_MARGIN);
+
+  return { top: clampedTop, left };
+}
+
+/**
+ * Floating "Quote" pill that appears while a non-collapsed, non-whitespace
+ * text selection lives inside `containerRef` (the run panel's messages
+ * viewport). Clicking it turns the selection into a markdown blockquote and
+ * hands it to `onQuote`.
+ *
+ * Entirely imperative — `document.selectionchange` + `resize` + capture-phase
+ * `scroll` listeners recompute a `{ top, left } | null` position via
+ * `requestAnimationFrame`, never synchronously per event. This keeps
+ * selection handling fully outside the message stream's render path (no
+ * selection state is threaded through `RunEventList`/`sections`).
+ */
+export function QuoteSelectionButton({ containerRef, disabled = false, onQuote }: Props) {
+  const [position, setPosition] = useState<Position | null>(null);
+  const rafRef = useRef<number | null>(null);
+  // Mirrors `position !== null` but readable synchronously inside listeners
+  // without depending on the latest render's closure.
+  const visibleRef = useRef(false);
+  // Captured into a ref (same idiom as RunPanel's `onCloseRef`) so the main
+  // effect doesn't need `disabled` in its deps — toggling it (e.g. every
+  // send) would otherwise tear down + re-add all these listeners.
+  const disabledRef = useRef(disabled);
+  disabledRef.current = disabled;
+
+  // Hide immediately when disabled flips true mid-selection (e.g. a send
+  // kicks off while the pill is showing) instead of waiting for the next
+  // selectionchange/scroll/resize to notice.
+  useEffect(() => {
+    if (!disabled) return;
+    visibleRef.current = false;
+    setPosition(null);
+  }, [disabled]);
+
+  useEffect(() => {
+    const schedule = (fn: () => void) => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(fn);
+    };
+
+    const recompute = () => {
+      const container = containerRef.current;
+      if (disabledRef.current || !container) {
+        visibleRef.current = false;
+        setPosition(null);
+        return;
+      }
+
+      const sel = readValidSelection(container);
+      if (!sel) {
+        visibleRef.current = false;
+        setPosition(null);
+        return;
+      }
+
+      const rect = sel.getRangeAt(0).getBoundingClientRect();
+      const box = container.getBoundingClientRect();
+      // The selection's anchor lives inside `container` in the DOM sense,
+      // but may not be visible there right now (a zero-area rect — e.g. a
+      // collapsed ancestor — or a rect that's scrolled entirely above/below
+      // the container's own viewport slice). Hide rather than clamp: a
+      // clamped pill pointing at content that isn't actually on screen is
+      // misleading.
+      const zeroArea = rect.width === 0 && rect.height === 0;
+      const outsideContainer = rect.bottom < box.top || rect.top > box.bottom;
+      if (zeroArea || outsideContainer) {
+        visibleRef.current = false;
+        setPosition(null);
+        return;
+      }
+
+      visibleRef.current = true;
+      setPosition(computePosition(rect));
+    };
+
+    const onSelectionChange = () => {
+      if (disabledRef.current) return;
+      // Cheap early-bail before the rAF-scheduled work: this listener fires
+      // on every composer keystroke (selectionchange isn't scoped to our
+      // container), so when the pill isn't already showing and the current
+      // selection isn't even a plausible candidate (none, empty, or
+      // collapsed), skip scheduling a frame entirely. The full containment/
+      // whitespace check still has to happen inside `recompute` once
+      // something IS scheduled, since `getSelection()` here may not reflect
+      // the final selection yet (some browsers fire `selectionchange`
+      // mid-drag).
+      const sel = window.getSelection();
+      if (!visibleRef.current && (!sel || sel.rangeCount === 0 || sel.isCollapsed)) return;
+      schedule(recompute);
+    };
+    const onReposition = () => {
+      if (!visibleRef.current) return;
+      schedule(recompute);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || !visibleRef.current) return;
+      visibleRef.current = false;
+      setPosition(null);
+    };
+
+    document.addEventListener("selectionchange", onSelectionChange);
+    window.addEventListener("resize", onReposition);
+    // Capture phase: the messages list scrolls an inner div, not the
+    // window/document, and scroll events don't bubble.
+    document.addEventListener("scroll", onReposition, true);
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.removeEventListener("selectionchange", onSelectionChange);
+      window.removeEventListener("resize", onReposition);
+      document.removeEventListener("scroll", onReposition, true);
+      document.removeEventListener("keydown", onKeyDown);
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [containerRef]);
+
+  if (disabled || !position) return null;
+
+  // Portaled to `document.body`: RunPanel's slide-over `<aside>` carries a
+  // `translate-x-*` transform, which makes it the containing block for any
+  // `position: fixed` descendant (per the CSS spec, a transformed ancestor
+  // becomes the containing block for fixed descendants). Left in place, the
+  // pill's "viewport" coordinates would actually be relative to the aside
+  // and paint off-screen. Portaling out from under it restores true
+  // viewport-relative fixed positioning; `z-50` now applies globally rather
+  // than only within the aside's stacking context.
+  return createPortal(
+    <div
+      // RunPanel's Escape listeners check for `[data-quote-open]` before
+      // closing the panel/search bar — without this attribute, dismissing
+      // the pill with Escape would also close a layer underneath it. Not
+      // `data-popover-open`: that marker also gates the panel's Cmd/Ctrl+F
+      // guard, and a passive text selection must not suppress find-in-panel.
+      data-quote-open=""
+      style={{ position: "fixed", top: position.top, left: position.left }}
+      className="z-50"
+    >
+      <Button
+        size="sm"
+        variant="secondary"
+        className="h-8 gap-1.5 px-2.5 text-xs shadow"
+        // Prevent the mousedown from collapsing the selection before onClick
+        // gets a chance to read it.
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => {
+          const container = containerRef.current;
+          const sel = container ? readValidSelection(container) : null;
+          const quoted = sel ? formatQuote(sel.toString()) : "";
+          if (quoted) onQuote(quoted);
+          sel?.removeAllRanges();
+          visibleRef.current = false;
+          setPosition(null);
+        }}
+      >
+        <TextQuote className="size-3.5" />
+        Quote
+      </Button>
+    </div>,
+    document.body,
+  );
+}

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -16,6 +16,8 @@ import { latestPrProposal } from "@/lib/pr-proposal";
 import { parsePrUrl, parsePullNumber, canOfferResolveConflicts } from "@/lib/pr-url";
 import { buildResolveConflictsPrompt } from "@/lib/resolve-conflicts-prompt";
 import { eventWindowKeepCount } from "@/lib/event-window";
+import { appendQuote } from "@/lib/quote-selection";
+import { QuoteSelectionButton } from "./QuoteSelectionButton";
 import type { GitHubPullPrefill } from "./GitHubDialog";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Badge, badgeVariants } from "@/components/ui/badge";
@@ -229,9 +231,11 @@ export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClos
   // Escape closes the panel — but only when no higher-priority dismissable
   // layer is up: a modal Dialog (confirm, edit, settings, tmux-missing —
   // each renders `[role="dialog"][aria-modal="true"]`), an open search-select
-  // / multi-search-select popover (marked with `[data-popover-open]`), or the
-  // in-panel message search bar (marked with `[data-search-open]` — see
-  // RunPanelBody). Esc peels one layer at a time, top down.
+  // / multi-search-select popover (marked with `[data-popover-open]`), the
+  // floating quote pill (marked with `[data-quote-open]` — see
+  // QuoteSelectionButton), or the in-panel message search bar (marked with
+  // `[data-search-open]` — see RunPanelBody). Esc peels one layer at a time,
+  // top down.
   //
   // Note: stopPropagation/stopImmediatePropagation can't help here because
   // both the panel and the popovers attach to `document`, so DOM markers
@@ -246,7 +250,7 @@ export function RunPanel({ task, agents, harnesses, agentModels, homeDir, onClos
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
-      if (document.querySelector('[role="dialog"][aria-modal="true"], [data-popover-open], [data-search-open]')) return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"], [data-popover-open], [data-quote-open], [data-search-open]')) return;
       e.preventDefault();
       onCloseRef.current();
     };
@@ -1420,15 +1424,15 @@ function RunPanelBody({
   // within the panel (not just while the input itself is focused) — matching
   // "Escape peels one layer at a time" from the panel's own listener. Gated
   // on `searchOpen` so it's only attached while there's something to close,
-  // and bails on the same higher-priority dismissable layer (modal dialog /
-  // open search-select popover) as every other document-level listener here
-  // so Escape closes the topmost layer first instead of skipping straight to
-  // the search bar underneath it.
+  // and bails on the same higher-priority dismissable layers (modal dialog /
+  // open search-select popover / floating quote pill) as every other
+  // document-level listener here so Escape closes the topmost layer first
+  // instead of skipping straight to the search bar underneath it.
   useEffect(() => {
     if (!searchOpen) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
-      if (document.querySelector('[role="dialog"][aria-modal="true"], [data-popover-open]')) return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"], [data-popover-open], [data-quote-open]')) return;
       e.preventDefault();
       closeSearch();
     };
@@ -1796,6 +1800,24 @@ function RunPanelBody({
   const focusComposer = useCallback(() => {
     requestAnimationFrame(() => { sendRef.current?.focus(); });
   }, []);
+  // Append a quoted selection (see QuoteSelectionButton) to the composer and
+  // land the caret at its end. Caret BEFORE focus — SlashAutocomplete syncs
+  // its tracked caret on the native `focus` event, so focusing first would
+  // read the stale pre-insert offset (same fix as ExtensionPicker's `insert`,
+  // commit bcf0d07).
+  const handleQuote = useCallback(
+    (quoted: string) => {
+      const { text, caret } = appendQuote(input, quoted);
+      setInput(text);
+      requestAnimationFrame(() => {
+        const el = sendRef.current;
+        if (!el) return;
+        el.setSelectionRange(caret, caret);
+        el.focus();
+      });
+    },
+    [input],
+  );
   useEffect(() => {
     if (!task.workdir.trim()) { setSendCommands([]); setSendExtensions([]); return; }
     let cancelled = false;
@@ -2931,13 +2953,15 @@ function RunPanelBody({
                   requestAnimationFrame(() => {
                     const el = sendRef.current;
                     if (!el) return;
-                    el.focus();
-                    // Pin the caret to the end of the inserted text — without
-                    // this the textarea keeps its stale prior caret offset,
-                    // which can land inside a `/command` token and pop
-                    // SlashAutocomplete (whose keydown handler then swallows
-                    // the next Enter).
+                    // Pin the caret to the end of the inserted text, and do it
+                    // BEFORE focus() — SlashAutocomplete syncs its tracked
+                    // caret on the native `focus` event, so focusing first
+                    // reads the stale prior offset, which can land inside a
+                    // `/command` token and pop SlashAutocomplete (whose
+                    // keydown handler then swallows the next Enter). Same fix
+                    // as ExtensionPicker's `insert` (commit bcf0d07).
                     el.setSelectionRange(text.length, text.length);
+                    el.focus();
                   });
                 }}
                 className="absolute right-1.5 top-1.5 z-10"
@@ -2967,6 +2991,18 @@ function RunPanelBody({
             <p className="mt-1 text-[10px] text-muted-foreground">{sendHint}</p>
           )}
         </div>
+      )}
+      {/* Same gate as the composer dock above (`archived && !canSend` ? static
+          notice, `activeStream !== "main"` ? read-only footer, else the live
+          composer) — the quote pill only makes sense where there's an
+          editable composer to insert into. `position: fixed`, so it doesn't
+          need to live inside the composer's own JSX branch. `disabled` mirrors
+          how ExtensionPicker/MessageHistoryPicker/Save-for-later gate
+          themselves (`sending || backlogBusy`) — a quote clicked while a send
+          is in flight would otherwise get wiped by the resolving
+          `setInput("")` + `clearTaskDraft`. */}
+      {!(archived && !canSend) && activeStream === "main" && (
+        <QuoteSelectionButton containerRef={logRef} disabled={sending || backlogBusy} onQuote={handleQuote} />
       )}
       {/* Keyed by plan id (stable across in-place status/edit updates as
           `plans` refreshes from the poll or a mutation's returned Task) so

--- a/src/mainview/lib/quote-selection.test.ts
+++ b/src/mainview/lib/quote-selection.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "bun:test";
+import { appendQuote, formatQuote } from "./quote-selection.ts";
+
+// --- formatQuote ---------------------------------------------------------
+
+test("formatQuote prefixes a single line with '> '", () => {
+  expect(formatQuote("hello")).toBe("> hello");
+});
+
+test("formatQuote prefixes every line of a multi-line selection", () => {
+  expect(formatQuote("a\nb\nc")).toBe("> a\n> b\n> c");
+});
+
+test("formatQuote normalizes CRLF to LF before quoting", () => {
+  expect(formatQuote("a\r\nb\r\nc")).toBe("> a\n> b\n> c");
+});
+
+test("formatQuote strips leading and trailing blank lines", () => {
+  expect(formatQuote("\n\nhello\n\n")).toBe("> hello");
+});
+
+test("formatQuote turns an embedded blank line into a bare '>'", () => {
+  // Blank lines *inside* the selection are preserved (unlike the
+  // leading/trailing ones), just re-rendered without the trailing space
+  // a naive `"> " + line` would leave behind.
+  expect(formatQuote("a\n\nb")).toBe("> a\n>\n> b");
+});
+
+test("formatQuote returns '' for whitespace-only input (spaces, tabs, newlines)", () => {
+  expect(formatQuote("   \n\t\n   ")).toBe("");
+});
+
+test("formatQuote returns '' for an empty string", () => {
+  expect(formatQuote("")).toBe("");
+});
+
+test("formatQuote renders a whitespace-only inner line as a bare '>' with no trailing whitespace", () => {
+  const out = formatQuote("a\n   \nb");
+  expect(out).toBe("> a\n>\n> b");
+  // Guard against a regression that leaves "> " (space, no content) instead
+  // of the bare ">" — split the line back out and check it literally.
+  const middle = out.split("\n")[1]!;
+  expect(middle).toBe(">");
+  expect(middle.endsWith(" ")).toBe(false);
+});
+
+test("formatQuote double-prefixes already-quoted input", () => {
+  expect(formatQuote("> hello")).toBe("> > hello");
+});
+
+test("formatQuote passes markdown syntax through verbatim", () => {
+  const src = "**bold** and `code` and [a link](https://example.com)";
+  expect(formatQuote(src)).toBe(`> ${src}`);
+});
+
+// --- appendQuote -----------------------------------------------------------
+
+test("appendQuote with empty quoted returns existing unchanged, caret at existing.length", () => {
+  const { text, caret } = appendQuote("draft text", "");
+  expect(text).toBe("draft text");
+  expect(caret).toBe("draft text".length);
+});
+
+test("appendQuote with empty existing returns quoted + trailing blank line, caret at end", () => {
+  const quoted = "> hi";
+  const { text, caret } = appendQuote("", quoted);
+  expect(text).toBe(`${quoted}\n\n`);
+  expect(caret).toBe(text.length);
+});
+
+test("appendQuote with existing content trims trailing whitespace, joins with blank lines, caret at end", () => {
+  const quoted = "> quoted line";
+  const { text, caret } = appendQuote("hello world", quoted);
+  expect(text).toBe(`hello world\n\n${quoted}\n\n`);
+  expect(caret).toBe(text.length);
+});
+
+test("appendQuote collapses existing trailing newlines/spaces to a single blank line before the quote", () => {
+  const quoted = "> q";
+  const { text } = appendQuote("hello\n\n\n   ", quoted);
+  // Trailing whitespace (including the newlines) is stripped entirely
+  // before the separator is added back, so this must not produce more
+  // than one blank line ahead of the quote.
+  expect(text).toBe(`hello\n\n${quoted}\n\n`);
+  expect(text).not.toContain("\n\n\n");
+});
+
+test("appendQuote stacks repeated appends with a single blank line between quotes", () => {
+  const first = appendQuote("draft", "> one");
+  const second = appendQuote(first.text, "> two");
+  expect(second.text).toBe("draft\n\n> one\n\n> two\n\n");
+  expect(second.text).not.toContain("\n\n\n");
+});
+
+test("appendQuote caret always equals text.length", () => {
+  const cases: Array<[string, string]> = [
+    ["", ""],
+    ["draft", ""],
+    ["", "> hi"],
+    ["hello world", "> quoted"],
+    ["hello\n\n\n   ", "> q"],
+  ];
+  for (const [existing, quoted] of cases) {
+    const { text, caret } = appendQuote(existing, quoted);
+    expect(caret).toBe(text.length);
+  }
+});
+
+test("appendQuote leaves a trailing blank line after the quote whenever quoted is non-empty", () => {
+  const cases: Array<[string, string]> = [
+    ["", "> hi"],
+    ["hello world", "> quoted"],
+    ["hello\n\n\n   ", "> q"],
+  ];
+  for (const [existing, quoted] of cases) {
+    const { text } = appendQuote(existing, quoted);
+    expect(text.endsWith("\n\n")).toBe(true);
+  }
+});

--- a/src/mainview/lib/quote-selection.ts
+++ b/src/mainview/lib/quote-selection.ts
@@ -1,0 +1,53 @@
+// Turn a text selection from the run panel's messages list into a markdown
+// blockquote appended to the composer. Pure formatting/join logic only — no
+// React, no DOM — mirroring the split that `diff-selection.ts` uses for the
+// diff-compose feature: selection/DOM handling stays in the component,
+// string arithmetic lives here where it can be unit tested directly.
+
+/** Normalize `selected` (CRLF -> LF, strip leading/trailing blank lines) and
+ *  prefix every remaining line with `"> "` (a bare `">"` for an empty inner
+ *  line, so the blockquote doesn't gain trailing whitespace per line).
+ *  Whitespace-only or empty input returns `""` — callers use that as the
+ *  "nothing to quote" signal instead of a separate boolean. */
+export function formatQuote(selected: string): string {
+  const normalized = selected.replace(/\r\n?/g, "\n");
+  if (!normalized.trim()) return "";
+
+  const lines = normalized.split("\n");
+  // Strip leading/trailing blank lines (selections often pick up a stray
+  // newline at either edge from the containing block elements) without
+  // touching blank lines *inside* the selection.
+  let start = 0;
+  let end = lines.length - 1;
+  while (start <= end && lines[start]!.trim() === "") start++;
+  while (end >= start && lines[end]!.trim() === "") end--;
+
+  return lines
+    .slice(start, end + 1)
+    .map((line) => (line.trim() === "" ? ">" : `> ${line}`))
+    .join("\n");
+}
+
+/** Append `quoted` (already formatted by `formatQuote`) to the composer's
+ *  `existing` text, one blank line below any existing content, with a
+ *  trailing blank line after the quote — and report where the caret should
+ *  land.
+ *
+ *  The trailing blank line is deliberate, not cosmetic: markdown's lazy
+ *  continuation rule means a line typed immediately after a blockquote (no
+ *  blank line between) is treated as part of that blockquote. Landing the
+ *  caret right after the quote text would silently swallow whatever the user
+ *  types next into the quoted block. The blank line both visually separates
+ *  the quote and gives the caret a paragraph of its own, outside the quote,
+ *  to type into.
+ *
+ *  `quoted === ""` (nothing survived `formatQuote`, e.g. a whitespace-only
+ *  selection) is a no-op: `existing` is returned unchanged with the caret at
+ *  its end. */
+export function appendQuote(existing: string, quoted: string): { text: string; caret: number } {
+  if (!quoted) return { text: existing, caret: existing.length };
+
+  const trimmed = existing.replace(/\s+$/, "");
+  const text = trimmed ? `${trimmed}\n\n${quoted}\n\n` : `${quoted}\n\n`;
+  return { text, caret: text.length };
+}


### PR DESCRIPTION
## What

Selecting text anywhere in the run panel's messages list — user messages, assistant replies, thinking, tool calls, tool results, any rendered event — now surfaces a floating **Quote** pill (quote icon + "Quote" label) near the selection. It stays visible while the selection is live. Clicking it appends the selection to the composer as a markdown blockquote:

```
> the selected text
> across multiple lines
```

separated from any existing draft text by one blank line, with the composer focused and the caret placed on the line below the quote so you can keep typing. Quotes can be stacked repeatedly on the same draft.

## How

- **`src/mainview/lib/quote-selection.ts`** (new) — pure helpers mirroring `diff-selection.ts`: `formatQuote` (CRLF-normalized, `> ` per line, bare `>` for blank/whitespace-only lines, empty for whitespace-only selections) and `appendQuote` (blank-line join, caret at end). The trailing blank line after each quote is deliberate: markdown lazy continuation would otherwise absorb typed text into the blockquote. 17 unit tests.
- **`src/mainview/components/kanban/QuoteSelectionButton.tsx`** (new) — imperative `selectionchange`/scroll/resize listeners with rAF repositioning; shows only for a non-collapsed, non-whitespace selection fully inside the messages list. Portaled to `document.body` because the panel `<aside>`'s `translate-x-*` transform is a containing block for `position: fixed` descendants (viewport coords would paint off-screen otherwise). Carries a dedicated `data-quote-open` marker wired into the panel/search Escape layering — deliberately not `data-popover-open`, which would have disabled Cmd/Ctrl+F whenever text was selected. Hides (rather than clamps) when the selection scrolls out of view; `onMouseDown` preventDefault keeps the selection alive through the click.
- **`RunPanel.tsx` wiring** (minimal diff) — mounted only when the editable composer exists (hidden on background-agent tabs and archived tasks), gated on `sending || backlogBusy` but not `canSend`/`modalPending` (composing stays decoupled from sending). Caret is set **before** `focus()` per the SlashAutocomplete stale-caret gotcha (bcf0d07).
- **`e2e/quote.spec.ts`** (new) — drives the real flow in the Playwright headless harness: seeds a task via the API, produces stream events with the fake claude driver (new `webServer.env` entries in `playwright.config.ts`, inert for the theme spec), builds a real DOM selection, clicks the pill, asserts blockquote content, trailing blank line, caret position, and second-quote stacking.
- **Drive-by fix** — `MessageHistoryPicker.onPick` still had the focus-before-`setSelectionRange` ordering bug that bcf0d07 fixed in `ExtensionPicker`; now ordered correctly.

## Verification

- `bun run typecheck` green
- `bun test` — 2483 pass / 0 fail (17 new)
- `bunx playwright test` — 7/7 (6 theme + 1 quote)

Plan: `docs/plans/quote-messages-list.md`