### PR TITLE
feature: Cmd+/Cmd− app-wide font-size control with Settings stepper and parallel-safe e2e harness

### DIFF
--- a/docs/plans/cmd-font-size-controller.md
+++ b/docs/plans/cmd-font-size-controller.md
@@ -1,0 +1,105 @@
+# Plan — Cmd+/Cmd− global font-size (UI zoom) control
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-11 |
+| Source | /implement task: "Cmd+ and Cmd- to control the font size in whole agetor. Consider the current size as the default one and also the smaller. Set an enough maximum" |
+| Config | AGENTS_CONFIG.yml (balanced preset, v1 schema) |
+| Branch | feature/cmd-cmd-font-size-controller |
+| Base SHA | 43709c7d87388ecb926623670e9ef4cfc427f591 |
+| Mode | **Autonomous** — the grill and plan-approval gates were self-resolved; every assumption is logged in §8 |
+
+## 1. Objective & success criteria
+
+Cmd+= / Cmd+− (Ctrl on non-Mac dev builds) scale the font size of the entire agetor webview; Cmd+0 resets. The current size (root 16px) is both the default and the **minimum**; the maximum is **170%**, stepped in 10% increments. The chosen size persists as a preference and is applied **before first paint** on the next launch (no size-jump flash), exactly like the theme preference. The xterm terminal panes scale too (separate explicit path — xterm renders to canvas, outside the CSS cascade).
+
+Success = shortcut works from anywhere in the app (including with a terminal focused), value clamps at 100/170, persists across restarts flash-free, terminal text scales and re-fits, `bun run typecheck` + `bun test` + `bunx playwright test` green.
+
+## 2. Context & constraints (investigation findings, with anchors)
+
+- **No root font-size is set anywhere** — `src/mainview/index.css` has no `html {font-size}` rule; WKWebView default 16px is in effect. `tailwind.config.js` has no `fontSize`/`spacing` overrides, so the whole UI is Tailwind default rem-based → setting `document.documentElement.style.fontSize` scales everything proportionally.
+- **Sole absolute-px exception**: `src/mainview/components/kanban/TerminalView.tsx:108` — xterm `fontSize: 12`, set once at construction. Live-updatable via `term.options.fontSize` mirroring the theme-reactivity effect at `TerminalView.tsx:218-226`; must re-run `fit()` and notify the PTY (`sendResize`, `:135-139`) since glyph cell size changes cols/rows.
+- **Preferences KV store**: `src/bun/db.ts:505-534` (`preferences.get/list/set`), routes `GET /preferences` + `PUT /preferences/:key` (`src/bun/server.ts:2571-2587`), client `api.listPreferences`/`api.setPreference` (`src/mainview/lib/api.ts:1049-1054`). Opaque string values — **no migration, no new route needed**.
+- **Boot no-flash channels (theme precedent, to clone)**: `resolveThemePreference()` in `src/bun/window-url.ts:19-27` (sync DB read, swallow-throw → default) → `src/bun/index.ts:394-438` delivers via BOTH `window.__AGETOR` preload globals (packaged `views://` path — rejects URL fragments) AND `buildWindowHash` (`window-url.ts:38-40`, Vite dev path) → blocking inline `<head>` script in `src/mainview/index.html:7-64` applies before splash CSS parses. `ThemeProvider` seeds React state synchronously from the same globals/hash (`theme-provider.tsx:29-32,60-65`); `App.tsx:204-212` reconciles the DB value once at boot.
+- **Shortcut pattern**: no central registry — features attach their own `document` keydown listeners (Escape: `RunPanel.tsx:249-259`; Cmd+F: `RunPanel.tsx:1397-1421` with `IS_MAC_PLATFORM` sniff at `:172-173`). Native menu (`src/bun/index.ts:51-92`) registers **no** Cmd+Plus/Minus/0 accelerators, so keydowns reach the webview's JS untouched.
+- **Electrobun alternative rejected**: `BrowserWindow.setPageZoom/getPageZoom` exist (electrobun ^1.18.1) but are main-process-controlled, WebKit-only, untestable in the Chromium e2e harness, and add an IPC hop per step. Rem scaling matches the theme precedent. (Decision by reasoning, not spike — see §8.)
+- **Test conventions**: no `.test.tsx` — pure logic extracted to `src/mainview/lib/*.ts` with co-located `bun test` files (`theme.ts`/`theme.test.ts` template). Bun-side preference/route tests: `src/bun/theme-preference.test.ts` (mkdtemp `AGETOR_DATA_DIR`, **unique** `AGETOR_API_PORT`, dynamic imports in `beforeAll`). E2e: Playwright — `playwright.config.ts`, `e2e/theme.spec.ts` template (`bunx playwright test`; `scripts/dev-headless.sh`, data dir `~/.agetor-dev-e2e`, pinned `E2E_API_TOKEN`; assert **computed styles**, never screenshots).
+
+## 3. Approach & key decisions
+
+- **Root rem scaling**: preference `fontSize` stores a percent as string (`"100"`…`"170"`). Applied as `document.documentElement.style.fontSize = (16 * pct/100) + "px"`; at exactly 100% the inline style is **removed/omitted** so the default state stays pristine (and boot channels can skip work).
+- **Constants + clamp live in `src/shared/types.ts`** (the one both-process import point) so bun and mainview can't drift. `index.html`'s blocking script necessarily duplicates the minimal parse/clamp inline (no module imports pre-paint — same as theme).
+- **Shortcut handling**: one `document` keydown listener in **capture phase** with `preventDefault()` when handled, owned by a new `FontSizeProvider` (clone of ThemeProvider's shape). Capture phase guarantees xterm's own key handlers can't swallow it; scope is intentionally global — the ask is "whole agetor", and terminal panes scale with everything else. Primary modifier: meta on Mac, ctrl elsewhere (the `IS_MAC_PLATFORM` approach; keeps Ctrl+− available to terminal programs on the shipped Mac build). Keys: `=`/`+` increase, `-`/`_` decrease, `0` reset; ignore when `altKey`.
+- **Feedback**: sonner toast with a fixed `id: "font-size"` (updates in place, no stacking) showing e.g. "Font size: 120%", "Font size: maximum (170%)".
+- **Persistence**: optimistic set + `api.setPreference("fontSize", …)` with rollback + toast on failure (ThemeProvider's pattern at `theme-provider.tsx:96-109`).
+- **No Settings-dialog control in this slice** — the ask is shortcuts only; a General-section stepper is a natural follow-up (noted in §8).
+
+### Exact contracts (both Wave-1 tasks code against these; typecheck at the barrier catches drift)
+
+`src/shared/types.ts` (owned by T1):
+```ts
+export const FONT_SIZE_MIN = 100;      // percent — current size is default AND minimum
+export const FONT_SIZE_MAX = 170;
+export const FONT_SIZE_STEP = 10;
+export const FONT_SIZE_DEFAULT = 100;
+/** Parse anything (string|number|null|undefined) → int percent clamped to [MIN,MAX]; invalid → DEFAULT. */
+export function clampFontSizePercent(raw: unknown): number;
+```
+
+`src/bun/window-url.ts` (T1): `resolveFontSizePreference(): number` (reads `preferences.get("fontSize")`, clamps, try/catch → `FONT_SIZE_DEFAULT`); `buildWindowHash` gains a `fontSize: number` field → `…&fontSize=<n>` (omit the param when 100 is acceptable, but keep the field required in the opts type).
+
+`src/bun/index.ts` (T1): `window.__AGETOR = { port, token, theme, fontSize }`; the preload apply-script also sets `document.documentElement.style.fontSize` when pct ≠ 100.
+
+`src/mainview/index.html` (T1): blocking script reads `window.__AGETOR.fontSize` first, hash `fontSize` param second; inline parse + clamp (100–170, invalid → 100); applies when ≠ 100 — before the splash `<style>`.
+
+`src/mainview/lib/font-size.ts` (T2):
+```ts
+export type FontSizeAction = "increase" | "decrease" | "reset";
+export function stepFontSize(pct: number, action: FontSizeAction): number;   // clamped
+export function rootFontSizeStyle(pct: number): string | null;               // "19.2px" | null at 100
+export function terminalFontSize(pct: number): number;                       // Math.round(12 * pct/100)
+export function readFontSizeFromBoot(agetorGlobal: unknown, hash: string): number;
+export function fontSizeShortcutAction(
+  e: { key: string; metaKey: boolean; ctrlKey: boolean; altKey: boolean },
+  isMac: boolean,
+): FontSizeAction | null;
+```
+
+`src/mainview/components/font-size-provider.tsx` (T2): `FontSizeProvider` + `useFontSize(): { percent, setPercent, increase, decrease, reset }` — synchronous boot seed, effect applying/removing the root inline style, capture-phase keydown, toast, optimistic persist w/ rollback. T2 also extends the `window.__AGETOR` type declaration (lives mainview-side) with `fontSize?`.
+
+## 4. Work breakdown — implementation (Wave 1, parallel, file-disjoint)
+
+**T1 — Boot channels & bun side.** Owns: `src/shared/types.ts`, `src/bun/window-url.ts`, `src/bun/index.ts`, `src/mainview/index.html`, `src/bun/theme-preference.test.ts` (its `buildWindowHash` assertions hardcode the hash shape and must be updated for the new field). Acceptance: constants/clamp exported per contract; all three boot channels deliver `fontSize`; at 100% no inline style is written; existing tests still pass.
+
+**T2 — Mainview runtime.** Owns: `src/mainview/lib/font-size.ts`, `src/mainview/components/font-size-provider.tsx`, the `window.__AGETOR` type declaration, provider mount point (wherever `ThemeProvider` mounts — `main.tsx` or `App.tsx`), `App.tsx` boot reconcile (mirror theme's at `App.tsx:204-212`), `src/mainview/components/kanban/TerminalView.tsx` (live `term.options.fontSize` + refit + PTY resize; use the `resolvedRef` pattern at `:95-100` so the mount effect doesn't remount on change). Must verify `terminal-keys.ts` doesn't map Cmd+=/− (investigation says it doesn't). Acceptance: shortcut works globally incl. focused terminal; clamps with toast; persists; no WebSocket teardown on size change.
+
+## 5. Work breakdown — tests (Wave 2, parallel, file-disjoint)
+
+**T3 — Unit tests.** Owns: `src/mainview/lib/font-size.test.ts` (step/clamp/shortcut-parse edge cases: invalid strings, floats, alt-modifier, ctrl-vs-meta per platform, `+`/`_` shifted keys) and `src/bun/font-size-preference.test.ts` (clone `theme-preference.test.ts`: `resolveFontSizePreference` defaults/clamping/DB round-trip, `buildWindowHash` shape, `PUT /preferences/fontSize` route; **pick an `AGETOR_API_PORT` unused by any other test file**).
+
+**T4 — E2e.** Owns: `e2e/font-size.spec.ts`, modeled on `e2e/theme.spec.ts`: (a) boot no-flash — seed `PUT /preferences/fontSize=140` via API token, load, assert computed `documentElement` font-size early via `addInitScript`; (b) shortcut steps the computed size (`expect.poll`); (c) clamps at 170 and at 100; (d) Cmd/Ctrl+0 resets; (e) persistence across `page.reload()`. Assert computed values only. E2e applies because the feature is a user-visible whole-app flow crossing webview→API→DB; the harness exists and runs headless via `scripts/dev-headless.sh`.
+
+## 6. Execution waves
+
+1. **Wave 1**: T1 ∥ T2 → barrier → `bun run typecheck` + `bun test` sanity → commit.
+2. **Phase 5**: code review (opus) of `git diff 43709c7…HEAD`.
+3. **Wave 2**: T3 ∥ T4 → commit.
+4. **Phase 7**: runner executes `bun run typecheck`, `bun test`, `bunx playwright test` (owns the whole e2e lifecycle).
+5. **Phase 8**: fixes if needed, re-run to green (cap 3 rounds).
+
+## 7. Blast radius & risks
+
+- `buildWindowHash` signature change → `src/bun/index.ts` call site + `theme-preference.test.ts` (both owned by T1).
+- Capture-phase `preventDefault` on Cmd+=/−/0 removes any browser-default zoom in dev Chromium (intended; the packaged WKWebView had none).
+- xterm font change alters cols/rows → must `fit()` + `sendResize` or the PTY renders stale geometry.
+- Rem scaling scales Tailwind spacing too (`w-80` etc.) — intended "whole UI zoom" behavior, but at 170% narrow layouts get tighter; min=100 caps the risk downward.
+- The three boot channels must stay consistent — same clamp everywhere; `index.html` duplication is deliberate (no pre-paint imports), same as theme.
+
+## 8. Open questions / assumptions (autonomous-mode log)
+
+1. **Max = 170%, step = 10%** — "enough maximum" interpreted as generous-but-layout-safe; trivially adjustable via the shared constants.
+2. **Cmd+0 reset added** though not asked — standard zoom convention, near-zero cost.
+3. **Rem scaling chosen over Electrobun `setPageZoom`** (reasoning in §2/§3; no spike run — the API exists but is untestable in the e2e harness and main-process-bound).
+4. **Shortcut fires even with a terminal focused** — "whole agetor" framing; terminal emulator-style per-pane font zoom rejected.
+5. **No Settings-dialog stepper in this slice** — natural follow-up in `GeneralSection` (`SettingsDialog.tsx:570-647`).
+6. Both human gates (grill, plan approval) self-resolved under autonomous mode.

--- a/docs/plans/e2e-per-worker-backends.md
+++ b/docs/plans/e2e-per-worker-backends.md
@@ -1,0 +1,55 @@
+# Plan — Per-worker e2e backends (remove the Playwright workers:1 cap)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-12 |
+| Source | User: "fix it" — the proper fix flagged in c740d3a: per-worker data dir + port instead of serializing on a shared backend |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/cmd-cmd-font-size-controller |
+| Base SHA | c740d3a |
+| Mode | Autonomous (assumptions in §5) |
+
+## 1. Objective
+
+`bunx playwright test` runs all spec files in parallel (no `workers: 1` cap) deterministically: each Playwright worker provisions its own headless backend (own `AGETOR_DATA_DIR`, own API port, own token), while a single shared Vite serves the static webview to all of them. Suite green across repeated runs at default parallelism; no leaked processes or data dirs.
+
+## 2. Ground truth (investigation anchors)
+
+- The cap guards two things at once: shared SQLite preference state AND the single static `webServer` block that can only start one backend (`playwright.config.ts:36,45-89`).
+- Vite must stay single-instance (`vite.config.ts:18-19` — `port: 5173, strictPort: true`) and CAN be shared: no proxy; the client reads `#api=<port>&token=<token>` from the hash (`src/mainview/lib/api.ts:265`).
+- `src/bun/headless.ts` supports N simultaneous instances on distinct dir/port pairs — env read per process (`AGETOR_DATA_DIR` at `db.ts:42` module load; `AGETOR_API_PORT`/`AGETOR_API_TOKEN` via `api-config.ts:21-24`); creds/pid state all lives under `dataDir`. **Trap**: idle self-shutdown after ~5 min unless `AGETOR_DAEMON_IDLE_MS=0` (`headless.ts:129-143`).
+- Fake-driver env (`AGETOR_CLAUDE_DRIVER=fake`, `AGETOR_CLAUDE_BIN=/bin/echo`, `AGETOR_TMUX_BIN=/bin/echo`, `AGETOR_CLAUDE_ARGS=""`) currently rides on `webServer.env` (`playwright.config.ts:67-88`) and is required by quote.spec.ts (creates + starts a real run) — must move onto each per-worker backend's env.
+- Ports claimed elsewhere: 4317 (packaged default), 4318 (dev/e2e), 4399–4531 (bun unit tests, one static port per file). Per-worker ports go to **4600 + parallelIndex**.
+- No fixture infra exists (zero `test.extend` hits); all three specs import `E2E_API_PORT`/`E2E_API_TOKEN`/`E2E_BASE_URL` from `../playwright.config` and duplicate `gotoApp`/`openSettingsGeneral`/preference helpers.
+- `scripts/dev-headless.sh` stays untouched — it remains the manual/interactive recipe; the fixture spawns `bun src/bun/headless.ts` directly (no nohup/pidfile indirection needed when the fixture owns the child process handle).
+
+## 3. Design
+
+**New `e2e/fixtures.ts`** — the only place backend lifecycle lives:
+- `export const test = base.extend<{}, { backend: E2EBackend }>` with a **worker-scoped** `backend` fixture; `export { expect }`.
+- `E2EBackend = { apiPort: number; apiToken: string; apiBase: string; bootBase: string; dataDir: string }` where `apiBase = http://127.0.0.1:<port>` and `bootBase = ${E2E_BASE_URL}/#api=<port>&token=<token>` (specs append `&theme=`/`&fontSize=` etc. as today).
+- Provision: `apiPort = 4600 + workerInfo.parallelIndex`; `apiToken` = unique per worker (fixed prefix + index is fine — loopback-only, disposable); `dataDir = mkdtemp(os.tmpdir()/agetor-e2e-)` — a fresh dir per worker per run kills the stale-state class entirely and needs no pretest sweep.
+- Spawn `bun src/bun/headless.ts` (child_process, stdio to a log file under the dataDir for debuggability) with env: the dir/port/token trio + `AGETOR_DAEMON_IDLE_MS=0` + the fake-driver quartet. Poll `GET /health` until 200 (≤30s) before yielding.
+- Teardown (after `use`): SIGTERM, wait ≤4s, SIGKILL fallback, then `rm -rf` the temp dataDir. The fixture holds the ChildProcess handle, so no pidfiles.
+
+**`playwright.config.ts`**:
+- `webServer` becomes Vite-only: command `bun run hmr`, `url: E2E_BASE_URL`, keep `reuseExistingServer: !CI` (an interactive `bun run dev:hmr` Vite on 5173 is reusable — it serves the same bundle). Drop the trap/tail wrapper and the backend env block (moved to the fixture).
+- Remove `workers: 1` (keep `fullyParallel: false` — within-file serial is still intended; the specs are written stateful-serial by design).
+- Keep `E2E_VITE_PORT`/`E2E_BASE_URL` exports. Remove `E2E_API_PORT`/`E2E_API_TOKEN`/`E2E_DATA_DIR` exports once nothing imports them (dev-headless.sh does not — it has its own defaults).
+
+**New `e2e/helpers.ts`** — consolidate the duplicated per-spec helpers, parametrized by `E2EBackend`: `gotoApp`, `openSettingsGeneral`, `putPreference`/`getPreferences` (bearer-token fetch wrappers). Specs keep any spec-specific helpers local.
+
+**Spec migrations** (`theme.spec.ts`, `font-size.spec.ts`, `quote.spec.ts`): import `test`/`expect` from `./fixtures`; derive `API_BASE`/`BOOT_URL`/auth from the `backend` fixture (worker-scoped, so a file-level `test.beforeAll(({ backend }) => …)` or per-test destructuring — implementer picks the least-churn shape); swap duplicated helpers for `helpers.ts`. Test bodies/assertions unchanged.
+
+## 4. Work breakdown & execution
+
+- **I1 (sonnet, single agent — the pieces are tightly coupled)**: everything in §3. Verify: `bun run typecheck`; `bunx playwright test` at default parallelism 3× consecutively green; one `--workers=1` run also green (both modes must work); confirm no leftover `agetor-e2e-*` dirs in tmp and no orphan `headless.ts` processes after runs.
+- **Review (opus)**: diff review, focus on lifecycle correctness (leaks on failure paths, health-poll robustness, teardown ordering) and port/token collision reasoning.
+- **Fixes if needed → final runner (haiku)**: typecheck + bun test + playwright (default workers).
+
+## 5. Assumptions (autonomous)
+
+1. Worker backends spawn `headless.ts` directly instead of reusing `dev-headless.sh` — the script keeps its manual-use contract untouched; the fixture owns its child handle, which is strictly more robust than pidfiles.
+2. Temp-dir data dirs (not `~/.agetor-dev-e2e-<n>`) — fresh state per run is a feature for tests; the named `~/.agetor-dev-e2e` dir remains only for whoever uses dev-headless.sh manually.
+3. Port base 4600, disjoint from all known claims.
+4. `fullyParallel` stays `false`; parallelism unit remains the spec file.

--- a/docs/plans/font-size-settings-stepper.md
+++ b/docs/plans/font-size-settings-stepper.md
@@ -1,0 +1,35 @@
+# Plan — Settings → General font-size stepper
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-12 |
+| Source | Follow-up to docs/plans/cmd-font-size-controller.md ("no Settings stepper yet"); user: "/implement it" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/cmd-cmd-font-size-controller |
+| Base SHA | 8551625 (tip after the shortcut slice) |
+| Mode | Autonomous (small, fully-specified slice; assumptions logged in §4) |
+
+## 1. Objective
+
+A "Font size" section in Settings → General (`GeneralSection`, `src/mainview/components/settings/SettingsDialog.tsx:570-647`) that shows the current percent and steps it ±10% within [100, 170], with a reset affordance — a discoverable mirror of the existing Cmd+/Cmd−/Cmd+0 shortcuts. All state/persistence/clamping already lives in `useFontSize()` (`font-size-provider.tsx`); this slice adds UI only.
+
+## 2. Design (contract pinned for the e2e task)
+
+New `<section>` after the Theme section, matching its label/control/hint shape:
+
+- Row: outline icon `Button` **aria-label "Decrease font size"** (lucide `Minus`, disabled at `percent <= FONT_SIZE_MIN`) · percent readout `{percent}%` (tabular-nums, fixed width) · outline icon `Button` **aria-label "Increase font size"** (lucide `Plus`, disabled at `percent >= FONT_SIZE_MAX`) · ghost `Button` **aria-label "Reset font size"**, text "Reset", disabled at `percent === FONT_SIZE_DEFAULT`.
+- Hint (`text-[11px] text-muted-foreground` like the Theme hint): platform-aware via `isMacPlatform()` — "⌘= / ⌘− work anywhere; ⌘0 resets." (Ctrl variants on non-Mac).
+- Clicks call the context's `increase`/`decrease`/`reset` (persistence, debounce, clamping already handled there; whether the shared path toasts on stepper clicks is the implementer's call — visible readout change is the primary feedback, don't add a second feedback path).
+
+## 3. Work breakdown
+
+- **I1 (sonnet)**: `SettingsDialog.tsx` only (+ `font-size-provider.tsx` strictly if the context surface is missing something — not expected). Typecheck + existing tests stay green.
+- **Review (opus)**: diff of I1.
+- **E1 (sonnet)**: extend `e2e/font-size.spec.ts` with a Settings-driven test mirroring the theme picker e2e: open Settings → General, click increase twice → computed root 19.2px, readout "120%", persisted "120" (debounce-aware poll); reset → 16px; bound-disabled assertions. Sequenced after I1 (needs the real selectors).
+- **Run (haiku)**: typecheck + bun test + full playwright.
+
+## 4. Assumptions (autonomous)
+
+1. Stepper (−/%/+/Reset) over a slider or select — matches the discrete 10% steps and the button-row idiom already in GeneralSection.
+2. Placement after Theme; no new Settings section.
+3. Reset button always rendered, disabled at 100% (stable e2e selector, clearer affordance).

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,176 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { type WriteStream, createWriteStream, existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test as base } from "@playwright/test";
+import { E2E_BASE_URL } from "../playwright.config";
+
+export { expect } from "@playwright/test";
+export type { APIRequestContext, Locator, Page } from "@playwright/test";
+
+/**
+ * Worker-scoped headless-backend fixture (docs/plans/e2e-per-worker-backends
+ * .md §3). Each Playwright worker spawns its own `bun src/bun/headless.ts`
+ * on a dedicated data dir + port + token, so `bunx playwright test` can run
+ * every spec file's worker in parallel without any of them racing shared
+ * SQLite preference/task state. Vite stays single-instance and shared — see
+ * `playwright.config.ts`'s `webServer` block.
+ */
+export interface E2EBackend {
+  apiPort: number;
+  apiToken: string;
+  apiBase: string;
+  bootBase: string;
+  dataDir: string;
+}
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+
+// Disjoint from 4317 (packaged app default), 4318 (legacy single-shared e2e
+// port), and 4399-4531 (bun unit tests, one static port per file).
+const BASE_API_PORT = 4600;
+
+const HEALTH_TIMEOUT_MS = 30_000;
+const HEALTH_POLL_INTERVAL_MS = 200;
+const TEARDOWN_GRACE_MS = 4_000;
+
+async function waitForHealth(apiBase: string, logFile: string): Promise<void> {
+  const deadline = Date.now() + HEALTH_TIMEOUT_MS;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${apiBase}/health`);
+      if (res.ok) return;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS));
+  }
+
+  const logTail = existsSync(logFile)
+    ? await readFile(logFile, "utf8")
+        .then((s) => s.slice(-4_000))
+        .catch(() => "<log file unreadable>")
+    : "<no log file>";
+  throw new Error(
+    `headless backend at ${apiBase} never became healthy within ${HEALTH_TIMEOUT_MS}ms` +
+      (lastError ? ` (last poll error: ${String(lastError)})` : "") +
+      `\n--- log tail (${logFile}) ---\n${logTail}`,
+  );
+}
+
+/** SIGTERM, wait up to TEARDOWN_GRACE_MS for a clean exit, SIGKILL fallback.
+ *  Resolves only once the process has actually exited, so the caller can
+ *  safely `rm -rf` the data dir right after (no file-lock/EBUSY race with a
+ *  still-shutting-down SQLite connection). */
+async function killGracefully(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  child.kill("SIGTERM");
+  const timedOut = await Promise.race([
+    exited.then(() => false as const),
+    new Promise<true>((resolve) => setTimeout(() => resolve(true), TEARDOWN_GRACE_MS)),
+  ]);
+  if (timedOut) {
+    child.kill("SIGKILL");
+    await exited;
+  }
+}
+
+export const test = base.extend<{}, { backend: E2EBackend }>({
+  backend: [
+    async ({}, use, workerInfo) => {
+      // `parallelIndex` is the stable 0..(workers-1) slot this worker
+      // process occupies for the whole run; `workerIndex` increments every
+      // time Playwright restarts a worker (e.g. after a crash), so a
+      // restarted worker could reuse another worker's still-live
+      // `workerIndex`-derived port. `parallelIndex` never collides with a
+      // concurrently-running worker, which is what a port assignment needs.
+      const apiPort = BASE_API_PORT + workerInfo.parallelIndex;
+      const apiToken = `e2e-worker-token-${workerInfo.parallelIndex}`;
+      const dataDir = await mkdtemp(path.join(tmpdir(), "agetor-e2e-"));
+      const apiBase = `http://127.0.0.1:${apiPort}`;
+      const logFile = path.join(dataDir, "backend.log");
+
+      const logStream: WriteStream = createWriteStream(logFile);
+      await new Promise<void>((resolve, reject) => {
+        logStream.once("open", () => resolve());
+        logStream.once("error", reject);
+      });
+
+      const child = spawn("bun", ["src/bun/headless.ts"], {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          AGETOR_DATA_DIR: dataDir,
+          AGETOR_API_PORT: String(apiPort),
+          AGETOR_API_TOKEN: apiToken,
+          // Disables headless.ts's idle self-shutdown (defaults to ~5min) —
+          // a worker's backend must stay up for the whole run regardless of
+          // gaps between tests.
+          AGETOR_DAEMON_IDLE_MS: "0",
+          // Same fake-driver combo orchestrator.test.ts uses: with
+          // AGETOR_CLAUDE_DRIVER=fake, spawnAgent's claude-code branch
+          // returns an in-process fake agent instead of shelling out to
+          // tmux. checkHarness (the start-task pre-flight) is a separate
+          // code path that doesn't know about the driver override — it
+          // still resolves a claude-shaped binary AND a tmux binary
+          // regardless — so AGETOR_CLAUDE_BIN/AGETOR_TMUX_BIN point both at
+          // `/bin/echo` (always present) purely to satisfy that probe;
+          // AGETOR_CLAUDE_ARGS is cleared so buildCommand's argv (recorded
+          // by the fake but never executed) isn't polluted by an inherited
+          // shell override. Required by quote.spec.ts; inert for the other
+          // specs, which never start a run.
+          AGETOR_CLAUDE_DRIVER: "fake",
+          AGETOR_CLAUDE_BIN: "/bin/echo",
+          AGETOR_TMUX_BIN: "/bin/echo",
+          AGETOR_CLAUDE_ARGS: "",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      child.stdout?.pipe(logStream);
+      child.stderr?.pipe(logStream);
+
+      // Race the health poll against an early exit/spawn failure (e.g. `bun`
+      // not on PATH, or headless.ts throwing before it binds) so a
+      // misconfigured child fails fast with a useful error instead of
+      // burning the full health-poll timeout. `.catch(() => {})` on the
+      // standalone reference keeps a late rejection (the child exiting
+      // normally during teardown, well after the race has already resolved)
+      // from surfacing as an unhandled rejection.
+      const spawnError = new Promise<never>((_, reject) => {
+        child.once("error", reject);
+        child.once("exit", (code, signal) => {
+          reject(new Error(`headless backend exited early (code=${code}, signal=${signal})`));
+        });
+      });
+      spawnError.catch(() => {});
+
+      try {
+        await Promise.race([waitForHealth(apiBase, logFile), spawnError]);
+      } catch (err) {
+        await killGracefully(child);
+        logStream.end();
+        await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+        throw err;
+      }
+
+      const backend: E2EBackend = {
+        apiPort,
+        apiToken,
+        apiBase,
+        bootBase: `${E2E_BASE_URL}/#api=${apiPort}&token=${apiToken}`,
+        dataDir,
+      };
+
+      await use(backend);
+
+      await killGracefully(child);
+      logStream.end();
+      await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+    },
+    { scope: "worker" },
+  ],
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { type WriteStream, createWriteStream, existsSync } from "node:fs";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -32,11 +33,62 @@ const REPO_ROOT = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "..
 // port), and 4399-4531 (bun unit tests, one static port per file).
 const BASE_API_PORT = 4600;
 
-const HEALTH_TIMEOUT_MS = 30_000;
+// Overridable so a slow/loaded machine (many concurrent worker backends
+// booting at once) can widen the budget without editing source — mirrors the
+// old webServer timeout, which this fixture's health poll effectively
+// replaced per worker.
+const HEALTH_TIMEOUT_MS = Number(process.env.E2E_HEALTH_TIMEOUT_MS ?? 60_000);
 const HEALTH_POLL_INTERVAL_MS = 200;
 const TEARDOWN_GRACE_MS = 4_000;
+const FINAL_KILL_WAIT_MS = 2_000;
+const PREFLIGHT_TIMEOUT_MS = 2_000;
 
-async function waitForHealth(apiBase: string, logFile: string): Promise<void> {
+async function tailFile(filePath: string, maxBytes = 4_000): Promise<string> {
+  if (!existsSync(filePath)) return `<${filePath} not found>`;
+  try {
+    const contents = await readFile(filePath, "utf8");
+    return contents.slice(-maxBytes);
+  } catch {
+    return `<${filePath} unreadable>`;
+  }
+}
+
+/** headless.ts's real diagnostics (bind failures, shutdown reason, idle
+ *  reaper errors) go through `daemonLog` to `<dataDir>/daemon.log`, NOT to
+ *  the piped stdout/stderr in `backend.log` — most startup failures leave
+ *  backend.log empty and the useful signal in daemon.log. Tail both so a
+ *  failure message always points at the actual cause. */
+async function formatLogTails(logFile: string, daemonLogFile: string): Promise<string> {
+  const [stdoutTail, daemonTail] = await Promise.all([tailFile(logFile), tailFile(daemonLogFile)]);
+  return (
+    `--- stdout/stderr tail (${logFile}) ---\n${stdoutTail}\n` +
+    `--- daemon log tail (${daemonLogFile}) ---\n${daemonTail}`
+  );
+}
+
+/** Pre-flight guard against adopting a stale/foreign backend: `/health` is
+ *  unauthenticated, so if anything is already listening on this worker's
+ *  port (an orphaned headless.ts from a prior interrupted run, most likely)
+ *  the post-spawn health poll would happily treat it as "ours" — the token
+ *  mismatch would only surface later, on the first authenticated request,
+ *  far from this fixture and hard to diagnose. Fail fast here instead. */
+async function assertPortFree(apiBase: string, apiPort: number): Promise<void> {
+  let answered: boolean;
+  try {
+    await fetch(`${apiBase}/health`, { signal: AbortSignal.timeout(PREFLIGHT_TIMEOUT_MS) });
+    answered = true;
+  } catch {
+    answered = false; // connection refused/timed out — port is free, proceed
+  }
+  if (!answered) return;
+  throw new Error(
+    `port ${apiPort} is already serving something (pre-flight GET ${apiBase}/health got a ` +
+      `response before we spawned anything) — a stale headless.ts from a prior run is the ` +
+      `likely cause. Recover with:\n  lsof -ti :${apiPort} | xargs kill`,
+  );
+}
+
+async function waitForHealth(apiBase: string): Promise<void> {
   const deadline = Date.now() + HEALTH_TIMEOUT_MS;
   let lastError: unknown;
   while (Date.now() < deadline) {
@@ -48,26 +100,38 @@ async function waitForHealth(apiBase: string, logFile: string): Promise<void> {
     }
     await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS));
   }
-
-  const logTail = existsSync(logFile)
-    ? await readFile(logFile, "utf8")
-        .then((s) => s.slice(-4_000))
-        .catch(() => "<log file unreadable>")
-    : "<no log file>";
   throw new Error(
     `headless backend at ${apiBase} never became healthy within ${HEALTH_TIMEOUT_MS}ms` +
-      (lastError ? ` (last poll error: ${String(lastError)})` : "") +
-      `\n--- log tail (${logFile}) ---\n${logTail}`,
+      (lastError ? ` (last poll error: ${String(lastError)})` : ""),
   );
 }
 
 /** SIGTERM, wait up to TEARDOWN_GRACE_MS for a clean exit, SIGKILL fallback.
- *  Resolves only once the process has actually exited, so the caller can
- *  safely `rm -rf` the data dir right after (no file-lock/EBUSY race with a
- *  still-shutting-down SQLite connection). */
+ *  Resolves once the process has exited (or we've waited as long as we're
+ *  willing to), so the caller can `rm -rf` the data dir right after without
+ *  racing a still-shutting-down SQLite connection. Never hangs: a child that
+ *  never spawned (`pid === undefined`, e.g. `bun` missing from PATH raised
+ *  ENOENT) has nothing to wait for, and the post-SIGKILL wait is bounded —
+ *  a process wedged in uninterruptible I/O would otherwise stall teardown
+ *  forever. */
 async function killGracefully(child: ChildProcess): Promise<void> {
+  if (child.pid === undefined) return;
   if (child.exitCode !== null || child.signalCode !== null) return;
-  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+
+  let settled = false;
+  const exited = new Promise<void>((resolve) => {
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    // ENOENT-style spawn failures can emit 'error'+'close' without ever
+    // firing 'exit'; listen for both so we don't wait on the one that never
+    // comes.
+    child.once("exit", done);
+    child.once("close", done);
+  });
+
   child.kill("SIGTERM");
   const timedOut = await Promise.race([
     exited.then(() => false as const),
@@ -75,7 +139,7 @@ async function killGracefully(child: ChildProcess): Promise<void> {
   ]);
   if (timedOut) {
     child.kill("SIGKILL");
-    await exited;
+    await Promise.race([exited, new Promise<void>((resolve) => setTimeout(resolve, FINAL_KILL_WAIT_MS))]);
   }
 }
 
@@ -89,10 +153,19 @@ export const test = base.extend<{}, { backend: E2EBackend }>({
       // `workerIndex`-derived port. `parallelIndex` never collides with a
       // concurrently-running worker, which is what a port assignment needs.
       const apiPort = BASE_API_PORT + workerInfo.parallelIndex;
-      const apiToken = `e2e-worker-token-${workerInfo.parallelIndex}`;
-      const dataDir = await mkdtemp(path.join(tmpdir(), "agetor-e2e-"));
+      // Random, not deterministic: a deterministic per-worker token would
+      // let a stale backend still bound to this port (see assertPortFree
+      // above) silently authenticate as "ours" if the pre-flight check ever
+      // raced it. A random token makes any such impostor fail auth loudly
+      // instead.
+      const apiToken = `e2e-w${workerInfo.parallelIndex}-${randomUUID()}`;
       const apiBase = `http://127.0.0.1:${apiPort}`;
+
+      await assertPortFree(apiBase, apiPort);
+
+      const dataDir = await mkdtemp(path.join(tmpdir(), "agetor-e2e-"));
       const logFile = path.join(dataDir, "backend.log");
+      const daemonLogFile = path.join(dataDir, "daemon.log");
 
       const logStream: WriteStream = createWriteStream(logFile);
       await new Promise<void>((resolve, reject) => {
@@ -107,10 +180,13 @@ export const test = base.extend<{}, { backend: E2EBackend }>({
           AGETOR_DATA_DIR: dataDir,
           AGETOR_API_PORT: String(apiPort),
           AGETOR_API_TOKEN: apiToken,
-          // Disables headless.ts's idle self-shutdown (defaults to ~5min) —
-          // a worker's backend must stay up for the whole run regardless of
-          // gaps between tests.
-          AGETOR_DAEMON_IDLE_MS: "0",
+          // 10 min, not disabled (0): the idle-shutdown loop in headless.ts
+          // only fires once there's been no running run AND no attached
+          // client for the whole timeout, so it can't trip during an active
+          // suite. What it buys us: if this fixture's own teardown ever
+          // fails to kill the child (crash, bug), the backend self-reaps
+          // instead of squatting on its port forever.
+          AGETOR_DAEMON_IDLE_MS: "600000",
           // Same fake-driver combo orchestrator.test.ts uses: with
           // AGETOR_CLAUDE_DRIVER=fake, spawnAgent's claude-code branch
           // returns an in-process fake agent instead of shelling out to
@@ -133,6 +209,23 @@ export const test = base.extend<{}, { backend: E2EBackend }>({
       child.stdout?.pipe(logStream);
       child.stderr?.pipe(logStream);
 
+      // Surfaces a backend that dies mid-suite (crash, OOM, someone `kill`s
+      // it by hand) instead of leaving it silent — later tests would just
+      // see ECONNREFUSED and point at the wrong thing. Guarded by
+      // `tearingDown` so our own intentional kill in the teardown path below
+      // isn't misreported as a mid-suite death.
+      let tearingDown = false;
+      // Boxed in an object (rather than a bare reassigned `let`) so TS
+      // doesn't narrow the read below back to `null` across the intervening
+      // `await use(backend)` — a plain closure-mutated `let` loses that
+      // narrowing.
+      const deathReport: { info: { code: number | null; signal: NodeJS.Signals | null } | null } = {
+        info: null,
+      };
+      child.on("exit", (code, signal) => {
+        if (!tearingDown) deathReport.info = { code, signal };
+      });
+
       // Race the health poll against an early exit/spawn failure (e.g. `bun`
       // not on PATH, or headless.ts throwing before it binds) so a
       // misconfigured child fails fast with a useful error instead of
@@ -149,12 +242,26 @@ export const test = base.extend<{}, { backend: E2EBackend }>({
       spawnError.catch(() => {});
 
       try {
-        await Promise.race([waitForHealth(apiBase, logFile), spawnError]);
+        await Promise.race([waitForHealth(apiBase), spawnError]);
+        // `/health` answered, but confirm it was actually *our* child that
+        // answered it and not some other process that raced in and bound
+        // the port after assertPortFree's pre-flight check but before (or
+        // during) our own spawn — e.g. our child crashed immediately after
+        // binding and something else grabbed the now-free port before this
+        // check ran.
+        if (child.exitCode !== null || child.signalCode !== null) {
+          throw new Error(
+            `${apiBase}/health answered but our child (pid ${child.pid}) had already exited ` +
+              `(code=${child.exitCode}, signal=${child.signalCode}) — another process owns that port.`,
+          );
+        }
       } catch (err) {
+        const tails = await formatLogTails(logFile, daemonLogFile);
+        tearingDown = true;
         await killGracefully(child);
         logStream.end();
         await rm(dataDir, { recursive: true, force: true }).catch(() => {});
-        throw err;
+        throw new Error(`${(err as Error).message}\n${tails}`);
       }
 
       const backend: E2EBackend = {
@@ -167,9 +274,24 @@ export const test = base.extend<{}, { backend: E2EBackend }>({
 
       await use(backend);
 
+      if (deathReport.info) {
+        const tails = await formatLogTails(logFile, daemonLogFile);
+        // eslint-disable-next-line no-console -- deliberate loud stderr so the
+        // report points at infrastructure, not a flaky test.
+        console.error(
+          `[e2e] backend for worker ${workerInfo.parallelIndex} died mid-suite: ` +
+            `code=${deathReport.info.code} signal=${deathReport.info.signal}\n${tails}`,
+        );
+      }
+
+      tearingDown = true;
       await killGracefully(child);
       logStream.end();
-      await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+      if (process.env.E2E_KEEP_DATA_DIR) {
+        console.log(`[e2e] E2E_KEEP_DATA_DIR set — keeping ${dataDir}`);
+      } else {
+        await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+      }
     },
     { scope: "worker" },
   ],

--- a/e2e/font-size.spec.ts
+++ b/e2e/font-size.spec.ts
@@ -1,0 +1,261 @@
+import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
+import { E2E_API_PORT, E2E_API_TOKEN, E2E_BASE_URL } from "../playwright.config";
+
+/**
+ * E2E coverage for the Cmd+=/Cmd+-/Cmd+0 global font-size (UI zoom) feature
+ * (docs/plans/cmd-font-size-controller.md, T4). Modeled directly on
+ * e2e/theme.spec.ts's harness: real Chromium against the real webview
+ * (Vite dev server) + the real Bun API/orchestrator (both started by
+ * `playwright.config.ts`'s `webServer`) — no mocked fetches.
+ *
+ * Assert **computed root font-size** only (`getComputedStyle(document
+ * .documentElement).fontSize`), never screenshots — see theme.spec.ts's doc
+ * comment for the full rationale (Chromium's rendering differs from the
+ * WKWebView the app ships in).
+ *
+ * Tests share one headless server + SQLite DB and run serially — each test
+ * still starts from a known preference via the direct `PUT
+ * /preferences/fontSize` call in `setFontSizePreference`, so ordering never
+ * has to be inferred from UI state (mirrors theme.spec.ts exactly; there is
+ * no font-size Settings-dialog control in this slice, only the shortcut).
+ */
+
+const API_BASE = `http://127.0.0.1:${E2E_API_PORT}`;
+const BOOT_BASE = `${E2E_BASE_URL}/#api=${E2E_API_PORT}&token=${E2E_API_TOKEN}`;
+
+test.describe.configure({ mode: "serial" });
+
+/** Arrange-only helper: seeds the persisted preference directly through the
+ *  API so each test starts from a known state. */
+async function setFontSizePreference(request: APIRequestContext, value: string): Promise<void> {
+  const res = await request.put(`${API_BASE}/preferences/fontSize`, {
+    headers: { authorization: `Bearer ${E2E_API_TOKEN}` },
+    data: { value },
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
+async function getPersistedFontSize(request: APIRequestContext): Promise<string | undefined> {
+  const res = await request.get(`${API_BASE}/preferences`, {
+    headers: { authorization: `Bearer ${E2E_API_TOKEN}` },
+  });
+  const body = (await res.json()) as Record<string, string>;
+  return body.fontSize;
+}
+
+/** Navigates to the app boot URL — optionally carrying `&fontSize=<pct>` on
+ *  the hash, mirroring what `buildWindowHash` (src/bun/window-url.ts) would
+ *  produce for a persisted non-default value on the Vite dev path — and
+ *  waits for real rendered content (the Settings button) rather than a
+ *  fixed sleep. */
+async function gotoApp(page: Page, bootFontSize?: number): Promise<void> {
+  const url = bootFontSize === undefined ? BOOT_BASE : `${BOOT_BASE}&fontSize=${bootFontSize}`;
+  await page.goto(url);
+  await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
+}
+
+function rootFontSizePx(page: Page): Promise<string> {
+  return page.evaluate(() => getComputedStyle(document.documentElement).fontSize);
+}
+
+function rootInlineFontSize(page: Page): Promise<string> {
+  return page.evaluate(() => document.documentElement.style.fontSize);
+}
+
+/** Same `metaKey` (Mac) vs `ctrlKey` (elsewhere) sniff the app itself uses
+ *  (`isMacPlatform` in src/mainview/lib/font-size.ts), evaluated in-page so
+ *  the correct modifier is pressed regardless of the host platform Chromium
+ *  reports. */
+async function shortcutModifier(page: Page): Promise<"Meta" | "Control"> {
+  const isMac = await page.evaluate(() => /mac/i.test(navigator.platform || navigator.userAgent || ""));
+  return isMac ? "Meta" : "Control";
+}
+
+async function pressZoomIn(page: Page, mod: "Meta" | "Control"): Promise<void> {
+  await page.keyboard.press(`${mod}+Equal`);
+}
+
+async function pressZoomOut(page: Page, mod: "Meta" | "Control"): Promise<void> {
+  await page.keyboard.press(`${mod}+Minus`);
+}
+
+async function pressReset(page: Page, mod: "Meta" | "Control"): Promise<void> {
+  await page.keyboard.press(`${mod}+Digit0`);
+}
+
+test.describe("font-size: boot resolution (no flash)", () => {
+  test("boots directly at a persisted non-default size, before first paint", async ({ page, request }) => {
+    await setFontSizePreference(request, "140");
+
+    // Record the computed root font-size the instant the document finishes
+    // parsing (i.e. right after index.html's blocking <head> script has
+    // run, and well before React mounts) so we can prove the size was
+    // already scaled then — not merely correct by the time our assertions
+    // run after full load. Mirrors theme.spec.ts's `__themeAtParse` capture.
+    await page.addInitScript(() => {
+      (window as unknown as { __fontSizeAtParse?: string }).__fontSizeAtParse = undefined;
+      document.addEventListener(
+        "readystatechange",
+        () => {
+          if (document.readyState !== "loading" && !(window as any).__fontSizeAtParse) {
+            (window as any).__fontSizeAtParse = getComputedStyle(document.documentElement).fontSize;
+          }
+        },
+        { once: false },
+      );
+    });
+
+    // The Vite dev path has no window.__AGETOR preload — the persisted DB
+    // value only reaches the client via the `fontSize` hash param (the same
+    // one `buildWindowHash` appends for a non-default value on this path,
+    // and the same one App.tsx's post-mount reconcile effect exists to
+    // catch up on, too late for pre-paint, if this param is absent).
+    await gotoApp(page, 140);
+
+    const atParse = await page.evaluate(
+      () => (window as unknown as { __fontSizeAtParse?: string }).__fontSizeAtParse,
+    );
+    expect(atParse, "font size should already be scaled right after HTML parsing").toBe("22.4px");
+
+    // And it must still hold after the app has fully mounted — no late
+    // correction/flip once React's FontSizeProvider + boot-reconcile effect
+    // take over.
+    expect(await rootFontSizePx(page)).toBe("22.4px");
+
+    await setFontSizePreference(request, "100");
+  });
+});
+
+test.describe("font-size: shortcut stepping", () => {
+  test("Cmd/Ctrl+=/− steps the computed root font size by 10%, then persists after the debounce", async ({
+    page,
+    request,
+  }) => {
+    await setFontSizePreference(request, "100");
+    await gotoApp(page);
+    expect(await rootFontSizePx(page)).toBe("16px");
+
+    const mod = await shortcutModifier(page);
+
+    await pressZoomIn(page, mod);
+    await expect.poll(() => rootFontSizePx(page)).toBe("17.6px");
+
+    await pressZoomIn(page, mod);
+    await expect.poll(() => rootFontSizePx(page)).toBe("19.2px");
+
+    await pressZoomOut(page, mod);
+    await expect.poll(() => rootFontSizePx(page)).toBe("17.6px");
+
+    // The PUT persist is debounced 300ms trailing-edge — poll the API
+    // rather than asserting immediately after the last keypress.
+    await expect
+      .poll(() => getPersistedFontSize(request), {
+        message: "expected the settled 110% to persist to the server",
+        timeout: 5_000,
+      })
+      .toBe("110");
+
+    await setFontSizePreference(request, "100");
+  });
+});
+
+test.describe("font-size: clamping", () => {
+  test("stepping down at the 100% floor stays clamped at 16px", async ({ page, request }) => {
+    await setFontSizePreference(request, "100");
+    await gotoApp(page);
+    expect(await rootFontSizePx(page)).toBe("16px");
+
+    const mod = await shortcutModifier(page);
+    await pressZoomOut(page, mod);
+    await pressZoomOut(page, mod);
+
+    // No state change occurs at the floor (stepFontSize clamps, and
+    // applyStep's no-op guard skips setPercent entirely), so there is
+    // nothing to poll for — assert directly, after giving any accidental
+    // async update more than the debounce window to have shown up.
+    await page.waitForTimeout(400);
+    expect(await rootFontSizePx(page)).toBe("16px");
+    expect(await rootInlineFontSize(page)).toBe("");
+
+    const persisted = await getPersistedFontSize(request);
+    expect(persisted === undefined || persisted === "100").toBe(true);
+  });
+
+  test("stepping up past the 170% ceiling clamps at 27.2px", async ({ page, request }) => {
+    await setFontSizePreference(request, "100");
+    await gotoApp(page);
+
+    const mod = await shortcutModifier(page);
+    // 7 presses reach the 170% ceiling (100 -> 170 in steps of 10); a few
+    // extra presses confirm it stays clamped rather than overshooting.
+    for (let i = 0; i < 10; i++) {
+      await pressZoomIn(page, mod);
+    }
+
+    await expect.poll(() => rootFontSizePx(page)).toBe("27.2px");
+
+    await expect
+      .poll(() => getPersistedFontSize(request), {
+        message: "expected the clamped 170% to persist to the server",
+        timeout: 5_000,
+      })
+      .toBe("170");
+
+    await setFontSizePreference(request, "100");
+  });
+});
+
+test.describe("font-size: reset", () => {
+  test("Cmd/Ctrl+0 resets to 100% and removes the inline style", async ({ page, request }) => {
+    await setFontSizePreference(request, "140");
+    await gotoApp(page, 140);
+    expect(await rootFontSizePx(page)).toBe("22.4px");
+
+    const mod = await shortcutModifier(page);
+    await pressReset(page, mod);
+
+    await expect.poll(() => rootFontSizePx(page)).toBe("16px");
+    expect(await rootInlineFontSize(page)).toBe("");
+
+    await expect
+      .poll(() => getPersistedFontSize(request), {
+        message: "expected the reset 100% to persist to the server",
+        timeout: 5_000,
+      })
+      .toBe("100");
+  });
+});
+
+test.describe("font-size: persists across reload", () => {
+  test("a non-default size survives page.reload()", async ({ page, request }) => {
+    await setFontSizePreference(request, "100");
+    await gotoApp(page);
+
+    const mod = await shortcutModifier(page);
+    await pressZoomIn(page, mod); // 110%
+    await pressZoomIn(page, mod); // 120%
+    await expect.poll(() => rootFontSizePx(page)).toBe("19.2px");
+
+    // Wait for the debounced write to land before reloading, so the
+    // persisted DB row actually holds 120% by the time the reload's boot
+    // reconcile (App.tsx, fires once at mount) reads it back.
+    await expect
+      .poll(() => getPersistedFontSize(request), {
+        message: "expected 120% to persist before reloading",
+        timeout: 5_000,
+      })
+      .toBe("120");
+
+    // Reload keeps the same URL (no `fontSize` hash param was ever set on
+    // it — the shortcut mutates React state, not the location bar), so on
+    // this dev path the value only reaches the client via App.tsx's
+    // post-mount `api.listPreferences()` reconcile, not a pre-paint boot
+    // channel — hence polling rather than asserting the instant the
+    // "Settings" button appears.
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
+    await expect.poll(() => rootFontSizePx(page)).toBe("19.2px");
+
+    await setFontSizePreference(request, "100");
+  });
+});

--- a/e2e/font-size.spec.ts
+++ b/e2e/font-size.spec.ts
@@ -1,22 +1,31 @@
-import { test, expect, type APIRequestContext, type Locator, type Page } from "@playwright/test";
-import { E2E_API_PORT, E2E_API_TOKEN, E2E_BASE_URL } from "../playwright.config";
+import {
+  test,
+  expect,
+  type APIRequestContext,
+  type E2EBackend,
+  type Locator,
+  type Page,
+} from "./fixtures";
+import { gotoApp as gotoAppUrl, openSettingsGeneral, getPreferences, putPreference } from "./helpers";
 
 /**
  * E2E coverage for the Cmd+=/Cmd+-/Cmd+0 global font-size (UI zoom) feature
  * (docs/plans/cmd-font-size-controller.md, T4). Modeled directly on
  * e2e/theme.spec.ts's harness: real Chromium against the real webview
- * (Vite dev server) + the real Bun API/orchestrator (both started by
- * `playwright.config.ts`'s `webServer`) — no mocked fetches.
+ * (Vite dev server) + the real Bun API/orchestrator (a per-worker instance
+ * provisioned by the `backend` fixture in e2e/fixtures.ts) — no mocked
+ * fetches.
  *
  * Assert **computed root font-size** only (`getComputedStyle(document
  * .documentElement).fontSize`), never screenshots — see theme.spec.ts's doc
  * comment for the full rationale (Chromium's rendering differs from the
  * WKWebView the app ships in).
  *
- * Tests share one headless server + SQLite DB and run serially — each test
- * still starts from a known preference via the direct `PUT
- * /preferences/fontSize` call in `setFontSizePreference`, so ordering never
- * has to be inferred from UI state (mirrors theme.spec.ts exactly).
+ * All tests in this file share this worker's one headless backend + SQLite
+ * DB and run serially — each test still starts from a known preference via
+ * the direct `PUT /preferences/fontSize` call in `setFontSizePreference`, so
+ * ordering never has to be inferred from UI state (mirrors theme.spec.ts
+ * exactly).
  *
  * The Settings → General "Font size" stepper (docs/plans/font-size-settings
  * -stepper.md, commit 68bc973) is a thin UI layer over the same
@@ -25,26 +34,23 @@ import { E2E_API_PORT, E2E_API_TOKEN, E2E_BASE_URL } from "../playwright.config"
  * conventions as the shortcut tests above.
  */
 
-const API_BASE = `http://127.0.0.1:${E2E_API_PORT}`;
-const BOOT_BASE = `${E2E_BASE_URL}/#api=${E2E_API_PORT}&token=${E2E_API_TOKEN}`;
-
 test.describe.configure({ mode: "serial" });
 
 /** Arrange-only helper: seeds the persisted preference directly through the
  *  API so each test starts from a known state. */
-async function setFontSizePreference(request: APIRequestContext, value: string): Promise<void> {
-  const res = await request.put(`${API_BASE}/preferences/fontSize`, {
-    headers: { authorization: `Bearer ${E2E_API_TOKEN}` },
-    data: { value },
-  });
-  expect(res.ok()).toBeTruthy();
+async function setFontSizePreference(
+  request: APIRequestContext,
+  backend: E2EBackend,
+  value: string,
+): Promise<void> {
+  await putPreference(request, backend, "fontSize", value);
 }
 
-async function getPersistedFontSize(request: APIRequestContext): Promise<string | undefined> {
-  const res = await request.get(`${API_BASE}/preferences`, {
-    headers: { authorization: `Bearer ${E2E_API_TOKEN}` },
-  });
-  const body = (await res.json()) as Record<string, string>;
+async function getPersistedFontSize(
+  request: APIRequestContext,
+  backend: E2EBackend,
+): Promise<string | undefined> {
+  const body = await getPreferences(request, backend);
   return body.fontSize;
 }
 
@@ -53,10 +59,12 @@ async function getPersistedFontSize(request: APIRequestContext): Promise<string 
  *  produce for a persisted non-default value on the Vite dev path — and
  *  waits for real rendered content (the Settings button) rather than a
  *  fixed sleep. */
-async function gotoApp(page: Page, bootFontSize?: number): Promise<void> {
-  const url = bootFontSize === undefined ? BOOT_BASE : `${BOOT_BASE}&fontSize=${bootFontSize}`;
-  await page.goto(url);
-  await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
+async function gotoApp(page: Page, backend: E2EBackend, bootFontSize?: number): Promise<void> {
+  const url =
+    bootFontSize === undefined
+      ? backend.bootBase
+      : `${backend.bootBase}&fontSize=${bootFontSize}`;
+  await gotoAppUrl(page, url);
 }
 
 function rootFontSizePx(page: Page): Promise<string> {
@@ -88,15 +96,6 @@ async function pressReset(page: Page, mod: "Meta" | "Control"): Promise<void> {
   await page.keyboard.press(`${mod}+Digit0`);
 }
 
-/** Opens Settings → General (the default section on open — no tab click
- *  needed), mirroring theme.spec.ts's `openSettingsGeneral` exactly. */
-async function openSettingsGeneral(page: Page) {
-  await page.getByRole("button", { name: "Settings", exact: true }).click();
-  const dialog = page.getByRole("dialog");
-  await expect(dialog.getByRole("heading", { name: "Settings" })).toBeVisible();
-  return dialog;
-}
-
 /** Locates the "Font size" `role="group"` row inside an already-open
  *  Settings dialog and returns its four addressable parts, per the markup
  *  pinned in SettingsDialog.tsx's `GeneralSection` (docs/plans/font-size-
@@ -114,8 +113,8 @@ function fontSizeStepper(dialog: Locator) {
 }
 
 test.describe("font-size: boot resolution (no flash)", () => {
-  test("boots directly at a persisted non-default size, before first paint", async ({ page, request }) => {
-    await setFontSizePreference(request, "140");
+  test("boots directly at a persisted non-default size, before first paint", async ({ page, request, backend }) => {
+    await setFontSizePreference(request, backend, "140");
 
     // Record the computed root font-size the instant the document finishes
     // parsing (i.e. right after index.html's blocking <head> script has
@@ -140,7 +139,7 @@ test.describe("font-size: boot resolution (no flash)", () => {
     // one `buildWindowHash` appends for a non-default value on this path,
     // and the same one App.tsx's post-mount reconcile effect exists to
     // catch up on, too late for pre-paint, if this param is absent).
-    await gotoApp(page, 140);
+    await gotoApp(page, backend, 140);
 
     const atParse = await page.evaluate(
       () => (window as unknown as { __fontSizeAtParse?: string }).__fontSizeAtParse,
@@ -152,7 +151,7 @@ test.describe("font-size: boot resolution (no flash)", () => {
     // take over.
     expect(await rootFontSizePx(page)).toBe("22.4px");
 
-    await setFontSizePreference(request, "100");
+    await setFontSizePreference(request, backend, "100");
   });
 });
 
@@ -160,9 +159,10 @@ test.describe("font-size: shortcut stepping", () => {
   test("Cmd/Ctrl+=/− steps the computed root font size by 10%, then persists after the debounce", async ({
     page,
     request,
+    backend,
   }) => {
-    await setFontSizePreference(request, "100");
-    await gotoApp(page);
+    await setFontSizePreference(request, backend, "100");
+    await gotoApp(page, backend);
     expect(await rootFontSizePx(page)).toBe("16px");
 
     const mod = await shortcutModifier(page);
@@ -179,20 +179,20 @@ test.describe("font-size: shortcut stepping", () => {
     // The PUT persist is debounced 300ms trailing-edge — poll the API
     // rather than asserting immediately after the last keypress.
     await expect
-      .poll(() => getPersistedFontSize(request), {
+      .poll(() => getPersistedFontSize(request, backend), {
         message: "expected the settled 110% to persist to the server",
         timeout: 5_000,
       })
       .toBe("110");
 
-    await setFontSizePreference(request, "100");
+    await setFontSizePreference(request, backend, "100");
   });
 });
 
 test.describe("font-size: clamping", () => {
-  test("stepping down at the 100% floor stays clamped at 16px", async ({ page, request }) => {
-    await setFontSizePreference(request, "100");
-    await gotoApp(page);
+  test("stepping down at the 100% floor stays clamped at 16px", async ({ page, request, backend }) => {
+    await setFontSizePreference(request, backend, "100");
+    await gotoApp(page, backend);
     expect(await rootFontSizePx(page)).toBe("16px");
 
     const mod = await shortcutModifier(page);
@@ -207,13 +207,13 @@ test.describe("font-size: clamping", () => {
     expect(await rootFontSizePx(page)).toBe("16px");
     expect(await rootInlineFontSize(page)).toBe("");
 
-    const persisted = await getPersistedFontSize(request);
+    const persisted = await getPersistedFontSize(request, backend);
     expect(persisted === undefined || persisted === "100").toBe(true);
   });
 
-  test("stepping up past the 170% ceiling clamps at 27.2px", async ({ page, request }) => {
-    await setFontSizePreference(request, "100");
-    await gotoApp(page);
+  test("stepping up past the 170% ceiling clamps at 27.2px", async ({ page, request, backend }) => {
+    await setFontSizePreference(request, backend, "100");
+    await gotoApp(page, backend);
 
     const mod = await shortcutModifier(page);
     // 7 presses reach the 170% ceiling (100 -> 170 in steps of 10); a few
@@ -225,20 +225,20 @@ test.describe("font-size: clamping", () => {
     await expect.poll(() => rootFontSizePx(page)).toBe("27.2px");
 
     await expect
-      .poll(() => getPersistedFontSize(request), {
+      .poll(() => getPersistedFontSize(request, backend), {
         message: "expected the clamped 170% to persist to the server",
         timeout: 5_000,
       })
       .toBe("170");
 
-    await setFontSizePreference(request, "100");
+    await setFontSizePreference(request, backend, "100");
   });
 });
 
 test.describe("font-size: reset", () => {
-  test("Cmd/Ctrl+0 resets to 100% and removes the inline style", async ({ page, request }) => {
-    await setFontSizePreference(request, "140");
-    await gotoApp(page, 140);
+  test("Cmd/Ctrl+0 resets to 100% and removes the inline style", async ({ page, request, backend }) => {
+    await setFontSizePreference(request, backend, "140");
+    await gotoApp(page, backend, 140);
     expect(await rootFontSizePx(page)).toBe("22.4px");
 
     const mod = await shortcutModifier(page);
@@ -248,7 +248,7 @@ test.describe("font-size: reset", () => {
     expect(await rootInlineFontSize(page)).toBe("");
 
     await expect
-      .poll(() => getPersistedFontSize(request), {
+      .poll(() => getPersistedFontSize(request, backend), {
         message: "expected the reset 100% to persist to the server",
         timeout: 5_000,
       })
@@ -257,9 +257,9 @@ test.describe("font-size: reset", () => {
 });
 
 test.describe("font-size: persists across reload", () => {
-  test("a non-default size survives page.reload()", async ({ page, request }) => {
-    await setFontSizePreference(request, "100");
-    await gotoApp(page);
+  test("a non-default size survives page.reload()", async ({ page, request, backend }) => {
+    await setFontSizePreference(request, backend, "100");
+    await gotoApp(page, backend);
 
     const mod = await shortcutModifier(page);
     await pressZoomIn(page, mod); // 110%
@@ -270,7 +270,7 @@ test.describe("font-size: persists across reload", () => {
     // persisted DB row actually holds 120% by the time the reload's boot
     // reconcile (App.tsx, fires once at mount) reads it back.
     await expect
-      .poll(() => getPersistedFontSize(request), {
+      .poll(() => getPersistedFontSize(request, backend), {
         message: "expected 120% to persist before reloading",
         timeout: 5_000,
       })
@@ -286,7 +286,7 @@ test.describe("font-size: persists across reload", () => {
     await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
     await expect.poll(() => rootFontSizePx(page)).toBe("19.2px");
 
-    await setFontSizePreference(request, "100");
+    await setFontSizePreference(request, backend, "100");
   });
 });
 
@@ -294,9 +294,10 @@ test.describe("font-size: Settings stepper", () => {
   test("clicking Increase steps the readout and the computed root size, and persists after the debounce", async ({
     page,
     request,
+    backend,
   }) => {
-    await setFontSizePreference(request, "100");
-    await gotoApp(page);
+    await setFontSizePreference(request, backend, "100");
+    await gotoApp(page, backend);
     const dialog = await openSettingsGeneral(page);
     const { readout, increase } = fontSizeStepper(dialog);
 
@@ -311,18 +312,18 @@ test.describe("font-size: Settings stepper", () => {
     expect(await rootFontSizePx(page)).toBe("19.2px");
 
     await expect
-      .poll(() => getPersistedFontSize(request), {
+      .poll(() => getPersistedFontSize(request, backend), {
         message: "expected the settled 120% to persist to the server",
         timeout: 5_000,
       })
       .toBe("120");
 
-    await setFontSizePreference(request, "100");
+    await setFontSizePreference(request, backend, "100");
   });
 
-  test("clicking Reset returns to 100%, clears the inline style, and persists", async ({ page, request }) => {
-    await setFontSizePreference(request, "140");
-    await gotoApp(page, 140);
+  test("clicking Reset returns to 100%, clears the inline style, and persists", async ({ page, request, backend }) => {
+    await setFontSizePreference(request, backend, "140");
+    await gotoApp(page, backend, 140);
     const dialog = await openSettingsGeneral(page);
     const { readout, reset } = fontSizeStepper(dialog);
 
@@ -336,7 +337,7 @@ test.describe("font-size: Settings stepper", () => {
     expect(await rootInlineFontSize(page)).toBe("");
 
     await expect
-      .poll(() => getPersistedFontSize(request), {
+      .poll(() => getPersistedFontSize(request, backend), {
         message: "expected the reset 100% to persist to the server",
         timeout: 5_000,
       })
@@ -346,9 +347,10 @@ test.describe("font-size: Settings stepper", () => {
   test("Decrease/Reset are aria-disabled at the 100% floor (and a click on Decrease is a no-op); Increase is aria-disabled at the 170% ceiling", async ({
     page,
     request,
+    backend,
   }) => {
-    await setFontSizePreference(request, "100");
-    await gotoApp(page);
+    await setFontSizePreference(request, backend, "100");
+    await gotoApp(page, backend);
     const dialog = await openSettingsGeneral(page);
     const { readout, decrease, increase, reset } = fontSizeStepper(dialog);
 
@@ -368,7 +370,7 @@ test.describe("font-size: Settings stepper", () => {
     await page.waitForTimeout(400);
     await expect(readout).toHaveText("100%");
     expect(await rootFontSizePx(page)).toBe("16px");
-    const persistedAtFloor = await getPersistedFontSize(request);
+    const persistedAtFloor = await getPersistedFontSize(request, backend);
     expect(persistedAtFloor === undefined || persistedAtFloor === "100").toBe(true);
 
     // 7 clicks reach the 170% ceiling (100 -> 170 in steps of 10).
@@ -380,7 +382,7 @@ test.describe("font-size: Settings stepper", () => {
     await expect(increase).toHaveAttribute("aria-disabled", "true");
     expect(await rootFontSizePx(page)).toBe("27.2px");
 
-    await setFontSizePreference(request, "100");
+    await setFontSizePreference(request, backend, "100");
   });
 });
 
@@ -388,9 +390,10 @@ test.describe("font-size: Settings ↔ shortcut coherence", () => {
   test("pressing the keyboard shortcut while Settings is open updates the live readout", async ({
     page,
     request,
+    backend,
   }) => {
-    await setFontSizePreference(request, "100");
-    await gotoApp(page);
+    await setFontSizePreference(request, backend, "100");
+    await gotoApp(page, backend);
     const dialog = await openSettingsGeneral(page);
     const { readout } = fontSizeStepper(dialog);
     await expect(readout).toHaveText("100%");
@@ -404,12 +407,12 @@ test.describe("font-size: Settings ↔ shortcut coherence", () => {
     expect(await rootFontSizePx(page)).toBe("19.2px");
 
     await expect
-      .poll(() => getPersistedFontSize(request), {
+      .poll(() => getPersistedFontSize(request, backend), {
         message: "expected the settled 120% to persist to the server",
         timeout: 5_000,
       })
       .toBe("120");
 
-    await setFontSizePreference(request, "100");
+    await setFontSizePreference(request, backend, "100");
   });
 });

--- a/e2e/font-size.spec.ts
+++ b/e2e/font-size.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
+import { test, expect, type APIRequestContext, type Locator, type Page } from "@playwright/test";
 import { E2E_API_PORT, E2E_API_TOKEN, E2E_BASE_URL } from "../playwright.config";
 
 /**
@@ -16,8 +16,13 @@ import { E2E_API_PORT, E2E_API_TOKEN, E2E_BASE_URL } from "../playwright.config"
  * Tests share one headless server + SQLite DB and run serially — each test
  * still starts from a known preference via the direct `PUT
  * /preferences/fontSize` call in `setFontSizePreference`, so ordering never
- * has to be inferred from UI state (mirrors theme.spec.ts exactly; there is
- * no font-size Settings-dialog control in this slice, only the shortcut).
+ * has to be inferred from UI state (mirrors theme.spec.ts exactly).
+ *
+ * The Settings → General "Font size" stepper (docs/plans/font-size-settings
+ * -stepper.md, commit 68bc973) is a thin UI layer over the same
+ * `useFontSize()` context the shortcut drives — same debounced persist, same
+ * clamp — so its coverage below reuses the same state-cleanup and polling
+ * conventions as the shortcut tests above.
  */
 
 const API_BASE = `http://127.0.0.1:${E2E_API_PORT}`;
@@ -81,6 +86,31 @@ async function pressZoomOut(page: Page, mod: "Meta" | "Control"): Promise<void> 
 
 async function pressReset(page: Page, mod: "Meta" | "Control"): Promise<void> {
   await page.keyboard.press(`${mod}+Digit0`);
+}
+
+/** Opens Settings → General (the default section on open — no tab click
+ *  needed), mirroring theme.spec.ts's `openSettingsGeneral` exactly. */
+async function openSettingsGeneral(page: Page) {
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByRole("heading", { name: "Settings" })).toBeVisible();
+  return dialog;
+}
+
+/** Locates the "Font size" `role="group"` row inside an already-open
+ *  Settings dialog and returns its four addressable parts, per the markup
+ *  pinned in SettingsDialog.tsx's `GeneralSection` (docs/plans/font-size-
+ *  settings-stepper.md §2): a `role="group" aria-label="Font size"`
+ *  container holding Decrease/readout/Increase/Reset. */
+function fontSizeStepper(dialog: Locator) {
+  const group = dialog.getByRole("group", { name: "Font size", exact: true });
+  return {
+    group,
+    readout: group.getByRole("status"),
+    decrease: group.getByRole("button", { name: "Decrease font size", exact: true }),
+    increase: group.getByRole("button", { name: "Increase font size", exact: true }),
+    reset: group.getByRole("button", { name: "Reset font size", exact: true }),
+  };
 }
 
 test.describe("font-size: boot resolution (no flash)", () => {
@@ -255,6 +285,130 @@ test.describe("font-size: persists across reload", () => {
     await page.reload();
     await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
     await expect.poll(() => rootFontSizePx(page)).toBe("19.2px");
+
+    await setFontSizePreference(request, "100");
+  });
+});
+
+test.describe("font-size: Settings stepper", () => {
+  test("clicking Increase steps the readout and the computed root size, and persists after the debounce", async ({
+    page,
+    request,
+  }) => {
+    await setFontSizePreference(request, "100");
+    await gotoApp(page);
+    const dialog = await openSettingsGeneral(page);
+    const { readout, increase } = fontSizeStepper(dialog);
+
+    await expect(readout).toHaveText("100%");
+    await increase.click();
+    await expect(readout).toHaveText("110%");
+    await increase.click();
+    await expect(readout).toHaveText("120%");
+
+    // The dialog doesn't block root scaling — the stepper drives the same
+    // `useFontSize()` context the shortcut does.
+    expect(await rootFontSizePx(page)).toBe("19.2px");
+
+    await expect
+      .poll(() => getPersistedFontSize(request), {
+        message: "expected the settled 120% to persist to the server",
+        timeout: 5_000,
+      })
+      .toBe("120");
+
+    await setFontSizePreference(request, "100");
+  });
+
+  test("clicking Reset returns to 100%, clears the inline style, and persists", async ({ page, request }) => {
+    await setFontSizePreference(request, "140");
+    await gotoApp(page, 140);
+    const dialog = await openSettingsGeneral(page);
+    const { readout, reset } = fontSizeStepper(dialog);
+
+    await expect(readout).toHaveText("140%");
+    expect(await rootFontSizePx(page)).toBe("22.4px");
+
+    await reset.click();
+
+    await expect(readout).toHaveText("100%");
+    await expect.poll(() => rootFontSizePx(page)).toBe("16px");
+    expect(await rootInlineFontSize(page)).toBe("");
+
+    await expect
+      .poll(() => getPersistedFontSize(request), {
+        message: "expected the reset 100% to persist to the server",
+        timeout: 5_000,
+      })
+      .toBe("100");
+  });
+
+  test("Decrease/Reset are aria-disabled at the 100% floor (and a click on Decrease is a no-op); Increase is aria-disabled at the 170% ceiling", async ({
+    page,
+    request,
+  }) => {
+    await setFontSizePreference(request, "100");
+    await gotoApp(page);
+    const dialog = await openSettingsGeneral(page);
+    const { readout, decrease, increase, reset } = fontSizeStepper(dialog);
+
+    await expect(decrease).toHaveAttribute("aria-disabled", "true");
+    await expect(reset).toHaveAttribute("aria-disabled", "true");
+    await expect(increase).toHaveAttribute("aria-disabled", "false");
+
+    // aria-disabled (not the `disabled` DOM property) leaves the button in
+    // the DOM as a clickable element — the onClick handler guard is what
+    // makes this a no-op, per docs/plans/font-size-settings-stepper.md's
+    // contract. Playwright's own actionability check treats aria-disabled
+    // the same as the native `disabled` attribute and refuses a plain
+    // `.click()` (it waits for "enabled", timing out), so `force: true` is
+    // required here to actually dispatch the click and exercise the
+    // handler's own guard rather than Playwright's unrelated guard.
+    await decrease.click({ force: true });
+    await page.waitForTimeout(400);
+    await expect(readout).toHaveText("100%");
+    expect(await rootFontSizePx(page)).toBe("16px");
+    const persistedAtFloor = await getPersistedFontSize(request);
+    expect(persistedAtFloor === undefined || persistedAtFloor === "100").toBe(true);
+
+    // 7 clicks reach the 170% ceiling (100 -> 170 in steps of 10).
+    for (let i = 0; i < 7; i++) {
+      await increase.click();
+    }
+
+    await expect(readout).toHaveText("170%");
+    await expect(increase).toHaveAttribute("aria-disabled", "true");
+    expect(await rootFontSizePx(page)).toBe("27.2px");
+
+    await setFontSizePreference(request, "100");
+  });
+});
+
+test.describe("font-size: Settings ↔ shortcut coherence", () => {
+  test("pressing the keyboard shortcut while Settings is open updates the live readout", async ({
+    page,
+    request,
+  }) => {
+    await setFontSizePreference(request, "100");
+    await gotoApp(page);
+    const dialog = await openSettingsGeneral(page);
+    const { readout } = fontSizeStepper(dialog);
+    await expect(readout).toHaveText("100%");
+
+    const mod = await shortcutModifier(page);
+    await pressZoomIn(page, mod);
+    await expect(readout).toHaveText("110%");
+    await pressZoomIn(page, mod);
+    await expect(readout).toHaveText("120%");
+
+    expect(await rootFontSizePx(page)).toBe("19.2px");
+
+    await expect
+      .poll(() => getPersistedFontSize(request), {
+        message: "expected the settled 120% to persist to the server",
+        timeout: 5_000,
+      })
+      .toBe("120");
 
     await setFontSizePreference(request, "100");
   });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,54 @@
+import { expect, type APIRequestContext, type Locator, type Page } from "@playwright/test";
+import type { E2EBackend } from "./fixtures";
+
+/**
+ * Helpers shared across e2e/*.spec.ts. Parametrized by the worker's
+ * `E2EBackend` (e2e/fixtures.ts) rather than the old static
+ * E2E_API_PORT/E2E_API_TOKEN module constants — each worker now owns its own
+ * backend, so there is no single fixed port/token pair to close over.
+ */
+
+/** Navigates to a boot URL and waits for real rendered content — the
+ *  Settings button in the app bar — rather than a fixed sleep. Callers
+ *  assemble the URL themselves (`backend.bootBase` plus any spec-specific
+ *  hash params, e.g. font-size.spec's `&fontSize=`). */
+export async function gotoApp(page: Page, url: string): Promise<void> {
+  await page.goto(url);
+  await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
+}
+
+/** Opens Settings → General (the default section on open — no tab click
+ *  needed) and waits for the dialog to render. */
+export async function openSettingsGeneral(page: Page): Promise<Locator> {
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByRole("heading", { name: "Settings" })).toBeVisible();
+  return dialog;
+}
+
+/** Arrange-only helper: seeds a persisted preference directly through the
+ *  API so a test starts from a known state, without that setup step itself
+ *  being the thing under test. */
+export async function putPreference(
+  request: APIRequestContext,
+  backend: E2EBackend,
+  key: string,
+  value: string,
+): Promise<void> {
+  const res = await request.put(`${backend.apiBase}/preferences/${key}`, {
+    headers: { authorization: `Bearer ${backend.apiToken}` },
+    data: { value },
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
+/** Reads back the full persisted-preferences object. */
+export async function getPreferences(
+  request: APIRequestContext,
+  backend: E2EBackend,
+): Promise<Record<string, string>> {
+  const res = await request.get(`${backend.apiBase}/preferences`, {
+    headers: { authorization: `Bearer ${backend.apiToken}` },
+  });
+  return (await res.json()) as Record<string, string>;
+}

--- a/e2e/quote.spec.ts
+++ b/e2e/quote.spec.ts
@@ -1,20 +1,20 @@
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
-import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
-import { E2E_API_PORT, E2E_API_TOKEN, E2E_BASE_URL } from "../playwright.config";
+import { test, expect, type APIRequestContext, type E2EBackend, type Page } from "./fixtures";
+import { gotoApp } from "./helpers";
 
 /**
  * E2E coverage for quote-on-select in the run panel's messages list
  * (docs/plans/quote-messages-list.md, §5 TT2). Runs Chromium against the
- * real webview + real Bun API/orchestrator (both started by
- * `playwright.config.ts`'s `webServer`) — no mocked fetches, no component
- * harness standing in for the actual DOM.
+ * real webview + real Bun API/orchestrator (a per-worker instance
+ * provisioned by the `backend` fixture in e2e/fixtures.ts) — no mocked
+ * fetches, no component harness standing in for the actual DOM.
  *
  * Producing a rendered message without a real `claude` CLI or tmux: the
- * config's `webServer.env` sets `AGETOR_CLAUDE_DRIVER=fake` (see the comment
- * there), which makes `spawnAgent`'s claude-code branch return an in-process
- * fake agent (`makeFakeAgent` in `src/bun/agents.ts`) instead of shelling out
- * to tmux. That fake emits a plain `stdout` chunk — `"fake response to:
+ * backend fixture sets `AGETOR_CLAUDE_DRIVER=fake` (see the comment there),
+ * which makes `spawnAgent`'s claude-code branch return an in-process fake
+ * agent (`makeFakeAgent` in `src/bun/agents.ts`) instead of shelling out to
+ * tmux. That fake emits a plain `stdout` chunk — `"fake response to:
  * <prompt>"` — ~5ms after start, which the run panel renders through the
  * generic `RawText` block (`RunPanel.tsx`'s `case "stdout"`), i.e. plain
  * selectable text inside a `[data-evid]` wrapper. `AGETOR_CLAUDE_BIN` /
@@ -33,14 +33,11 @@ import { E2E_API_PORT, E2E_API_TOKEN, E2E_BASE_URL } from "../playwright.config"
  * textarea's value/caret.
  *
  * Serial within this file since both tests below would otherwise race the
- * one task/composer they share; `theme.spec.ts` runs as a separate file
- * (separate worker/browser context) and never starts a run, so the two
- * specs don't observe each other's state.
+ * one task/composer they share; `theme.spec.ts` runs as a separate file (its
+ * own worker, browser context, and — since e2e/fixtures.ts — its own
+ * headless backend) and never starts a run, so the two specs don't observe
+ * each other's state.
  */
-
-const API_BASE = `http://127.0.0.1:${E2E_API_PORT}`;
-const BOOT_URL = `${E2E_BASE_URL}/#api=${E2E_API_PORT}&token=${E2E_API_TOKEN}`;
-const AUTH = { authorization: `Bearer ${E2E_API_TOKEN}` };
 
 test.describe.configure({ mode: "serial" });
 
@@ -55,29 +52,26 @@ interface TaskRow {
  *  `expect`) rather than leaving a silent 400 for a later step to trip on. */
 async function createAndStartFakeClaudeTask(
   request: APIRequestContext,
+  backend: E2EBackend,
   prompt: string,
 ): Promise<TaskRow> {
-  const createRes = await request.post(`${API_BASE}/tasks`, {
-    headers: AUTH,
+  const auth = { authorization: `Bearer ${backend.apiToken}` };
+  const createRes = await request.post(`${backend.apiBase}/tasks`, {
+    headers: auth,
     data: { title: prompt, prompt, isolation: "none", workdir: tmpdir() },
   });
   expect(createRes.ok(), `POST /tasks -> ${createRes.status()}: ${await createRes.text()}`).toBeTruthy();
   const task = (await createRes.json()) as TaskRow;
 
-  const startRes = await request.post(`${API_BASE}/tasks/${task.id}/start`, { headers: AUTH });
+  const startRes = await request.post(`${backend.apiBase}/tasks/${task.id}/start`, {
+    headers: auth,
+  });
   expect(
     startRes.ok(),
     `POST /tasks/${task.id}/start -> ${startRes.status()}: ${await startRes.text()}`,
   ).toBeTruthy();
 
   return task;
-}
-
-/** Navigate to the app boot URL and wait for real rendered content — same
- *  pattern as theme.spec.ts's `gotoApp`. */
-async function gotoApp(page: Page): Promise<void> {
-  await page.goto(BOOT_URL);
-  await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
 }
 
 /** The run panel's slide-over `<aside>`. `RunPanel` is mounted after
@@ -135,16 +129,17 @@ test.describe("quote-on-select", () => {
   test("selecting a rendered message shows the Quote pill; quoting it twice stacks blockquotes in the composer", async ({
     page,
     request,
+    backend,
   }) => {
     const prompt = `quote-e2e ${randomUUID()}`;
-    await createAndStartFakeClaudeTask(request, prompt);
+    await createAndStartFakeClaudeTask(request, backend, prompt);
     // The fake driver's canned reply — see the fake-response comment atop
     // this file. Unique per test run via the prompt's uuid, so the
     // tree-walking text search below can never match stale content from a
     // prior run sharing the disposable e2e data dir.
     const responseMarker = `fake response to: ${prompt}`;
 
-    await gotoApp(page);
+    await gotoApp(page, backend.bootBase);
     const panel = await openTask(page, prompt);
 
     // Replayed over the task's unified SSE event stream regardless of

--- a/e2e/quote.spec.ts
+++ b/e2e/quote.spec.ts
@@ -32,11 +32,13 @@ import { gotoApp } from "./helpers";
  * pill's `data-quote-open` marker + accessible name, and the composer
  * textarea's value/caret.
  *
- * Serial within this file since both tests below would otherwise race the
- * one task/composer they share; `theme.spec.ts` runs as a separate file (its
- * own worker, browser context, and — since e2e/fixtures.ts — its own
- * headless backend) and never starts a run, so the two specs don't observe
- * each other's state.
+ * `test.describe.configure({ mode: "serial" })` below is future-proofing:
+ * this file currently has one test, but a second test added later would
+ * share the same worker's backend/DB (per e2e/fixtures.ts) and could race
+ * this one's task/composer state without serial mode. `theme.spec.ts` runs
+ * as a separate file (its own worker, browser context, and its own headless
+ * backend) and never starts a run, so the two specs don't observe each
+ * other's state regardless.
  */
 
 test.describe.configure({ mode: "serial" });
@@ -134,9 +136,10 @@ test.describe("quote-on-select", () => {
     const prompt = `quote-e2e ${randomUUID()}`;
     await createAndStartFakeClaudeTask(request, backend, prompt);
     // The fake driver's canned reply — see the fake-response comment atop
-    // this file. Unique per test run via the prompt's uuid, so the
-    // tree-walking text search below can never match stale content from a
-    // prior run sharing the disposable e2e data dir.
+    // this file. Unique per test via the prompt's uuid — this worker's
+    // backend/DB is shared across every test in the file for the whole run
+    // (per e2e/fixtures.ts), so if this file gains more tests the uuid keeps
+    // the tree-walking text search below from matching another test's task.
     const responseMarker = `fake response to: ${prompt}`;
 
     await gotoApp(page, backend.bootBase);

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -1,13 +1,13 @@
-import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
-import { E2E_API_PORT, E2E_API_TOKEN, E2E_BASE_URL } from "../playwright.config";
+import { test, expect, type APIRequestContext, type E2EBackend, type Page } from "./fixtures";
+import { gotoApp as gotoAppUrl, openSettingsGeneral, putPreference } from "./helpers";
 
 /**
  * E2E coverage for the Auto/Dark/Light theme feature
  * (docs/plans/auto-dark-light-theme.md, T10). Runs Chromium against the real
  * webview served by `bun run hmr` and the real Bun API/orchestrator served
- * by `src/bun/headless.ts` (both started by `playwright.config.ts`'s
- * `webServer`) — no mocked fetches, no internal API calls standing in for UI
- * interaction.
+ * by `src/bun/headless.ts` (a per-worker instance provisioned by the
+ * `backend` fixture in e2e/fixtures.ts) — no mocked fetches, no internal API
+ * calls standing in for UI interaction.
  *
  * These assert **computed colors and DOM classes**, never pixel/screenshot
  * diffs: Chromium's rendering differs from the WKWebView the app actually
@@ -15,15 +15,13 @@ import { E2E_API_PORT, E2E_API_TOKEN, E2E_BASE_URL } from "../playwright.config"
  * product. `screenshot: "only-on-failure"` in the config still captures
  * human-reviewable artifacts on failure.
  *
- * Tests share one headless server + SQLite DB (see `E2E_DATA_DIR`) and run
- * serially — the persistence spec depends on the DB state a prior test left
- * behind, and each test still starts from a known preference via the direct
- * `PUT /preferences/theme` call in `setThemePreference`, so ordering never
- * has to be inferred from Settings-UI state.
+ * All tests in this file share this worker's one headless backend + SQLite
+ * DB and run serially — the persistence spec depends on the DB state a
+ * prior test left behind, and each test still starts from a known
+ * preference via the direct `PUT /preferences/theme` call in
+ * `setThemePreference`, so ordering never has to be inferred from
+ * Settings-UI state.
  */
-
-const API_BASE = `http://127.0.0.1:${E2E_API_PORT}`;
-const BOOT_URL = `${E2E_BASE_URL}/#api=${E2E_API_PORT}&token=${E2E_API_TOKEN}`;
 
 test.describe.configure({ mode: "serial" });
 
@@ -33,20 +31,16 @@ test.describe.configure({ mode: "serial" });
  *  through the Settings UI, which is what's meant to be under test). */
 async function setThemePreference(
   request: APIRequestContext,
+  backend: E2EBackend,
   value: "auto" | "dark" | "light",
 ): Promise<void> {
-  const res = await request.put(`${API_BASE}/preferences/theme`, {
-    headers: { authorization: `Bearer ${E2E_API_TOKEN}` },
-    data: { value },
-  });
-  expect(res.ok()).toBeTruthy();
+  await putPreference(request, backend, "theme", value);
 }
 
 /** Navigates to the app boot URL and waits for real rendered content — the
  *  Settings button in the app bar — rather than a fixed sleep. */
-async function gotoApp(page: Page): Promise<void> {
-  await page.goto(BOOT_URL);
-  await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
+async function gotoApp(page: Page, backend: E2EBackend): Promise<void> {
+  await gotoAppUrl(page, backend.bootBase);
 }
 
 function isDark(page: Page): Promise<boolean> {
@@ -61,20 +55,14 @@ function bodyBackground(page: Page): Promise<string> {
   return page.evaluate(() => getComputedStyle(document.body).backgroundColor);
 }
 
-async function openSettingsGeneral(page: Page) {
-  await page.getByRole("button", { name: "Settings", exact: true }).click();
-  const dialog = page.getByRole("dialog");
-  await expect(dialog.getByRole("heading", { name: "Settings" })).toBeVisible();
-  return dialog;
-}
-
 test.describe("theme: boot resolution (no flash)", () => {
   for (const system of ["dark", "light"] as const) {
     test(`resolves "auto" to the system's ${system} scheme before first paint`, async ({
       page,
       request,
+      backend,
     }) => {
-      await setThemePreference(request, "auto");
+      await setThemePreference(request, backend, "auto");
 
       // Record the `dark` class + color-scheme the instant the document
       // finishes parsing (i.e. right after index.html's blocking <head>
@@ -99,7 +87,7 @@ test.describe("theme: boot resolution (no flash)", () => {
       });
 
       await page.emulateMedia({ colorScheme: system });
-      await gotoApp(page);
+      await gotoApp(page, backend);
 
       const atParse = await page.evaluate(
         () => (window as unknown as { __themeAtParse?: { cls: string; scheme: string } }).__themeAtParse,
@@ -122,9 +110,10 @@ test.describe("theme: Settings → General picker", () => {
   test("selecting Light flips <html> off dark and repaints body; selecting Dark restores it", async ({
     page,
     request,
+    backend,
   }) => {
-    await setThemePreference(request, "dark");
-    await gotoApp(page);
+    await setThemePreference(request, backend, "dark");
+    await gotoApp(page, backend);
     expect(await isDark(page)).toBe(true);
     const darkBg = await bodyBackground(page);
 
@@ -146,9 +135,9 @@ test.describe("theme: Settings → General picker", () => {
     expect(await bodyBackground(page)).toBe(darkBg);
   });
 
-  test("persists the choice across a reload", async ({ page, request }) => {
-    await setThemePreference(request, "dark");
-    await gotoApp(page);
+  test("persists the choice across a reload", async ({ page, request, backend }) => {
+    await setThemePreference(request, backend, "dark");
+    await gotoApp(page, backend);
 
     const dialog = await openSettingsGeneral(page);
     await dialog.getByRole("button", { name: "Light", exact: true }).click();
@@ -162,8 +151,8 @@ test.describe("theme: Settings → General picker", () => {
     expect(await isDark(page)).toBe(false);
     expect(await colorScheme(page)).toBe("light");
 
-    const prefs = await request.get(`${API_BASE}/preferences`, {
-      headers: { authorization: `Bearer ${E2E_API_TOKEN}` },
+    const prefs = await request.get(`${backend.apiBase}/preferences`, {
+      headers: { authorization: `Bearer ${backend.apiToken}` },
     });
     expect((await prefs.json()).theme).toBe("light");
   });
@@ -173,10 +162,11 @@ test.describe("theme: Auto follows the system", () => {
   test("tracks the emulated OS preference, including a live flip while open", async ({
     page,
     request,
+    backend,
   }) => {
-    await setThemePreference(request, "auto");
+    await setThemePreference(request, backend, "auto");
     await page.emulateMedia({ colorScheme: "light" });
-    await gotoApp(page);
+    await gotoApp(page, backend);
     expect(await isDark(page)).toBe(false);
 
     // Live flip — no reload, no re-navigation. This is the behavior
@@ -199,14 +189,15 @@ test.describe("theme: token layer is live", () => {
   test("a converted status token (--danger) actually differs between themes", async ({
     page,
     request,
+    backend,
   }) => {
     const readDanger = () =>
       page.evaluate(() =>
         getComputedStyle(document.documentElement).getPropertyValue("--danger").trim(),
       );
 
-    await setThemePreference(request, "dark");
-    await gotoApp(page);
+    await setThemePreference(request, backend, "dark");
+    await gotoApp(page, backend);
     const dangerDark = await readDanger();
 
     const dialog = await openSettingsGeneral(page);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,6 +28,12 @@ export const E2E_BASE_URL = `http://localhost:${E2E_VITE_PORT}`;
 export default defineConfig({
   testDir: "e2e",
   fullyParallel: false,
+  // `fullyParallel: false` only serializes tests WITHIN a file — Playwright
+  // still gives each spec file its own worker, and every worker hits the one
+  // shared headless backend + SQLite data dir. Cross-file races on shared
+  // preference state (theme, fontSize) flake the suite; one worker keeps it
+  // deterministic.
+  workers: 1,
   retries: 0,
   reporter: process.env.CI ? [["list"]] : [["list"], ["html", { open: "never" }]],
   use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,39 +1,46 @@
 import { defineConfig, devices } from "@playwright/test";
 
 /**
- * E2E harness for the theme feature (docs/plans/auto-dark-light-theme.md,
- * T10). Drives the real Bun API + orchestrator via `scripts/dev-headless.sh`
- * (landed in 94b1f2d) — no Electrobun window, just Vite on :5173 and the
- * headless backend — against Chromium. This is the "spike verdict" recipe
- * from the plan's §2, not a fresh exploration.
+ * E2E harness for the theme, font-size, and quote-on-select features
+ * (docs/plans/auto-dark-light-theme.md T10, cmd-font-size-controller.md T4,
+ * quote-messages-list.md §5 TT2). Drives Chromium against two pieces of real
+ * infrastructure — no mocked fetches, no component harness standing in for
+ * the actual DOM:
  *
- * Pinning `AGETOR_API_TOKEN` (rather than scraping the token file
- * `dev-headless.sh` persists to `$AGETOR_DATA_DIR/headless-dev/token`) keeps
- * the harness deterministic. This is a disposable, e2e-only value — the API
- * it authorizes is loopback-bound (127.0.0.1) and only lives for the
- * duration of `bun run test:e2e`.
+ *   - **One shared Vite dev server** (`bun run hmr`, :5173), started by the
+ *     `webServer` block below. Vite must stay single-instance — it's pinned
+ *     to `port: 5173, strictPort: true` (vite.config.ts) — and CAN be
+ *     shared across every worker's browser context, because it's stateless:
+ *     each worker's page just carries its own backend's port/token on the
+ *     `#api=<port>&token=<token>` URL hash, which the client already reads
+ *     at boot (src/mainview/lib/api.ts).
+ *   - **One headless Bun backend per Playwright worker** (its own
+ *     `AGETOR_DATA_DIR`, `AGETOR_API_PORT`, and token), provisioned by the
+ *     worker-scoped `backend` fixture in e2e/fixtures.ts. Because each
+ *     worker's SQLite state (theme/fontSize preferences, tasks) is fully
+ *     isolated from every other worker's, spec files can run in parallel
+ *     without racing each other — see e2e/fixtures.ts for spawn/health-poll/
+ *     teardown, and e2e/helpers.ts for the gotoApp/openSettingsGeneral/
+ *     preference helpers shared across specs, both parametrized by the
+ *     worker's `E2EBackend`.
  *
- * `AGETOR_DATA_DIR` is a dedicated `~/.agetor-dev-e2e` directory, distinct
- * from both the real `~/.agetor` (never touch — that's the user's live data)
- * and `~/.agetor-dev` (the interactive `bun run dev:hmr` dir) so an
- * automated test run can't disturb either.
+ * `docs/plans/e2e-per-worker-backends.md` has the full design; this config
+ * used to also own backend spawning (a single shared `scripts/dev-headless
+ * .sh`-driven backend gated behind `workers: 1`) before that moved to the
+ * per-worker fixture.
  */
 export const E2E_VITE_PORT = 5173;
-export const E2E_API_PORT = 4318;
-export const E2E_API_TOKEN =
-  "e2e0000000000000000000000000000000000000000000000000000000000";
-export const E2E_DATA_DIR = `${process.env.HOME}/.agetor-dev-e2e`;
 export const E2E_BASE_URL = `http://localhost:${E2E_VITE_PORT}`;
 
 export default defineConfig({
   testDir: "e2e",
   fullyParallel: false,
   // `fullyParallel: false` only serializes tests WITHIN a file — Playwright
-  // still gives each spec file its own worker, and every worker hits the one
-  // shared headless backend + SQLite data dir. Cross-file races on shared
-  // preference state (theme, fontSize) flake the suite; one worker keeps it
-  // deterministic.
-  workers: 1,
+  // still gives each spec file its own worker, and (since e2e/fixtures.ts)
+  // each worker now owns its own headless backend + data dir, so cross-file
+  // races on shared preference state are no longer possible. That's what
+  // let the old `workers: 1` cap (needed when every worker hit one shared
+  // backend) go away.
   retries: 0,
   reporter: process.env.CI ? [["list"]] : [["list"], ["html", { open: "never" }]],
   use: {
@@ -43,48 +50,9 @@ export default defineConfig({
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: {
-    // `dev-headless.sh start` backgrounds the actual vite/bun processes via
-    // `nohup … &` and returns immediately once the API is healthy — so the
-    // command Playwright spawns wouldn't otherwise stay alive for it to
-    // manage. Trapping SIGTERM/SIGINT/EXIT to run `… stop` and then tailing
-    // the logs (keeping the shell in the foreground) lets Playwright's
-    // normal "kill the webServer process on teardown" path double as the
-    // proven recipe's teardown step, without a separate globalTeardown file.
-    command:
-      'bash -c \'trap "scripts/dev-headless.sh stop" EXIT INT TERM; scripts/dev-headless.sh start; tail -f "$AGETOR_DATA_DIR/headless-dev/backend.log" "$AGETOR_DATA_DIR/headless-dev/vite.log"\'',
-    // The backend (not vite) is the slower, dependency-bearing half — vite
-    // typically answers on :5173 within a few hundred ms, well before the
-    // Bun API has finished opening/migrating SQLite. Gating readiness on
-    // vite alone let Playwright start running tests (which hit the API
-    // directly, e.g. `setThemePreference`) before the backend was actually
-    // listening, causing an intermittent ECONNREFUSED. Health-checking the
-    // backend instead is a stronger guarantee, since `dev-headless.sh`
-    // starts vite first — by the time the backend is healthy, vite has had
-    // even more of a head start.
-    url: `http://127.0.0.1:${E2E_API_PORT}/health`,
+    command: "bun run hmr",
+    url: E2E_BASE_URL,
     timeout: 60_000,
     reuseExistingServer: !process.env.CI,
-    env: {
-      AGETOR_DATA_DIR: E2E_DATA_DIR,
-      AGETOR_API_PORT: String(E2E_API_PORT),
-      AGETOR_API_TOKEN: E2E_API_TOKEN,
-      // Added for e2e/quote.spec.ts (docs/plans/quote-messages-list.md §5
-      // TT2). Same fake-driver combo `orchestrator.test.ts` uses: with
-      // AGETOR_CLAUDE_DRIVER=fake, spawnAgent's claude-code branch returns an
-      // in-process fake agent instead of shelling out to tmux, so a run can
-      // be driven end to end without a real `claude` CLI or tmux session.
-      // `checkHarness` (the start-task pre-flight) is a separate code path
-      // that doesn't know about the driver override — it still resolves a
-      // `claude`-shaped binary AND a tmux binary regardless — so
-      // AGETOR_CLAUDE_BIN/AGETOR_TMUX_BIN point both at `/bin/echo` (always
-      // present) purely to satisfy that probe; AGETOR_CLAUDE_ARGS is cleared
-      // so buildCommand's argv (recorded by the fake but never executed)
-      // isn't polluted by an inherited shell override. Inert for
-      // theme.spec.ts, which never starts a run.
-      AGETOR_CLAUDE_DRIVER: "fake",
-      AGETOR_CLAUDE_BIN: "/bin/echo",
-      AGETOR_TMUX_BIN: "/bin/echo",
-      AGETOR_CLAUDE_ARGS: "",
-    },
   },
 });

--- a/scripts/dev-headless.sh
+++ b/scripts/dev-headless.sh
@@ -75,6 +75,25 @@ resolve_theme() {
   esac
 }
 
+# Same idea as resolve_theme above, for the `fontSize` boot channel
+# (src/bun/window-url.ts's resolveFontSizePreference) — without this the
+# browser-driven (Playwright) path would boot at the default 100% regardless
+# of what's persisted, showing a size-jump flash once main.tsx's React tree
+# reconciles the real preference. Falls back to 100 (FONT_SIZE_DEFAULT) on
+# any failure, matching resolveFontSizePreference's own default.
+resolve_font_size() {
+  local fs
+  fs="$(cd "$REPO_ROOT" && AGETOR_DATA_DIR="$DATA_DIR" bun -e '
+    import("./src/bun/window-url.ts").then((m) => {
+      process.stdout.write(String(m.resolveFontSizePreference()));
+    });
+  ' 2>/dev/null | tail -n1)"
+  case "$fs" in
+    ''|*[!0-9]*) echo 100 ;;
+    *) echo "$fs" ;;
+  esac
+}
+
 read_pid_file() {
   [ -f "$1" ] && cat "$1" || true
 }
@@ -119,13 +138,19 @@ wait_for_health() {
 print_access_info() {
   local token="$1"
   local theme; theme="$(resolve_theme)"
+  local fs; fs="$(resolve_font_size)"
+  local font_size_param=""
+  # Omit the param at the 100 default, matching buildWindowHash's own
+  # omit-at-default rule (src/bun/window-url.ts) so this printed URL is
+  # byte-identical to the pre-font-size shape for the common case.
+  [ "$fs" != "100" ] && font_size_param="&fontSize=$fs"
   echo
   grn "agetor dev (headless) is up"
   echo "  backend:  http://127.0.0.1:$API_PORT  (log: $BACKEND_LOG)"
   echo "  frontend: http://127.0.0.1:$VITE_PORT  (log: $VITE_LOG)"
   echo
   echo "Open in a browser (tunnel both ports first if this is a remote host):"
-  grn "  http://localhost:$VITE_PORT/#api=$API_PORT&token=$token&theme=$theme"
+  grn "  http://localhost:$VITE_PORT/#api=$API_PORT&token=$token&theme=$theme$font_size_param"
   echo
   dim "  curl -H \"Authorization: Bearer $token\" http://127.0.0.1:$API_PORT/tasks"
   echo

--- a/src/bun/font-size-preference.test.ts
+++ b/src/bun/font-size-preference.test.ts
@@ -1,0 +1,256 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-font-size-preference-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+// Unique port, distinct from every other *.test.ts file's AGETOR_API_PORT.
+process.env.AGETOR_API_PORT = "4531";
+
+let server: { stop: () => void; port: number };
+let token: string;
+let preferences: typeof import("./db.ts").preferences;
+let resolveFontSizePreference: typeof import("./window-url.ts").resolveFontSizePreference;
+let buildWindowHash: typeof import("./window-url.ts").buildWindowHash;
+
+beforeAll(async () => {
+  ({ preferences } = await import("./db.ts"));
+  ({ resolveFontSizePreference, buildWindowHash } = await import("./window-url.ts"));
+  const { startApiServer, API_TOKEN } = await import("./server.ts");
+  server = startApiServer() as unknown as { stop: () => void; port: number };
+  token = API_TOKEN;
+});
+
+afterAll(() => {
+  server?.stop?.();
+});
+
+const url = (p: string) => `http://127.0.0.1:4531${p}`;
+// Built lazily — `token` is only assigned in beforeAll, after module load.
+const auth = () => ({ authorization: `Bearer ${token}` });
+
+// --- /preferences + /preferences/:key over HTTP ---------------------------
+
+test("GET /preferences omits the fontSize key entirely when nothing has been set", async () => {
+  const res = await fetch(url("/preferences"), { headers: auth() });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Record<string, string>;
+  expect(Object.prototype.hasOwnProperty.call(body, "fontSize")).toBe(false);
+});
+
+test("PUT /preferences/fontSize persists '130' and GET reflects it", async () => {
+  const put = await fetch(url("/preferences/fontSize"), {
+    method: "PUT",
+    headers: { ...auth(), "content-type": "application/json" },
+    body: JSON.stringify({ value: "130" }),
+  });
+  expect(put.status).toBe(204);
+
+  const get = await fetch(url("/preferences"), { headers: auth() });
+  const body = (await get.json()) as Record<string, string>;
+  expect(body.fontSize).toBe("130");
+});
+
+test("overwriting fontSize replaces the value rather than duplicating it (ON CONFLICT DO UPDATE)", async () => {
+  await fetch(url("/preferences/fontSize"), {
+    method: "PUT",
+    headers: { ...auth(), "content-type": "application/json" },
+    body: JSON.stringify({ value: "110" }),
+  });
+  await fetch(url("/preferences/fontSize"), {
+    method: "PUT",
+    headers: { ...auth(), "content-type": "application/json" },
+    body: JSON.stringify({ value: "150" }),
+  });
+
+  const get = await fetch(url("/preferences"), { headers: auth() });
+  const body = (await get.json()) as Record<string, string>;
+  expect(body.fontSize).toBe("150");
+  expect(preferences.get("fontSize")).toBe("150");
+});
+
+test("PUT /preferences/fontSize with a non-string value ({ value: 130 }) is rejected with 400 and leaves the stored value unchanged", async () => {
+  await fetch(url("/preferences/fontSize"), {
+    method: "PUT",
+    headers: { ...auth(), "content-type": "application/json" },
+    body: JSON.stringify({ value: "140" }),
+  });
+
+  const res = await fetch(url("/preferences/fontSize"), {
+    method: "PUT",
+    headers: { ...auth(), "content-type": "application/json" },
+    body: JSON.stringify({ value: 130 }),
+  });
+  expect(res.status).toBe(400);
+  expect(preferences.get("fontSize")).toBe("140");
+});
+
+test("PUT /preferences/fontSize with an empty body ({}) is rejected with 400 and leaves the stored value unchanged", async () => {
+  await fetch(url("/preferences/fontSize"), {
+    method: "PUT",
+    headers: { ...auth(), "content-type": "application/json" },
+    body: JSON.stringify({ value: "140" }),
+  });
+
+  const res = await fetch(url("/preferences/fontSize"), {
+    method: "PUT",
+    headers: { ...auth(), "content-type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  expect(res.status).toBe(400);
+  expect(preferences.get("fontSize")).toBe("140");
+});
+
+test("requests without a bearer token are rejected with 401", async () => {
+  const getRes = await fetch(url("/preferences"));
+  expect(getRes.status).toBe(401);
+
+  const putRes = await fetch(url("/preferences/fontSize"), {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ value: "140" }),
+  });
+  expect(putRes.status).toBe(401);
+});
+
+test("writing fontSize does not disturb other preference keys, and vice versa", async () => {
+  await fetch(url("/preferences/defaultHarness"), {
+    method: "PUT",
+    headers: { ...auth(), "content-type": "application/json" },
+    body: JSON.stringify({ value: "claude-code" }),
+  });
+  await fetch(url("/preferences/fontSize"), {
+    method: "PUT",
+    headers: { ...auth(), "content-type": "application/json" },
+    body: JSON.stringify({ value: "120" }),
+  });
+
+  const get = await fetch(url("/preferences"), { headers: auth() });
+  const body = (await get.json()) as Record<string, string>;
+  expect(body.fontSize).toBe("120");
+  expect(body.defaultHarness).toBe("claude-code");
+});
+
+test("the server stores fontSize as an opaque string — no server-side clamping of the 100-170 bounds", async () => {
+  // Contrast with src/shared/types.ts's clampFontSizePercent, which is the
+  // actual defense against an out-of-range or garbage value — the server
+  // itself performs no such check and will happily round-trip anything
+  // that's a string, exactly like theme.
+  const put = await fetch(url("/preferences/fontSize"), {
+    method: "PUT",
+    headers: { ...auth(), "content-type": "application/json" },
+    body: JSON.stringify({ value: "not-a-number" }),
+  });
+  expect(put.status).toBe(204);
+
+  const get = await fetch(url("/preferences"), { headers: auth() });
+  const body = (await get.json()) as Record<string, string>;
+  expect(body.fontSize).toBe("not-a-number");
+});
+
+test("the server round-trips an out-of-range numeric string ('300') verbatim — clamping happens client/boot-side, not server-side", async () => {
+  const put = await fetch(url("/preferences/fontSize"), {
+    method: "PUT",
+    headers: { ...auth(), "content-type": "application/json" },
+    body: JSON.stringify({ value: "300" }),
+  });
+  expect(put.status).toBe(204);
+
+  const get = await fetch(url("/preferences"), { headers: auth() });
+  const body = (await get.json()) as Record<string, string>;
+  expect(body.fontSize).toBe("300");
+});
+
+// --- window-url.ts: resolveFontSizePreference + buildWindowHash -----------
+
+test("resolveFontSizePreference falls back to 100 when nothing is stored", async () => {
+  // Reach for the store directly and confirm the current state, since
+  // resolveFontSizePreference reads through the same `preferences` module
+  // the HTTP tests above mutate. There's no delete on the store, so instead
+  // verify the fallback contract precisely: anything that isn't a valid
+  // in-range value resolves to FONT_SIZE_DEFAULT (100).
+  preferences.set("fontSize", "not-a-real-size");
+  expect(resolveFontSizePreference()).toBe(100);
+});
+
+test("resolveFontSizePreference clamps an out-of-range stored value to the nearer bound", () => {
+  preferences.set("fontSize", "300");
+  expect(resolveFontSizePreference()).toBe(170);
+
+  preferences.set("fontSize", "1");
+  expect(resolveFontSizePreference()).toBe(100);
+});
+
+test("resolveFontSizePreference falls back to 100 for a non-numeric stored value", () => {
+  preferences.set("fontSize", "abc");
+  expect(resolveFontSizePreference()).toBe(100);
+});
+
+test("resolveFontSizePreference passes an in-range stored value through unchanged", () => {
+  preferences.set("fontSize", "140");
+  expect(resolveFontSizePreference()).toBe(140);
+
+  preferences.set("fontSize", "100");
+  expect(resolveFontSizePreference()).toBe(100);
+
+  preferences.set("fontSize", "170");
+  expect(resolveFontSizePreference()).toBe(170);
+});
+
+test("resolveFontSizePreference rounds a fractional stored value", () => {
+  preferences.set("fontSize", "133.6");
+  expect(resolveFontSizePreference()).toBe(134);
+});
+
+test("resolveFontSizePreference falls back to 100 (instead of throwing) when the DB read itself throws", () => {
+  // Regression coverage for the window-build path: buildWindow in
+  // src/bun/index.ts awaits resolveFontSizePreference() before constructing
+  // the BrowserWindow — an uncaught throw here (e.g. a locked/corrupt
+  // SQLite file) must not reject that promise and block the main window
+  // from ever opening. Simulate the throw at the `preferences.get` boundary
+  // rather than actually corrupting the on-disk DB (which would poison
+  // every other test in this file that shares AGETOR_DATA_DIR).
+  const realGet = preferences.get;
+  preferences.get = () => {
+    throw new Error("simulated: database disk image is malformed");
+  };
+  try {
+    expect(resolveFontSizePreference()).toBe(100);
+  } finally {
+    preferences.get = realGet;
+  }
+  // The store itself is unaffected — restoring the stub didn't lose data.
+  preferences.set("fontSize", "140");
+  expect(resolveFontSizePreference()).toBe(140);
+});
+
+test("buildWindowHash omits &fontSize= entirely when fontSize is exactly the 100 default", () => {
+  const hash = buildWindowHash({ port: "4317", token: "sekrit-token", theme: "dark", fontSize: 100 });
+  expect(hash).toBe("#api=4317&token=sekrit-token&theme=dark");
+  expect(hash.includes("fontSize")).toBe(false);
+});
+
+test("buildWindowHash appends &fontSize=<n> as the trailing param when fontSize is not the default", () => {
+  const hash = buildWindowHash({ port: "4317", token: "sekrit-token", theme: "dark", fontSize: 140 });
+  expect(hash).toBe("#api=4317&token=sekrit-token&theme=dark&fontSize=140");
+});
+
+test("buildWindowHash reflects the maximum (170) verbatim, unclamped — clamping is resolveFontSizePreference's job, not buildWindowHash's", () => {
+  const hash = buildWindowHash({ port: "4317", token: "tok", theme: "auto", fontSize: 170 });
+  expect(hash).toBe("#api=4317&token=tok&theme=auto&fontSize=170");
+});
+
+test("buildWindowHash passes an out-of-range fontSize value through verbatim — it does not clamp", () => {
+  // buildWindowHash is a pure string template; normalization is
+  // resolveFontSizePreference's job. A caller that hands it an
+  // already-resolved-but-out-of-range value (shouldn't happen in practice,
+  // but the function itself performs no defense) sees it echoed as-is.
+  const hash = buildWindowHash({ port: "4317", token: "tok", theme: "auto", fontSize: 9999 });
+  expect(hash).toBe("#api=4317&token=tok&theme=auto&fontSize=9999");
+});
+
+test("buildWindowHash keeps fontSize as the last param regardless of theme value", () => {
+  const hash = buildWindowHash({ port: "1", token: "t", theme: "light", fontSize: 120 });
+  expect(hash).toBe("#api=1&token=t&theme=light&fontSize=120");
+});

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -4,8 +4,8 @@ import { rehydratePath } from "./login-path.ts";
 import { startApiServer, API_PORT, API_TOKEN, type ApiNative } from "./server.ts";
 import { db, harnesses, pidFilePath, tasks, dataDir } from "./db.ts";
 import { reconcileOrphans, sweepArchivedTeardowns, reapIdleSessions } from "./orchestrator.ts";
-import { SESSION_REAP_SWEEP_MS } from "../shared/types.ts";
-import { resolveThemePreference, buildWindowHash } from "./window-url.ts";
+import { SESSION_REAP_SWEEP_MS, FONT_SIZE_DEFAULT } from "../shared/types.ts";
+import { resolveThemePreference, resolveFontSizePreference, buildWindowHash } from "./window-url.ts";
 import { broadcastAppEvent, consumeForceQuit } from "./quit-guard.ts";
 import { refreshDiscoveredModels } from "./agent-discovery.ts";
 import { startUpdaterLoop, applyUpdate, checkForUpdate, getUpdateSnapshot } from "./updater.ts";
@@ -394,6 +394,7 @@ const windowLifecycle = makeWindowLifecycle({
   buildWindow: async (frame: Frame) => {
     const url = await getMainViewUrl();
     const theme = resolveThemePreference();
+    const fontSize = resolveFontSizePreference();
     // The native views:// scheme handler refuses URLs that carry a fragment
     // or query — it treats the part after the scheme as a literal file path,
     // so `views://mainview/index.html#api=…` resolves to a non-existent file
@@ -430,12 +431,30 @@ const windowLifecycle = makeWindowLifecycle({
       `var r=document.documentElement;` +
       `if(r){r.classList.toggle("dark",d);r.style.colorScheme=d?"dark":"light";}` +
       `}catch(e){}`;
+    // Same rationale as themeApplyScript above: applies the resolved
+    // font-size percent itself, rather than only exposing it for
+    // index.html's inline <head> script to read back, so neither script has
+    // to win a race against the other — both derive the identical px value
+    // from the identical `fontSize` number. At FONT_SIZE_DEFAULT (100) this
+    // is the empty string: no inline style is written, matching the
+    // "pristine at default" contract (there's nothing to clear, since
+    // nothing was ever set). The px value is computed once here in Bun and
+    // inlined as a literal — re-running this script (e.g. if the preload
+    // and index.html's script both fire) just re-assigns the same value, an
+    // idempotent no-op.
+    const fontSizeApplyScript =
+      fontSize === FONT_SIZE_DEFAULT
+        ? ""
+        : `try{var r2=document.documentElement;` +
+          `if(r2){r2.style.fontSize=${JSON.stringify(`${(16 * fontSize) / 100}px`)};}` +
+          `}catch(e){}`;
     const bootGlobals =
       `window.__AGETOR=${JSON.stringify({
         port: String(API_PORT),
         token: API_TOKEN,
         theme,
-      })};` + themeApplyScript;
+        fontSize,
+      })};` + themeApplyScript + fontSizeApplyScript;
     const isHttpUrl = url.startsWith("http://") || url.startsWith("https://");
     // `remembered` (window-lifecycle.ts) is in-memory only, updated live from
     // "move"/"resize" events — it's never validated against the display
@@ -459,7 +478,9 @@ const windowLifecycle = makeWindowLifecycle({
       title: "Agetor",
       titleBarStyle: "hiddenInset",
       trafficLightOffset: { x: 8, y: 8 },
-      url: isHttpUrl ? `${url}${buildWindowHash({ port: String(API_PORT), token: API_TOKEN, theme })}` : url,
+      url: isHttpUrl
+        ? `${url}${buildWindowHash({ port: String(API_PORT), token: API_TOKEN, theme, fontSize })}`
+        : url,
       preload: bootGlobals,
       frame: safeFrame,
     });

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -4,7 +4,7 @@ import { rehydratePath } from "./login-path.ts";
 import { startApiServer, API_PORT, API_TOKEN, type ApiNative } from "./server.ts";
 import { db, harnesses, pidFilePath, tasks, dataDir } from "./db.ts";
 import { reconcileOrphans, sweepArchivedTeardowns, reapIdleSessions } from "./orchestrator.ts";
-import { SESSION_REAP_SWEEP_MS, FONT_SIZE_DEFAULT } from "../shared/types.ts";
+import { SESSION_REAP_SWEEP_MS, FONT_SIZE_DEFAULT, FONT_SIZE_BASE_PX } from "../shared/types.ts";
 import { resolveThemePreference, resolveFontSizePreference, buildWindowHash } from "./window-url.ts";
 import { broadcastAppEvent, consumeForceQuit } from "./quit-guard.ts";
 import { refreshDiscoveredModels } from "./agent-discovery.ts";
@@ -446,7 +446,7 @@ const windowLifecycle = makeWindowLifecycle({
       fontSize === FONT_SIZE_DEFAULT
         ? ""
         : `try{var r2=document.documentElement;` +
-          `if(r2){r2.style.fontSize=${JSON.stringify(`${(16 * fontSize) / 100}px`)};}` +
+          `if(r2){r2.style.fontSize=${JSON.stringify(`${(FONT_SIZE_BASE_PX * fontSize) / 100}px`)};}` +
           `}catch(e){}`;
     const bootGlobals =
       `window.__AGETOR=${JSON.stringify({

--- a/src/bun/theme-preference.test.ts
+++ b/src/bun/theme-preference.test.ts
@@ -229,7 +229,7 @@ test("resolveThemePreference falls back to 'auto' (instead of throwing) when the
 });
 
 test("buildWindowHash includes api, token, and theme as a hash fragment (not a query string)", () => {
-  const hash = buildWindowHash({ port: "4317", token: "sekrit-token", theme: "dark" });
+  const hash = buildWindowHash({ port: "4317", token: "sekrit-token", theme: "dark", fontSize: 100 });
   expect(hash).toBe("#api=4317&token=sekrit-token&theme=dark");
   expect(hash.startsWith("#")).toBe(true);
   expect(hash.includes("?")).toBe(false);
@@ -244,6 +244,15 @@ test("buildWindowHash passes an unknown/garbage theme value through verbatim (it
     port: "4317",
     token: "tok",
     theme: "not-a-real-theme" as unknown as "auto",
+    fontSize: 100,
   });
   expect(hash).toBe("#api=4317&token=tok&theme=not-a-real-theme");
+});
+
+test("buildWindowHash appends &fontSize=<n> only when fontSize is not the 100 default", () => {
+  const atDefault = buildWindowHash({ port: "4317", token: "tok", theme: "auto", fontSize: 100 });
+  expect(atDefault).toBe("#api=4317&token=tok&theme=auto");
+
+  const scaled = buildWindowHash({ port: "4317", token: "tok", theme: "auto", fontSize: 140 });
+  expect(scaled).toBe("#api=4317&token=tok&theme=auto&fontSize=140");
 });

--- a/src/bun/window-url.ts
+++ b/src/bun/window-url.ts
@@ -1,5 +1,6 @@
 import { preferences } from "./db.ts";
 import type { ThemePreference } from "../shared/types.ts";
+import { clampFontSizePercent, FONT_SIZE_DEFAULT } from "../shared/types.ts";
 
 /**
  * Resolve the persisted theme preference for the boot payload. Falls back to
@@ -27,14 +28,47 @@ export function resolveThemePreference(): ThemePreference {
 }
 
 /**
- * Pure builder for the URL hash fragment carrying the per-launch boot
- * payload to the dev (Vite `http://`) window URL — `#api=<port>&token=<token>&theme=<pref>`.
- * Exported so a bun-side test can assert on the exact fragment shape without
- * constructing a BrowserWindow. This only backs the `isHttpUrl` branch below;
- * the bundled `views://` path threads the same three fields through
- * `bootGlobals` (`window.__AGETOR`) instead, since that scheme handler
- * rejects URLs carrying a fragment (see the comment on `buildWindow` below).
+ * Resolve the persisted font-size preference for the boot payload, mirroring
+ * `resolveThemePreference` exactly: a synchronous DB read run through the
+ * shared clamp, with any throw (locked/corrupt SQLite file) swallowed and
+ * treated as "nothing stored" — falls back to FONT_SIZE_DEFAULT rather than
+ * rejecting the caller's promise and blocking the main window from ever
+ * opening. `clampFontSizePercent` already normalizes a missing/garbage
+ * value to FONT_SIZE_DEFAULT, so the try/catch only needs to guard the read
+ * itself.
  */
-export function buildWindowHash(input: { port: string; token: string; theme: ThemePreference }): string {
-  return `#api=${input.port}&token=${input.token}&theme=${input.theme}`;
+export function resolveFontSizePreference(): number {
+  let stored: string | null;
+  try {
+    stored = preferences.get("fontSize");
+  } catch {
+    return FONT_SIZE_DEFAULT;
+  }
+  return clampFontSizePercent(stored);
+}
+
+/**
+ * Pure builder for the URL hash fragment carrying the per-launch boot
+ * payload to the dev (Vite `http://`) window URL —
+ * `#api=<port>&token=<token>&theme=<pref>[&fontSize=<n>]`. Exported so a
+ * bun-side test can assert on the exact fragment shape without constructing
+ * a BrowserWindow. This only backs the `isHttpUrl` branch below; the bundled
+ * `views://` path threads the same fields through `bootGlobals`
+ * (`window.__AGETOR`) instead, since that scheme handler rejects URLs
+ * carrying a fragment (see the comment on `buildWindow` below).
+ *
+ * `fontSize` is a required field (callers must always resolve one via
+ * `resolveFontSizePreference`), but the param is appended to the hash only
+ * when it's not FONT_SIZE_DEFAULT (100) — this keeps the common-case URL
+ * identical to the pre-font-size shape, and the mainview's boot parser
+ * already defaults an absent param to 100.
+ */
+export function buildWindowHash(input: {
+  port: string;
+  token: string;
+  theme: ThemePreference;
+  fontSize: number;
+}): string {
+  const base = `#api=${input.port}&token=${input.token}&theme=${input.theme}`;
+  return input.fontSize === FONT_SIZE_DEFAULT ? base : `${base}&fontSize=${input.fontSize}`;
 }

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -145,7 +145,7 @@ function reconcileById<T>(
  */
 function AppInner() {
   const { preference: themePreference, setPreference: setThemePreference } = useTheme();
-  const { percent: fontSizePercent, setPercent: setFontSizePercent } = useFontSize();
+  const { setPercent: setFontSizePercent, percentRef: fontSizePercentRef, hasUserAdjustedRef: fontSizeUserAdjustedRef } = useFontSize();
   const [tasks, setTasks] = useState<Task[]>([]);
   const [agents, setAgents] = useState<AgentStatus[]>([]);
   const [harnesses, setHarnesses] = useState<Harness[]>([]);
@@ -207,13 +207,22 @@ function AppInner() {
   // reason as theme above: the boot channel (window.__AGETOR / hash, read
   // synchronously by FontSizeProvider before this component even mounts) is
   // authoritative for first paint — this only catches the DB having been
-  // edited out-of-band since then.
+  // edited out-of-band since then. Unlike theme, this compares against a
+  // *live* ref (`fontSizePercentRef`) rather than the `fontSizePercent`
+  // value this effect's closure would otherwise capture at mount — by the
+  // time this async `.then()` resolves, a fast Cmd+= press could already
+  // have moved the real state past that stale snapshot. It also bails
+  // entirely once the user has touched the shortcut at all
+  // (`fontSizeUserAdjustedRef`), since at that point a possibly-stale DB
+  // read racing the user's own change should never win.
   useEffect(() => {
     api.listPreferences().then((prefs) => {
       const dbTheme = parseThemePreference(prefs.theme);
       if (dbTheme !== themePreference) setThemePreference(dbTheme);
-      const dbFontSize = clampFontSizePercent(prefs.fontSize);
-      if (dbFontSize !== fontSizePercent) setFontSizePercent(dbFontSize);
+      if (!fontSizeUserAdjustedRef.current) {
+        const dbFontSize = clampFontSizePercent(prefs.fontSize);
+        if (dbFontSize !== fontSizePercentRef.current) setFontSizePercent(dbFontSize);
+      }
     }).catch(() => { /* keep the boot-seeded preferences */ });
     // Run once at boot only — intentionally not re-run when either local
     // preference changes (that would fight the user's own picker/shortcut).

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -3,7 +3,7 @@ import { DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors } f
 import { AlertTriangle, FolderGit2, GitPullRequest, Settings, X } from "lucide-react";
 import { api, type AgentModelMap } from "@/lib/api";
 import { Button } from "@/components/ui/button";
-import { COLUMNS, type AgentStatus, type ColumnId, type GlobalEvent, type Harness, type Project, type Task, type TaskType } from "../shared/types.ts";
+import { clampFontSizePercent, COLUMNS, type AgentStatus, type ColumnId, type GlobalEvent, type Harness, type Project, type Task, type TaskType } from "../shared/types.ts";
 import { AgentIcon } from "@/components/kanban/AgentIcon";
 import { Column } from "@/components/kanban/Column";
 import { DiffDialog } from "@/components/kanban/DiffDialog";
@@ -12,6 +12,7 @@ import { KanbanFilters } from "@/components/kanban/KanbanFilters";
 import { NewTaskForm } from "@/components/kanban/NewTaskForm";
 import { EXIT_DURATION_MS as RUN_PANEL_EXIT_MS, RunPanel } from "@/components/kanban/RunPanel";
 import { SettingsDialog } from "@/components/settings/SettingsDialog";
+import { FontSizeProvider, useFontSize } from "@/components/font-size-provider";
 import { ThemeProvider, useTheme } from "@/components/theme-provider";
 import { TmuxInstallDialog } from "@/components/tmux/TmuxInstallDialog";
 import { TmuxMissingBanner, errorIsTmuxMissing, isTmuxMissing } from "@/components/tmux/TmuxMissingBanner";
@@ -144,6 +145,7 @@ function reconcileById<T>(
  */
 function AppInner() {
   const { preference: themePreference, setPreference: setThemePreference } = useTheme();
+  const { percent: fontSizePercent, setPercent: setFontSizePercent } = useFontSize();
   const [tasks, setTasks] = useState<Task[]>([]);
   const [agents, setAgents] = useState<AgentStatus[]>([]);
   const [harnesses, setHarnesses] = useState<Harness[]>([]);
@@ -201,13 +203,20 @@ function AppInner() {
   // authoritative for first paint — this only catches the DB having been
   // edited out-of-band since then, so on the normal path `themePreference`
   // already matches and this is a silent no-op (no flash).
+  // Reconcile the font-size preference from the same fetch, for the same
+  // reason as theme above: the boot channel (window.__AGETOR / hash, read
+  // synchronously by FontSizeProvider before this component even mounts) is
+  // authoritative for first paint — this only catches the DB having been
+  // edited out-of-band since then.
   useEffect(() => {
     api.listPreferences().then((prefs) => {
       const dbTheme = parseThemePreference(prefs.theme);
       if (dbTheme !== themePreference) setThemePreference(dbTheme);
-    }).catch(() => { /* keep the boot-seeded preference */ });
-    // Run once at boot only — intentionally not re-run when the local
-    // preference changes (that would fight the user's own picker clicks).
+      const dbFontSize = clampFontSizePercent(prefs.fontSize);
+      if (dbFontSize !== fontSizePercent) setFontSizePercent(dbFontSize);
+    }).catch(() => { /* keep the boot-seeded preferences */ });
+    // Run once at boot only — intentionally not re-run when either local
+    // preference changes (that would fight the user's own picker/shortcut).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -957,12 +966,15 @@ function AppInner() {
   );
 }
 
-/** Root export — mounts `ThemeProvider` above everything so `AppInner` (and,
- *  transitively, `SettingsDialog`'s Theme picker) can call `useTheme()`. */
+/** Root export — mounts `ThemeProvider` and `FontSizeProvider` above
+ *  everything so `AppInner` (and, transitively, `SettingsDialog`'s Theme
+ *  picker) can call `useTheme()` / `useFontSize()`. */
 export default function App() {
   return (
     <ThemeProvider>
-      <AppInner />
+      <FontSizeProvider>
+        <AppInner />
+      </FontSizeProvider>
     </ThemeProvider>
   );
 }

--- a/src/mainview/components/font-size-provider.tsx
+++ b/src/mainview/components/font-size-provider.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import { toast } from "sonner";
+import { FONT_SIZE_DEFAULT, FONT_SIZE_MAX, FONT_SIZE_MIN } from "../../shared/types.ts";
+import { api } from "@/lib/api";
+import {
+  fontSizeShortcutAction,
+  isMacPlatform,
+  readFontSizeFromBoot,
+  rootFontSizeStyle,
+  stepFontSize,
+  type FontSizeAction,
+} from "@/lib/font-size";
+
+export interface FontSizeContextValue {
+  percent: number;
+  setPercent: (pct: number) => void;
+  increase: () => void;
+  decrease: () => void;
+  reset: () => void;
+}
+
+const FontSizeContext = React.createContext<FontSizeContextValue | null>(null);
+
+/**
+ * Mount once near the React root, alongside `ThemeProvider` — see App.tsx's
+ * root export for where the two are wired in together.
+ *
+ * Seeds `percent` synchronously from whichever boot channel carried it
+ * (`window.__AGETOR.fontSize` for the bundled `views://` path, else the URL
+ * hash for the Vite dev path) — the same value `src/bun/index.ts` resolved
+ * and `index.html`'s inline boot script already applied to `<html>` before
+ * first paint, so this provider's initial render is a no-op repaint, not the
+ * moment scaling first takes effect. Mirrors `ThemeProvider`'s seeding
+ * exactly (see that file's doc comment for the full rationale).
+ *
+ * The keydown listener is registered in the **capture phase** so a focused
+ * xterm pane (which attaches its own key handler — see `TerminalView.tsx`)
+ * can't swallow the shortcut first; `terminal-keys.ts`'s `macEditSequence`
+ * doesn't map any of `=`/`+`/`-`/`_`/`0`, so there's no real contention, but
+ * capture-phase + `preventDefault()` would win regardless. The shortcut is
+ * deliberately global — it fires with focus anywhere (an input, a terminal,
+ * a dialog) since Cmd+=/−/0 have no conflicting editable-text meaning.
+ */
+export function FontSizeProvider({ children }: { children: React.ReactNode }) {
+  const [percent, setPercentState] = React.useState<number>(() => {
+    if (typeof window === "undefined") return FONT_SIZE_DEFAULT;
+    return readFontSizeFromBoot((window as unknown as { __AGETOR?: unknown }).__AGETOR, window.location.hash);
+  });
+
+  React.useEffect(() => {
+    const root = document.documentElement;
+    const style = rootFontSizeStyle(percent);
+    if (style === null) {
+      root.style.removeProperty("font-size");
+    } else {
+      root.style.fontSize = style;
+    }
+  }, [percent]);
+
+  // Mirrors ThemeProvider's `preferenceRef` pattern: read via a ref inside
+  // the stable-identity callbacks below so a failed save can roll back to
+  // whatever was current *at the moment of that call*, without making the
+  // callbacks depend on (and be re-created by) `percent`.
+  const percentRef = React.useRef(percent);
+  percentRef.current = percent;
+
+  const setPercent = React.useCallback((pct: number) => {
+    const previous = percentRef.current;
+    setPercentState(pct);
+    void api.setPreference("fontSize", String(pct)).catch(() => {
+      setPercentState(previous);
+      toast.error("Couldn't save font size preference", {
+        description: "Reverted to the previous setting — try again.",
+      });
+    });
+  }, []);
+
+  const applyStep = React.useCallback(
+    (action: FontSizeAction) => {
+      const next = stepFontSize(percentRef.current, action);
+      if (next === percentRef.current) return;
+      setPercent(next);
+      if (next === FONT_SIZE_MAX) {
+        toast(`Font size: maximum (${FONT_SIZE_MAX}%)`, { id: "font-size" });
+      } else if (next === FONT_SIZE_MIN) {
+        toast(`Font size: default (${FONT_SIZE_MIN}%)`, { id: "font-size" });
+      } else {
+        toast(`Font size: ${next}%`, { id: "font-size" });
+      }
+    },
+    [setPercent],
+  );
+
+  const increase = React.useCallback(() => applyStep("increase"), [applyStep]);
+  const decrease = React.useCallback(() => applyStep("decrease"), [applyStep]);
+  const reset = React.useCallback(() => applyStep("reset"), [applyStep]);
+
+  React.useEffect(() => {
+    const isMac = isMacPlatform();
+    const onKey = (e: KeyboardEvent) => {
+      const action = fontSizeShortcutAction(e, isMac);
+      if (!action) return;
+      e.preventDefault();
+      applyStep(action);
+    };
+    document.addEventListener("keydown", onKey, { capture: true });
+    return () => document.removeEventListener("keydown", onKey, { capture: true });
+  }, [applyStep]);
+
+  const value = React.useMemo<FontSizeContextValue>(
+    () => ({ percent, setPercent, increase, decrease, reset }),
+    [percent, setPercent, increase, decrease, reset],
+  );
+
+  return <FontSizeContext.Provider value={value}>{children}</FontSizeContext.Provider>;
+}
+
+export function useFontSize(): FontSizeContextValue {
+  const ctx = React.useContext(FontSizeContext);
+  if (!ctx) throw new Error("useFontSize must be used inside <FontSizeProvider>");
+  return ctx;
+}

--- a/src/mainview/components/font-size-provider.tsx
+++ b/src/mainview/components/font-size-provider.tsx
@@ -16,20 +16,31 @@ import {
 // ~300ms after the last press, with whatever value settled.
 const PERSIST_DEBOUNCE_MS = 300;
 
+/** Options accepted by `increase`/`decrease`/`reset`. `silent: true` suppresses
+ *  the sonner toast — used by Settings → General's stepper buttons, where the
+ *  toast's top-right, very-high-z-index surface can cover the dialog's own
+ *  Close button and eat the next click. The keyboard-shortcut path (which has
+ *  no on-screen readout to lean on) always calls `applyStep` directly and so
+ *  keeps its toast regardless of this option. */
+export interface FontSizeStepOptions {
+  silent?: boolean;
+}
+
 export interface FontSizeContextValue {
   percent: number;
   setPercent: (pct: number) => void;
-  increase: () => void;
-  decrease: () => void;
-  reset: () => void;
+  increase: (opts?: FontSizeStepOptions) => void;
+  decrease: (opts?: FontSizeStepOptions) => void;
+  reset: (opts?: FontSizeStepOptions) => void;
   /** Live mirror of `percent`, updated synchronously every render — for
    *  App.tsx's one-shot boot reconcile, which runs inside an async
    *  `.then()` callback where the `percent` value closed over at effect-
    *  registration time would otherwise be stale by the time it resolves.
    *  Not meant for general consumption; prefer `percent` in render. */
   percentRef: React.RefObject<number>;
-  /** Flips to `true` the first time the user fires a recognized shortcut
-   *  press (see `applyStep` below) and never resets. App.tsx's boot
+  /** Flips to `true` the first time the user makes a deliberate font-size
+   *  change — a recognized shortcut press or a Settings → General stepper
+   *  click (see `applyStep` below) — and never resets. App.tsx's boot
    *  reconcile checks this to avoid clobbering a state the user has already
    *  deliberately changed with a possibly-stale DB read that raced it. */
   hasUserAdjustedRef: React.RefObject<boolean>;
@@ -152,18 +163,22 @@ export function FontSizeProvider({ children }: { children: React.ReactNode }) {
   }, [doPersist]);
 
   const applyStep = React.useCallback(
-    (action: FontSizeAction) => {
+    (action: FontSizeAction, opts?: FontSizeStepOptions) => {
       hasUserAdjustedRef.current = true;
       const next = stepFontSize(percentRef.current, action);
       // Feedback fires for every recognized press, even a no-op at a bound
       // (Cmd+= already at 170%, Cmd+0 already at 100%) — only the state
-      // update + persist stay behind the no-change guard below.
-      if (next === FONT_SIZE_MAX) {
-        toast(`Font size: maximum (${FONT_SIZE_MAX}%)`, { id: "font-size" });
-      } else if (next === FONT_SIZE_MIN) {
-        toast(`Font size: default (${FONT_SIZE_MIN}%)`, { id: "font-size" });
-      } else {
-        toast(`Font size: ${next}%`, { id: "font-size" });
+      // update + persist stay behind the no-change guard below. Skipped
+      // entirely for `silent` callers (the Settings stepper), which have
+      // their own on-screen readout as feedback instead.
+      if (!opts?.silent) {
+        if (next === FONT_SIZE_MAX) {
+          toast(`Font size: maximum (${FONT_SIZE_MAX}%)`, { id: "font-size" });
+        } else if (next === FONT_SIZE_MIN) {
+          toast(`Font size: default (${FONT_SIZE_MIN}%)`, { id: "font-size" });
+        } else {
+          toast(`Font size: ${next}%`, { id: "font-size" });
+        }
       }
       if (next === percentRef.current) return;
       setPercent(next);
@@ -171,9 +186,18 @@ export function FontSizeProvider({ children }: { children: React.ReactNode }) {
     [setPercent],
   );
 
-  const increase = React.useCallback(() => applyStep("increase"), [applyStep]);
-  const decrease = React.useCallback(() => applyStep("decrease"), [applyStep]);
-  const reset = React.useCallback(() => applyStep("reset"), [applyStep]);
+  const increase = React.useCallback(
+    (opts?: FontSizeStepOptions) => applyStep("increase", opts),
+    [applyStep],
+  );
+  const decrease = React.useCallback(
+    (opts?: FontSizeStepOptions) => applyStep("decrease", opts),
+    [applyStep],
+  );
+  const reset = React.useCallback(
+    (opts?: FontSizeStepOptions) => applyStep("reset", opts),
+    [applyStep],
+  );
 
   React.useEffect(() => {
     const isMac = isMacPlatform();

--- a/src/mainview/components/font-size-provider.tsx
+++ b/src/mainview/components/font-size-provider.tsx
@@ -11,12 +11,28 @@ import {
   type FontSizeAction,
 } from "@/lib/font-size";
 
+// Trailing-edge debounce for the persisted write: a burst of Cmd+= presses
+// updates the optimistic UI state on every keystroke, but only writes once,
+// ~300ms after the last press, with whatever value settled.
+const PERSIST_DEBOUNCE_MS = 300;
+
 export interface FontSizeContextValue {
   percent: number;
   setPercent: (pct: number) => void;
   increase: () => void;
   decrease: () => void;
   reset: () => void;
+  /** Live mirror of `percent`, updated synchronously every render — for
+   *  App.tsx's one-shot boot reconcile, which runs inside an async
+   *  `.then()` callback where the `percent` value closed over at effect-
+   *  registration time would otherwise be stale by the time it resolves.
+   *  Not meant for general consumption; prefer `percent` in render. */
+  percentRef: React.RefObject<number>;
+  /** Flips to `true` the first time the user fires a recognized shortcut
+   *  press (see `applyStep` below) and never resets. App.tsx's boot
+   *  reconcile checks this to avoid clobbering a state the user has already
+   *  deliberately changed with a possibly-stale DB read that raced it. */
+  hasUserAdjustedRef: React.RefObject<boolean>;
 }
 
 const FontSizeContext = React.createContext<FontSizeContextValue | null>(null);
@@ -38,8 +54,11 @@ const FontSizeContext = React.createContext<FontSizeContextValue | null>(null);
  * can't swallow the shortcut first; `terminal-keys.ts`'s `macEditSequence`
  * doesn't map any of `=`/`+`/`-`/`_`/`0`, so there's no real contention, but
  * capture-phase + `preventDefault()` would win regardless. The shortcut is
- * deliberately global — it fires with focus anywhere (an input, a terminal,
- * a dialog) since Cmd+=/−/0 have no conflicting editable-text meaning.
+ * deliberately global on macOS — it fires with focus anywhere (an input, a
+ * terminal, a dialog) since Cmd+=/−/0 have no conflicting editable-text
+ * meaning there. On non-Mac dev builds it steps aside for a focused
+ * terminal instead: Ctrl+- doubles as readline's `undo` and Ctrl+_ is its
+ * literal binding, so swallowing them would break shell editing.
  */
 export function FontSizeProvider({ children }: { children: React.ReactNode }) {
   const [percent, setPercentState] = React.useState<number>(() => {
@@ -58,28 +77,87 @@ export function FontSizeProvider({ children }: { children: React.ReactNode }) {
   }, [percent]);
 
   // Mirrors ThemeProvider's `preferenceRef` pattern: read via a ref inside
-  // the stable-identity callbacks below so a failed save can roll back to
-  // whatever was current *at the moment of that call*, without making the
+  // the stable-identity callbacks below so a failed save can roll back
+  // (and a stale write can recognize it's stale) without making those
   // callbacks depend on (and be re-created by) `percent`.
   const percentRef = React.useRef(percent);
   percentRef.current = percent;
 
-  const setPercent = React.useCallback((pct: number) => {
-    const previous = percentRef.current;
-    setPercentState(pct);
-    void api.setPreference("fontSize", String(pct)).catch(() => {
-      setPercentState(previous);
-      toast.error("Couldn't save font size preference", {
-        description: "Reverted to the previous setting — try again.",
+  const hasUserAdjustedRef = React.useRef(false);
+
+  // The last value confirmed to have round-tripped to the server (seeded
+  // from the boot value, which is either the DB's own last-written value or
+  // the untouched default — either way a safe rollback target before any
+  // write has completed). Updated only on a successful PUT.
+  const persistedRef = React.useRef(percent);
+
+  // Debounce + flush plumbing for the actual network write — see the
+  // module doc comment. `generationRef` lets a failed write recognize it's
+  // been superseded by a later one (in which case the later write, not this
+  // stale failure, should own the eventual rollback-or-not decision).
+  const debounceTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingPctRef = React.useRef<number | null>(null);
+  const generationRef = React.useRef(0);
+
+  const doPersist = React.useCallback((pct: number) => {
+    const gen = ++generationRef.current;
+    void api
+      .setPreference("fontSize", String(pct))
+      .then(() => {
+        persistedRef.current = pct;
+      })
+      .catch(() => {
+        // Only roll back if no newer write has since been scheduled AND the
+        // live value hasn't already moved past what this write attempted to
+        // persist — either signals a later write should own the outcome
+        // instead of this stale failure stomping on it.
+        if (generationRef.current !== gen) return;
+        if (percentRef.current !== pct) return;
+        setPercentState(persistedRef.current);
+        toast.error("Couldn't save font size preference", {
+          description: "Reverted to the previous setting — try again.",
+        });
       });
-    });
   }, []);
+
+  const setPercent = React.useCallback(
+    (pct: number) => {
+      setPercentState(pct);
+      pendingPctRef.current = pct;
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = setTimeout(() => {
+        debounceTimerRef.current = null;
+        const p = pendingPctRef.current;
+        pendingPctRef.current = null;
+        if (p !== null) doPersist(p);
+      }, PERSIST_DEBOUNCE_MS);
+    },
+    [doPersist],
+  );
+
+  // Flush any still-pending debounced write on unmount (in practice: HMR in
+  // dev — this provider mounts once for the app's lifetime otherwise) so a
+  // burst right before teardown still round-trips instead of being silently
+  // dropped because its timer never got to fire.
+  React.useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+      const p = pendingPctRef.current;
+      pendingPctRef.current = null;
+      if (p !== null) doPersist(p);
+    };
+  }, [doPersist]);
 
   const applyStep = React.useCallback(
     (action: FontSizeAction) => {
+      hasUserAdjustedRef.current = true;
       const next = stepFontSize(percentRef.current, action);
-      if (next === percentRef.current) return;
-      setPercent(next);
+      // Feedback fires for every recognized press, even a no-op at a bound
+      // (Cmd+= already at 170%, Cmd+0 already at 100%) — only the state
+      // update + persist stay behind the no-change guard below.
       if (next === FONT_SIZE_MAX) {
         toast(`Font size: maximum (${FONT_SIZE_MAX}%)`, { id: "font-size" });
       } else if (next === FONT_SIZE_MIN) {
@@ -87,6 +165,8 @@ export function FontSizeProvider({ children }: { children: React.ReactNode }) {
       } else {
         toast(`Font size: ${next}%`, { id: "font-size" });
       }
+      if (next === percentRef.current) return;
+      setPercent(next);
     },
     [setPercent],
   );
@@ -98,8 +178,16 @@ export function FontSizeProvider({ children }: { children: React.ReactNode }) {
   React.useEffect(() => {
     const isMac = isMacPlatform();
     const onKey = (e: KeyboardEvent) => {
+      // OS key-repeat on a held Cmd+=/− would otherwise slam straight from
+      // 100 to 170 on one long press instead of stepping once per tap.
+      if (e.repeat) return;
       const action = fontSizeShortcutAction(e, isMac);
       if (!action) return;
+      // Non-Mac only: a focused terminal pane owns Ctrl+-/Ctrl+_ (readline
+      // undo) — let it through instead of swallowing it here. On Mac the
+      // shortcut stays global including terminals, per the plan (there's no
+      // Cmd+-bound readline binding to protect).
+      if (!isMac && (e.target as Element | null)?.closest?.(".xterm")) return;
       e.preventDefault();
       applyStep(action);
     };
@@ -108,7 +196,7 @@ export function FontSizeProvider({ children }: { children: React.ReactNode }) {
   }, [applyStep]);
 
   const value = React.useMemo<FontSizeContextValue>(
-    () => ({ percent, setPercent, increase, decrease, reset }),
+    () => ({ percent, setPercent, increase, decrease, reset, percentRef, hasUserAdjustedRef }),
     [percent, setPercent, increase, decrease, reset],
   );
 

--- a/src/mainview/components/kanban/TerminalView.tsx
+++ b/src/mainview/components/kanban/TerminalView.tsx
@@ -245,16 +245,29 @@ function TerminalPane({
   // terminal rescales without remounting (which would drop its WebSocket).
   // Changing glyph cell size changes cols/rows, so a refit + PTY resize
   // notification must follow — same sequence the ResizeObserver callback in
-  // the mount effect above uses for a host-size change.
+  // the mount effect above uses for a host-size change. The fit + resize are
+  // deferred one frame via rAF: `term.options.fontSize` writes synchronously,
+  // but FontSizeProvider's own effect (a sibling, mounted higher up the
+  // tree) hasn't necessarily written the new `documentElement.style.fontSize`
+  // yet when *this* effect runs — React flushes child effects before parent
+  // effects, but siblings run in tree order, and this component doesn't
+  // control which mounts first. Fitting synchronously here could measure the
+  // host box before the root rem size (and therefore the host's pixel size)
+  // has actually changed, shipping stale cols/rows to the PTY. One rAF is
+  // enough since the root font-size write happens in a plain effect, which
+  // (like this one) resolves before the next paint.
   useEffect(() => {
     const term = termRef.current;
     if (!term) return;
     term.options.fontSize = terminalFontSize(fontSizePercent);
-    try { fitRef.current?.fit(); } catch { /* not visible yet */ }
-    const ws = wsRef.current;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ t: "resize", cols: term.cols, rows: term.rows }));
-    }
+    const id = requestAnimationFrame(() => {
+      try { fitRef.current?.fit(); } catch { /* not visible yet */ }
+      const ws = wsRef.current;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ t: "resize", cols: term.cols, rows: term.rows }));
+      }
+    });
+    return () => cancelAnimationFrame(id);
   }, [fontSizePercent]);
 
   // Refit + focus when this pane becomes the active one (its size is stable

--- a/src/mainview/components/kanban/TerminalView.tsx
+++ b/src/mainview/components/kanban/TerminalView.tsx
@@ -6,7 +6,9 @@ import { Plus, X, TerminalSquare } from "lucide-react";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { useFontSize } from "../font-size-provider.tsx";
 import { useTheme } from "../theme-provider.tsx";
+import { terminalFontSize } from "@/lib/font-size";
 import { macEditSequence } from "./terminal-keys.ts";
 import type { TerminalTab } from "../../../shared/types.ts";
 import type { ITheme } from "@xterm/xterm";
@@ -91,13 +93,24 @@ function TerminalPane({
   const hostRef = useRef<HTMLDivElement>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const termRef = useRef<Terminal | null>(null);
+  // Mirrors the mount effect's local `ws` so the font-size reactivity effect
+  // below can send a resize frame after a live refit without needing its own
+  // WebSocket plumbing.
+  const wsRef = useRef<WebSocket | null>(null);
   const { resolved } = useTheme();
+  const { percent: fontSizePercent } = useFontSize();
   // Read via a ref inside the mount effect below so the effect's own
   // dependency array doesn't need `resolved` — recreating the terminal (and
   // its WebSocket) on every theme flip would drop the connection. The
   // separate effect further down re-applies the theme in place instead.
   const resolvedRef = useRef(resolved);
   resolvedRef.current = resolved;
+  // Same pattern for font size — the mount effect must not depend on
+  // `fontSizePercent`, or every Cmd+=/− would tear down and reconnect the
+  // WebSocket. The reactivity effect below re-applies it to the live
+  // instance instead.
+  const fontSizePercentRef = useRef(fontSizePercent);
+  fontSizePercentRef.current = fontSizePercent;
 
   useEffect(() => {
     const host = hostRef.current;
@@ -105,7 +118,7 @@ function TerminalPane({
 
     const term = new Terminal({
       fontFamily: "var(--font-mono, ui-monospace, monospace)",
-      fontSize: 12,
+      fontSize: terminalFontSize(fontSizePercentRef.current),
       cursorBlink: true,
       theme: resolvedRef.current === "light" ? XTERM_THEME_LIGHT : XTERM_THEME_DARK,
       scrollback: 5000,
@@ -142,6 +155,7 @@ function TerminalPane({
       const sock = new WebSocket(api.terminalSocketUrl(terminalId));
       sock.binaryType = "arraybuffer";
       ws = sock;
+      wsRef.current = sock;
       sock.onopen = () => { attempts = 0; sendResize(); };
       sock.onmessage = (ev) => {
         if (typeof ev.data === "string") {
@@ -209,6 +223,7 @@ function TerminalPane({
         ws.onmessage = null;
         ws.close();
       }
+      wsRef.current = null;
       term.dispose();
       termRef.current = null;
       fitRef.current = null;
@@ -224,6 +239,23 @@ function TerminalPane({
     if (!term) return;
     term.options.theme = resolved === "light" ? XTERM_THEME_LIGHT : XTERM_THEME_DARK;
   }, [resolved]);
+
+  // Re-apply the xterm font size in place when the whole-app font-size
+  // preference changes (Cmd+=/−/0 — see FontSizeProvider), so an already-open
+  // terminal rescales without remounting (which would drop its WebSocket).
+  // Changing glyph cell size changes cols/rows, so a refit + PTY resize
+  // notification must follow — same sequence the ResizeObserver callback in
+  // the mount effect above uses for a host-size change.
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.fontSize = terminalFontSize(fontSizePercent);
+    try { fitRef.current?.fit(); } catch { /* not visible yet */ }
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ t: "resize", cols: term.cols, rows: term.rows }));
+    }
+  }, [fontSizePercent]);
 
   // Refit + focus when this pane becomes the active one (its size is stable
   // because the host is absolutely positioned, but the fit on a freshly-shown

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronLeft, Monitor, Moon, Plus, Sun, Terminal, Trash2, X } from "lucide-react";
+import { ChevronLeft, Minus, Monitor, Moon, Plus, Sun, Terminal, Trash2, X } from "lucide-react";
 import { toast } from "sonner";
 import { ApiError, api, type HarnessesPayload, type HarnessInput } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -12,7 +12,9 @@ import { useConfirm } from "@/components/ui/confirm";
 import { AgentIcon } from "@/components/kanban/AgentIcon";
 import { GitHubTokensSection } from "@/components/settings/GitHubTokensSection";
 import { SavedPromptsSection } from "@/components/settings/SavedPromptsSection";
+import { useFontSize } from "@/components/font-size-provider";
 import { useTheme } from "@/components/theme-provider";
+import { isMacPlatform } from "@/lib/font-size";
 import { abbreviateHome, cn } from "@/lib/utils";
 import {
   SETTINGS_SECTIONS,
@@ -26,6 +28,9 @@ import {
   type SettingsView,
 } from "@/lib/settings-dialog-view";
 import {
+  FONT_SIZE_DEFAULT,
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
   HARNESS_TEMPLATES,
   THEME_PREFERENCES,
   type AgentKind,
@@ -33,6 +38,16 @@ import {
   type HarnessTemplate,
   type ThemePreference,
 } from "../../../shared/types.ts";
+
+// Computed once at module load, same convention as RunPanel's
+// `IS_MAC_PLATFORM` — the Settings → General font-size hint text names the
+// platform-appropriate shortcut. The non-Mac string calls out "outside a
+// terminal" because `font-size-provider.tsx`'s keydown handler lets a
+// focused `.xterm` pane keep Ctrl+-/Ctrl+_ for readline's undo/literal
+// bindings there.
+const FONT_SIZE_HINT = isMacPlatform()
+  ? "⌘= and ⌘− also work anywhere; ⌘0 resets."
+  : "Ctrl+= and Ctrl+− also work anywhere outside a terminal; Ctrl+0 resets.";
 
 /** Icon shown per theme preference in the Settings → General picker. */
 const THEME_PREFERENCE_ICON: Record<ThemePreference, typeof Monitor> = {
@@ -586,6 +601,10 @@ function GeneralSection({
   // soft-deleted harness can't silently become the default for new tasks.
   const enabledHarnesses = payload.harnesses.filter((h) => h.enabled);
   const { preference: themePreference, setPreference: setThemePreference } = useTheme();
+  const { percent: fontSizePercent, increase: increaseFontSize, decrease: decreaseFontSize, reset: resetFontSize } = useFontSize();
+  const canDecreaseFontSize = fontSizePercent > FONT_SIZE_MIN;
+  const canIncreaseFontSize = fontSizePercent < FONT_SIZE_MAX;
+  const canResetFontSize = fontSizePercent !== FONT_SIZE_DEFAULT;
   return (
     <div className="space-y-4 pt-3 text-sm">
       <section className="space-y-1">
@@ -641,6 +660,55 @@ function GeneralSection({
         <p className="text-[11px] text-muted-foreground">
           Auto follows your system's appearance and switches live if it changes.
         </p>
+      </section>
+
+      <section className="space-y-1">
+        <label className="text-xs text-muted-foreground">Font size</label>
+        <div role="group" aria-label="Font size" className="flex items-center gap-1.5">
+          <Button
+            size="sm"
+            variant="outline"
+            className="w-8 px-0 aria-disabled:cursor-default aria-disabled:opacity-50"
+            aria-label="Decrease font size"
+            aria-disabled={!canDecreaseFontSize}
+            onClick={() => {
+              if (!canDecreaseFontSize) return;
+              decreaseFontSize({ silent: true });
+            }}
+          >
+            <Minus className="size-3.5" />
+          </Button>
+          <span role="status" aria-live="polite" className="w-10 text-center text-xs tabular-nums">
+            {fontSizePercent}%
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            className="w-8 px-0 aria-disabled:cursor-default aria-disabled:opacity-50"
+            aria-label="Increase font size"
+            aria-disabled={!canIncreaseFontSize}
+            onClick={() => {
+              if (!canIncreaseFontSize) return;
+              increaseFontSize({ silent: true });
+            }}
+          >
+            <Plus className="size-3.5" />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="aria-disabled:cursor-default aria-disabled:opacity-50"
+            aria-label="Reset font size"
+            aria-disabled={!canResetFontSize}
+            onClick={() => {
+              if (!canResetFontSize) return;
+              resetFontSize({ silent: true });
+            }}
+          >
+            Reset
+          </Button>
+        </div>
+        <p className="text-[11px] text-muted-foreground">{FONT_SIZE_HINT}</p>
       </section>
     </div>
   );

--- a/src/mainview/index.html
+++ b/src/mainview/index.html
@@ -28,39 +28,6 @@
       // application, reading `&theme=<pref>` off the URL hash instead
       // (`buildWindowHash` in index.ts). Check window.__AGETOR first, hash
       // second, so the bundled path prefers its own value over a stale hash.
-      // Font size (Cmd+=/Cmd+-): same precedence + duplication rationale as
-      // the theme block above — window.__AGETOR.fontSize first (bundled
-      // views:// path, whose preload script already applied it too — a
-      // harmless idempotent re-run), then the hash `fontSize` param (Vite
-      // dev path). Inline-duplicates the minimal parse+clamp from
-      // clampFontSizePercent (src/shared/types.ts) since no module import is
-      // possible before first paint; invalid/absent → 100 (the default AND
-      // minimum), clamped to [100, 170]. At exactly 100 nothing is written —
-      // the inline style stays omitted, matching the "pristine at default"
-      // contract.
-      (function () {
-        var fontSize = 100;
-        try {
-          var injectedSize = window.__AGETOR && window.__AGETOR.fontSize;
-          var rawSize = injectedSize;
-          if (typeof rawSize !== "number" && typeof rawSize !== "string") {
-            var sizeHash = window.location.hash || "";
-            if (sizeHash.charAt(0) === "#") sizeHash = sizeHash.slice(1);
-            var sizeParams = new URLSearchParams(sizeHash);
-            rawSize = sizeParams.get("fontSize");
-          }
-          var parsed = typeof rawSize === "number" ? rawSize : parseFloat(rawSize);
-          if (isFinite(parsed)) {
-            fontSize = Math.min(170, Math.max(100, Math.round(parsed)));
-          }
-          if (fontSize !== 100) {
-            document.documentElement.style.fontSize = (16 * fontSize) / 100 + "px";
-          }
-        } catch (e) {
-          // Parsing failed — leave the root at its default (unset) size
-          // rather than risk an unreadable or wildly-scaled UI.
-        }
-      })();
       (function () {
         try {
           var injected = window.__AGETOR && window.__AGETOR.theme;
@@ -93,6 +60,43 @@
           // not "today's only theme" (Light is a real, supported option now).
           document.documentElement.classList.add("dark");
           document.documentElement.style.colorScheme = "dark";
+        }
+      })();
+      // Font size (Cmd+=/Cmd+-): same precedence + duplication rationale as
+      // the theme block above — window.__AGETOR.fontSize first (bundled
+      // views:// path, whose preload script already applied it too — a
+      // harmless idempotent re-run), then the hash `fontSize` param (Vite
+      // dev path). Order relative to the theme IIFE above doesn't matter —
+      // both only need to run before the splash <style> below. Inline-duplicates
+      // the minimal parse+clamp from clampFontSizePercent (src/shared/types.ts)
+      // since no module import is possible before first paint: the clamp bounds
+      // (100 and 170, i.e. FONT_SIZE_MIN/FONT_SIZE_MAX) and the rem baseline
+      // (16, i.e. FONT_SIZE_BASE_PX) are copied literals — keep them in sync
+      // with src/shared/types.ts if those constants ever change. Invalid/absent
+      // → 100 (FONT_SIZE_DEFAULT, the default AND minimum). At exactly 100
+      // nothing is written — the inline style stays omitted, matching the
+      // "pristine at default" contract.
+      (function () {
+        var fontSize = 100;
+        try {
+          var injectedSize = window.__AGETOR && window.__AGETOR.fontSize;
+          var rawSize = injectedSize;
+          if (typeof rawSize !== "number" && typeof rawSize !== "string") {
+            var sizeHash = window.location.hash || "";
+            if (sizeHash.charAt(0) === "#") sizeHash = sizeHash.slice(1);
+            var sizeParams = new URLSearchParams(sizeHash);
+            rawSize = sizeParams.get("fontSize");
+          }
+          var parsed = typeof rawSize === "number" ? rawSize : parseFloat(rawSize);
+          if (isFinite(parsed)) {
+            fontSize = Math.min(170, Math.max(100, Math.round(parsed)));
+          }
+          if (fontSize !== 100) {
+            document.documentElement.style.fontSize = (16 * fontSize) / 100 + "px";
+          }
+        } catch (e) {
+          // Parsing failed — leave the root at its default (unset) size
+          // rather than risk an unreadable or wildly-scaled UI.
         }
       })();
     </script>

--- a/src/mainview/index.html
+++ b/src/mainview/index.html
@@ -28,6 +28,39 @@
       // application, reading `&theme=<pref>` off the URL hash instead
       // (`buildWindowHash` in index.ts). Check window.__AGETOR first, hash
       // second, so the bundled path prefers its own value over a stale hash.
+      // Font size (Cmd+=/Cmd+-): same precedence + duplication rationale as
+      // the theme block above — window.__AGETOR.fontSize first (bundled
+      // views:// path, whose preload script already applied it too — a
+      // harmless idempotent re-run), then the hash `fontSize` param (Vite
+      // dev path). Inline-duplicates the minimal parse+clamp from
+      // clampFontSizePercent (src/shared/types.ts) since no module import is
+      // possible before first paint; invalid/absent → 100 (the default AND
+      // minimum), clamped to [100, 170]. At exactly 100 nothing is written —
+      // the inline style stays omitted, matching the "pristine at default"
+      // contract.
+      (function () {
+        var fontSize = 100;
+        try {
+          var injectedSize = window.__AGETOR && window.__AGETOR.fontSize;
+          var rawSize = injectedSize;
+          if (typeof rawSize !== "number" && typeof rawSize !== "string") {
+            var sizeHash = window.location.hash || "";
+            if (sizeHash.charAt(0) === "#") sizeHash = sizeHash.slice(1);
+            var sizeParams = new URLSearchParams(sizeHash);
+            rawSize = sizeParams.get("fontSize");
+          }
+          var parsed = typeof rawSize === "number" ? rawSize : parseFloat(rawSize);
+          if (isFinite(parsed)) {
+            fontSize = Math.min(170, Math.max(100, Math.round(parsed)));
+          }
+          if (fontSize !== 100) {
+            document.documentElement.style.fontSize = (16 * fontSize) / 100 + "px";
+          }
+        } catch (e) {
+          // Parsing failed — leave the root at its default (unset) size
+          // rather than risk an unreadable or wildly-scaled UI.
+        }
+      })();
       (function () {
         try {
           var injected = window.__AGETOR && window.__AGETOR.theme;

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -252,7 +252,7 @@ export interface GitHubTokensResult {
 // Fall back to URL hash for the Vite HMR path, which loads from a plain
 // http:// URL where the hash payload still works.
 declare global {
-  interface Window { __AGETOR?: { port: string; token: string; theme?: string } }
+  interface Window { __AGETOR?: { port: string; token: string; theme?: string; fontSize?: number | string } }
 }
 // Guard `window` access for the test runtime (`bun test` runs this module
 // outside a browser). Production paths always have a real window, so the

--- a/src/mainview/lib/font-size.test.ts
+++ b/src/mainview/lib/font-size.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, test } from "bun:test";
+import {
+  fontSizeShortcutAction,
+  readFontSizeFromBoot,
+  rootFontSizeStyle,
+  stepFontSize,
+  terminalFontSize,
+  type FontSizeAction,
+} from "./font-size.ts";
+import { clampFontSizePercent, FONT_SIZE_DEFAULT, FONT_SIZE_MAX, FONT_SIZE_MIN } from "../../shared/types.ts";
+
+describe("clampFontSizePercent", () => {
+  const cases: { name: string; input: unknown; expected: number }[] = [
+    { name: "an in-range integer string passes through", input: "120", expected: 120 },
+    // Math.round(120.5) rounds towards +Infinity, not banker's rounding.
+    { name: "a fractional string rounds to the nearest integer", input: "120.5", expected: 121 },
+    { name: "a fractional string rounding down", input: "120.4", expected: 120 },
+    { name: "a plain number passes through", input: 150, expected: 150 },
+    { name: "a fractional number rounds", input: 133.6, expected: 134 },
+    { name: "a non-numeric string falls back to default", input: "abc", expected: FONT_SIZE_DEFAULT },
+    { name: "an empty string falls back to default", input: "", expected: FONT_SIZE_DEFAULT },
+    { name: "null falls back to default", input: null, expected: FONT_SIZE_DEFAULT },
+    { name: "undefined falls back to default", input: undefined, expected: FONT_SIZE_DEFAULT },
+    { name: "an object falls back to default", input: { pct: 120 }, expected: FONT_SIZE_DEFAULT },
+    { name: "an array falls back to default", input: [120], expected: FONT_SIZE_DEFAULT },
+    { name: "a boolean falls back to default", input: true, expected: FONT_SIZE_DEFAULT },
+    { name: "NaN falls back to default", input: NaN, expected: FONT_SIZE_DEFAULT },
+    { name: "positive Infinity falls back to default", input: Infinity, expected: FONT_SIZE_DEFAULT },
+    { name: "negative Infinity falls back to default", input: -Infinity, expected: FONT_SIZE_DEFAULT },
+    { name: "a negative number clamps up to the minimum", input: -50, expected: FONT_SIZE_MIN },
+    { name: "zero clamps up to the minimum", input: 0, expected: FONT_SIZE_MIN },
+    { name: "a value below the minimum clamps up to the minimum", input: 42, expected: FONT_SIZE_MIN },
+    { name: "exactly the minimum passes through", input: 100, expected: FONT_SIZE_MIN },
+    { name: "exactly the maximum passes through", input: 170, expected: FONT_SIZE_MAX },
+    { name: "a value above the maximum clamps down to the maximum", input: 999, expected: FONT_SIZE_MAX },
+    { name: "a numeric string above the maximum clamps down", input: "500", expected: FONT_SIZE_MAX },
+    { name: "a numeric string below the minimum clamps up", input: "10", expected: FONT_SIZE_MIN },
+    { name: "whitespace-padded numeric string parses (parseFloat trims leading whitespace)", input: "  120  ", expected: 120 },
+  ];
+
+  for (const { name, input, expected } of cases) {
+    test(name, () => {
+      expect(clampFontSizePercent(input)).toBe(expected);
+    });
+  }
+});
+
+describe("stepFontSize", () => {
+  const cases: { name: string; pct: number; action: FontSizeAction; expected: number }[] = [
+    { name: "increase steps up by FONT_SIZE_STEP", pct: 100, action: "increase", expected: 110 },
+    { name: "increase from a mid value", pct: 140, action: "increase", expected: 150 },
+    { name: "increase clamps at the maximum", pct: 170, action: "increase", expected: 170 },
+    { name: "increase clamps when one more step would overshoot the maximum", pct: 165, action: "increase", expected: 170 },
+    { name: "decrease steps down by FONT_SIZE_STEP", pct: 130, action: "decrease", expected: 120 },
+    { name: "decrease clamps at the minimum", pct: 100, action: "decrease", expected: 100 },
+    { name: "decrease clamps when already below the minimum", pct: 100, action: "decrease", expected: 100 },
+    { name: "reset jumps straight to the default regardless of current value", pct: 170, action: "reset", expected: 100 },
+    { name: "reset from the minimum is a no-op value-wise", pct: 100, action: "reset", expected: 100 },
+    // Callers are documented to hold already-clamped state, but the result is
+    // re-clamped anyway so a stray out-of-range input can't escape the bounds.
+    { name: "increase re-clamps an out-of-range input from above", pct: 500, action: "increase", expected: 170 },
+    { name: "decrease re-clamps an out-of-range input from below", pct: -20, action: "decrease", expected: 100 },
+  ];
+
+  for (const { name, pct, action, expected } of cases) {
+    test(name, () => {
+      expect(stepFontSize(pct, action)).toBe(expected);
+    });
+  }
+});
+
+describe("rootFontSizeStyle", () => {
+  test("120% maps to 19.2px", () => {
+    expect(rootFontSizeStyle(120)).toBe("19.2px");
+  });
+
+  test("exactly the default (100%) returns null so callers remove the inline style", () => {
+    expect(rootFontSizeStyle(100)).toBeNull();
+  });
+
+  test("the minimum (100%) is treated identically to the default — also null", () => {
+    expect(rootFontSizeStyle(FONT_SIZE_DEFAULT)).toBeNull();
+  });
+
+  test("the maximum (170%) maps to 27.2px", () => {
+    expect(rootFontSizeStyle(170)).toBe("27.2px");
+  });
+
+  test("110% maps to 17.6px", () => {
+    expect(rootFontSizeStyle(110)).toBe("17.6px");
+  });
+});
+
+describe("terminalFontSize", () => {
+  test("100% maps to the 12px terminal baseline", () => {
+    expect(terminalFontSize(100)).toBe(12);
+  });
+
+  test("170% rounds Math.round(12 * 1.7) = 20.4 -> 20", () => {
+    expect(terminalFontSize(170)).toBe(20);
+  });
+
+  test("150% rounds Math.round(18) = 18 exactly", () => {
+    expect(terminalFontSize(150)).toBe(18);
+  });
+
+  test("110% rounds Math.round(13.2) = 13", () => {
+    expect(terminalFontSize(110)).toBe(13);
+  });
+
+  test("130% rounds Math.round(15.6) = 16", () => {
+    expect(terminalFontSize(130)).toBe(16);
+  });
+});
+
+describe("readFontSizeFromBoot", () => {
+  const cases: { name: string; agetorGlobal: unknown; hash: string; expected: number }[] = [
+    { name: "no boot global and no hash falls back to default", agetorGlobal: undefined, hash: "", expected: FONT_SIZE_DEFAULT },
+    { name: "null boot global and no hash falls back to default", agetorGlobal: null, hash: "", expected: FONT_SIZE_DEFAULT },
+    {
+      name: "a numeric __AGETOR.fontSize wins outright, hash is not consulted",
+      agetorGlobal: { fontSize: 140 },
+      hash: "#fontSize=110",
+      expected: 140,
+    },
+    {
+      name: "a string __AGETOR.fontSize wins outright, hash is not consulted",
+      agetorGlobal: { fontSize: "150" },
+      hash: "#fontSize=110",
+      expected: 150,
+    },
+    {
+      name: "__AGETOR.fontSize present but out of range still clamps via the number/string path (not a fall-through)",
+      agetorGlobal: { fontSize: 9999 },
+      hash: "#fontSize=110",
+      expected: FONT_SIZE_MAX,
+    },
+    {
+      name: "a boolean __AGETOR.fontSize is not a recognized type — falls through to the hash",
+      agetorGlobal: { fontSize: true },
+      hash: "#fontSize=130",
+      expected: 130,
+    },
+    {
+      name: "an object __AGETOR.fontSize is not a recognized type — falls through to the hash",
+      agetorGlobal: { fontSize: { pct: 130 } },
+      hash: "#fontSize=120",
+      expected: 120,
+    },
+    {
+      name: "a null __AGETOR.fontSize falls through to the hash",
+      agetorGlobal: { fontSize: null },
+      hash: "#fontSize=125",
+      expected: 125,
+    },
+    {
+      name: "an undefined __AGETOR.fontSize (key present, value undefined) falls through to the hash",
+      agetorGlobal: { fontSize: undefined },
+      hash: "#fontSize=125",
+      expected: 125,
+    },
+    {
+      name: "__AGETOR present but with no fontSize key falls through to the hash",
+      agetorGlobal: { theme: "dark" },
+      hash: "#fontSize=160",
+      expected: 160,
+    },
+    {
+      name: "a malformed-typed __AGETOR global falls through to the hash",
+      agetorGlobal: "not-an-object",
+      hash: "#fontSize=115",
+      expected: 115,
+    },
+    { name: "only the hash param is present, no leading #", agetorGlobal: undefined, hash: "fontSize=145", expected: 145 },
+    {
+      name: "a realistic boot hash with fontSize alongside api/token/theme",
+      agetorGlobal: undefined,
+      hash: "#api=4318&token=abc123&theme=dark&fontSize=140",
+      expected: 140,
+    },
+    { name: "hash present but without a fontSize param falls back to default", agetorGlobal: undefined, hash: "#api=4318&token=abc123", expected: FONT_SIZE_DEFAULT },
+    { name: "a bare hash with nothing after it falls back to default", agetorGlobal: undefined, hash: "#", expected: FONT_SIZE_DEFAULT },
+    { name: "an out-of-range hash value clamps", agetorGlobal: undefined, hash: "#fontSize=9999", expected: FONT_SIZE_MAX },
+    { name: "a garbage hash fontSize value falls back to default via clamp", agetorGlobal: undefined, hash: "#fontSize=abc", expected: FONT_SIZE_DEFAULT },
+    // Both boot global and hash absent/invalid entirely.
+    { name: "both boot global and hash are absent", agetorGlobal: undefined, hash: "", expected: FONT_SIZE_DEFAULT },
+    // Both present: number type on __AGETOR wins even when the hash also has a valid value.
+    {
+      name: "both present and valid — __AGETOR wins",
+      agetorGlobal: { fontSize: 170 },
+      hash: "#fontSize=100",
+      expected: 170,
+    },
+  ];
+
+  for (const { name, agetorGlobal, hash, expected } of cases) {
+    test(name, () => {
+      expect(readFontSizeFromBoot(agetorGlobal, hash)).toBe(expected);
+    });
+  }
+
+  test("a malformed hash content does not throw — URLSearchParams parses leniently", () => {
+    expect(readFontSizeFromBoot(undefined, "#not a=valid=query&&fontSize=120")).toBe(120);
+  });
+});
+
+describe("fontSizeShortcutAction", () => {
+  const base = { key: "=", metaKey: false, ctrlKey: false, altKey: false };
+
+  // --- Mac: metaKey && !ctrlKey ---
+  describe("on Mac (isMac = true)", () => {
+    test("Cmd+= increases", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "=", metaKey: true }, true)).toBe("increase");
+    });
+    test("Cmd++ increases", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "+", metaKey: true }, true)).toBe("increase");
+    });
+    test("Cmd+- decreases", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "-", metaKey: true }, true)).toBe("decrease");
+    });
+    test("Cmd+_ decreases", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "_", metaKey: true }, true)).toBe("decrease");
+    });
+    test("Cmd+0 resets", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "0", metaKey: true }, true)).toBe("reset");
+    });
+    test("an unrelated key with Cmd held returns null", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "a", metaKey: true }, true)).toBeNull();
+    });
+    test("Ctrl+= without Cmd does not fire on Mac", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "=", ctrlKey: true }, true)).toBeNull();
+    });
+    test("neither modifier held does not fire", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "=" }, true)).toBeNull();
+    });
+    test("Ctrl+Cmd+= (both modifiers) does not fire on Mac — ctrl disqualifies", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "=", metaKey: true, ctrlKey: true }, true)).toBeNull();
+    });
+    test("Alt+Cmd+= does not fire — altKey disqualifies", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "=", metaKey: true, altKey: true }, true)).toBeNull();
+    });
+    test("Alt alone with Cmd+0 does not fire", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "0", metaKey: true, altKey: true }, true)).toBeNull();
+    });
+  });
+
+  // --- non-Mac: ctrlKey && !metaKey ---
+  describe("on non-Mac (isMac = false)", () => {
+    test("Ctrl+= increases", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "=", ctrlKey: true }, false)).toBe("increase");
+    });
+    test("Ctrl++ increases", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "+", ctrlKey: true }, false)).toBe("increase");
+    });
+    test("Ctrl+- decreases", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "-", ctrlKey: true }, false)).toBe("decrease");
+    });
+    test("Ctrl+_ decreases", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "_", ctrlKey: true }, false)).toBe("decrease");
+    });
+    test("Ctrl+0 resets", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "0", ctrlKey: true }, false)).toBe("reset");
+    });
+    test("an unrelated key with Ctrl held returns null", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "z", ctrlKey: true }, false)).toBeNull();
+    });
+    test("Cmd+= without Ctrl does not fire on non-Mac", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "=", metaKey: true }, false)).toBeNull();
+    });
+    test("neither modifier held does not fire", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "=" }, false)).toBeNull();
+    });
+    test("Ctrl+Cmd+= (both modifiers) does not fire on non-Mac — meta disqualifies", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "=", ctrlKey: true, metaKey: true }, false)).toBeNull();
+    });
+    test("Alt+Ctrl+= does not fire — altKey disqualifies", () => {
+      expect(fontSizeShortcutAction({ ...base, key: "=", ctrlKey: true, altKey: true }, false)).toBeNull();
+    });
+  });
+});

--- a/src/mainview/lib/font-size.ts
+++ b/src/mainview/lib/font-size.ts
@@ -1,4 +1,10 @@
-import { clampFontSizePercent, FONT_SIZE_DEFAULT, FONT_SIZE_STEP } from "../../shared/types.ts";
+import {
+  clampFontSizePercent,
+  FONT_SIZE_BASE_PX,
+  FONT_SIZE_DEFAULT,
+  FONT_SIZE_STEP,
+  TERMINAL_FONT_SIZE_BASE_PX,
+} from "../../shared/types.ts";
 
 /**
  * Pure font-size logic — no DOM, no React. Mirrors `theme.ts`'s split:
@@ -26,14 +32,14 @@ export function stepFontSize(pct: number, action: FontSizeAction): number {
  *  pristine, matching the boot-channel contract in `src/shared/types.ts`. */
 export function rootFontSizeStyle(pct: number): string | null {
   if (pct === FONT_SIZE_DEFAULT) return null;
-  return `${(16 * pct) / 100}px`;
+  return `${(FONT_SIZE_BASE_PX * pct) / 100}px`;
 }
 
 /** xterm's `fontSize` option scales off its own 12px baseline (unrelated to
  *  the 16px root rem baseline — see `TerminalView.tsx`, which reads CSS
  *  variables for everything else but sets this as an absolute pixel value). */
 export function terminalFontSize(pct: number): number {
-  return Math.round((12 * pct) / 100);
+  return Math.round((TERMINAL_FONT_SIZE_BASE_PX * pct) / 100);
 }
 
 /**
@@ -46,7 +52,14 @@ export function terminalFontSize(pct: number): number {
  */
 export function readFontSizeFromBoot(agetorGlobal: unknown, hash: string): number {
   const injected = (agetorGlobal as { fontSize?: unknown } | null | undefined)?.fontSize;
-  if (injected !== undefined && injected !== null) return clampFontSizePercent(injected);
+  // Only a number or string counts as "present" — matches index.html's inline
+  // boot script, which falls through to the hash param unless __AGETOR.fontSize
+  // is one of those two types. Without this, an unexpected shape (object,
+  // boolean, …) would resolve via clampFontSizePercent's NaN fallback (100)
+  // instead of consulting the hash the way the boot script does.
+  if (typeof injected === "number" || typeof injected === "string") {
+    return clampFontSizePercent(injected);
+  }
 
   const stripped = hash.startsWith("#") ? hash.slice(1) : hash;
   if (!stripped) return FONT_SIZE_DEFAULT;
@@ -61,19 +74,21 @@ export function readFontSizeFromBoot(agetorGlobal: unknown, hash: string): numbe
 
 /**
  * Map a keydown to a font-size action, or `null` if the combo isn't one we
- * handle. The primary modifier is `metaKey` on macOS, `ctrlKey` elsewhere
- * (same `isMac` sniff convention as `RunPanel.tsx`'s `IS_MAC_PLATFORM`) —
- * the *other* modifier being also held doesn't disqualify (mirrors how
- * physical keyboards can report both during a fast chord), but `altKey` does,
- * since Option/Alt-modified punctuation produces different glyphs on some
- * layouts and isn't part of this shortcut's contract.
+ * handle. The primary modifier is `metaKey` on macOS, `ctrlKey` elsewhere,
+ * matching `RunPanel.tsx`'s Cmd/Ctrl+F convention exactly: the *other*
+ * modifier being also held disqualifies (Mac wants meta-without-ctrl, other
+ * platforms want ctrl-without-meta) so a combo like Ctrl+Cmd+= — which some
+ * window managers or IMEs can report — doesn't ambiguously fire both this
+ * and a platform-native binding. `altKey` also disqualifies, since
+ * Option/Alt-modified punctuation produces different glyphs on some layouts
+ * and isn't part of this shortcut's contract.
  */
 export function fontSizeShortcutAction(
   e: { key: string; metaKey: boolean; ctrlKey: boolean; altKey: boolean },
   isMac: boolean,
 ): FontSizeAction | null {
   if (e.altKey) return null;
-  const primaryDown = isMac ? e.metaKey : e.ctrlKey;
+  const primaryDown = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
   if (!primaryDown) return null;
   switch (e.key) {
     case "=":

--- a/src/mainview/lib/font-size.ts
+++ b/src/mainview/lib/font-size.ts
@@ -1,0 +1,97 @@
+import { clampFontSizePercent, FONT_SIZE_DEFAULT, FONT_SIZE_STEP } from "../../shared/types.ts";
+
+/**
+ * Pure font-size logic — no DOM, no React. Mirrors `theme.ts`'s split:
+ * `font-size-provider.tsx` and the boot-time inline script in `index.html`
+ * (owned by the boot-channel side of this feature) are thin DOM-touching
+ * wrappers around these functions.
+ */
+
+export type FontSizeAction = "increase" | "decrease" | "reset";
+
+/** Step `pct` by one `FONT_SIZE_STEP` increment (or jump straight to
+ *  `FONT_SIZE_DEFAULT` on "reset"), clamped to [FONT_SIZE_MIN, FONT_SIZE_MAX].
+ *  `pct` is assumed already-valid (callers hold clamped state); the result is
+ *  re-clamped anyway so a caller passing a stray out-of-range value can't
+ *  escape the bounds. */
+export function stepFontSize(pct: number, action: FontSizeAction): number {
+  if (action === "reset") return FONT_SIZE_DEFAULT;
+  const delta = action === "increase" ? FONT_SIZE_STEP : -FONT_SIZE_STEP;
+  return clampFontSizePercent(pct + delta);
+}
+
+/** The `documentElement.style.fontSize` value for a given percent, or `null`
+ *  at exactly `FONT_SIZE_DEFAULT` — callers must *remove* the inline property
+ *  in that case (not set it to the computed 16px) so the default state stays
+ *  pristine, matching the boot-channel contract in `src/shared/types.ts`. */
+export function rootFontSizeStyle(pct: number): string | null {
+  if (pct === FONT_SIZE_DEFAULT) return null;
+  return `${(16 * pct) / 100}px`;
+}
+
+/** xterm's `fontSize` option scales off its own 12px baseline (unrelated to
+ *  the 16px root rem baseline — see `TerminalView.tsx`, which reads CSS
+ *  variables for everything else but sets this as an absolute pixel value). */
+export function terminalFontSize(pct: number): number {
+  return Math.round((12 * pct) / 100);
+}
+
+/**
+ * Read the boot-seeded font size: `window.__AGETOR.fontSize` first (the
+ * WKUserScript `preload` payload for the bundled `views://` path), the
+ * `fontSize` URL-hash param second (Vite dev path — see `buildWindowHash` in
+ * `src/bun/window-url.ts`), `FONT_SIZE_DEFAULT` when neither is present.
+ * `agetorGlobal` is passed in (rather than read from `window` directly) so
+ * this stays testable without a DOM.
+ */
+export function readFontSizeFromBoot(agetorGlobal: unknown, hash: string): number {
+  const injected = (agetorGlobal as { fontSize?: unknown } | null | undefined)?.fontSize;
+  if (injected !== undefined && injected !== null) return clampFontSizePercent(injected);
+
+  const stripped = hash.startsWith("#") ? hash.slice(1) : hash;
+  if (!stripped) return FONT_SIZE_DEFAULT;
+  try {
+    const params = new URLSearchParams(stripped);
+    const fromHash = params.get("fontSize");
+    return fromHash === null ? FONT_SIZE_DEFAULT : clampFontSizePercent(fromHash);
+  } catch {
+    return FONT_SIZE_DEFAULT;
+  }
+}
+
+/**
+ * Map a keydown to a font-size action, or `null` if the combo isn't one we
+ * handle. The primary modifier is `metaKey` on macOS, `ctrlKey` elsewhere
+ * (same `isMac` sniff convention as `RunPanel.tsx`'s `IS_MAC_PLATFORM`) —
+ * the *other* modifier being also held doesn't disqualify (mirrors how
+ * physical keyboards can report both during a fast chord), but `altKey` does,
+ * since Option/Alt-modified punctuation produces different glyphs on some
+ * layouts and isn't part of this shortcut's contract.
+ */
+export function fontSizeShortcutAction(
+  e: { key: string; metaKey: boolean; ctrlKey: boolean; altKey: boolean },
+  isMac: boolean,
+): FontSizeAction | null {
+  if (e.altKey) return null;
+  const primaryDown = isMac ? e.metaKey : e.ctrlKey;
+  if (!primaryDown) return null;
+  switch (e.key) {
+    case "=":
+    case "+":
+      return "increase";
+    case "-":
+    case "_":
+      return "decrease";
+    case "0":
+      return "reset";
+    default:
+      return null;
+  }
+}
+
+/** Same platform-sniff convention as `RunPanel.tsx`'s `IS_MAC_PLATFORM`,
+ *  duplicated here rather than imported — that constant isn't exported, and
+ *  this module intentionally stays DOM-adjacent-but-standalone like `theme.ts`. */
+export function isMacPlatform(): boolean {
+  return typeof navigator !== "undefined" && /mac/i.test(navigator.platform || navigator.userAgent || "");
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2848,3 +2848,40 @@ export const THEME_PREFERENCES: readonly { id: ThemePreference; label: string }[
   { id: "dark", label: "Dark" },
   { id: "light", label: "Light" },
 ];
+
+// ───────────────────────────────────────────────────────────────────────────
+// Font size (Cmd+= / Cmd+- global UI zoom)
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * The current root font size (16px) is both the DEFAULT and the MINIMUM —
+ * Cmd+- has nowhere to go below "what it looks like today". FONT_SIZE_MAX
+ * (170%) and FONT_SIZE_STEP (10%) are the generous-but-layout-safe bounds
+ * chosen in docs/plans/cmd-font-size-controller.md §8. Persisted as the
+ * `fontSize` key in the `preferences` table (see `src/bun/db.ts`) as a plain
+ * percent string ("100"–"170"), round-tripped through `GET/PUT /preferences`
+ * exactly like `theme`. Applied as
+ * `document.documentElement.style.fontSize = (16 * pct/100) + "px"`; at
+ * exactly FONT_SIZE_DEFAULT the inline style is omitted entirely so the
+ * default state stays pristine (and the boot no-flash channels can skip the
+ * write).
+ */
+export const FONT_SIZE_MIN = 100;
+export const FONT_SIZE_MAX = 170;
+export const FONT_SIZE_STEP = 10;
+export const FONT_SIZE_DEFAULT = 100;
+
+/**
+ * Parse anything (a persisted preference string, a hash-fragment param, a
+ * `window.__AGETOR` global, …) into a valid integer font-size percent,
+ * clamped to [FONT_SIZE_MIN, FONT_SIZE_MAX]. Accepts a string ("120",
+ * "120.5") or a number; floats are rounded to the nearest integer before
+ * clamping. Anything else — null/undefined, an empty/non-numeric string,
+ * NaN, ±Infinity — falls back to FONT_SIZE_DEFAULT. Never throws.
+ */
+export function clampFontSizePercent(raw: unknown): number {
+  const n = typeof raw === "number" ? raw : typeof raw === "string" ? parseFloat(raw) : NaN;
+  if (!Number.isFinite(n)) return FONT_SIZE_DEFAULT;
+  const rounded = Math.round(n);
+  return Math.min(FONT_SIZE_MAX, Math.max(FONT_SIZE_MIN, rounded));
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2871,6 +2871,17 @@ export const FONT_SIZE_MAX = 170;
 export const FONT_SIZE_STEP = 10;
 export const FONT_SIZE_DEFAULT = 100;
 
+/** Root `<html>` font size at 100% (px) — the rem baseline every percent is
+ *  scaled against (`FONT_SIZE_BASE_PX * pct/100`). Consumed by `src/bun/index.ts`
+ *  (preload apply-script) and duplicated inline in `src/mainview/index.html`'s
+ *  blocking boot script, which can't import a module before first paint. */
+export const FONT_SIZE_BASE_PX = 16;
+
+/** xterm terminal pane font size at 100% (px) — the separate baseline
+ *  `TerminalView.tsx` scales against, since xterm renders to canvas outside
+ *  the CSS/rem cascade `FONT_SIZE_BASE_PX` drives. */
+export const TERMINAL_FONT_SIZE_BASE_PX = 12;
+
 /**
  * Parse anything (a persisted preference string, a hash-fragment param, a
  * `window.__AGETOR` global, …) into a valid integer font-size percent,


### PR DESCRIPTION
## What

Adds user-controllable UI zoom for the whole agetor webview, plus the e2e-harness rework that keeps it (and future preference features) testable in parallel.

### Font-size shortcuts
- **Cmd+= / Cmd+−** (Ctrl on non-Mac dev builds) scale the entire UI; **Cmd+0** resets. Current size (16px root) is the default **and the minimum**; maximum is **170%** in 10% steps (`FONT_SIZE_*` constants in `src/shared/types.ts`).
- Implemented as root rem scaling (`documentElement.style.fontSize`; inline style removed at 100%) — the whole Tailwind-rem UI scales proportionally. xterm panes scale via a separate explicit path (`term.options.fontSize` + one-rAF-deferred `fit()` + PTY resize), since xterm renders to canvas outside the CSS cascade.
- Persisted as a `fontSize` preference (existing KV store, no migration) with a 300ms trailing-edge debounce and generation-guarded rollback so rapid stepping can't diverge UI ↔ DB.
- **No flash on boot**: delivered through all four boot channels like `theme` — `window-url.ts` (`buildWindowHash`), `index.ts` boot globals + preload script, the blocking inline script in `index.html`, and `scripts/dev-headless.sh`.
- Capture-phase keydown listener with `e.repeat` guard; on non-Mac the Ctrl variant yields to focused terminals (Ctrl+_ is readline undo). Toast feedback with a fixed id (updates in place, incl. at the clamp bounds).

### Settings → General stepper
- New "Font size" row (− / % readout / + / Reset) wired to the same provider: same debounce, clamping, and persistence.
- Stepper clicks are silent (no toast — sonner's top-right toast overlaps the dialog's Close button and eats clicks); the readout is a `role="status"` live region instead.
- Bounds use `aria-disabled` + handler guards rather than hard `disabled`, so focus isn't dropped when a button disables mid-interaction.

### E2e harness: per-worker backends
- Replaces the shared-backend setup (which required a `workers: 1` cap after cross-file preference races were observed, including in the pre-existing theme spec) with real isolation: one shared Vite + **one headless backend per Playwright worker** via a new worker-scoped fixture (`e2e/fixtures.ts`) — fresh mkdtemp data dir, port `4600 + parallelIndex`, per-run random token, health-poll, SIGTERM→SIGKILL→cleanup teardown.
- Hardened against stale-backend adoption (pre-flight port probe, child-liveness assert after the health poll, random tokens), spawn-failure hangs, and undiagnosable failures (`daemon.log` tailed into errors; `E2E_KEEP_DATA_DIR=1` retains a worker's data dir; `E2E_HEALTH_TIMEOUT_MS` overrides the 60s boot budget).
- Shared spec helpers consolidated into `e2e/helpers.ts`; `scripts/dev-headless.sh` unchanged for manual use.

## Why

Reading dense agent output all day at one fixed size is rough; this makes the whole app zoomable with the keys everyone already knows, discoverable via Settings, and remembered across launches without a size-jump flash at boot. The harness rework was required to test it honestly: the suite now runs at full parallelism deterministically instead of hiding shared-state races behind a worker cap.

## Testing

- `bun run typecheck` clean; `bun test` green (2590 tests; one pre-existing timing-sensitive assertion in `claude-tmux-queue.test.ts` flakes only under full-suite machine load and passes in isolation — untouched by this branch).
- `bunx playwright test`: **17/17**, repeatedly, at default parallelism (3 workers) and with `--workers=1`; no leaked processes or temp dirs. Includes 10 new font-size specs: boot no-flash, shortcut stepping, both clamps, reset, reload persistence, stepper stepping/reset, `aria-disabled` bounds, and shortcut↔readout live coherence.
- Negative-path check: a decoy process squatting on a worker's port makes that worker fail fast with a clear pre-flight error instead of silently testing against foreign state.

## Notes

- 106 new unit tests cover the pure logic (clamp/step/boot-precedence/shortcut matrix) and the bun-side preference plumbing.
- Plans and logged decisions live in `docs/plans/cmd-font-size-controller.md`, `docs/plans/font-size-settings-stepper.md`, and `docs/plans/e2e-per-worker-backends.md`. Max (170%) and step (10%) are single constants if we want to tune them.