### PR TITLE
fix: close the Cursor plan modal automatically after a successful approve

### DIFF
--- a/src/mainview/components/kanban/PlanDialog.tsx
+++ b/src/mainview/components/kanban/PlanDialog.tsx
@@ -128,6 +128,11 @@ export function PlanDialog({ task, plan, onClose, onPlanUpdated, focusComposer }
   const [closeError, setCloseError] = useState<string | null>(null);
 
   const requestClose = (afterClose?: () => void) => {
+    // Never close mid-mutation: unmounting while `approvePlan` is in flight
+    // would lose the `sentButUnconfirmed` latch, and a reopened dialog (fresh
+    // mount, plan still `pending`) would let a second approval message reach
+    // the live agent — exactly what the latch exists to prevent.
+    if (saving || closeSaving) return;
     if (dirty) {
       setCloseError(null);
       setConfirmClose({ afterClose });
@@ -198,8 +203,22 @@ export function PlanDialog({ task, plan, onClose, onPlanUpdated, focusComposer }
     setError(null);
     try {
       await checkNoPendingInteractions();
+      // The preview shows `text` (the original content on this path), but the
+      // server approves `editedContent ?? content` — a stale persisted draft
+      // can still exist here (e.g. a revert whose server-side clear failed),
+      // and approving it would deliver text the user isn't looking at. Clear
+      // it first so what's approved is what's on screen.
+      if (plan.editedContent !== null && text === plan.content) {
+        onPlanUpdated(await api.savePlanEdit(task.id, plan.id, null));
+      }
       const updated = await api.approvePlan(task.id, plan.id);
       onPlanUpdated(updated);
+      // Approval succeeded and the message reached the agent — the dialog's
+      // job is done. Close directly (not `requestClose`): any persisted draft
+      // was reconciled above, so the only local divergence left is a
+      // whitespace-only edit that was never saved — an "unsaved edits" prompt
+      // after approving would be noise.
+      onClose();
     } catch (e) {
       handleApproveError(e);
     } finally {
@@ -213,9 +232,14 @@ export function PlanDialog({ task, plan, onClose, onPlanUpdated, focusComposer }
     setError(null);
     try {
       await checkNoPendingInteractions();
-      await api.savePlanEdit(task.id, plan.id, text);
+      // Publish the save result immediately — if the approve below fails, the
+      // parent's `plans` mirror already carries the persisted edit, so the
+      // dialog doesn't read falsely dirty until the next poll catches up.
+      onPlanUpdated(await api.savePlanEdit(task.id, plan.id, text));
       const updated = await api.approvePlan(task.id, plan.id);
       onPlanUpdated(updated);
+      // Same as doApprove — the edit was just persisted, so nothing is dirty.
+      onClose();
     } catch (e) {
       handleApproveError(e);
     } finally {


### PR DESCRIPTION
## What

After clicking **Approve Plan** / **Save & Approve** in the Cursor plan dialog, the approval was applied and the message auto-sent to the agent correctly — but the modal stayed open, re-rendering in its read-only "Approved" state. Both approve handlers in `PlanDialog.tsx` updated the plan state via `onPlanUpdated(updated)` but never called `onClose()`.

The dialog now closes automatically once the approve succeeds. Failure paths are unchanged: API errors and the `sentButUnconfirmed` case (approval message delivered but plan status not persisted) still keep the dialog open showing their error/notice. The close is direct rather than routed through the dirty-close prompt, since after a successful approve nothing meaningful is left unsaved.

## Hardening (from code review of the change)

Review of the diff surfaced one issue introduced-adjacent to the fix and two pre-existing bugs in the same flow; all three are addressed in this commit:

- **Stale-draft approve (WYSIWYG guarantee).** The pending preview renders the local `text`, but the server approves `editedContent ?? content`. A stale persisted draft with `text === plan.content` is reachable (e.g. a Revert whose server-side clear failed) — Approve would then deliver the *hidden draft* while the user sees the original, and with auto-close there'd be no visible clue. `doApprove` now clears the stale draft before approving, so what's approved is always what's on screen.
- **False-dirty after partial success.** In `doSaveAndApprove`, if the save succeeded but the approve failed, the parent's `plans` mirror stayed stale and the dialog prompted about "unsaved edits" that were already persisted. The save result is now published via `onPlanUpdated` before the approve call.
- **Close during in-flight approve loses the double-send guard.** Escape/backdrop during an in-flight approve unmounted the dialog, dropping the `sentButUnconfirmed` latch — reopening re-enabled Approve and could send a **second** approval message to the live agent. `requestClose` now early-returns while a mutation is in flight.

## Verification

- `bun run typecheck` clean
- `bun test`: 2483 pass / 0 fail (run after the initial fix and again after the hardening)