### PR TITLE
fix: auto-scroll the composer to the bottom after quoting a selection

### DIFF
--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -1814,6 +1814,12 @@ function RunPanelBody({
         if (!el) return;
         el.setSelectionRange(caret, caret);
         el.focus();
+        // A textarea doesn't scroll to reveal a programmatically-set caret —
+        // when the composer already overflows, the appended quote (and the
+        // caret, which appendQuote always lands at the very end) sits below
+        // the fold until the user scrolls. Bottom IS the caret here, so
+        // pinning scrollTop to scrollHeight is exact, not approximate.
+        el.scrollTop = el.scrollHeight;
       });
     },
     [input],


### PR DESCRIPTION
## What

After quoting selected message text into the RunPanel composer (the quote pill from #166), the textarea now scrolls to the bottom so the appended quote and the caret are immediately visible.

## Why

`handleQuote` already placed the caret at the end of the appended quote via `setSelectionRange` and focused the textarea — but browsers never scroll a textarea to reveal a *programmatically*-set caret. When the composer already had enough content to overflow, the quote landed below the fold and looked like nothing happened until the user scrolled manually.

## How

One addition inside `handleQuote`'s existing `requestAnimationFrame` in `src/mainview/components/kanban/RunPanel.tsx`, after `setSelectionRange` + `focus()`:

```ts
el.scrollTop = el.scrollHeight;
```

This is exact rather than approximate: `appendQuote` always lands the caret at the very end of the composed text, so the bottom of the textarea *is* the caret position.

## Verified

- `bun run typecheck` — green
- `bun test src/mainview/lib/quote-selection.test.ts` — 17/17 pass (the pure formatting lib is untouched; the scroll is DOM behavior, which has no unit harness in this repo)