### PR TITLE
fix: Last Messages lists sent messages from all harnesses

### DIFF
--- a/docs/plans/composer-message-history-dropdown.md
+++ b/docs/plans/composer-message-history-dropdown.md
@@ -1,5 +1,7 @@
 # Plan — Composer message-history dropdown (past sent messages across same-harness tasks)
 
+> Superseded in part by docs/plans/last-messages-all-harnesses.md — the harness-kind scoping described here was removed; userMessageHistory now takes only (limit).
+
 | Field | Value |
 | --- | --- |
 | Date | 2026-08-08 |

--- a/docs/plans/last-messages-all-harnesses.md
+++ b/docs/plans/last-messages-all-harnesses.md
@@ -1,0 +1,101 @@
+# Plan — Last Messages across all harnesses
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-10 |
+| Source | /implement "let's make Last Messages list all last messages, not limited to the same harness" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | fix/last-messages-open-for-all |
+| Base SHA | b0efc2add7debdf30c881e69f3cd85dbc2c2d838 |
+| Mode | Autonomous (no owner present — grill skipped, plan self-approved; see §8) |
+
+## 1. Objective & success criteria
+
+The composer's "Last Messages" history dropdown (MessageHistoryPicker) currently
+lists past sent user messages only from tasks whose harness *kind* matches the
+current task's. Remove that restriction: the dropdown lists the most recent
+sent messages across **all** tasks regardless of harness.
+
+Done when: `GET /tasks/:id/messages/history` returns messages from every
+harness kind, tests assert the new behavior, typecheck + full `bun test` green.
+
+## 2. Context & constraints (grounded)
+
+- Route: `src/bun/server.ts:4686` — builds `agentIds` as the kind-sibling union
+  via `harnesses.getByIdOrKind(task.agent)` + `harnesses.list()` filter, falls
+  back to `[task.agent]` for unknown agents, then calls
+  `runs.userMessageHistory(agentIds, limit)`.
+- Query: `src/bun/db.ts:984` `userMessageHistory(agentIds, limit)` — the only
+  harness scoping is `AND tasks.agent IN (…)`. Sole non-test caller is the
+  route above.
+- Index: `migrations/039_run_events_user_history.sql` covers
+  `(stream, id DESC) WHERE subagent_id IS NULL` — no `tasks.agent` involvement,
+  stays valid unchanged. **No migration needed.**
+- Client: `src/mainview/components/kanban/MessageHistoryPicker.tsx` — fetches,
+  cleans (CR-normalize → canonicalizeAttachmentText → parseUserMessage →
+  splitReferences), dedups on cleaned text, caps at 50. The pipeline is
+  harness-agnostic (fleet knowledge entry 81fcbc7a); non-claude harnesses'
+  user events are appended by agetor's own sendInput path, so they contain
+  plain user text and pass through the cleaner unchanged.
+- Tests: `src/bun/message-history.test.ts` — two tests assert the *old*
+  kind-scoping (cross-kind exclusion, unknown-agent isolation); the rest
+  (streams/blank/dup/ordering/limit/shape/project/auth) are scope-agnostic.
+
+## 3. Approach & key decisions
+
+Drop the filter at the query, simplify the route, fix the copy, update tests.
+
+- Keep the route shape `/tasks/:id/messages/history` and its 404-on-unknown-task:
+  the task id remains the natural UI call site and API-shape churn buys nothing.
+- `userMessageHistory(limit)` loses the `agentIds` param entirely rather than
+  accepting an optional one — one caller, and a dead param is drift bait.
+- The route's `harnesses` lookup block for this endpoint is deleted.
+- Empty-state copy "No past messages for this agent yet." → "No past messages
+  yet." (the qualifier is now wrong).
+
+## 4. Work breakdown — implementation
+
+Single wave, single task (files are small and cohesive; splitting buys nothing).
+
+- **T1** — remove harness scoping end to end. Owns:
+  `src/bun/db.ts` (userMessageHistory signature + SQL),
+  `src/bun/server.ts` (history route only),
+  `src/mainview/components/kanban/MessageHistoryPicker.tsx` (empty-state copy
+  + stale doc comments mentioning per-agent scoping, if any),
+  `src/bun/message-history.test.ts` (rewrite the two kind-scoping tests to
+  assert cross-harness inclusion; leave scope-agnostic tests untouched).
+  Acceptance: history returns messages from claude-code, codex and
+  custom-harness tasks alike; unknown agent strings included too.
+
+## 5. Work breakdown — tests
+
+Folded into T1: this changes behavior an existing suite already pins, so the
+test edits are inseparable from the code change. New coverage = the rewritten
+cross-harness-inclusion test (bare kind + custom harness + different kind +
+unknown agent all mutually visible). **E2e: not applicable** — no e2e harness
+exists in this repo; the HTTP-level bun tests exercise the full route.
+
+## 6. Execution waves
+
+Wave 1: T1. Then review (opus) → test run (haiku: `bun run typecheck` +
+`bun test`).
+
+## 7. Blast radius & risks
+
+- Sole caller of `userMessageHistory` is the route; sole consumer of the route
+  is MessageHistoryPicker. No other surface reads these.
+- Index unaffected; no migration.
+- Risk: non-claude user-event shapes reaching the cleaner — mitigated by the
+  pipeline being shape-agnostic and by dedup-on-cleaned-text.
+- Behavior note: list may now surface messages typed to a different harness
+  (e.g. codex-flavored slash commands into a claude task). Accepted — that is
+  exactly what was asked for.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+1. "All last messages" = across all tasks/projects/harnesses globally. The
+   feature already crossed tasks and projects; the only remaining scoping was
+   harness kind, which the request names.
+2. Archived tasks' messages are currently included (no archived filter exists);
+   preserved as-is — out of scope.
+3. Route stays per-task (`/tasks/:id/…`); no API-shape change.

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -975,20 +975,17 @@ export const runs = {
     ).all(taskId);
   },
   /** Past sent user messages (main-stream only, blank ones excluded) across
-   *  every task whose `agent` resolves to one of `agentIds` — used to build a
-   *  cross-task "message history" picker scoped to a single harness kind.
-   *  Byte-identical texts are collapsed to their most recent occurrence via
-   *  `GROUP BY data` + `MAX(id)`: SQLite's bare-column-with-single-MAX
-   *  semantics (https://www.sqlite.org/lang_select.html#bareagg) guarantees
-   *  the other selected columns come from that same max-id row. */
+   *  every task, regardless of harness — used to build a cross-task "message
+   *  history" picker shared by all tasks. Byte-identical texts are collapsed
+   *  to their most recent occurrence via `GROUP BY data` + `MAX(id)`:
+   *  SQLite's bare-column-with-single-MAX semantics
+   *  (https://www.sqlite.org/lang_select.html#bareagg) guarantees the other
+   *  selected columns come from that same max-id row. */
   userMessageHistory(
-    agentIds: string[],
     limit: number,
   ): Array<{ id: number; data: string; ts: number; taskId: string; taskTitle: string; taskWorkdir: string; projectName: string | null }> {
-    if (agentIds.length === 0) return [];
     type Row = { id: number; data: string; ts: number; taskId: string; taskTitle: string; taskWorkdir: string; projectName: string | null };
-    const placeholders = agentIds.map(() => "?").join(", ");
-    return db.query<Row, Array<string | number>>(
+    return db.query<Row, [number]>(
       `SELECT MAX(run_events.id) as id, run_events.data as data, ts, tasks.id as taskId, tasks.title as taskTitle,
               tasks.workdir as taskWorkdir, projects.name as projectName
        FROM run_events
@@ -998,11 +995,10 @@ export const runs = {
        WHERE run_events.stream = 'user'
          AND run_events.subagent_id IS NULL
          AND trim(run_events.data, char(32,9,10,13)) != ''
-         AND tasks.agent IN (${placeholders})
        GROUP BY run_events.data
        ORDER BY id DESC
        LIMIT ?`,
-    ).all(...agentIds, limit);
+    ).all(limit);
   },
   /** Cheap existence check — is there at least one persisted event for this
    *  task older than `beforeId`? Backs the `hasMore` flag on both the SSE

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -983,11 +983,11 @@ export const runs = {
    *  selected columns come from that same max-id row. */
   userMessageHistory(
     limit: number,
-  ): Array<{ id: number; data: string; ts: number; taskId: string; taskTitle: string; taskWorkdir: string; projectName: string | null }> {
-    type Row = { id: number; data: string; ts: number; taskId: string; taskTitle: string; taskWorkdir: string; projectName: string | null };
+  ): Array<{ id: number; data: string; ts: number; taskId: string; taskTitle: string; taskWorkdir: string; projectName: string | null; taskAgent: string }> {
+    type Row = { id: number; data: string; ts: number; taskId: string; taskTitle: string; taskWorkdir: string; projectName: string | null; taskAgent: string };
     return db.query<Row, [number]>(
       `SELECT MAX(run_events.id) as id, run_events.data as data, ts, tasks.id as taskId, tasks.title as taskTitle,
-              tasks.workdir as taskWorkdir, projects.name as projectName
+              tasks.workdir as taskWorkdir, projects.name as projectName, tasks.agent as taskAgent
        FROM run_events
        JOIN runs ON runs.id = run_events.run_id
        JOIN tasks ON tasks.id = runs.task_id

--- a/src/bun/message-history.test.ts
+++ b/src/bun/message-history.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { test, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -37,15 +37,21 @@ afterAll(() => {
 // that count rows across the shared `tasks`/`runs`/`run_events`/`harnesses`
 // tables rely on a clean slate between suites, so wipe everything we
 // inserted after every test — same pattern as db-events-paging.test.ts.
+// Wiping BEFORE each test matters too: `userMessageHistory` is global (no
+// task/harness scoping), and this file asserts exact result sets, so user
+// events leaked by sibling files that ran earlier in the same `bun test`
+// process would otherwise surface in our responses.
 // Custom harness rows are scoped to ids we control (never touch the seeded
 // built-ins `claude-code`/`codex`/`cursor`).
-afterEach(async () => {
+const wipe = () => {
   db.run(`DELETE FROM run_events`);
   db.run(`DELETE FROM runs`);
   db.run(`DELETE FROM tasks`);
   db.run(`DELETE FROM harnesses WHERE is_builtin = 0`);
   db.run(`DELETE FROM projects`);
-});
+};
+beforeEach(wipe);
+afterEach(wipe);
 
 const BASE = () => `http://127.0.0.1:${server.port}`;
 const authedFetch = (p: string, init: RequestInit = {}) =>

--- a/src/bun/message-history.test.ts
+++ b/src/bun/message-history.test.ts
@@ -131,25 +131,30 @@ test("cross-harness collection: messages from every harness kind are shared acro
 
   const resA = await authedFetch(`/tasks/${a.taskId}/messages/history`);
   expect(resA.status).toBe(200);
-  const bodyA = await resA.json() as { messages: Array<{ text: string; taskId: string }> };
+  const bodyA = await resA.json() as { messages: Array<{ text: string; taskId: string; agent: string }> };
   const textsA = bodyA.messages.map((m) => m.text);
-  expect(textsA).toContain("hello from A");
-  expect(textsA).toContain("hello from B");
-  expect(textsA).toContain("hello from C");
+  expect(textsA.slice().sort()).toEqual(["hello from A", "hello from B", "hello from C"]);
 
+  // The response is identical regardless of which task's endpoint is hit —
+  // `:id` only gates existence, it never scopes the payload.
   const resB = await authedFetch(`/tasks/${b.taskId}/messages/history`);
   const bodyB = await resB.json() as { messages: Array<{ text: string }> };
   const textsB = bodyB.messages.map((m) => m.text);
-  expect(textsB).toContain("hello from A");
-  expect(textsB).toContain("hello from B");
-  expect(textsB).toContain("hello from C");
+  expect(textsB).toEqual(textsA);
 
   const resC = await authedFetch(`/tasks/${c.taskId}/messages/history`);
   const bodyC = await resC.json() as { messages: Array<{ text: string }> };
   const textsC = bodyC.messages.map((m) => m.text);
-  expect(textsC).toContain("hello from A");
-  expect(textsC).toContain("hello from B");
-  expect(textsC).toContain("hello from C");
+  expect(textsC).toEqual(textsA);
+
+  // Codex's message carries a different harness label than the claude-flavored
+  // tasks (bare kind "claude-code" and custom-harness-id "my-claude-harness").
+  const byText = new Map(bodyA.messages.map((m) => [m.text, m.agent]));
+  expect(byText.get("hello from A")).toBe(harnesses.getByIdOrKind("claude-code")!.label);
+  expect(byText.get("hello from B")).toBe("My Claude");
+  expect(byText.get("hello from C")).toBe(harnesses.getByIdOrKind("codex")!.label);
+  expect(byText.get("hello from C")).not.toBe(byText.get("hello from A"));
+  expect(byText.get("hello from C")).not.toBe(byText.get("hello from B"));
 });
 
 test("excludes non-user streams, subagent rows, and blank/space-only data", async () => {
@@ -283,7 +288,7 @@ test("limit: a negative limit falls back to the default", async () => {
   expect(body.messages.map((m) => m.text)).toEqual(["only message"]);
 });
 
-test("response shape: { messages: [{ id, text, ts, taskId, taskTitle, project }] } mirroring run_events.data and the correct task title", async () => {
+test("response shape: { messages: [{ id, text, ts, taskId, taskTitle, project, agent }] } mirroring run_events.data and the correct task title", async () => {
   const { taskId, runId } = seedTask("claude-code", { title: "My Special Task Title" });
   appendUserEvent(runId, "shape check message");
 
@@ -291,12 +296,15 @@ test("response shape: { messages: [{ id, text, ts, taskId, taskTitle, project }]
   const body = await res.json() as { messages: Array<Record<string, unknown>> };
   expect(body.messages.length).toBe(1);
   const msg = body.messages[0]!;
-  expect(Object.keys(msg).sort()).toEqual(["id", "project", "taskId", "taskTitle", "text", "ts"]);
+  expect(Object.keys(msg).sort()).toEqual(["agent", "id", "project", "taskId", "taskTitle", "text", "ts"]);
   expect(typeof msg.id).toBe("number");
   expect(msg.text).toBe("shape check message");
   expect(typeof msg.ts).toBe("number");
   expect(msg.taskId).toBe(taskId);
   expect(msg.taskTitle).toBe("My Special Task Title");
+  // "agent" is the resolved harness *label*, not the raw agent id stored on
+  // the task row.
+  expect(msg.agent).toBe(harnesses.getByIdOrKind("claude-code")!.label);
 });
 
 test("project: registered projects row supplies the name; unregistered workdirs fall back to the path basename", async () => {
@@ -350,7 +358,12 @@ test("unknown-agent tasks are not isolated: unrecognized agent strings share his
   const resD = await authedFetch(`/tasks/${d.taskId}/messages/history`);
   const bodyD = await resD.json() as { messages: Array<{ text: string }> };
   const textsD = bodyD.messages.map((m) => m.text);
-  expect(textsD).toContain("message from D");
-  expect(textsD).toContain("message from E");
-  expect(textsD).toContain("message from F");
+  expect(textsD.slice().sort()).toEqual(["message from D", "message from E", "message from F"]);
+
+  // Same invariant as the cross-harness test: the payload doesn't depend on
+  // which task's endpoint served it, even for an unrecognized agent string.
+  const resF = await authedFetch(`/tasks/${f.taskId}/messages/history`);
+  const bodyF = await resF.json() as { messages: Array<{ text: string }> };
+  const textsF = bodyF.messages.map((m) => m.text);
+  expect(textsF).toEqual(textsD);
 });

--- a/src/bun/message-history.test.ts
+++ b/src/bun/message-history.test.ts
@@ -115,7 +115,7 @@ function appendUserEvent(runId: string, text: string) {
 // GET /tasks/:id/messages/history
 // ---------------------------------------------------------------------------
 
-test("cross-task same-kind collection: bare-kind task and custom-harness task of the same kind share history; a different kind is excluded both ways", async () => {
+test("cross-harness collection: messages from every harness kind are shared across all tasks", async () => {
   // Task A: legacy bare-kind agent string "claude-code".
   const a = seedTask("claude-code");
   appendUserEvent(a.runId, "hello from A");
@@ -125,7 +125,7 @@ test("cross-task same-kind collection: bare-kind task and custom-harness task of
   const b = seedTask("my-claude-harness");
   appendUserEvent(b.runId, "hello from B");
 
-  // Task C: agent "codex" — a different kind entirely.
+  // Task C: agent "codex" — a different kind entirely, no longer excluded.
   const c = seedTask("codex");
   appendUserEvent(c.runId, "hello from C");
 
@@ -135,21 +135,21 @@ test("cross-task same-kind collection: bare-kind task and custom-harness task of
   const textsA = bodyA.messages.map((m) => m.text);
   expect(textsA).toContain("hello from A");
   expect(textsA).toContain("hello from B");
-  expect(textsA).not.toContain("hello from C");
+  expect(textsA).toContain("hello from C");
 
   const resB = await authedFetch(`/tasks/${b.taskId}/messages/history`);
   const bodyB = await resB.json() as { messages: Array<{ text: string }> };
   const textsB = bodyB.messages.map((m) => m.text);
   expect(textsB).toContain("hello from A");
   expect(textsB).toContain("hello from B");
-  expect(textsB).not.toContain("hello from C");
+  expect(textsB).toContain("hello from C");
 
   const resC = await authedFetch(`/tasks/${c.taskId}/messages/history`);
   const bodyC = await resC.json() as { messages: Array<{ text: string }> };
   const textsC = bodyC.messages.map((m) => m.text);
+  expect(textsC).toContain("hello from A");
+  expect(textsC).toContain("hello from B");
   expect(textsC).toContain("hello from C");
-  expect(textsC).not.toContain("hello from A");
-  expect(textsC).not.toContain("hello from B");
 });
 
 test("excludes non-user streams, subagent rows, and blank/space-only data", async () => {
@@ -333,7 +333,7 @@ test("401 without a bearer token, and 401 with the wrong one", async () => {
   expect(wrongAuth.status).toBe(401);
 });
 
-test("unknown-harness fallback: an agent id with no harnesses row and not a bare kind only matches the identical agent string", async () => {
+test("unknown-agent tasks are not isolated: unrecognized agent strings share history with every other task", async () => {
   const UNKNOWN_AGENT = "totally-unknown-agent-xyz";
   const OTHER_UNKNOWN_AGENT = "another-unknown-agent-abc";
 
@@ -343,7 +343,7 @@ test("unknown-harness fallback: an agent id with no harnesses row and not a bare
   const e = seedTask(UNKNOWN_AGENT);
   appendUserEvent(e.runId, "message from E");
 
-  // F has a *different* unrecognized agent string — must not leak in.
+  // F has a *different* unrecognized agent string — no longer excluded.
   const f = seedTask(OTHER_UNKNOWN_AGENT);
   appendUserEvent(f.runId, "message from F");
 
@@ -352,5 +352,5 @@ test("unknown-harness fallback: an agent id with no harnesses row and not a bare
   const textsD = bodyD.messages.map((m) => m.text);
   expect(textsD).toContain("message from D");
   expect(textsD).toContain("message from E");
-  expect(textsD).not.toContain("message from F");
+  expect(textsD).toContain("message from F");
 });

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -4683,6 +4683,8 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
         }),
       },
 
+      // `:id` is only a 404-on-unknown-task existence gate — the payload
+      // itself is global (every task, every harness), not scoped to `:id`.
       "/tasks/:id/messages/history": {
         GET: authed((req) => {
           const taskId = req.params.id;
@@ -4696,6 +4698,13 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             ? Math.max(1, Math.min(Math.floor(limitRaw), 200))
             : 50;
           const rows = runs.userMessageHistory(limit);
+          // Resolve each distinct agent id/kind to its human harness label
+          // once per request rather than per row.
+          const agentLabels = new Map<string, string>();
+          for (const row of rows) {
+            if (agentLabels.has(row.taskAgent)) continue;
+            agentLabels.set(row.taskAgent, harnesses.getByIdOrKind(row.taskAgent)?.label ?? row.taskAgent);
+          }
           const messages = rows.map((row) => ({
             id: row.id,
             text: row.data,
@@ -4703,6 +4712,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             taskId: row.taskId,
             taskTitle: row.taskTitle,
             project: row.projectName ?? (row.taskWorkdir.split("/").filter(Boolean).pop() ?? row.taskWorkdir),
+            agent: agentLabels.get(row.taskAgent)!,
           }));
           return json({ messages }, { headers: corsHeaders(req) });
         }),

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -4695,11 +4695,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           const limit = Number.isFinite(limitRaw) && limitRaw > 0
             ? Math.max(1, Math.min(Math.floor(limitRaw), 200))
             : 50;
-          const harness = harnesses.getByIdOrKind(task.agent);
-          const agentIds = harness
-            ? Array.from(new Set([harness.kind, ...harnesses.list().filter((h) => h.kind === harness.kind).map((h) => h.id)]))
-            : [task.agent];
-          const rows = runs.userMessageHistory(agentIds, limit);
+          const rows = runs.userMessageHistory(limit);
           const messages = rows.map((row) => ({
             id: row.id,
             text: row.data,

--- a/src/mainview/components/kanban/MessageHistoryPicker.tsx
+++ b/src/mainview/components/kanban/MessageHistoryPicker.tsx
@@ -25,6 +25,7 @@ interface CleanedItem {
   ts: number;
   taskTitle: string;
   project: string;
+  agent: string;
 }
 
 /** Reduce a raw sent-message payload to display text: normalize CR newlines,
@@ -138,7 +139,7 @@ export function MessageHistoryPicker({ taskId, disabled, onPick, className }: Pr
           if (!text) continue;
           if (seen.has(text)) continue;
           seen.add(text);
-          cleaned.push({ key: String(m.id), text, ts: m.ts, taskTitle: m.taskTitle, project: m.project });
+          cleaned.push({ key: String(m.id), text, ts: m.ts, taskTitle: m.taskTitle, project: m.project, agent: m.agent });
         }
         // Cap AFTER cleaning/dedup — the server's own LIMIT (FETCH_LIMIT) is
         // taken before dedup/empty/command-output filtering can drop rows,
@@ -212,7 +213,7 @@ export function MessageHistoryPicker({ taskId, disabled, onPick, className }: Pr
                   >
                     <span className="line-clamp-2 text-xs text-foreground">{item.text}</span>
                     <span className="text-[11px] text-muted-foreground">
-                      {item.project} · {item.taskTitle} · {formatTime(item.ts)}
+                      {item.project} · {item.taskTitle} · {item.agent} · {formatTime(item.ts)}
                     </span>
                   </button>
                 </li>

--- a/src/mainview/components/kanban/MessageHistoryPicker.tsx
+++ b/src/mainview/components/kanban/MessageHistoryPicker.tsx
@@ -68,8 +68,9 @@ function formatTime(ts: number): string {
 
 /**
  * Small popover, triggered by a `History` icon button, listing past sent
- * messages for the current task (server-provided, coarsely deduped) so the
- * user can re-insert one into the composer instead of retyping it.
+ * messages across all tasks and harnesses (server-provided, coarsely
+ * deduped) so the user can re-insert one into the composer instead of
+ * retyping it.
  *
  * Client-side cleaning collapses the remaining duplicate shapes the server
  * can't see cheaply: a slash-command send shows up twice in claude-code's
@@ -194,7 +195,7 @@ export function MessageHistoryPicker({ taskId, disabled, onPick, className }: Pr
           )}
           {!loading && !error && items !== null && items.length === 0 && (
             <p className="px-3 py-2 text-xs text-muted-foreground">
-              No past messages for this agent yet.
+              No past messages yet.
             </p>
           )}
           {!loading && !error && items !== null && items.length > 0 && (

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -337,6 +337,7 @@ export interface SentMessageItem {
   taskId: string;
   taskTitle: string;
   project: string;
+  agent: string;
 }
 
 export interface HarnessesPayload { harnesses: Harness[]; statuses: HarnessStatus[] }
@@ -1183,8 +1184,10 @@ export const api = {
     if (limit) q.set("limit", String(limit));
     return j<TaskEventsPage>(`/tasks/${taskId}/events/page?${q.toString()}`);
   },
-  /** Past sent messages for a task, newest first — backs
-   *  `MessageHistoryPicker`'s "insert a past message" dropdown. */
+  /** Past sent messages across every task and harness, newest first — backs
+   *  `MessageHistoryPicker`'s "insert a past message" dropdown. `taskId` only
+   *  selects which task's endpoint is called (and gates 404-on-unknown-task);
+   *  it does not scope the returned payload. */
   fetchMessageHistory: (taskId: string, limit?: number) => {
     const q = limit ? `?${new URLSearchParams({ limit: String(limit) }).toString()}` : "";
     return j<{ messages: SentMessageItem[] }>(`/tasks/${taskId}/messages/history${q}`);


### PR DESCRIPTION
## What

The composer's **Last Messages** history dropdown previously listed past sent messages only from tasks of the **same harness kind** as the current task (claude-code tasks saw only claude-flavored history, codex only codex, etc.). It now lists the most recent sent messages across **all** tasks and harnesses.

- `runs.userMessageHistory(limit)` — dropped the `agentIds` parameter and the `tasks.agent IN (…)` SQL filter (`src/bun/db.ts`).
- `GET /tasks/:id/messages/history` no longer builds the kind-sibling harness id union via `harnesses.getByIdOrKind`; the `:id` is now purely a 404 existence gate (documented on the route) — the payload is global.
- Each history row now carries the **source harness label** (`project · task · harness · time` in the dropdown), so provenance stays visible once harnesses mix. Resolved via `getByIdOrKind(...).label` with a raw-agent-string fallback, threaded `db.ts` → `server.ts` → `SentMessageItem` → `MessageHistoryPicker`.
- Copy/doc drift fixed: picker empty-state ("No past messages yet."), `api.fetchMessageHistory` doc comment, and a supersede marker on `docs/plans/composer-message-history-dropdown.md`.

## Why

Re-usable prompts aren't harness-specific — a message worth re-sending to a claude task is usually just as useful typed at a codex or cursor task. The kind scoping made the dropdown feel arbitrarily empty on newer/less-used harnesses.

## Notes

- **No migration needed**: the covering index (`039_run_events_user_history.sql`) never involved `tasks.agent`; the query plan is byte-identical before/after (verified via `EXPLAIN QUERY PLAN`, ~12% measured cost increase at 100k user events — the `GROUP BY data` temp b-tree already dominated).
- Reviewed (approve, 0 must-fix); deliberately out of scope: excluding archived tasks' messages (they were never excluded) and a perf recency window.
- Tests: the two kind-scoping tests were rewritten to pin cross-harness inclusion, tightened to exact result sets plus the "response is identical regardless of task id" invariant. This exposed a test-isolation gap — `bun test` shares one SQLite DB across files, and rows leaked by sibling suites surfaced once the query went global — fixed by wiping shared tables in `beforeEach` as well as `afterEach`.
- Verified: `bun run typecheck` clean; full `bun test` **2483 pass / 0 fail / 3 skip** (157 files).

Plan: `docs/plans/last-messages-all-harnesses.md`.