### PR TITLE
feature: binary file previews (images & PDFs) in task and PR diffs, with per-host git API bases

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "ink": "^7.0.5",
         "ink-spinner": "^5.0.0",
         "lucide-react": "^1.14.0",
+        "pdfjs-dist": "6.2.108",
         "picocolors": "^1.1.1",
         "react": "^19.2.6",
         "react-devtools-core": "^6.1.2",
@@ -194,6 +195,30 @@
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
+
+    "@napi-rs/canvas": ["@napi-rs/canvas@1.0.5", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "1.0.5", "@napi-rs/canvas-darwin-arm64": "1.0.5", "@napi-rs/canvas-darwin-x64": "1.0.5", "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.5", "@napi-rs/canvas-linux-arm64-gnu": "1.0.5", "@napi-rs/canvas-linux-arm64-musl": "1.0.5", "@napi-rs/canvas-linux-riscv64-gnu": "1.0.5", "@napi-rs/canvas-linux-x64-gnu": "1.0.5", "@napi-rs/canvas-linux-x64-musl": "1.0.5", "@napi-rs/canvas-win32-arm64-msvc": "1.0.5", "@napi-rs/canvas-win32-x64-msvc": "1.0.5" } }, "sha512-GaPlicMtnvgPr5SowFRprkEJicDSrV3qCq17U4jiF5u0kNORZo3IbdN2Bk4SfcZJAMYFHbMVJ81O3w21CYxazg=="],
+
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@1.0.5", "", { "os": "android", "cpu": "arm64" }, "sha512-ZzDlpKQocwFfCwhMh17UWre6Qt5yZN3kNIJoUpGfRZqwDDZ164IKOsPOHsRd3d8Tuj5KM6bDjGuPmZxuPuG3NQ=="],
+
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@1.0.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Hr8v6CA/TBe+OJOePdV3sXWxzQHQKfQsTKPbc8wG7iPqVeAx6MMdzKGXlYID6SVvpfwV/zqkvGcdImYWSlhrZg=="],
+
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@1.0.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-9BXlLHBXpYnK4jSae1MdFdyPq09Xi1I3PeCNpvRzqgmUUBhgJS7aC1z7SZEP8JUXDHtbfIrolCS3sFuT9IGP2A=="],
+
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-zEW4fgvtYsOJ/N56Us4TQPfaFrUf0shGr9CgGSj3GACc+NHfUM3ci0YF9xFTjwJWGDmaEhYPL6KqCfFCxwm/qg=="],
+
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@1.0.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-HFprwLspelJxCEtZvdMcz95Mwvfs63GzFVedLFmC/wslHnaOXhjXxgYxPCM/VdM4Jhx3CV4Lk0vVmh6hJv2etQ=="],
+
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@1.0.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-FNMGFAx8DvtDwlLfWyBJ+oQjgPXoIAqCnNTJYqtJCFRwwzK3AyAe5B1Ll3NZ6hcOzqw7HylZsq4nQxVyPCQX1Q=="],
+
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@1.0.5", "", { "os": "linux", "cpu": "none" }, "sha512-2vd5v8Lui+37Hh/spITKIvTT384ip4dnUc5XBn0E+sMNS4b7au7IswyT5YDG2udPTjSh/eLUs3sGuB5YHooFOA=="],
+
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@1.0.5", "", { "os": "linux", "cpu": "x64" }, "sha512-iQIPy+Uey0expZTOszLri5n8rY7x4WUpMaY82mcXNIgbil30iHvc01OsiizhZC1KQHTK90RFMFWSpwFU+ON3aA=="],
+
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@1.0.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Npthji25t7FUqIAKsoEkFS0qY5CYVkHjvI3tuZjDTG92wX8g4dst+Lfb4hhubdqPazlDcIwalPzInsFCtf3FFg=="],
+
+    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@1.0.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-bi+JsdCdbfVJDoAQybTYmkLKwh1xpYpptg5j/BNr2BB56u4/R26jrVvtjqff+CxYMXV6Kz1/jeDVhZCuj6bDng=="],
+
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@1.0.5", "", { "os": "win32", "cpu": "x64" }, "sha512-KQQwG9/sBmcGxqaLFIQf+k2OefREGoyEaIBmRuTM8bUuFKOEE9Xk5pel90hE6pmBwk/vo4RB0OdX+FxobJGMFw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -1190,6 +1215,8 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "pdfjs-dist": ["pdfjs-dist@6.2.108", "", { "optionalDependencies": { "@napi-rs/canvas": "^1.0.0" } }, "sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/docs/plans/binary-diff-previews-providers.md
+++ b/docs/plans/binary-diff-previews-providers.md
@@ -1,0 +1,104 @@
+# Plan — Binary previews follow-up: GitLab/Bitbucket blobs + root-relative untracked paths
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-12 |
+| Source | /implement follow-up on docs/plans/binary-diff-previews.md open items 1 & 4 |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/load-binary-files-on-diff-modal-and-git |
+| Base SHA | 04969c4 (end of first run) |
+| Mode | Autonomous — gates self-resolved; assumptions in §8 |
+
+## 1. Objective & success criteria
+(a) GitLab and Bitbucket PR diffs render binary previews like GitHub's (server `pullBlob` branches
+implemented; UI gate widened); (b) `getTaskDiff`'s untracked-file entries become repo-root-relative
+so one `TaskDiff` no longer mixes path namespaces. Typecheck + unit + e2e stay green.
+
+## 2. Context (investigated, verified)
+- Dispatch seam: git-host.ts:428-436 `pullBlob` (isSafeRelPath already applied; github branch live;
+  else 501). `PullBlobResult.ok` carries `ref` for the route's content-addressed ETag.
+- Providers receive `ProviderRepoInfo { provider, host, remoteHost, owner, name }` (types.ts:2646).
+- GitLab: auth `PRIVATE-TOKEN` via fetchGitLab (gitlab.ts:85-109); project id = encodeURIComponent
+  ("owner/name") (encodeProjectId :111). MR detail `diff_refs.base_sha` IS the merge base (GitLab
+  docs, confirmed); `/versions` endpoint (used by createGitLabPullLineComment :746) is the
+  synchronous fallback since diff_refs populates async. Raw file: GET /projects/:id/repository/
+  files/:urlencoded-path/raw?ref=<sha> returns raw bytes, PRIVATE-TOKEN auth. Fork MRs: new side
+  lives in `source_project_id` (numeric id valid as :id).
+- Bitbucket: auth Basic/Bearer via fetchBitbucket (bitbucket.ts:190-215); raw file: GET /2.0/
+  repositories/{ws}/{slug}/src/{commit}/{path} returns raw bytes (docs confirmed). PR diff is
+  merge-base-anchored (three-dot; Atlassian blog confirmed) but NO official merge-base endpoint.
+  PR detail carries source.commit.hash / destination.commit.hash (source read at :953, :1093).
+  Cross-repo: source/destination repository full_names read in normalizeBitbucketMergeability.
+- github.ts getGitHubPullBlob (:1710-1940) is the structural template (pullDetailCache 60s TTL,
+  mergeBaseCache, contentTypeForPreviewPath, 20MB double-guard, ok+ref shape).
+- UI gate: GitHubDialog.tsx:6598 blobCtx useMemo `provider === "github"` — documented v1 restriction.
+- worktree.ts:919-934 untracked loop emits CWD-relative paths (git ls-files run in cwd);
+  getTaskDiffBlob :1024-1056 root-join-then-cwd-fallback exists precisely to absorb that.
+- Existing tests asserting the 501s: git-host.test.ts (T6's dispatch tests) — will need updating in
+  the same change that removes the 501s.
+
+## 3. Approach & key decisions
+1. **GitLab old side = diff_refs.base_sha** (merge base, no compare round-trip); fallback to
+   `/versions` latest (`base_commit_sha`/`head_commit_sha`) when diff_refs absent/incomplete.
+   New side = head_sha, fetched from source project when `source_project_id !== target_project_id`.
+2. **Bitbucket old side**: primary — fetch `/pullrequests/{n}/diff` with `redirect: "manual"` and
+   parse the resolved `{source}..{dest}`-style spec from the Location header if it yields a usable
+   merge-base sha; fallback — `destination.commit.hash` **approximation**, clearly doc-commented
+   (same "approximated" convention the module already uses). No commits-pagination walk (unbounded,
+   and wrong under back-merges anyway). — decision
+3. **Both new provider functions mirror github.ts's shape**: per-PR detail cache (60s TTL, 200-cap
+   wholesale clear), MAX_BLOB_PREVIEW_BYTES double-guard, contentTypeForPreviewPath, local
+   result type structurally matching PullBlobResult (avoids git-host import-direction issue),
+   `ref` = the sha actually fetched.
+4. **Untracked-path normalization at the source**: getTaskDiff prefixes each untracked `rel` with
+   `path.relative(root, cwd)` (posix-joined) so DiffFile.path is always root-relative; the
+   `--no-index` git call keeps using the cwd-relative path. getTaskDiffBlob's cwd-fallback stays
+   (harmless, defensive) with an updated comment. UI display changes for subdir-workdir tasks
+   (paths now shown root-relative) — accepted as more correct/consistent.
+5. **UI gate widens** to any concrete provider (`github | gitlab | bitbucket`) on pull items;
+   `mixed`/null keep the placeholder.
+
+## 4. Work breakdown — implementation
+Contracts (wave-1 tasks compile together):
+```ts
+// gitlab.ts
+export async function getGitLabPullBlob(repo: ProviderRepoInfo, number: number, relPath: string, side: "old" | "new"): Promise<GitLabBlobResult>; // structurally = PullBlobResult
+// bitbucket.ts
+export async function getBitbucketPullBlob(repo: ProviderRepoInfo, number: number, relPath: string, side: "old" | "new"): Promise<BitbucketBlobResult>; // structurally = PullBlobResult
+```
+
+| ID | Goal | Owns | Deps |
+| --- | --- | --- | --- |
+| A | getGitLabPullBlob (per §3.1/§3.3) + pullBlob dispatch for BOTH new providers + update git-host.test.ts's two 501 dispatch tests to the new behavior | src/bun/gitlab.ts, src/bun/git-host.ts, src/bun/git-host.test.ts | — |
+| B | getBitbucketPullBlob (per §3.2/§3.3) | src/bun/bitbucket.ts | — |
+| C | Root-relative untracked paths in getTaskDiff (§3.4) + comment update in getTaskDiffBlob + adjust/extend worktree.test.ts (subdir-workdir untracked assertions) | src/bun/worktree.ts, src/bun/worktree.test.ts | — |
+| D | Widen blobCtx gate (§3.5) | src/mainview/components/kanban/GitHubDialog.tsx | wave 1 |
+
+## 5. Work breakdown — tests
+| ID | Goal | Owns | Covers |
+| --- | --- | --- | --- |
+| E | Network-mocked unit tests: gitlab-network.test.ts (blob happy path old/new, fork MR source-project routing, diff_refs→versions fallback, 404/413), bitbucket-network.test.ts (blob happy path, redirect-parse merge base, destination-tip fallback, 404/413) — following each file's existing mock harness | src/bun/gitlab-network.test.ts, src/bun/bitbucket-network.test.ts | A, B |
+
+E2e: NOT applicable for provider blobs (needs live GitLab/Bitbucket PRs); existing
+e2e/binary-diff.spec.ts already covers the task-diff surface C touches — recorded decision.
+
+## 6. Execution waves
+Wave 1: A, B, C (disjoint). Wave 2: D. Review (opus) → test task E → full run (typecheck, bun test, playwright).
+
+## 7. Blast radius & risks
+- git-host.test.ts 501 assertions must change with the dispatch (A owns both, same change).
+- Untracked-path normalization changes DiffFile.path values for subdir-workdir tasks: consumers are
+  DiffDialog display, compose-from-diff labels (both fine with root-relative), getTaskDiffBlob
+  (root-join-first already), e2e spec (uses repo-root workdirs — unaffected).
+- Bitbucket merge-base approximation can show a drifted "Before" when the destination moved AND
+  touched the same file and the redirect-parse failed — bounded, documented.
+- GitLab raw-file rate limit (5/min for >10MB blobs) — acceptable for modal-scoped fetches.
+
+## 8. Open questions / assumptions (autonomous mode)
+1. Bitbucket redirect-Location parse is best-effort; destination-tip fallback accepted. — decision
+2. Bitbucket commit-hash length unverified in docs; we pass through whatever the API returns
+   (src/{commit}/ accepts either). — assumption
+3. GitLab fork-MR new-side routing via numeric source_project_id. — assumption (doc-supported)
+4. No e2e for provider blobs (no live PR fixtures). — decision
+5. Subdir-workdir tasks now display root-relative untracked paths (behavior change, more
+   consistent). — decision

--- a/docs/plans/binary-diff-previews-providers.md
+++ b/docs/plans/binary-diff-previews-providers.md
@@ -26,7 +26,11 @@ so one `TaskDiff` no longer mixes path namespaces. Typecheck + unit + e2e stay g
   lives in `source_project_id` (numeric id valid as :id).
 - Bitbucket: auth Basic/Bearer via fetchBitbucket (bitbucket.ts:190-215); raw file: GET /2.0/
   repositories/{ws}/{slug}/src/{commit}/{path} returns raw bytes (docs confirmed). PR diff is
-  merge-base-anchored (three-dot; Atlassian blog confirmed) but NO official merge-base endpoint.
+  merge-base-anchored (three-dot; Atlassian blog confirmed). CORRECTION (Phase-5 review): an
+  official merge-base endpoint DOES exist — GET /2.0/repositories/{ws}/{slug}/merge-base/
+  {sha1..sha2} returns the best common ancestor commit (api-group-commits docs). The original
+  "no endpoint" fact was an investigation miss; §3.2's redirect-sniff was rebuilt on the
+  documented endpoint in the review-fix wave.
   PR detail carries source.commit.hash / destination.commit.hash (source read at :953, :1093).
   Cross-repo: source/destination repository full_names read in normalizeBitbucketMergeability.
 - github.ts getGitHubPullBlob (:1710-1940) is the structural template (pullDetailCache 60s TTL,
@@ -95,7 +99,13 @@ Wave 1: A, B, C (disjoint). Wave 2: D. Review (opus) → test task E → full ru
 - GitLab raw-file rate limit (5/min for >10MB blobs) — acceptable for modal-scoped fetches.
 
 ## 8. Open questions / assumptions (autonomous mode)
-1. Bitbucket redirect-Location parse is best-effort; destination-tip fallback accepted. — decision
+1. ~~Bitbucket redirect-Location parse~~ SUPERSEDED by review: merge base resolved via the
+   official /merge-base/{revspec} endpoint; destination-tip fallback retained for resolver
+   failure (incl. cross-repo edge cases); cache validated by retry-on-404. — decision (revised)
+1b. `/github/pull-blob` route name now serves all three providers — kept deliberately (renaming
+   would churn the URL builder + tests for a cosmetic win); recorded here so it reads as a
+   decision, not a bug. The GitHubDialog "mixed"-provider exclusion is conservative, not
+   required (itemPath is per-item) — left as-is. — decision
 2. Bitbucket commit-hash length unverified in docs; we pass through whatever the API returns
    (src/{commit}/ accepts either). — assumption
 3. GitLab fork-MR new-side routing via numeric source_project_id. — assumption (doc-supported)

--- a/docs/plans/binary-diff-previews.md
+++ b/docs/plans/binary-diff-previews.md
@@ -1,0 +1,164 @@
+# Plan — Binary file previews (images & PDFs) in diff views
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-12 |
+| Source | /implement — "load binary files in the Task Details Diff Modal and Git Integration diffs; images and PDFs old vs new side by side, styled" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/load-binary-files-on-diff-modal-and-git |
+| Base SHA | 2a4f1a1f3eb8a88aae8bd9581592a5c109d87a85 |
+| Mode | Autonomous — Phase 2 grill and Phase 3 approval gates self-resolved; assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+When a diff contains a binary file that is an image or a PDF, both diff surfaces render an
+old-vs-new side-by-side preview instead of the current italic "Binary file — no textual diff."
+placeholder:
+
+- **Task Details Diff Modal** (`DiffDialog.tsx`) — worktree diffs.
+- **Git Integration modal PR diff** (`GitHubDialog.tsx` → `PullDiff` → `DiffFileBlock`) — GitHub PRs in v1; GitLab/Bitbucket keep the placeholder (§8).
+
+Success = images render 2-up with dimension labels, checkerboard behind transparency, and
+one-sided panes for added/deleted files; PDFs render 2-up paged canvases (pdf.js) with synced
+page controls; both themes look right using semantic tokens; oversized/missing blobs degrade to
+a friendly state; diff line-selection machinery is untouched; typecheck + unit + e2e green.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- `TaskDiff`/`DiffFile` (src/shared/types.ts:1672-1709) is the shared shape for task diffs AND
+  all provider PR diffs; `binary: true`, `hunks: ""` for binaries (src/bun/git-diff.ts:54,84).
+- Task diff: `getTaskDiff` (src/bun/worktree.ts:847) diffs `task.baseRef ?? "HEAD"` against the
+  working tree in `task.worktreePath` (isolation=worktree) or `HEAD` in `task.workdir`
+  (isolation=none). Untracked files come via `git diff --no-index /dev/null <f>` → status added.
+- PR diff: `getGitHubPullDiff` (src/bun/github.ts:1655) fetches the whole-PR `.diff` media type
+  (a three-dot diff, i.e. **against the merge base**) → `parseGitDiff`. No per-file shas reach
+  the client. The Bun side holds the token (`githubToken`, github.ts:843); `fetchGitHub`
+  (github.ts:1011) is the generic fetch helper; Contents-API precedent at github.ts:718,1907.
+- Byte transport precedent: `GET /files/preview` (src/bun/server.ts:3725) — token in query for
+  `<img>` (isAuthorized accepts `?token=`, server.ts:273-279), extension allowlist via
+  `isImagePath` (src/shared/attachments.ts:57), `st.isFile()`, `nosniff`, ETag. Fleet decision
+  3b94b2ec records the rationale; mirror the guardrails.
+- Binary placeholders to replace: DiffDialog.tsx:828-829 (FileBlock binary branch) and
+  GitHubDialog.tsx:8958-8966 (DiffFileBlock binary branch). Both live OUTSIDE the DiffBody row
+  list — previews must stay out of the `data-diff-path`/`data-diff-index` row-index space so
+  drag/shift-click selection math is untouched.
+- WKWebView (`bundleCEF: false`) inline `<embed>`/`<iframe>` PDF rendering is unreliable →
+  pdf.js canvas rendering; Vite worker wiring via `?url` import (pdfjs-dist v6,
+  `pdf.worker.min.mjs`). Lazy-load via dynamic import so board load cost is zero.
+- UI conventions: semantic tokens only (`text-success`/`text-danger`/`bg-muted/40`…), collapsible
+  file blocks, sticky header pattern in GitHubDialog (two-layer opaque bg), dialog primitives in
+  components/ui/.
+- Tests: bun test colocated `*.test.ts` (worktree.test.ts, git-diff, diff-rows/diff-selection,
+  /files/preview tests); Playwright e2e in `e2e/` with per-worker backends (e2e/fixtures.ts),
+  run via `bunx playwright test`; no React component-test harness.
+
+## 3. Approach & key decisions
+
+1. **One shared preview component** (`BinaryFilePreview`) consumed by both dialogs — the two
+   renderers already duplicate the placeholder; do not add a third copy. (Reasoning + fleet
+   knowledge 1821c945.)
+2. **Bytes over HTTP routes, not JSON/base64** — mirrors `/files/preview` decision. Images use
+   `<img src>` with `?token=`; PDFs use `fetch` with `Authorization: Bearer` → ArrayBuffer →
+   pdf.js `getDocument({ data })` (no token in URL where a fetch is possible anyway).
+3. **Task diff blobs**: new route `GET /tasks/:id/diff/blob?path=<repo-rel>&side=old|new`.
+   old = `git show <resolvedBase>:<path>` in the task's git cwd; new = on-disk file in that cwd
+   (that is literally what `git diff` compared). isolation=none → cwd=workdir, base=HEAD.
+4. **GitHub PR blobs**: new route `GET /github/pull-blob` (params mirror `/github/pull-diff`,
+   plus `path`, `side`). Server resolves pull → head sha + base; **old side anchors at the
+   merge base** (compare API, cached in-memory per (host,repo,number,headSha)) because the
+   `.diff` the UI shows is a three-dot diff — `base.sha` would show a wrong "old" when the base
+   branch moved. Blob bytes via Contents API `Accept: application/vnd.github.raw` at a ref.
+   Dispatch through `git-host.ts` `pullBlob`; GitLab/Bitbucket return `unsupported` in v1.
+5. **Previewable = extension-based**: images reuse shared `IMAGE_EXTENSIONS`; add `pdf`.
+   New shared helper `binaryPreviewKind(path): "image" | "pdf" | null` in
+   src/shared/attachments.ts. Other binaries keep today's placeholder.
+6. **Caps & guardrails**: `MAX_BLOB_PREVIEW_BYTES = 20_000_000` on both routes (413 → UI
+   "too large to preview"); extension allowlist on both routes (keeps them from becoming
+   generic file/blob readers, per fleet decision); repo-relative path validation (reject
+   absolute + `..`); `nosniff`; ETag (old side keyed by resolved sha:path → long cache; new
+   side size-mtime → must-revalidate, matching /files/preview).
+7. **PDF UX**: per-side paged canvas, page controls synced across old/new (single control bar:
+   ‹ page n / max(oldPages,newPages) ›), rendered at pane width; loading skeleton + error state.
+   pdfjs-dist pinned, dynamic-imported, worker via `?url`.
+8. **Image UX** (GitHub 2-up): checkerboard background, `naturalWidth×naturalHeight` caption,
+   Before/After header chips (danger/success tokens), one-sided layout for added/deleted,
+   `onError` → missing state (AttachmentChips precedent).
+
+## 4. Work breakdown — implementation
+
+**Contracts (agreed up front so wave-1 tasks compile together):**
+
+```ts
+// src/shared/attachments.ts
+export type BinaryPreviewKind = "image" | "pdf";
+export function isPdfPath(p: string): boolean;
+export function binaryPreviewKind(p: string): BinaryPreviewKind | null;
+
+// src/bun/git-host.ts
+export type PullBlobResult =
+  | { ok: true; bytes: Uint8Array; contentType: string }
+  | { ok: false; error: string; status?: number }; // status 413 for too-large, 404 missing, 501 unsupported provider
+pullBlob(opts: PullBlobOpts): Promise<PullBlobResult>  // PullBlobOpts mirrors pullDiff's opts + { path: string; side: "old" | "new" }
+
+// src/bun/worktree.ts
+export async function getTaskDiffBlob(task: Task, relPath: string, side: "old" | "new"):
+  Promise<{ ok: true; bytes: Uint8Array; etag: string } | { ok: false; error: string; status: number }>;
+
+// src/mainview/lib/api.ts
+taskDiffBlobUrl(taskId: string, path: string, side: "old" | "new"): string   // ?token= for <img>
+pullBlobUrl(opts /* same identifying params getGitHubPullDiff uses */ & { path; side }): string
+fetchPdfBytes(url: string): Promise<ArrayBuffer>  // Bearer-header fetch, throws typed TooLarge/NotFound
+```
+
+| ID | Goal | Owns (exact files) | Deps |
+| --- | --- | --- | --- |
+| T1 | Shared previewable helpers; task-blob server support: `getTaskDiffBlob` (git show + disk read, path validation, 20MB cap, etag) and BOTH routes in server.ts (`/tasks/:id/diff/blob`, `/github/pull-blob` — the latter written against T2's contract); extend content-type map with pdf | src/shared/attachments.ts, src/bun/worktree.ts, src/bun/server.ts | — |
+| T2 | GitHub blob fetch: pull detail → head/base, merge-base resolution w/ in-memory cache, Contents API raw fetch w/ cap; `pullBlob` dispatch (gitlab/bitbucket → 501 unsupported) | src/bun/github.ts, src/bun/git-host.ts | — |
+| T3 | `BinaryFilePreview` component (image 2-up + pdf 2-up w/ synced pager, all states: loading/missing/too-large/one-sided), pdf.js lazy loader, api.ts url/fetch helpers, add pdfjs-dist dep | src/mainview/components/kanban/BinaryFilePreview.tsx (new), src/mainview/lib/pdf.ts (new), src/mainview/lib/api.ts, package.json (+ lockfile via bun install) | — |
+| T4 | Wire preview into DiffDialog FileBlock binary branch (kind-gated; keep placeholder for non-previewable) | src/mainview/components/kanban/DiffDialog.tsx | wave 1 |
+| T5 | Wire preview into GitHubDialog DiffFileBlock binary branch: thread provider/repo/number identifiers from GitHubItemDetail → PullDiff → DiffFileBlock; GitHub-only gate, others keep placeholder | src/mainview/components/kanban/GitHubDialog.tsx | wave 1 |
+
+## 5. Work breakdown — tests
+
+| ID | Goal | Owns | Covers |
+| --- | --- | --- | --- |
+| T6 | Unit: attachments kind helpers; `getTaskDiffBlob` against a temp git repo (modified/added/deleted/renamed binary, traversal + cap + missing rejections); `/tasks/:id/diff/blob` route (auth, allowlist, content-type, 413) following the existing /files/preview test style; github pull-blob unit only if fetch is cleanly mockable per existing github.ts test conventions | src/shared/attachments.test.ts (new or extend), src/bun/worktree.test.ts, src/bun/server.test.ts (or the file housing /files/preview tests) | T1, T2 |
+| T7 | e2e (Playwright, extends e2e/fixtures.ts pattern): temp git repo with a committed PNG modified in the working tree → create isolation=none task via API → open Task Details → Diff modal → assert 2-up images render (both `<img>` loaded, checkerboard/dimension caption present); PDF variant asserting canvases render | e2e/binary-diff.spec.ts (new) | T1, T3, T4 |
+
+**E2e applies**: user-visible flow crossing webview→API→git; harness exists (per-worker
+backends). GitHub-PR-side e2e is NOT covered (needs a live GitHub PR) — covered by unit tests
++ manual verification instead; recorded as an open item.
+
+## 6. Execution waves
+
+- Wave 1 (parallel): T1, T2, T3 — file-disjoint (server.ts owned solely by T1; api.ts solely by T3).
+- Wave 2 (parallel): T4, T5 — each owns exactly one dialog file.
+- Review (Phase 5) → Wave 3 (parallel): T6, T7 (disjoint test files).
+- Phase 7: `bun run typecheck`, `bun test`, `bunx playwright test`.
+
+## 7. Blast radius & risks
+
+- DiffDialog selection machinery: previews render outside DiffBody rows — no `data-diff-index`
+  rows added, so drag/shift-select math untouched. Verify in review.
+- GitHubDialog is a very large file with a view union + resetComposers choke point; T5 adds no
+  composer-like state, so no resetComposers change — only prop threading into sibling sections.
+- New deps: pdfjs-dist only (webview-side). No native binaries, no Electrobun packaging impact
+  beyond Vite bundle (mitigated by dynamic import + `?url` worker asset).
+- pdf.js on WKWebView: pdf.js supports Safari; if the modern build misbehaves on WKWebView,
+  fall back to `pdfjs-dist/legacy`. e2e validates our wiring in Chromium, not WKWebView itself —
+  manual check in the real app recommended post-merge.
+- Security posture: routes are token-gated, extension-allowlisted, size-capped, path-validated —
+  equal trust to /files/preview per fleet decision 3b94b2ec.
+- GitHub API rate: +≤2 requests per blob side (merge-base cached per PR-head); acceptable for
+  modal-scoped, user-initiated views.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+1. GitLab/Bitbucket PR previews deferred to a follow-up; they keep today's placeholder (shared
+   component makes wiring later small). — assumption
+2. Old side of PR previews anchors at the merge base (correctness over the cheaper base.sha). — decision
+3. 20MB per-blob preview cap. — assumption
+4. PDF viewer = synced paged canvases (no zoom/thumbnails in v1). — assumption
+5. SVG previews allowed (already in IMAGE_EXTENSIONS; served with nosniff as today). — assumption
+6. No new caching layer beyond HTTP ETags; blobs load lazily when a binary file block is
+   expanded and visible. — assumption

--- a/docs/plans/per-host-git-api-bases.md
+++ b/docs/plans/per-host-git-api-bases.md
@@ -84,7 +84,17 @@ a separate wave — logged deviation from the default pipeline.
   (assume standard /api/v4).
 
 ## 8. Open questions / assumptions (autonomous mode)
-1. Standard `/api/v4` path prefix assumed for self-hosted GitLab (no custom-prefix field). — assumption
+1. Standard `/api/v4` path prefix assumed for self-hosted GitLab (no custom-prefix field). Also
+   assumed: https scheme and default port — a self-hosted instance on :8443 or plain http is not
+   supported this pass (parseGitRemote discards ports; ProviderRepoInfo carries no scheme/port).
+   Review-added limitations, recorded per finding NTH-8. — assumption
+1b. Review corrections applied (fix wave): canonical cloud hosts (github.com/gitlab.com/
+   bitbucket.org) short-circuit BEFORE any ssh -G spawn — the vendor-documented altssh
+   (SSH-over-443) HostName override must not redirect API traffic; gitlab token resolution is
+   scoped to the resolved host (exact store entry only for non-gitlab.com hosts — no cloud-PAT
+   fallback to third-party hosts); Bitbucket guard only rejects on positive evidence (dotted
+   non-cloud resolved host), passes dotless aliases through, and hints at ssh-config HostName in
+   its message; ssh -G timeout 750ms; fallbacks return normalized hosts + charset guard. — decision
 2. Hostname-substring provider detection retained; `git.mycompany.com` still unsupported. — assumption
 3. ssh -G resolution treated as authoritative when it succeeds. — decision
 4. GitHub Enterprise: follow-up, not this pass. — decision

--- a/docs/plans/per-host-git-api-bases.md
+++ b/docs/plans/per-host-git-api-bases.md
@@ -1,0 +1,90 @@
+# Plan — Per-host git-provider API bases (self-hosted GitLab; explicit Bitbucket Server rejection)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-12 |
+| Source | /implement follow-up: "self-hosted GitLab/Bitbucket API base URLs are hard-coded — can we improve it?" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/load-binary-files-on-diff-modal-and-git |
+| Base SHA | af9cd5a |
+| Mode | Autonomous — assumptions in §8 |
+
+## 1. Objective & success criteria
+- A self-hosted GitLab remote (hostname containing "gitlab", e.g. gitlab.mycompany.com) gets ALL
+  ~25 gitlab.ts API calls routed to `https://<real-host>/api/v4`, plus host-correct synthesized
+  web URLs. gitlab.com behavior byte-identical. The documented ssh-alias multi-identity setup
+  (alias → HostName gitlab.com) keeps hitting gitlab.com — no regression.
+- A Bitbucket Server/DC remote (hostname containing "bitbucket", not resolving to bitbucket.org)
+  gets a clear, actionable error from every adapter entry point instead of silent wrong calls to
+  api.bitbucket.org. bitbucket.org (incl. aliases resolving to it) unchanged.
+- Typecheck + full unit + e2e green.
+
+## 2. Context (investigated, file:line anchors)
+- Detection: canonicalGitHost (github.ts:570) substring-collapses any *gitlab*/*bitbucket* host
+  to the cloud literal; providerForHost (git-provider.ts:45) maps only the three cloud literals;
+  providerRepoForDir (git-provider.ts:65) returns { host: canonical, remoteHost: raw }.
+  remoteHost is the ONLY field carrying the real hostname.
+- gitlab.ts: `GITLAB_API_BASE = "https://gitlab.com/api/v4"` (:52), ~25 template sites (list in
+  investigation brief); repo.host never read; remoteHost used for tokens (gitlabToken) + cache
+  keys. Two web-URL literals: noteHtmlUrl (:264), synthesized webUrl (:503).
+- bitbucket.ts: `BITBUCKET_API_BASE = "https://api.bitbucket.org"` (:69); resolveUrl (:114) is
+  the near-single choke point; BITBUCKET_API_ORIGIN (:118) feeds sanitizeNextUrl's same-origin
+  check (keep constant — cloud-only). webUrl literal (:640).
+- github.ts: equally hard-coded (~60+ sites, GraphQL differs on GHE) — separate effort.
+- Token store (github-tokens.json) is already keyed by raw remoteHost with cloud fallback
+  (tokenForHost, github-tokens.ts:159) — identity routing needs NO change.
+- THE ambiguity: remoteHost can be an ~/.ssh/config alias whose HostName is gitlab.com
+  (multi-identity, docs/plans/github-remote-host-aliases.md) OR a real self-hosted domain.
+  Verbatim use as API host regresses the alias case (https://gitlab-work/api/v4 → DNS failure).
+- Tests: gitlab-network.test.ts matchers are path-substring based (host change safe);
+  bitbucket-network.test.ts has a few absolute api.bitbucket.org pagination assertions (fine —
+  cloud stays pinned). sampleAliasRepo exists in gitlab-test-util.ts.
+
+## 3. Approach & key decisions
+1. **`ssh -G <host>` resolves the ambiguity** (git-provider.ts): it prints the ssh-config-resolved
+   `hostname` for aliases and echoes the input for non-aliases; handles Include/Match; no network.
+   New `export function apiHostForRemote(remoteHost: string): string` — spawn `ssh -G`, parse
+   `^hostname <value>$`, cache in a module Map (no TTL; ssh config is session-stable), fall back
+   to the input on any failure/timeout. Binary overridable via `AGETOR_SSH_BIN` (house env-override
+   pattern) so tests can stub resolution. — decision
+2. **gitlabApiBase(repo) = `https://${apiHostForRemote(repo.remoteHost)}/api/v4`** replacing every
+   GITLAB_API_BASE use; same derived host for the two synthesized web-URL literals. gitlab.com
+   round-trips identically. — decision
+3. **Bitbucket stays cloud-only**: `bitbucketServerGuard(repo)` — when
+   `apiHostForRemote(repo.remoteHost) !== "bitbucket.org"`, every exported adapter function
+   returns its error shape with: "Bitbucket Server / Data Center is not supported — only
+   Bitbucket Cloud (bitbucket.org). This repo's remote points at <host>." Applied at the top of
+   each exported entry (they all have `repo`); BITBUCKET_API_BASE/ORIGIN stay constants. — decision
+4. **Detection heuristic unchanged** (hostname must contain "gitlab"/"bitbucket" substring to
+   classify) — a Settings-backed host→provider mapping is a separate feature. — assumption
+5. **GitHub Enterprise out of scope** — recorded follow-up. — decision
+
+## 4. Work breakdown
+Contract (wave-1 compiles together): `apiHostForRemote(remoteHost: string): string` exported from
+src/bun/git-provider.ts, sync, never throws.
+
+| ID | Goal | Owns | Deps |
+| --- | --- | --- | --- |
+| H1 | apiHostForRemote via `ssh -G` (cache, AGETOR_SSH_BIN override, failure fallback) + unit tests | src/bun/git-provider.ts, src/bun/git-provider.test.ts | — |
+| H2 | gitlabApiBase(repo) replacing all GITLAB_API_BASE sites + 2 web-URL literals + doc comments; network tests for a self-hosted host (assert absolute URL prefix) and an alias host (stubbed ssh → gitlab.com) | src/bun/gitlab.ts, src/bun/gitlab-network.test.ts, src/bun/gitlab-test-util.ts (if a helper is needed) | contract |
+| H3 | bitbucketServerGuard on every exported adapter entry + tests (server host rejected with the exact message + zero fetch calls; bitbucket.org + alias-to-cloud unaffected) | src/bun/bitbucket.ts, src/bun/bitbucket-network.test.ts | contract |
+
+Waves: H1+H2+H3 together (file-disjoint; H2/H3 code against H1's contract). Then review (opus) →
+fixes → full run. Tests are folded into each implementation task (small, module-scoped) instead of
+a separate wave — logged deviation from the default pipeline.
+
+## 7. Blast radius & risks
+- ssh -G spawn cost: once per unique host per process (cached); mirrors existing glab/gh shellouts.
+- A user whose ssh alias hostname ≠ what they want as API host (exotic) falls back cleanly: alias
+  resolves → that host is used; failure → raw host. Worst case equals today's behavior for cloud.
+- sanitizeNextUrl same-origin check untouched (cloud-only Bitbucket).
+- GitHubDialog's credential hint already advertises self-hosted GitLab — now true.
+- Not touched (follow-ups): GITLAB_TOKENS_URL settings deep-link (cosmetic), GitHub Enterprise,
+  Settings-backed host→provider mapping for hosts without the substring, custom API path prefixes
+  (assume standard /api/v4).
+
+## 8. Open questions / assumptions (autonomous mode)
+1. Standard `/api/v4` path prefix assumed for self-hosted GitLab (no custom-prefix field). — assumption
+2. Hostname-substring provider detection retained; `git.mycompany.com` still unsupported. — assumption
+3. ssh -G resolution treated as authoritative when it succeeds. — decision
+4. GitHub Enterprise: follow-up, not this pass. — decision

--- a/e2e/binary-diff.spec.ts
+++ b/e2e/binary-diff.spec.ts
@@ -1,0 +1,398 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import zlib from "node:zlib";
+import { test, expect, type APIRequestContext, type E2EBackend, type Locator, type Page } from "./fixtures";
+import { gotoApp } from "./helpers";
+
+/**
+ * E2E coverage for binary diff previews in the Task Details Diff modal
+ * (docs/plans/binary-diff-previews.md §5) — the 2-up image and PDF preview
+ * panes `BinaryFilePreview.tsx` renders for `DiffFile.binary` entries,
+ * gated correctly so an ordinary text file still gets the textual diff.
+ *
+ * Runs Chromium against the real webview + real Bun API (a per-worker
+ * headless backend from `e2e/fixtures.ts`) — no mocked fetches. Each test
+ * builds its own throwaway git repo under the OS tmpdir (parallel-safe: a
+ * fresh `mkdtemp` per test, cleaned up in `afterAll`), commits a binary
+ * fixture file, then dirties the working tree so `GET /tasks/:id/diff`
+ * (which — for an `isolation: "none"` task — always diffs literal `HEAD`
+ * against the on-disk working tree, per `getTaskDiff` in
+ * `src/bun/worktree.ts`) has something to show. The task is created via the
+ * API and never started: the diff endpoint works on any task whose workdir
+ * is a git repo with at least one commit, worktree or not.
+ *
+ * PNG and PDF fixtures are generated on the fly (raw PNG chunk/CRC32
+ * encoding, hand-assembled multi-object PDF with a real xref table) rather
+ * than hardcoded base64 blobs — both encoders were validated standalone
+ * against `pdfjs-dist`'s legacy Node build (page count + viewport) and the
+ * PNG dimensions decoded by macOS `sips`/`file` before being folded into
+ * this spec, so the bytes are known-good rather than asserted-and-hoped.
+ * Distinct, deliberately-mismatched dimensions per side (e.g. 4×4 vs 8×6)
+ * let the test assert the *actual* pixel dimensions pdf.js/the browser
+ * decoded, not just "an image loaded" — a stronger signal that the old and
+ * new blob endpoints really served different bytes.
+ */
+
+test.describe.configure({ mode: "serial" });
+
+const cleanupDirs: string[] = [];
+
+test.afterAll(async () => {
+  await Promise.all(cleanupDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+/* --------------------------- git repo fixtures --------------------------- */
+
+function git(cwd: string, args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+}
+
+/** A fresh, isolated git repo (own author identity, gpg signing forced off
+ *  so a machine with `commit.gpgsign=true` in its global config doesn't
+ *  hang the test on a passphrase prompt) with one commit: a `.gitattributes`
+ *  that force-marks `*.png`/`*.pdf` as `binary`. Without it, git's own
+ *  binary-detection heuristic (scan for a NUL byte in the first ~8000
+ *  bytes) is content-dependent — a hand-built minimal PDF with only
+ *  uncompressed text content streams has no NUL bytes at all and git
+ *  diffs it as plain text, never emitting the "Binary files … differ"
+ *  marker `parseGitDiff` (src/bun/git-diff.ts) keys `DiffFile.binary` off
+ *  of. The `.gitattributes` rule makes binary-ness deterministic
+ *  regardless of what bytes the fixture actually contains. Registered for
+ *  `afterAll` cleanup immediately — a failure partway through a test's
+ *  setup still gets the directory removed. */
+async function initRepo(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "agetor-e2e-diff-"));
+  cleanupDirs.push(dir);
+  git(dir, ["init", "-q", "-b", "main"]);
+  git(dir, ["config", "user.email", "e2e@example.com"]);
+  git(dir, ["config", "user.name", "e2e"]);
+  git(dir, ["config", "commit.gpgsign", "false"]);
+  await writeFile(path.join(dir, ".gitattributes"), "*.png binary\n*.pdf binary\n");
+  await commitAll(dir, "gitattributes: force binary diffing for png/pdf fixtures");
+  return dir;
+}
+
+async function commitAll(dir: string, message: string): Promise<void> {
+  git(dir, ["add", "-A"]);
+  git(dir, ["commit", "-q", "-m", message]);
+}
+
+/* ------------------------------ PNG encoder ------------------------------ */
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buf: Buffer): number {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) c = CRC_TABLE[(c ^ buf[i]!) & 0xff]! ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const typeBuf = Buffer.from(type, "ascii");
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length, 0);
+  const crcBuf = Buffer.alloc(4);
+  crcBuf.writeUInt32BE(crc32(Buffer.concat([typeBuf, data])), 0);
+  return Buffer.concat([len, typeBuf, data, crcBuf]);
+}
+
+/** Minimal valid 8-bit RGB, no-interlace, single-solid-color PNG of exactly
+ *  `width`x`height` — hand-encoded (IHDR + one zlib-deflated IDAT scanline
+ *  block + IEND) rather than a hardcoded blob, so distinct fixture dims are
+ *  cheap and self-evidently correct (verified against `sips`/`file` and
+ *  Node's `zlib` during authoring). */
+function makePng(width: number, height: number, rgb: [number, number, number]): Buffer {
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const ihdrData = Buffer.alloc(13);
+  ihdrData.writeUInt32BE(width, 0);
+  ihdrData.writeUInt32BE(height, 4);
+  ihdrData[8] = 8; // bit depth
+  ihdrData[9] = 2; // color type: RGB
+  ihdrData[10] = 0;
+  ihdrData[11] = 0;
+  ihdrData[12] = 0;
+  const ihdr = pngChunk("IHDR", ihdrData);
+
+  const rowBytes = 1 + width * 3;
+  const raw = Buffer.alloc(rowBytes * height);
+  for (let y = 0; y < height; y++) {
+    const rowStart = y * rowBytes;
+    raw[rowStart] = 0; // filter: none
+    for (let x = 0; x < width; x++) {
+      const px = rowStart + 1 + x * 3;
+      raw[px] = rgb[0];
+      raw[px + 1] = rgb[1];
+      raw[px + 2] = rgb[2];
+    }
+  }
+  const idat = pngChunk("IDAT", zlib.deflateSync(raw));
+  const iend = pngChunk("IEND", Buffer.alloc(0));
+  return Buffer.concat([sig, ihdr, idat, iend]);
+}
+
+/* ------------------------------ PDF encoder ------------------------------ */
+
+/** Hand-assembled multi-page PDF (real byte-offset xref table, one Type1
+ *  Helvetica content stream per page) — one entry in `pages` per page, its
+ *  string rendered as the page's only text. Validated standalone against
+ *  `pdfjs-dist`'s legacy Node build (`getPage(1).getViewport()`, page count)
+ *  during authoring, so pdf.js parsing it in Chromium is expected to work,
+ *  not merely hoped. */
+function makePdf(pages: string[]): Buffer {
+  const numPages = pages.length;
+  const objects: string[] = [];
+  const pageObjNumStart = 3;
+  const fontObjNum = pageObjNumStart + numPages;
+  const contentObjNumStart = fontObjNum + 1;
+
+  const kids = Array.from({ length: numPages }, (_, i) => `${pageObjNumStart + i} 0 R`).join(" ");
+  objects[1] = `1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n`;
+  objects[2] = `2 0 obj\n<< /Type /Pages /Kids [${kids}] /Count ${numPages} >>\nendobj\n`;
+  for (let i = 0; i < numPages; i++) {
+    const pageNum = pageObjNumStart + i;
+    const contentNum = contentObjNumStart + i;
+    objects[pageNum] =
+      `${pageNum} 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] ` +
+      `/Resources << /Font << /F1 ${fontObjNum} 0 R >> >> /Contents ${contentNum} 0 R >>\nendobj\n`;
+  }
+  objects[fontObjNum] = `${fontObjNum} 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n`;
+  for (let i = 0; i < numPages; i++) {
+    const contentNum = contentObjNumStart + i;
+    const streamText = `BT /F1 24 Tf 50 100 Td (${pages[i]}) Tj ET`;
+    objects[contentNum] =
+      `${contentNum} 0 obj\n<< /Length ${streamText.length} >>\nstream\n${streamText}\nendstream\nendobj\n`;
+  }
+
+  const totalObjs = contentObjNumStart + numPages - 1;
+  let body = "%PDF-1.4\n";
+  const offsets: number[] = new Array(totalObjs + 1).fill(0);
+  for (let n = 1; n <= totalObjs; n++) {
+    offsets[n] = Buffer.byteLength(body, "latin1");
+    body += objects[n];
+  }
+  const xrefOffset = Buffer.byteLength(body, "latin1");
+  let xref = `xref\n0 ${totalObjs + 1}\n0000000000 65535 f \n`;
+  for (let n = 1; n <= totalObjs; n++) {
+    xref += `${String(offsets[n]).padStart(10, "0")} 00000 n \n`;
+  }
+  const trailer = `trailer\n<< /Size ${totalObjs + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`;
+  body += xref + trailer;
+  return Buffer.from(body, "latin1");
+}
+
+/* ------------------------------- API + UI -------------------------------- */
+
+interface TaskRow {
+  id: string;
+  title: string;
+}
+
+/** Create a task (isolation "none", `workdir` = a real git repo) via the
+ *  worker's API. Deliberately never started — `GET /tasks/:id/diff` works
+ *  on any `isolation: "none"` task whose workdir is a git repo with a
+ *  commit, per `getTaskDiff` (src/bun/worktree.ts): it diffs literal `HEAD`
+ *  against the on-disk working tree directly, no worktree/run required. */
+async function createDiffTask(
+  request: APIRequestContext,
+  backend: E2EBackend,
+  title: string,
+  workdir: string,
+): Promise<TaskRow> {
+  const res = await request.post(`${backend.apiBase}/tasks`, {
+    headers: { authorization: `Bearer ${backend.apiToken}` },
+    data: { title, prompt: title, isolation: "none", workdir },
+  });
+  expect(res.ok(), `POST /tasks -> ${res.status()}: ${await res.text()}`).toBeTruthy();
+  return (await res.json()) as TaskRow;
+}
+
+/** The kanban Card for a task, scoped by its (unique, uuid-suffixed) title
+ *  text — `TaskCard.tsx` puts `cursor-grab` on the Card root unconditionally
+ *  (draggable via dnd-kit), which is the only stable hook available since
+ *  this feature ships no `data-testid`s. Titles carry a `randomUUID()` per
+ *  test so `hasText` substring matching can't cross-match another task. */
+function taskCard(page: Page, title: string): Locator {
+  return page.locator('[class*="cursor-grab"]').filter({ hasText: title });
+}
+
+/** Click a task card's "View changes (git diff)" icon button (present on
+ *  every card, independent of column/run state — TaskCard.tsx:198) and wait
+ *  for the resulting dialog to render. */
+async function openDiffDialog(page: Page, title: string): Promise<Locator> {
+  const card = taskCard(page, title);
+  await expect(card).toBeVisible();
+  await card.getByTitle("View changes (git diff)").click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Changes")).toBeVisible();
+  return dialog;
+}
+
+/** Scope to one file's `FileBlock` root inside the diff dialog. Starts from
+ *  the file path's own text node (matched exactly, so "image.png" doesn't
+ *  also match "new-image.png") and walks up to the nearest ancestor `<div>`
+ *  carrying `overflow-hidden`/`rounded-md` — the class combination unique to
+ *  `FileBlock`'s root in DiffDialog.tsx. XPath ancestor walk rather than
+ *  `locator(...).filter({ has })`, which resolves `has` against the whole
+ *  page rather than the outer locator's subtree and produced false negatives
+ *  here. */
+function fileBlock(dialog: Locator, filePath: string): Locator {
+  return dialog
+    .getByText(filePath, { exact: true })
+    .locator(
+      "xpath=ancestor::div[" +
+        "contains(concat(' ', normalize-space(@class), ' '), ' overflow-hidden ') and " +
+        "contains(concat(' ', normalize-space(@class), ' '), ' rounded-md ')" +
+        "][1]",
+    );
+}
+
+/* --------------------------------- tests ---------------------------------- */
+
+test.describe("binary diff previews", () => {
+  test("renders 2-up image previews (modified + untracked) and still renders textual diff for a modified .txt", async ({
+    page,
+    request,
+    backend,
+  }) => {
+    const dir = await initRepo();
+    const title = `binary-diff-image-${randomUUID()}`;
+
+    // image.png: committed 4x4 red, then overwritten (uncommitted) with an
+    // 8x6 blue PNG -> "modified", both sides present.
+    const imageOld = makePng(4, 4, [220, 40, 40]);
+    const imageNew = makePng(8, 6, [40, 120, 220]);
+    await writeFile(path.join(dir, "image.png"), imageOld);
+    // notes.txt: committed one line, then a second line appended
+    // (uncommitted) -> "modified", exercises the plain-text row rendering
+    // that must still work for a non-binary file in the same diff.
+    await writeFile(path.join(dir, "notes.txt"), "line one\n");
+    await commitAll(dir, "initial commit");
+
+    await writeFile(path.join(dir, "image.png"), imageNew);
+    await writeFile(path.join(dir, "notes.txt"), "line one\nline two\n");
+    // new-image.png: never committed -> "added" via the untracked-file path,
+    // old side must render the one-sided "no previous version" placeholder.
+    const imageUntracked = makePng(5, 5, [40, 200, 90]);
+    await writeFile(path.join(dir, "new-image.png"), imageUntracked);
+
+    await createDiffTask(request, backend, title, dir);
+
+    await gotoApp(page, backend.bootBase);
+    const dialog = await openDiffDialog(page, title);
+
+    // --- image.png: both sides present, real distinct pixel dimensions ---
+    const modifiedBlock = fileBlock(dialog, "image.png");
+    await expect(modifiedBlock).toBeVisible();
+
+    const oldImg = modifiedBlock.locator('img[src*="side=old"]');
+    const newImg = modifiedBlock.locator('img[src*="side=new"]');
+    await expect(oldImg).toHaveCount(1);
+    await expect(newImg).toHaveCount(1);
+    await expect(oldImg).toHaveAttribute("src", /\/tasks\/.*\/diff\/blob\?/);
+    await expect(newImg).toHaveAttribute("src", /\/tasks\/.*\/diff\/blob\?/);
+
+    await expect
+      .poll(() => oldImg.evaluate((el) => (el as HTMLImageElement).naturalWidth))
+      .toBeGreaterThan(0);
+    await expect
+      .poll(() => newImg.evaluate((el) => (el as HTMLImageElement).naturalWidth))
+      .toBeGreaterThan(0);
+
+    // Distinct real dimensions on each side proves old/new served different
+    // bytes, not just "something loaded".
+    await expect(modifiedBlock.getByText("4 × 4 px")).toBeVisible();
+    await expect(modifiedBlock.getByText("8 × 6 px")).toBeVisible();
+
+    // --- new-image.png: untracked -> one-sided, "no previous version" ----
+    const untrackedBlock = fileBlock(dialog, "new-image.png");
+    await expect(untrackedBlock).toBeVisible();
+    await expect(untrackedBlock.getByText("Added — no previous version")).toBeVisible();
+    await expect(untrackedBlock.locator('img[src*="side=old"]')).toHaveCount(0);
+
+    const untrackedNewImg = untrackedBlock.locator('img[src*="side=new"]');
+    await expect(untrackedNewImg).toHaveCount(1);
+    await expect
+      .poll(() => untrackedNewImg.evaluate((el) => (el as HTMLImageElement).naturalWidth))
+      .toBeGreaterThan(0);
+    await expect(untrackedBlock.getByText("5 × 5 px")).toBeVisible();
+
+    // --- notes.txt: negative case — a modified text file must still get --
+    // --- the textual row diff, not fall through the binary-preview gate --
+    const notesBlock = fileBlock(dialog, "notes.txt");
+    await expect(notesBlock).toBeVisible();
+    await expect(notesBlock.locator('[data-diff-path="notes.txt"]').filter({ hasText: "line two" })).toBeVisible();
+    await expect(notesBlock.locator("img")).toHaveCount(0);
+    await expect(notesBlock.locator("canvas")).toHaveCount(0);
+    await expect(notesBlock.getByText("Binary file — no textual diff.")).toHaveCount(0);
+  });
+
+  test("renders a 2-up PDF preview with a working page pager", async ({ page, request, backend }) => {
+    test.setTimeout(60_000); // pdf.js is a lazily-loaded ~1MB chunk; first fetch can be slow.
+
+    const dir = await initRepo();
+    const title = `binary-diff-pdf-${randomUUID()}`;
+
+    const pdfOld = makePdf(["Committed page one", "Committed page two"]);
+    const pdfNew = makePdf(["Modified page one", "Modified page two"]);
+    await writeFile(path.join(dir, "doc.pdf"), pdfOld);
+    await commitAll(dir, "add pdf");
+    await writeFile(path.join(dir, "doc.pdf"), pdfNew);
+
+    await createDiffTask(request, backend, title, dir);
+
+    await gotoApp(page, backend.bootBase);
+    const dialog = await openDiffDialog(page, title);
+
+    const block = fileBlock(dialog, "doc.pdf");
+    await expect(block).toBeVisible();
+
+    const oldImg = block.locator('img[src*="side=old"]');
+    const newImg = block.locator('img[src*="side=new"]');
+    // PDFs render via <canvas>, never <img> — confirms the pdf branch, not
+    // a mis-detected image preview.
+    await expect(oldImg).toHaveCount(0);
+    await expect(newImg).toHaveCount(0);
+
+    const canvases = block.locator("canvas");
+    await expect(canvases).toHaveCount(2, { timeout: 20_000 });
+    for (let i = 0; i < 2; i++) {
+      const canvas = canvases.nth(i);
+      await expect(canvas).toBeVisible({ timeout: 20_000 });
+      await expect
+        .poll(() => canvas.evaluate((el) => (el as HTMLCanvasElement).width), { timeout: 20_000 })
+        .toBeGreaterThan(0);
+      await expect
+        .poll(() => canvas.evaluate((el) => (el as HTMLCanvasElement).height))
+        .toBeGreaterThan(0);
+    }
+
+    // Pager only renders when the diff's max page count across both sides
+    // is >1 (BinaryFilePreview.tsx's `showPager`) — both sides here are
+    // 2-page PDFs, so it must be visible and start on page 1.
+    const pager = block.getByText(/^Page \d+ \/ \d+$/);
+    await expect(pager).toBeVisible();
+    await expect(pager).toHaveText("Page 1 / 2");
+
+    const prevBtn = block.getByRole("button", { name: "Previous page" });
+    const nextBtn = block.getByRole("button", { name: "Next page" });
+    await expect(prevBtn).toBeDisabled();
+    await expect(nextBtn).toBeEnabled();
+
+    await nextBtn.click();
+    await expect(pager).toHaveText("Page 2 / 2");
+    await expect(prevBtn).toBeEnabled();
+    await expect(nextBtn).toBeDisabled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ink": "^7.0.5",
     "ink-spinner": "^5.0.0",
     "lucide-react": "^1.14.0",
+    "pdfjs-dist": "6.2.108",
     "picocolors": "^1.1.1",
     "react": "^19.2.6",
     "react-devtools-core": "^6.1.2",

--- a/src/bun/bitbucket-network.test.ts
+++ b/src/bun/bitbucket-network.test.ts
@@ -2,13 +2,14 @@
 // path (URL, method, headers, body, pagination, error mapping) via the
 // fetch-mock harness in bitbucket-test-util.ts. Complements bitbucket.test.ts,
 // which unit-tests the pure helpers in isolation.
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test, expect, beforeAll, beforeEach, afterAll } from "bun:test";
+import { test, expect, beforeAll, beforeEach, afterEach, afterAll } from "bun:test";
 import { makeBitbucketPrJson, makeBitbucketRepo, mockGitHubFetch } from "./bitbucket-test-util.ts";
 import type { MockRoute } from "./bitbucket-test-util.ts";
 import { setGitHubToken, deleteGitHubToken } from "./github-tokens.ts";
+import { __clearApiHostCacheForTest } from "./git-provider.ts";
 import {
   __bitbucketInternals,
   closeBitbucketPull,
@@ -18,6 +19,7 @@ import {
   createBitbucketPullLineComment,
   getBitbucketPullBlob,
   getBitbucketPullDefaults,
+  getBitbucketPullDetail,
   getBitbucketPullDiff,
   getBitbucketPullMergeability,
   getBitbucketViewer,
@@ -72,6 +74,40 @@ const REPO = makeBitbucketRepo("acme", "app");
 beforeEach(() => {
   __bitbucketInternals.resetBitbucketPullBlobCaches();
 });
+
+// Every exported entry point now opens with a `bitbucketServerError` guard
+// (docs/plans/per-host-git-api-bases.md) that resolves `repo.remoteHost`
+// through `apiHostForRemote` (git-provider.ts, `ssh -G` under the hood).
+// `AGETOR_SSH_BIN` and `apiHostForRemote`'s module-level cache are reset
+// after every test in this file so a Server-host stub set by one test can
+// never leak a stale resolution into another test — this file's own tests,
+// or a sibling *.test.ts file sharing the same `bun test` process.
+const ORIGINAL_SSH_BIN = process.env.AGETOR_SSH_BIN;
+let sshStubDirs: string[] = [];
+
+afterEach(() => {
+  __clearApiHostCacheForTest();
+  if (ORIGINAL_SSH_BIN === undefined) delete process.env.AGETOR_SSH_BIN;
+  else process.env.AGETOR_SSH_BIN = ORIGINAL_SSH_BIN;
+  for (const dir of sshStubDirs) rmSync(dir, { recursive: true, force: true });
+  sshStubDirs = [];
+});
+
+/** Writes an executable stub standing in for `ssh`, mirroring
+ *  git-provider.test.ts's `writeSshStub` — `apiHostForRemote` invokes it as
+ *  `<stub> -G -- <host>`, so `$3` is the (lowercased) host argument. */
+function writeSshStub(script: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-bb-ssh-stub-"));
+  sshStubDirs.push(dir);
+  const binPath = path.join(dir, "ssh");
+  writeFileSync(binPath, script, { mode: 0o755 });
+  return binPath;
+}
+
+/** ssh stub that always echoes its input back as the resolved hostname —
+ *  the "identity" case (a genuine Server/DC domain, or a plain non-aliased
+ *  host, has no `~/.ssh/config` entry to redirect it). */
+const IDENTITY_SSH_STUB = '#!/bin/sh\necho "hostname $3"\n';
 
 // ---------------------------------------------------------------------------
 // listBitbucketItems
@@ -158,6 +194,13 @@ test("listBitbucketItems (issues) with NO credential at all surfaces the enriche
   const priorEmail = process.env.BITBUCKET_EMAIL;
   delete process.env.BITBUCKET_TOKEN;
   delete process.env.BITBUCKET_EMAIL;
+  // "bitbucket-work.com" is this suite's stand-in for a real `~/.ssh/config`
+  // multi-identity alias whose `HostName` is bitbucket.org (per the module
+  // doc comment above) — stub ssh to resolve it that way so the
+  // `bitbucketServerError` guard passes and this test still exercises what
+  // it's actually about: alias-host credential resolution, not API-host
+  // rejection.
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname bitbucket.org'\n");
   const aliasRepo = makeBitbucketRepo("acme", "app", "bitbucket-work.com");
   const mock = mockGitHubFetch([
     {
@@ -238,6 +281,7 @@ test("email:token credentials send Authorization: Basic base64(email:token)", as
 // ---------------------------------------------------------------------------
 
 test("a stored credential for the alias host authenticates the outgoing request with Basic email:api_token", async () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname bitbucket.org'\n");
   setGitHubToken("bitbucket-work.com", "user@example.com:storedtoken456");
   const aliasRepo = makeBitbucketRepo("acme", "app", "bitbucket-work.com");
   const mock = mockGitHubFetch([{ match: "/2.0/user", json: { nickname: "octo" } }]);
@@ -257,6 +301,7 @@ test("no credential at all (alias host, no stored entry, no env) sends an unauth
   const priorEmail = process.env.BITBUCKET_EMAIL;
   delete process.env.BITBUCKET_TOKEN;
   delete process.env.BITBUCKET_EMAIL;
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname bitbucket.org'\n");
   const aliasRepo = makeBitbucketRepo("acme", "app", "bitbucket-work.com");
   const bitbucketBody = {
     type: "error",
@@ -1116,6 +1161,100 @@ test("updateBitbucketIssue maps state:'closed' to 'resolved' and state:'open' pa
 
     await updateBitbucketIssue(REPO, 3, { state: "open" });
     expect(JSON.parse(mock.calls[1]!.body!)).toEqual({ state: "open" });
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Bitbucket Server / Data Center rejection (docs/plans/per-host-git-api-bases.md)
+//
+// Bitbucket Server/DC speaks a structurally different REST API
+// (`/rest/api/1.0`) than Bitbucket Cloud — this module is Cloud-only, so
+// every exported entry point now rejects a repo whose remote resolves (via
+// `apiHostForRemote`) to anything other than `bitbucket.org`, before making
+// any network call. These tests exercise four representative entry points
+// (a read, a blob fetch with its own `status` field, a detail fetch, and a
+// mutation) plus the alias-resolves-to-cloud happy path; every other
+// exported function is guarded identically (see bitbucket.ts).
+// ---------------------------------------------------------------------------
+
+const SERVER_REPO = makeBitbucketRepo("acme", "app", "bitbucket.mycompany.com");
+const ALIAS_TO_CLOUD_REPO = makeBitbucketRepo("acme", "app", "bb-work");
+
+test("getBitbucketPullDiff rejects a Bitbucket Server/DC remote host with zero fetch calls", async () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub(IDENTITY_SSH_STUB);
+  const mock = mockGitHubFetch([]);
+  try {
+    const res = await getBitbucketPullDiff(SERVER_REPO, 1);
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toBe(
+      "Bitbucket Server / Data Center is not supported — only Bitbucket Cloud (bitbucket.org). This repo's remote points at bitbucket.mycompany.com.",
+    );
+    expect(mock.calls).toHaveLength(0);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullBlob rejects a Bitbucket Server/DC remote host (status 501) with zero fetch calls", async () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub(IDENTITY_SSH_STUB);
+  const mock = mockGitHubFetch([]);
+  try {
+    const res = await getBitbucketPullBlob(SERVER_REPO, 1, "README.md", "new");
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toContain("Bitbucket Server / Data Center is not supported");
+    expect(res.status).toBe(501);
+    expect(mock.calls).toHaveLength(0);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullDetail rejects a Bitbucket Server/DC remote host with zero fetch calls", async () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub(IDENTITY_SSH_STUB);
+  const mock = mockGitHubFetch([]);
+  try {
+    const res = await getBitbucketPullDetail(SERVER_REPO, 1);
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toContain("Bitbucket Server / Data Center is not supported");
+    expect(mock.calls).toHaveLength(0);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("mergeBitbucketPull (a mutation) rejects a Bitbucket Server/DC remote host with zero fetch calls", async () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub(IDENTITY_SSH_STUB);
+  const mock = mockGitHubFetch([]);
+  try {
+    const res = await mergeBitbucketPull(SERVER_REPO, 1, "merge");
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toContain("Bitbucket Server / Data Center is not supported");
+    expect(mock.calls).toHaveLength(0);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("an ssh-alias host that resolves to bitbucket.org proceeds normally (alias-to-cloud)", async () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname bitbucket.org'\n");
+  const mock = mockGitHubFetch([
+    {
+      match: "/pullrequests/41",
+      json: { id: 41, title: "PR", state: "OPEN", links: { html: { href: "https://bitbucket.org/acme/app/pull-requests/41" } } },
+    },
+  ]);
+  try {
+    const res = await getBitbucketPullDetail(ALIAS_TO_CLOUD_REPO, 41);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.item.number).toBe(41);
+    expect(mock.calls).toHaveLength(1);
   } finally {
     mock.restore();
   }

--- a/src/bun/bitbucket-network.test.ts
+++ b/src/bun/bitbucket-network.test.ts
@@ -5,16 +5,18 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test, expect, beforeAll, afterAll } from "bun:test";
+import { test, expect, beforeAll, beforeEach, afterAll } from "bun:test";
 import { makeBitbucketPrJson, makeBitbucketRepo, mockGitHubFetch } from "./bitbucket-test-util.ts";
 import type { MockRoute } from "./bitbucket-test-util.ts";
 import { setGitHubToken, deleteGitHubToken } from "./github-tokens.ts";
 import {
+  __bitbucketInternals,
   closeBitbucketPull,
   createBitbucketComment,
   createBitbucketIssue,
   createBitbucketPull,
   createBitbucketPullLineComment,
+  getBitbucketPullBlob,
   getBitbucketPullDefaults,
   getBitbucketPullDiff,
   getBitbucketPullMergeability,
@@ -59,6 +61,17 @@ afterAll(() => {
 });
 
 const REPO = makeBitbucketRepo("acme", "app");
+
+// getBitbucketPullBlob caches PR detail (source/dest sha + repo full names)
+// and resolved merge-base shas across calls — bun test shares one process
+// across every *.test.ts file, and git-host.test.ts's own bitbucket pullBlob
+// dispatch test touches bitbucket.org/acme/app#1. Reset before every test in
+// this file so no test here can observe a stale entry left by another file,
+// regardless of run order. The tests below also use PR numbers (41+) distinct
+// from git-host.test.ts's #1 as defense in depth.
+beforeEach(() => {
+  __bitbucketInternals.resetBitbucketPullBlobCaches();
+});
 
 // ---------------------------------------------------------------------------
 // listBitbucketItems
@@ -343,6 +356,232 @@ test("getBitbucketPullDiff fetches the /diff endpoint as raw text and parses it 
     expect(res.files).toHaveLength(1);
     expect(res.files[0]!.path).toBe("src/a.ts");
     expect(res.files[0]!.status).toBe("modified");
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// getBitbucketPullBlob
+// ---------------------------------------------------------------------------
+
+test("getBitbucketPullBlob new side: reads source.commit.hash from the source repo, encoding a subdir+space path (slashes preserved, space as %20)", async () => {
+  const mock = mockGitHubFetch([
+    {
+      match: /\/pullrequests\/41$/,
+      json: {
+        id: 41,
+        source: { commit: { hash: "srcsha1" }, repository: { full_name: "acme/app" } },
+        destination: { commit: { hash: "destsha1" }, repository: { full_name: "acme/app" } },
+      },
+    },
+    {
+      match: "/2.0/repositories/acme/app/src/srcsha1/assets/sub/my%20file.png",
+      text: "NEWBYTES",
+      headers: { "content-type": "application/octet-stream" },
+    },
+  ]);
+  try {
+    const res = await getBitbucketPullBlob(REPO, 41, "assets/sub/my file.png", "new");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.ref).toBe("srcsha1");
+    expect(res.contentType).toBe("image/png");
+    expect(new TextDecoder().decode(res.bytes)).toBe("NEWBYTES");
+    // Unlike gitlab.ts (which %2F-encodes the whole path), bitbucket.ts's
+    // srcUrl encodes each path segment individually and rejoins with literal
+    // `/` — so a subdirectory does NOT show up as %2F here.
+    expect(mock.calls.some((c) => c.url.includes("/src/srcsha1/assets/sub/my%20file.png"))).toBe(true);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullBlob old side: uses the official merge-base endpoint (sourceSha..destSha) and reads from the destination repo", async () => {
+  const mock = mockGitHubFetch([
+    {
+      match: /\/pullrequests\/42$/,
+      json: {
+        id: 42,
+        source: { commit: { hash: "srcsha2" }, repository: { full_name: "acme/app" } },
+        destination: { commit: { hash: "destsha2" }, repository: { full_name: "acme/app" } },
+      },
+    },
+    { match: "/merge-base/srcsha2..destsha2", json: { hash: "mbsha2" } },
+    { match: "/2.0/repositories/acme/app/src/mbsha2/readme.png", text: "OLDBYTES" },
+  ]);
+  try {
+    const res = await getBitbucketPullBlob(REPO, 42, "readme.png", "old");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.ref).toBe("mbsha2");
+    expect(new TextDecoder().decode(res.bytes)).toBe("OLDBYTES");
+    expect(mock.calls.some((c) => c.url.includes("/merge-base/srcsha2..destsha2"))).toBe(true);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullBlob old side: merge-base endpoint failure (500) falls back to destination.commit.hash", async () => {
+  const mock = mockGitHubFetch([
+    {
+      match: /\/pullrequests\/43$/,
+      json: {
+        id: 43,
+        source: { commit: { hash: "srcsha3" }, repository: { full_name: "acme/app" } },
+        destination: { commit: { hash: "destsha3" }, repository: { full_name: "acme/app" } },
+      },
+    },
+    { match: "/merge-base/srcsha3..destsha3", status: 500, json: { error: { message: "Internal Server Error" } } },
+    { match: "/2.0/repositories/acme/app/src/destsha3/readme.png", text: "FALLBACK" },
+  ]);
+  try {
+    const res = await getBitbucketPullBlob(REPO, 43, "readme.png", "old");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.ref).toBe("destsha3");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullBlob old side: a stale/wrong merge base 404s on /src, is evicted, and retried once at destSha", async () => {
+  const mock = mockGitHubFetch([
+    {
+      match: /\/pullrequests\/44$/,
+      json: {
+        id: 44,
+        source: { commit: { hash: "srcsha4" }, repository: { full_name: "acme/app" } },
+        destination: { commit: { hash: "destsha4" }, repository: { full_name: "acme/app" } },
+      },
+    },
+    { match: "/merge-base/srcsha4..destsha4", json: { hash: "mbsha4" } },
+    { match: "/2.0/repositories/acme/app/src/mbsha4/readme.png", status: 404, json: { error: { message: "Not Found" } } },
+    { match: "/2.0/repositories/acme/app/src/destsha4/readme.png", text: "RETRIED_OK" },
+  ]);
+  try {
+    const res = await getBitbucketPullBlob(REPO, 44, "readme.png", "old");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.ref).toBe("destsha4");
+    expect(new TextDecoder().decode(res.bytes)).toBe("RETRIED_OK");
+    expect(mock.calls.some((c) => c.url.includes("/src/mbsha4/readme.png"))).toBe(true);
+    expect(mock.calls.some((c) => c.url.includes("/src/destsha4/readme.png"))).toBe(true);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullBlob fork PR new side: uses the source repo parsed from source.repository.full_name; 404s with 'fork may have been deleted' wording when full_name is absent", async () => {
+  const forkMock = mockGitHubFetch([
+    {
+      match: /\/pullrequests\/45$/,
+      json: {
+        id: 45,
+        source: { commit: { hash: "forksha5" }, repository: { full_name: "forker/app2" } },
+        destination: { commit: { hash: "destsha5" }, repository: { full_name: "acme/app" } },
+      },
+    },
+    { match: "/2.0/repositories/forker/app2/src/forksha5/img.png", text: "FORKBYTES" },
+  ]);
+  try {
+    const res = await getBitbucketPullBlob(REPO, 45, "img.png", "new");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.ref).toBe("forksha5");
+    expect(forkMock.calls.some((c) => c.url.includes("/2.0/repositories/forker/app2/src/forksha5/img.png"))).toBe(true);
+  } finally {
+    forkMock.restore();
+  }
+
+  const deletedForkMock = mockGitHubFetch([
+    {
+      match: /\/pullrequests\/46$/,
+      json: {
+        id: 46,
+        source: { commit: { hash: "forksha6" } }, // no `repository` key at all — full_name absent
+        destination: { commit: { hash: "destsha6" }, repository: { full_name: "acme/app" } },
+      },
+    },
+  ]);
+  try {
+    const res = await getBitbucketPullBlob(REPO, 46, "img.png", "new");
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.status).toBe(404);
+    expect(res.error).toContain("fork may have been deleted");
+    expect(deletedForkMock.calls).toHaveLength(1); // only the PR-detail fetch — no /src attempt
+  } finally {
+    deletedForkMock.restore();
+  }
+});
+
+test("getBitbucketPullBlob detail-cache: two blob calls for the same PR only issue ONE detail fetch", async () => {
+  const mock = mockGitHubFetch([
+    {
+      match: /\/pullrequests\/47$/,
+      json: {
+        id: 47,
+        source: { commit: { hash: "csrc" }, repository: { full_name: "acme/app" } },
+        destination: { commit: { hash: "cdest" }, repository: { full_name: "acme/app" } },
+      },
+    },
+    { match: "/merge-base/csrc..cdest", json: { hash: "cmb" } },
+    { match: "/2.0/repositories/acme/app/src/cmb/a.png", text: "A" },
+    { match: "/2.0/repositories/acme/app/src/csrc/a.png", text: "B" },
+  ]);
+  try {
+    const res1 = await getBitbucketPullBlob(REPO, 47, "a.png", "old");
+    const res2 = await getBitbucketPullBlob(REPO, 47, "a.png", "new");
+    expect(res1.ok).toBe(true);
+    expect(res2.ok).toBe(true);
+    expect(mock.calls.filter((c) => /\/pullrequests\/47$/.test(c.url))).toHaveLength(1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullBlob returns 413 from content-length alone, without needing to read a large body", async () => {
+  const mock = mockGitHubFetch([
+    {
+      match: /\/pullrequests\/48$/,
+      json: {
+        id: 48,
+        source: { commit: { hash: "srcsha8" }, repository: { full_name: "acme/app" } },
+        destination: { commit: { hash: "destsha8" }, repository: { full_name: "acme/app" } },
+      },
+    },
+    // Tiny body, huge content-length header — the 413 must come purely from
+    // the header check, before `.arrayBuffer()` is ever called.
+    { match: "/2.0/repositories/acme/app/src/srcsha8/huge.png", text: "x", headers: { "content-length": "21000000" } },
+  ]);
+  try {
+    const res = await getBitbucketPullBlob(REPO, 48, "huge.png", "new");
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.status).toBe(413);
+    expect(res.error).toContain("21 MB");
+    expect(mock.calls.filter((c) => c.url.includes("/src/srcsha8/huge.png"))).toHaveLength(1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getBitbucketPullBlob 404 from /src on a non-merge-base path (new side) -> {ok:false, status:404, error contains 'not present'}", async () => {
+  const mock = mockGitHubFetch([
+    {
+      match: /\/pullrequests\/49$/,
+      json: {
+        id: 49,
+        source: { commit: { hash: "srcsha9" }, repository: { full_name: "acme/app" } },
+        destination: { commit: { hash: "destsha9" }, repository: { full_name: "acme/app" } },
+      },
+    },
+    { match: "/2.0/repositories/acme/app/src/srcsha9/missing.png", status: 404, json: { error: { message: "Not Found" } } },
+  ]);
+  try {
+    const res = await getBitbucketPullBlob(REPO, 49, "missing.png", "new");
+    expect(res).toEqual({ ok: false, error: "file not present on this side", status: 404 });
   } finally {
     mock.restore();
   }

--- a/src/bun/bitbucket-network.test.ts
+++ b/src/bun/bitbucket-network.test.ts
@@ -1190,7 +1190,8 @@ test("getBitbucketPullDiff rejects a Bitbucket Server/DC remote host with zero f
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error("expected failure");
     expect(res.error).toBe(
-      "Bitbucket Server / Data Center is not supported — only Bitbucket Cloud (bitbucket.org). This repo's remote points at bitbucket.mycompany.com.",
+      "Bitbucket Server / Data Center is not supported — only Bitbucket Cloud (bitbucket.org). This repo's remote resolves to bitbucket.mycompany.com. "
+        + 'If bitbucket.mycompany.com is actually an SSH alias for Bitbucket Cloud, add a ~/.ssh/config entry with "HostName bitbucket.org" for it.',
     );
     expect(mock.calls).toHaveLength(0);
   } finally {
@@ -1255,6 +1256,62 @@ test("an ssh-alias host that resolves to bitbucket.org proceeds normally (alias-
     if (!res.ok) throw new Error(res.error);
     expect(res.item.number).toBe(41);
     expect(mock.calls).toHaveLength(1);
+  } finally {
+    mock.restore();
+  }
+});
+
+// SF-3 (docs/plans/per-host-git-api-bases.md §8.1b): `bitbucketServerError`
+// rejects only on positive evidence of a distinct, dotted Server/DC domain —
+// it fails open whenever ssh can't actually tell us anything useful.
+
+test("a dotless ssh alias with no ~/.ssh/config mapping (ssh echoes it back unchanged) is allowed — a dotless string can never be a Server/DC FQDN", async () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub(IDENTITY_SSH_STUB);
+  const dotlessAliasRepo = makeBitbucketRepo("acme", "app", "bitbucket-work");
+  const mock = mockGitHubFetch([
+    { match: "/2.0/repositories/acme/app", json: { mainbranch: { name: "main" } } },
+  ]);
+  try {
+    const res = await getBitbucketPullDefaults(dotlessAliasRepo);
+    expect(res.ok).toBe(true);
+    expect(mock.calls).toHaveLength(1);
+    expect(mock.calls[0]!.url).toContain("api.bitbucket.org");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("a dotted self-hosted domain with no ~/.ssh/config mapping (ssh echoes it back unchanged) is rejected with the ssh-config HostName hint", async () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub(IDENTITY_SSH_STUB);
+  const selfHostedRepo = makeBitbucketRepo("acme", "app", "bitbucket.mycompany.com");
+  const mock = mockGitHubFetch([]);
+  try {
+    const res = await getBitbucketPullDefaults(selfHostedRepo);
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toContain("This repo's remote resolves to bitbucket.mycompany.com.");
+    expect(res.error).toContain(
+      'If bitbucket.mycompany.com is actually an SSH alias for Bitbucket Cloud, add a ~/.ssh/config entry with "HostName bitbucket.org" for it.',
+    );
+    expect(mock.calls).toHaveLength(0);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("an ssh alias actively resolved to a distinct dotted domain is rejected with the 'resolves to' variant and no ssh-config hint", async () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname bitbucket.corp.example'\n");
+  const redirectedAliasRepo = makeBitbucketRepo("acme", "app", "bb-corp.example");
+  const mock = mockGitHubFetch([]);
+  try {
+    const res = await getBitbucketPullDefaults(redirectedAliasRepo);
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toBe(
+      "Bitbucket Server / Data Center is not supported — only Bitbucket Cloud (bitbucket.org). This repo's remote resolves to bitbucket.corp.example.",
+    );
+    expect(res.error).not.toContain("HostName bitbucket.org");
+    expect(mock.calls).toHaveLength(0);
   } finally {
     mock.restore();
   }

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -19,6 +19,7 @@ import type {
   TaskDiff,
 } from "../shared/types.ts";
 import { GIT_HOST_TOKENS_SECTION } from "../shared/types.ts";
+import { contentTypeForPreviewPath, MAX_BLOB_PREVIEW_BYTES } from "../shared/attachments.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
 import { bitbucketCreds, type BitbucketCreds } from "./git-provider.ts";
 
@@ -186,18 +187,23 @@ function fetchErrorMessage(e: unknown): string {
 /** Internal fetch wrapper: absolute-URL passthrough (for pagination `next`
  *  links), 30s abort, `user-agent: agetor`, and the resolved
  *  Basic/Bearer auth header. `accept` is caller-supplied since the diff
- *  endpoint wants a permissive/plain accept rather than `application/json`. */
+ *  endpoint wants a permissive/plain accept rather than `application/json`.
+ *  `init.redirect` defaults to the platform default (`"follow"`) when
+ *  omitted; `getBitbucketPullBlob`'s merge-base redirect-sniff is the only
+ *  caller that passes `"manual"`, to read a 30x `Location` header instead of
+ *  transparently following it. */
 async function fetchBitbucket(
   pathOrUrl: string,
   creds: BitbucketCreds | null,
   accept: string,
-  init?: { method?: string; body?: string },
+  init?: { method?: string; body?: string; redirect?: "follow" | "manual" },
 ): Promise<Response | BitbucketError> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), BITBUCKET_FETCH_TIMEOUT_MS);
   try {
     return await fetch(resolveUrl(pathOrUrl), {
       method: init?.method,
+      redirect: init?.redirect,
       signal: controller.signal,
       headers: {
         accept,
@@ -757,6 +763,289 @@ export async function getBitbucketPullDiff(repo: ProviderRepoInfo, number: numbe
     base: null,
     files,
     note: files.length === 0 ? "No diff returned for this pull request." : undefined,
+  };
+}
+
+/** Structurally identical to `git-host.ts`'s `PullBlobResult` — kept as a
+ *  separate declaration (rather than imported) for the same reason
+ *  github.ts's `GitHubBlobResult` is: `git-host.ts` is the consumer, not the
+ *  source, of this module's types, and TS's structural typing makes the two
+ *  interchangeable at the `pullBlob` dispatch call site. */
+type BitbucketBlobResult =
+  | { ok: true; bytes: Uint8Array<ArrayBuffer>; contentType: string; ref: string }
+  | { ok: false; error: string; status?: number };
+
+/** Short-TTL cache of a PR's source/destination commit shas + source/
+ *  destination repo full names, keyed `${remoteHost}/${owner}/${name}#${number}` —
+ *  mirrors github.ts's `pullDetailCache` (60s TTL, so a fresh push to the PR
+ *  is picked up reasonably promptly; crude size-guard eviction rather than an
+ *  LRU, since a single workstation's Git Integration modal won't realistically
+ *  open enough distinct PRs in one process lifetime to make eviction policy
+ *  matter). Without it, previewing both sides of a binary file — or paging
+ *  through several binary files in the same PR — would re-fetch
+ *  `GET /pullrequests/:number` from scratch every time. */
+interface BitbucketPullDetailCacheEntry {
+  sourceSha: string;
+  destSha: string;
+  sourceRepoFullName: string | null;
+  destRepoFullName: string | null;
+  fetchedAt: number;
+}
+const bitbucketPullDetailCache = new Map<string, BitbucketPullDetailCacheEntry>();
+const BITBUCKET_PULL_DETAIL_CACHE_LIMIT = 200;
+const BITBUCKET_PULL_DETAIL_CACHE_TTL_MS = 60_000;
+
+function cacheBitbucketPullDetail(key: string, entry: BitbucketPullDetailCacheEntry): void {
+  if (bitbucketPullDetailCache.size >= BITBUCKET_PULL_DETAIL_CACHE_LIMIT && !bitbucketPullDetailCache.has(key)) {
+    bitbucketPullDetailCache.clear();
+  }
+  bitbucketPullDetailCache.set(key, entry);
+}
+
+/** Merge-base sha cache for the "old" side of a PR blob fetch, keyed
+ *  `${remoteHost}/${owner}/${name}#${number}@${sourceSha}` — mirrors
+ *  github.ts's `mergeBaseCache` (no TTL: a resolved merge-base commit is
+ *  immutable once computed, unlike the PR detail above). Only successful
+ *  resolutions are cached; a failed redirect-sniff (see
+ *  `extractMergeBaseFromDiffLocation`) is re-attempted on the next request
+ *  rather than being cached as a permanent miss. */
+const bitbucketMergeBaseCache = new Map<string, string>();
+const BITBUCKET_MERGE_BASE_CACHE_LIMIT = 200;
+
+function cacheBitbucketMergeBase(key: string, sha: string): void {
+  if (bitbucketMergeBaseCache.size >= BITBUCKET_MERGE_BASE_CACHE_LIMIT && !bitbucketMergeBaseCache.has(key)) {
+    bitbucketMergeBaseCache.clear();
+  }
+  bitbucketMergeBaseCache.set(key, sha);
+}
+
+/**
+ * Extracts a merge-base sha candidate from the `Location` header of a
+ * `.../pullrequests/:id/diff` response fetched with `redirect: "manual"`.
+ * Bitbucket 30x-redirects that endpoint to a fully-resolved diff spec that
+ * embeds both the source and destination commits it computed the (merge-base
+ * -anchored, three-dot) diff against — the exact shape isn't documented
+ * (something like `.../diff/{workspace}/{slug}:{sourceSha}%0D{destSpec}` or a
+ * `{source}..{dest}`-style path segment), so this parses defensively: pull
+ * every 7-40 char hex run out of the Location, drop any that match the known
+ * `sourceSha` (by exact match or hex-prefix, either direction — Bitbucket may
+ * echo an abbreviated hash), and de-duplicate what's left. Exactly one
+ * surviving candidate is treated as the merge base; zero or two-or-more means
+ * the heuristic can't tell which one it is (nothing recognizable, or an
+ * ambiguous Location shape), so it gives up and returns null rather than
+ * guessing wrong — the caller falls back to `destination.commit.hash` in
+ * that case. Pure — exported via `__bitbucketInternals` for unit testing.
+ */
+function extractMergeBaseFromDiffLocation(location: string, sourceSha: string): string | null {
+  const hexRun = /\b[0-9a-f]{7,40}\b/gi;
+  const matches = location.match(hexRun) ?? [];
+  const sourceLower = sourceSha.toLowerCase();
+  const candidates = new Set(
+    matches
+      .map((m) => m.toLowerCase())
+      .filter((m) => m !== sourceLower && !m.startsWith(sourceLower) && !sourceLower.startsWith(m)),
+  );
+  return candidates.size === 1 ? [...candidates][0] ?? null : null;
+}
+
+/** Resolves the merge-base sha for the "old" side of a PR blob fetch:
+ *  primary strategy is the redirect-sniff (`extractMergeBaseFromDiffLocation`)
+ *  against the `.../diff` endpoint's 30x `Location`; returns null (not the
+ *  fallback sha) when the sniff fails so the caller can apply the documented
+ *  `destination.commit.hash` approximation itself and know which path was
+ *  taken. Cached only on success — see `bitbucketMergeBaseCache`. */
+async function resolveBitbucketMergeBase(
+  repo: ProviderRepoInfo,
+  number: number,
+  sourceSha: string,
+  creds: BitbucketCreds | null,
+): Promise<string | null> {
+  const cacheKey = `${repo.remoteHost}/${repo.owner}/${repo.name}#${number}@${sourceSha}`;
+  const cached = bitbucketMergeBaseCache.get(cacheKey);
+  if (cached) return cached;
+
+  const res = await fetchBitbucket(
+    `${repoBasePath(repo)}/pullrequests/${number}/diff`,
+    creds,
+    "*/*",
+    { redirect: "manual" },
+  );
+  if (!("status" in res)) return null;
+  const location = res.headers.get("location");
+  if (!location) return null;
+  const candidate = extractMergeBaseFromDiffLocation(location, sourceSha);
+  if (!candidate) return null;
+  cacheBitbucketMergeBase(cacheKey, candidate);
+  return candidate;
+}
+
+/** Builds a `ProviderRepoInfo` for a PR side's `full_name` (`"workspace/
+ *  repo_slug"`, as read off `source.repository.full_name`/
+ *  `destination.repository.full_name` or the cached
+ *  `BitbucketPullDetailCacheEntry`), reusing the *original* repo's `provider`
+ *  /`host`/`remoteHost` — the fork lives on the same Bitbucket workspace host,
+ *  and credentials are stored per-host, not per-repo. Returns null when
+ *  `fullName` is null (e.g. the fork/source repo was deleted) or malformed. */
+function bitbucketRepoFromFullName(fullName: string | null, base: ProviderRepoInfo): ProviderRepoInfo | null {
+  if (!fullName) return null;
+  const slash = fullName.indexOf("/");
+  if (slash === -1) return null;
+  return {
+    provider: base.provider,
+    host: base.host,
+    remoteHost: base.remoteHost,
+    owner: fullName.slice(0, slash),
+    name: fullName.slice(slash + 1),
+  };
+}
+
+/** `/src/{ref}/{path}` for a resolved repo — each path segment is
+ *  URL-encoded but `/` separators are preserved (Bitbucket treats them as
+ *  directories), mirroring `contentsUrl` in github.ts. */
+function srcUrl(repo: ProviderRepoInfo, ref: string, filePath: string): string {
+  const encodedPath = filePath.split("/").map(encodeURIComponent).join("/");
+  return `${repoBasePath(repo)}/src/${encodeURIComponent(ref)}/${encodedPath}`;
+}
+
+/**
+ * Fetches the raw bytes of a single file from one side (old/new) of a
+ * Bitbucket pull request's diff, for the binary-preview UI. Dispatched
+ * through `git-host.ts`'s `pullBlob`.
+ *
+ * - `side: "new"` reads the file at `source.commit.hash`, from the *source*
+ *   repository (a fork for a cross-repo PR).
+ * - `side: "old"` reads the file at the PR's merge-base commit — Bitbucket's
+ *   PR diff (`getBitbucketPullDiff`, same `.../diff` endpoint) is three-dot
+ *   (merge-base-anchored), and there is no official merge-base endpoint to
+ *   resolve it directly. This fetches it two ways: primary is a
+ *   redirect-sniff against the diff endpoint itself
+ *   (`resolveBitbucketMergeBase`); when that fails (no Location header, or
+ *   an ambiguous/unparseable one), it falls back to
+ *   `destination.commit.hash` — an **approximation** that drifts if the
+ *   destination branch has moved (and touched the same file) since the PR
+ *   diverged from it, the same "approximated" tone this module already uses
+ *   for `mergedAt`/`closedAt`. The old side is read from the *destination*
+ *   repository either way.
+ *
+ * Bytes come from the Source API (`GET .../src/{ref}/{path}`), which returns
+ * raw file content directly (no base64 envelope). Size is checked twice: from
+ * `content-length` before reading the body (cheap rejection of an obviously
+ * too-large file), and again against the actual byte count after
+ * `arrayBuffer()` (Bitbucket can send a chunked response with no
+ * `content-length`) — same double-guard as `getGitHubPullBlob`, against
+ * `MAX_BLOB_PREVIEW_BYTES` (not `BITBUCKET_DIFF_BODY_CAP_BYTES`, which bounds
+ * the unified diff text, a different budget from a single file's bytes).
+ *
+ * No short-circuit on missing credentials: like every other read in this
+ * module (`getBitbucketPullDiff`, `getBitbucketPullChecks`, …), a public
+ * repo's blob is readable with `creds: null`; a private one surfaces through
+ * `bitbucketAccessHint`'s 401/403/404 enrichment same as any other call.
+ */
+export async function getBitbucketPullBlob(
+  repo: ProviderRepoInfo,
+  number: number,
+  relPath: string,
+  side: "old" | "new",
+): Promise<BitbucketBlobResult> {
+  if (!Number.isInteger(number) || number <= 0) {
+    return { ok: false, error: "pull request number must be positive", status: 400 };
+  }
+  const path = relPath.trim().replace(/^\/+/, "");
+  if (!path) return { ok: false, error: "file path is required", status: 400 };
+
+  const creds = await bitbucketCreds(repo.remoteHost);
+
+  // PR detail (source/destination sha + repo full names) is cached for a
+  // short TTL — see `bitbucketPullDetailCache`'s doc comment. Avoids a
+  // redundant `GET /pullrequests/:number` for every blob request against the
+  // same PR.
+  const detailKey = `${repo.remoteHost}/${repo.owner}/${repo.name}#${number}`;
+  const cachedDetail = bitbucketPullDetailCache.get(detailKey);
+  let sourceSha: string;
+  let destSha: string;
+  let sourceRepoFullName: string | null;
+  let destRepoFullName: string | null;
+  if (cachedDetail && Date.now() - cachedDetail.fetchedAt < BITBUCKET_PULL_DETAIL_CACHE_TTL_MS) {
+    ({ sourceSha, destSha, sourceRepoFullName, destRepoFullName } = cachedDetail);
+  } else {
+    const prRes = await fetchBitbucket(`${repoBasePath(repo)}/pullrequests/${number}`, creds, "application/json");
+    if (!("status" in prRes)) return { ok: false, error: prRes.error, status: 502 };
+    const prJson = await prRes.json().catch(() => null);
+    if (!prRes.ok) {
+      return { ok: false, error: errorFrom(prRes, prJson, repo, !!creds), status: prRes.status };
+    }
+    const prObj = prJson && typeof prJson === "object" ? prJson as Record<string, unknown> : {};
+    const source = prObj.source && typeof prObj.source === "object" ? prObj.source as Record<string, unknown> : {};
+    const destination = prObj.destination && typeof prObj.destination === "object"
+      ? prObj.destination as Record<string, unknown>
+      : {};
+    const sourceCommit = source.commit && typeof source.commit === "object" ? source.commit as Record<string, unknown> : {};
+    const destCommit = destination.commit && typeof destination.commit === "object"
+      ? destination.commit as Record<string, unknown>
+      : {};
+    const resolvedSourceSha = typeof sourceCommit.hash === "string" ? sourceCommit.hash : null;
+    const resolvedDestSha = typeof destCommit.hash === "string" ? destCommit.hash : null;
+    if (!resolvedSourceSha || !resolvedDestSha) {
+      return { ok: false, error: "Bitbucket returned a pull request without source/destination commit hashes", status: 502 };
+    }
+    sourceSha = resolvedSourceSha;
+    destSha = resolvedDestSha;
+    const sourceRepo = source.repository && typeof source.repository === "object"
+      ? source.repository as Record<string, unknown>
+      : {};
+    const destRepo = destination.repository && typeof destination.repository === "object"
+      ? destination.repository as Record<string, unknown>
+      : {};
+    sourceRepoFullName = typeof sourceRepo.full_name === "string" ? sourceRepo.full_name : null;
+    destRepoFullName = typeof destRepo.full_name === "string" ? destRepo.full_name : null;
+    cacheBitbucketPullDetail(detailKey, { sourceSha, destSha, sourceRepoFullName, destRepoFullName, fetchedAt: Date.now() });
+  }
+
+  let blobRepo: ProviderRepoInfo;
+  let ref: string;
+  if (side === "new") {
+    blobRepo = bitbucketRepoFromFullName(sourceRepoFullName, repo) ?? repo;
+    ref = sourceSha;
+  } else {
+    blobRepo = bitbucketRepoFromFullName(destRepoFullName, repo) ?? repo;
+    const mergeBase = await resolveBitbucketMergeBase(repo, number, sourceSha, creds);
+    // Fallback: `destination.commit.hash` approximation — see this
+    // function's doc comment.
+    ref = mergeBase ?? destSha;
+  }
+
+  const fileRes = await fetchBitbucket(srcUrl(blobRepo, ref, path), creds, "*/*");
+  if (!("status" in fileRes)) return { ok: false, error: fileRes.error, status: 502 };
+  if (fileRes.status === 404) return { ok: false, error: "file not present on this side", status: 404 };
+  if (!fileRes.ok) {
+    const raw = await fileRes.text().catch(() => "");
+    let msg = raw;
+    try {
+      const parsed = JSON.parse(raw) as { error?: { message?: unknown } };
+      if (parsed.error && typeof parsed.error.message === "string") msg = parsed.error.message;
+    } catch { /* the src endpoint can return plain text on some errors too */ }
+    return {
+      ok: false,
+      error: bitbucketAccessHint(fileRes.status, msg || `${fileRes.status} ${fileRes.statusText}`, blobRepo, !!creds),
+      status: fileRes.status,
+    };
+  }
+
+  const contentLength = Number(fileRes.headers.get("content-length") ?? 0);
+  if (contentLength > MAX_BLOB_PREVIEW_BYTES) {
+    return { ok: false, error: `File is too large to preview (${Math.ceil(contentLength / 1_000_000)} MB).`, status: 413 };
+  }
+  const buf = await fileRes.arrayBuffer().catch(() => null);
+  if (!buf) return { ok: false, error: "Bitbucket returned an unreadable file response", status: 502 };
+  if (buf.byteLength > MAX_BLOB_PREVIEW_BYTES) {
+    return { ok: false, error: `File is too large to preview (${Math.ceil(buf.byteLength / 1_000_000)} MB).`, status: 413 };
+  }
+
+  return {
+    ok: true,
+    bytes: new Uint8Array(buf),
+    contentType: contentTypeForPreviewPath(path) ?? fileRes.headers.get("content-type") ?? "application/octet-stream",
+    ref,
   };
 }
 
@@ -1419,6 +1708,8 @@ export const __bitbucketInternals = {
   normalizeBitbucketLineComment,
   normalizeBitbucketCheckRun,
   normalizeBitbucketMergeability,
+  extractMergeBaseFromDiffLocation,
+  bitbucketRepoFromFullName,
   scanBitbucketDiffstatConflicts,
   escapeBBQLString,
   prStateParams,

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -85,22 +85,51 @@ const BITBUCKET_PAGELEN = 30;
  * today's failure mode.
  *
  * `apiHostForRemote` (git-provider.ts) resolves `repo.remoteHost` through
- * `~/.ssh/config` the same way `gitlabApiHost` does in gitlab.ts: an alias
- * whose `HostName` is `bitbucket.org` (the documented multi-identity setup)
- * resolves to `bitbucket.org` and passes; a real Server/DC domain (or an
- * alias pointing at one) echoes back unchanged and is rejected. It's sync,
- * never throws, and caches its own resolution per host, so calling this at
- * the top of every entry point below costs nothing beyond the first `ssh -G`
- * shellout for a given remote host.
+ * `~/.ssh/config` the same way `gitlabHost`/`gitlabApiBase` do in gitlab.ts:
+ * `bitbucket.org` itself short-circuits to itself, and an alias whose
+ * `HostName` is `bitbucket.org` (or one of Bitbucket's alternate SSH
+ * hostnames, `altssh.bitbucket.org`/`ssh.bitbucket.org`) also resolves to
+ * `bitbucket.org` — both pass. It's sync, never throws, and caches its own
+ * resolution per host, so calling this at the top of every entry point below
+ * costs nothing beyond the first `ssh -G` shellout for a given remote host.
  *
- * Returns `null` (no error — proceed) when the resolved host is
- * `bitbucket.org`; otherwise the rejection message every call site returns
- * verbatim in its own error shape, before making any network call.
+ * This function only ever *rejects* on positive evidence of a distinct,
+ * dotted Server/DC domain — it fails open whenever ssh can't tell us
+ * anything useful:
+ *  - Resolved host is `bitbucket.org` → allow.
+ *  - Resolved host has no dot at all (e.g. a bare alias like
+ *    `bitbucket-work` with no matching `~/.ssh/config` entry) → allow. A
+ *    dotless string can never be a Server/DC FQDN, so this is ssh actively
+ *    telling us nothing, not evidence of a different product. The request
+ *    proceeds to `api.bitbucket.org` keyed by the alias's own credentials —
+ *    the same multi-identity behavior this module has always supported.
+ *  - Resolved host is a dotted domain other than `bitbucket.org` → reject.
+ *    ssh either actively redirected the raw remote host elsewhere (a real
+ *    alias-to-Server/DC mapping) or simply echoed the raw host back
+ *    unchanged (no `~/.ssh/config` entry at all) — either way this is
+ *    positive evidence of a distinct domain, so the request is rejected
+ *    before any network call, with a hint to add a `HostName bitbucket.org`
+ *    entry when the echoed-back case is actually a not-yet-configured cloud
+ *    alias.
+ *
+ * Host comparisons are case-insensitive (the resolved host is lowercased
+ * before every comparison) as a defensive measure against a future
+ * `ProviderRepoInfo` producer that doesn't already lowercase.
+ *
+ * Returns `null` (no error — proceed) on either allow path above; otherwise
+ * the rejection message every call site returns verbatim in its own error
+ * shape, before making any network call.
  */
 function bitbucketServerError(repo: ProviderRepoInfo): string | null {
-  const resolvedHost = apiHostForRemote(repo.remoteHost);
-  if (resolvedHost === "bitbucket.org") return null;
-  return `Bitbucket Server / Data Center is not supported — only Bitbucket Cloud (bitbucket.org). This repo's remote points at ${resolvedHost}.`;
+  const resolved = apiHostForRemote(repo.remoteHost).toLowerCase();
+  if (resolved === "bitbucket.org") return null;
+  // Dotless: ssh has nothing to tell us (no matching config entry, no dot to
+  // even suggest a domain) — cannot be a Server/DC FQDN. Fail open.
+  if (!resolved.includes(".")) return null;
+  const raw = repo.remoteHost.toLowerCase();
+  const base = `Bitbucket Server / Data Center is not supported — only Bitbucket Cloud (bitbucket.org). This repo's remote resolves to ${resolved}.`;
+  if (resolved !== raw) return base;
+  return `${base} If ${resolved} is actually an SSH alias for Bitbucket Cloud, add a ~/.ssh/config entry with "HostName bitbucket.org" for it.`;
 }
 
 interface BitbucketError {

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -187,23 +187,18 @@ function fetchErrorMessage(e: unknown): string {
 /** Internal fetch wrapper: absolute-URL passthrough (for pagination `next`
  *  links), 30s abort, `user-agent: agetor`, and the resolved
  *  Basic/Bearer auth header. `accept` is caller-supplied since the diff
- *  endpoint wants a permissive/plain accept rather than `application/json`.
- *  `init.redirect` defaults to the platform default (`"follow"`) when
- *  omitted; `getBitbucketPullBlob`'s merge-base redirect-sniff is the only
- *  caller that passes `"manual"`, to read a 30x `Location` header instead of
- *  transparently following it. */
+ *  endpoint wants a permissive/plain accept rather than `application/json`. */
 async function fetchBitbucket(
   pathOrUrl: string,
   creds: BitbucketCreds | null,
   accept: string,
-  init?: { method?: string; body?: string; redirect?: "follow" | "manual" },
+  init?: { method?: string; body?: string },
 ): Promise<Response | BitbucketError> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), BITBUCKET_FETCH_TIMEOUT_MS);
   try {
     return await fetch(resolveUrl(pathOrUrl), {
       method: init?.method,
-      redirect: init?.redirect,
       signal: controller.signal,
       headers: {
         accept,
@@ -803,14 +798,21 @@ function cacheBitbucketPullDetail(key: string, entry: BitbucketPullDetailCacheEn
 }
 
 /** Merge-base sha cache for the "old" side of a PR blob fetch, keyed
- *  `${remoteHost}/${owner}/${name}#${number}@${sourceSha}` — mirrors
+ *  `${remoteHost}/${owner}/${name}@${sourceSha}..${destSha}` — mirrors
  *  github.ts's `mergeBaseCache` (no TTL: a resolved merge-base commit is
- *  immutable once computed, unlike the PR detail above). Only successful
- *  resolutions are cached; a failed redirect-sniff (see
- *  `extractMergeBaseFromDiffLocation`) is re-attempted on the next request
- *  rather than being cached as a permanent miss. */
+ *  immutable once computed, unlike the PR detail above). Keyed on the sha
+ *  pair rather than the PR number since the merge-base of two commits is a
+ *  pure function of the commit graph, not of which PR asked for it — lets a
+ *  re-request for the same PR (or a different PR between the same two
+ *  branches) reuse the same cache entry. Only successful resolutions are
+ *  cached; a failed lookup is re-attempted on the next request rather than
+ *  being cached as a permanent miss. */
 const bitbucketMergeBaseCache = new Map<string, string>();
 const BITBUCKET_MERGE_BASE_CACHE_LIMIT = 200;
+
+function bitbucketMergeBaseCacheKey(repo: ProviderRepoInfo, sourceSha: string, destSha: string): string {
+  return `${repo.remoteHost}/${repo.owner}/${repo.name}@${sourceSha}..${destSha}`;
+}
 
 function cacheBitbucketMergeBase(key: string, sha: string): void {
   if (bitbucketMergeBaseCache.size >= BITBUCKET_MERGE_BASE_CACHE_LIMIT && !bitbucketMergeBaseCache.has(key)) {
@@ -820,63 +822,56 @@ function cacheBitbucketMergeBase(key: string, sha: string): void {
 }
 
 /**
- * Extracts a merge-base sha candidate from the `Location` header of a
- * `.../pullrequests/:id/diff` response fetched with `redirect: "manual"`.
- * Bitbucket 30x-redirects that endpoint to a fully-resolved diff spec that
- * embeds both the source and destination commits it computed the (merge-base
- * -anchored, three-dot) diff against — the exact shape isn't documented
- * (something like `.../diff/{workspace}/{slug}:{sourceSha}%0D{destSpec}` or a
- * `{source}..{dest}`-style path segment), so this parses defensively: pull
- * every 7-40 char hex run out of the Location, drop any that match the known
- * `sourceSha` (by exact match or hex-prefix, either direction — Bitbucket may
- * echo an abbreviated hash), and de-duplicate what's left. Exactly one
- * surviving candidate is treated as the merge base; zero or two-or-more means
- * the heuristic can't tell which one it is (nothing recognizable, or an
- * ambiguous Location shape), so it gives up and returns null rather than
- * guessing wrong — the caller falls back to `destination.commit.hash` in
- * that case. Pure — exported via `__bitbucketInternals` for unit testing.
+ * Resolves the merge-base sha for the "old" side of a PR blob fetch via
+ * Bitbucket Cloud's documented merge-base endpoint (REST api-group-commits):
+ * `GET {repoBasePath}/merge-base/{sourceSha}..{destSha}` (accept:
+ * application/json) → `{ hash: string, ... }`, where `hash` is the best
+ * common ancestor of the two commits. Returns null — never `destSha` itself —
+ * on any transport failure, non-2xx response, or unparseable/missing `hash`,
+ * so the caller applies the documented `destination.commit.hash`
+ * approximation itself and can tell resolver success from fallback. This also
+ * covers cross-repo PRs where the destination repo may not hold the source
+ * commit at all (a fork that's since diverged or been deleted) — the
+ * merge-base lookup simply fails and the caller falls back the same way.
+ * Cached only on success — see `bitbucketMergeBaseCache`. The response body
+ * is always consumed (via `.json()`) before returning, on both the success
+ * and the parse-failure path, so no fetch ever leaves an unconsumed body
+ * behind.
  */
-function extractMergeBaseFromDiffLocation(location: string, sourceSha: string): string | null {
-  const hexRun = /\b[0-9a-f]{7,40}\b/gi;
-  const matches = location.match(hexRun) ?? [];
-  const sourceLower = sourceSha.toLowerCase();
-  const candidates = new Set(
-    matches
-      .map((m) => m.toLowerCase())
-      .filter((m) => m !== sourceLower && !m.startsWith(sourceLower) && !sourceLower.startsWith(m)),
-  );
-  return candidates.size === 1 ? [...candidates][0] ?? null : null;
-}
-
-/** Resolves the merge-base sha for the "old" side of a PR blob fetch:
- *  primary strategy is the redirect-sniff (`extractMergeBaseFromDiffLocation`)
- *  against the `.../diff` endpoint's 30x `Location`; returns null (not the
- *  fallback sha) when the sniff fails so the caller can apply the documented
- *  `destination.commit.hash` approximation itself and know which path was
- *  taken. Cached only on success — see `bitbucketMergeBaseCache`. */
 async function resolveBitbucketMergeBase(
   repo: ProviderRepoInfo,
-  number: number,
   sourceSha: string,
+  destSha: string,
   creds: BitbucketCreds | null,
 ): Promise<string | null> {
-  const cacheKey = `${repo.remoteHost}/${repo.owner}/${repo.name}#${number}@${sourceSha}`;
+  const cacheKey = bitbucketMergeBaseCacheKey(repo, sourceSha, destSha);
   const cached = bitbucketMergeBaseCache.get(cacheKey);
   if (cached) return cached;
 
   const res = await fetchBitbucket(
-    `${repoBasePath(repo)}/pullrequests/${number}/diff`,
+    `${repoBasePath(repo)}/merge-base/${encodeURIComponent(`${sourceSha}..${destSha}`)}`,
     creds,
-    "*/*",
-    { redirect: "manual" },
+    "application/json",
   );
   if (!("status" in res)) return null;
-  const location = res.headers.get("location");
-  if (!location) return null;
-  const candidate = extractMergeBaseFromDiffLocation(location, sourceSha);
-  if (!candidate) return null;
-  cacheBitbucketMergeBase(cacheKey, candidate);
-  return candidate;
+  if (!res.ok) {
+    await res.json().catch(() => null); // consume body; error is non-actionable here, caller falls back
+    return null;
+  }
+  const json = await res.json().catch(() => null);
+  const hash = json && typeof json === "object" ? (json as Record<string, unknown>).hash : null;
+  if (typeof hash !== "string" || !hash) return null;
+  cacheBitbucketMergeBase(cacheKey, hash);
+  return hash;
+}
+
+/** Clears both `getBitbucketPullBlob` caches (PR detail + merge base).
+ *  Test-only affordance — exported via `__bitbucketInternals` so network
+ *  tests can `beforeEach` a clean slate rather than relying on distinct
+ *  fixture shas per test to dodge cross-test cache hits. */
+function resetBitbucketPullBlobCaches(): void {
+  bitbucketPullDetailCache.clear();
+  bitbucketMergeBaseCache.clear();
 }
 
 /** Builds a `ProviderRepoInfo` for a PR side's `full_name` (`"workspace/
@@ -913,19 +908,24 @@ function srcUrl(repo: ProviderRepoInfo, ref: string, filePath: string): string {
  * through `git-host.ts`'s `pullBlob`.
  *
  * - `side: "new"` reads the file at `source.commit.hash`, from the *source*
- *   repository (a fork for a cross-repo PR).
- * - `side: "old"` reads the file at the PR's merge-base commit — Bitbucket's
- *   PR diff (`getBitbucketPullDiff`, same `.../diff` endpoint) is three-dot
- *   (merge-base-anchored), and there is no official merge-base endpoint to
- *   resolve it directly. This fetches it two ways: primary is a
- *   redirect-sniff against the diff endpoint itself
- *   (`resolveBitbucketMergeBase`); when that fails (no Location header, or
- *   an ambiguous/unparseable one), it falls back to
- *   `destination.commit.hash` — an **approximation** that drifts if the
- *   destination branch has moved (and touched the same file) since the PR
- *   diverged from it, the same "approximated" tone this module already uses
- *   for `mergedAt`/`closedAt`. The old side is read from the *destination*
- *   repository either way.
+ *   repository (a fork for a cross-repo PR). If the source repository's
+ *   `full_name` is missing/unparseable — the fork was deleted, or the API
+ *   simply omitted it — this returns 404 rather than silently falling back to
+ *   the destination repo: the destination almost certainly does not contain
+ *   the file at the fork-only commit, so a silent fallback would either 404
+ *   anyway or, worse, return the *wrong* file's bytes under the right path.
+ * - `side: "old"` reads the file at the PR's merge-base commit, resolved via
+ *   Bitbucket Cloud's documented merge-base endpoint
+ *   (`resolveBitbucketMergeBase`, `GET .../merge-base/{sourceSha}..{destSha}`
+ *   → `{hash}`). When the resolver fails (network error, non-2xx, or a
+ *   missing/unparseable `hash` — including the cross-repo case where the
+ *   destination repo doesn't share history with a since-diverged fork), this
+ *   falls back to `destination.commit.hash` — an **approximation** that
+ *   drifts if the destination branch has moved (and touched the same file)
+ *   since the PR diverged from it, the same "approximated" tone this module
+ *   already uses for `mergedAt`/`closedAt`. The old side is read from the
+ *   *destination* repository either way (`?? repo` fallback is fine here —
+ *   destination is the correct default when `destRepoFullName` is missing).
  *
  * Bytes come from the Source API (`GET .../src/{ref}/{path}`), which returns
  * raw file content directly (no base64 envelope). Size is checked twice: from
@@ -935,6 +935,14 @@ function srcUrl(repo: ProviderRepoInfo, ref: string, filePath: string): string {
  * `content-length`) — same double-guard as `getGitHubPullBlob`, against
  * `MAX_BLOB_PREVIEW_BYTES` (not `BITBUCKET_DIFF_BODY_CAP_BYTES`, which bounds
  * the unified diff text, a different budget from a single file's bytes).
+ *
+ * On the "old" side, a resolved (and possibly cached) merge base is never
+ * trusted blindly: if the `/src/{ref}/{path}` fetch 404s with `ref` set to a
+ * resolver-supplied sha (not `destSha`), the merge-base cache entry for this
+ * sha pair is evicted and the fetch is retried exactly once against
+ * `destSha` before surfacing a 404 to the caller. This keeps a stale or
+ * simply-wrong cached/resolved merge base from permanently breaking every
+ * old-side preview of a PR — a subsequent request re-resolves from scratch.
  *
  * No short-circuit on missing credentials: like every other read in this
  * module (`getBitbucketPullDiff`, `getBitbucketPullChecks`, …), a public
@@ -1004,18 +1012,36 @@ export async function getBitbucketPullBlob(
   let blobRepo: ProviderRepoInfo;
   let ref: string;
   if (side === "new") {
-    blobRepo = bitbucketRepoFromFullName(sourceRepoFullName, repo) ?? repo;
+    const sourceRepo = bitbucketRepoFromFullName(sourceRepoFullName, repo);
+    if (!sourceRepo) {
+      return {
+        ok: false,
+        error: "the source repository for this pull request is unavailable (the fork may have been deleted)",
+        status: 404,
+      };
+    }
+    blobRepo = sourceRepo;
     ref = sourceSha;
   } else {
     blobRepo = bitbucketRepoFromFullName(destRepoFullName, repo) ?? repo;
-    const mergeBase = await resolveBitbucketMergeBase(repo, number, sourceSha, creds);
+    const mergeBase = await resolveBitbucketMergeBase(repo, sourceSha, destSha, creds);
     // Fallback: `destination.commit.hash` approximation — see this
     // function's doc comment.
     ref = mergeBase ?? destSha;
   }
 
-  const fileRes = await fetchBitbucket(srcUrl(blobRepo, ref, path), creds, "*/*");
+  let fileRes = await fetchBitbucket(srcUrl(blobRepo, ref, path), creds, "*/*");
   if (!("status" in fileRes)) return { ok: false, error: fileRes.error, status: 502 };
+  if (fileRes.status === 404 && side === "old" && ref !== destSha) {
+    // The resolved (and possibly cached) merge base doesn't actually have
+    // this file — evict the stale/wrong cache entry and retry once against
+    // the documented destSha approximation before giving up. See this
+    // function's doc comment.
+    bitbucketMergeBaseCache.delete(bitbucketMergeBaseCacheKey(repo, sourceSha, destSha));
+    ref = destSha;
+    fileRes = await fetchBitbucket(srcUrl(blobRepo, ref, path), creds, "*/*");
+    if (!("status" in fileRes)) return { ok: false, error: fileRes.error, status: 502 };
+  }
   if (fileRes.status === 404) return { ok: false, error: "file not present on this side", status: 404 };
   if (!fileRes.ok) {
     const raw = await fileRes.text().catch(() => "");
@@ -1708,7 +1734,6 @@ export const __bitbucketInternals = {
   normalizeBitbucketLineComment,
   normalizeBitbucketCheckRun,
   normalizeBitbucketMergeability,
-  extractMergeBaseFromDiffLocation,
   bitbucketRepoFromFullName,
   scanBitbucketDiffstatConflicts,
   escapeBBQLString,
@@ -1718,6 +1743,7 @@ export const __bitbucketInternals = {
   buildIssuesBBQL,
   sortParam,
   bitbucketViewerUuid,
+  resetBitbucketPullBlobCaches,
   BITBUCKET_OPEN_ISSUE_STATES,
   BITBUCKET_CHECK_STATE_MAP,
   BITBUCKET_MERGE_STRATEGY,

--- a/src/bun/bitbucket.ts
+++ b/src/bun/bitbucket.ts
@@ -21,7 +21,7 @@ import type {
 import { GIT_HOST_TOKENS_SECTION } from "../shared/types.ts";
 import { contentTypeForPreviewPath, MAX_BLOB_PREVIEW_BYTES } from "../shared/attachments.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
-import { bitbucketCreds, type BitbucketCreds } from "./git-provider.ts";
+import { apiHostForRemote, bitbucketCreds, type BitbucketCreds } from "./git-provider.ts";
 
 /**
  * Bitbucket Cloud (api.bitbucket.org, REST 2.0) adapter
@@ -70,6 +70,38 @@ const BITBUCKET_API_BASE = "https://api.bitbucket.org";
 const BITBUCKET_FETCH_TIMEOUT_MS = 30_000;
 const BITBUCKET_DIFF_BODY_CAP_BYTES = 8_000_000;
 const BITBUCKET_PAGELEN = 30;
+
+/**
+ * Guards every exported entry point below against a Bitbucket Server / Data
+ * Center remote. This adapter (like `BITBUCKET_API_BASE` above) is Bitbucket
+ * *Cloud*-only by construction: Server/DC speaks a structurally different
+ * REST API (`/rest/api/1.0`, different resource shapes for PRs, issues,
+ * comments, diffs, …) — there is no base-URL swap that makes this module
+ * work against it, unlike GitLab's self-hosted case (which is the *same*
+ * `/api/v4` shape at a different host). Without this guard, a repo whose
+ * remote resolves to a Server/DC host would silently keep hitting the
+ * hardcoded `api.bitbucket.org` and come back with a misleading "repo not
+ * found" 404 instead of an actionable "wrong product" error — exactly
+ * today's failure mode.
+ *
+ * `apiHostForRemote` (git-provider.ts) resolves `repo.remoteHost` through
+ * `~/.ssh/config` the same way `gitlabApiHost` does in gitlab.ts: an alias
+ * whose `HostName` is `bitbucket.org` (the documented multi-identity setup)
+ * resolves to `bitbucket.org` and passes; a real Server/DC domain (or an
+ * alias pointing at one) echoes back unchanged and is rejected. It's sync,
+ * never throws, and caches its own resolution per host, so calling this at
+ * the top of every entry point below costs nothing beyond the first `ssh -G`
+ * shellout for a given remote host.
+ *
+ * Returns `null` (no error — proceed) when the resolved host is
+ * `bitbucket.org`; otherwise the rejection message every call site returns
+ * verbatim in its own error shape, before making any network call.
+ */
+function bitbucketServerError(repo: ProviderRepoInfo): string | null {
+  const resolvedHost = apiHostForRemote(repo.remoteHost);
+  if (resolvedHost === "bitbucket.org") return null;
+  return `Bitbucket Server / Data Center is not supported — only Bitbucket Cloud (bitbucket.org). This repo's remote points at ${resolvedHost}.`;
+}
 
 interface BitbucketError {
   ok: false;
@@ -591,6 +623,8 @@ export async function listBitbucketItems(
   repo: ProviderRepoInfo,
   opts: ListBitbucketItemsOptions,
 ): Promise<BitbucketListResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   const page = Number.isInteger(opts.page) && (opts.page as number) > 0 ? (opts.page as number) : 1;
 
@@ -652,6 +686,8 @@ export async function listBitbucketItems(
  *  doc comment) — the facade fills it in from local git the same way for
  *  every provider. */
 export async function getBitbucketPullDefaults(repo: ProviderRepoInfo): Promise<BitbucketPullDefaultsResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   const res = await fetchBitbucket(repoBasePath(repo), creds, "application/json");
   if (!("status" in res)) return res;
@@ -675,6 +711,8 @@ export async function createBitbucketPull(
   repo: ProviderRepoInfo,
   input: CreateBitbucketPullInput,
 ): Promise<BitbucketIssueResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   const title = input.title.trim();
   const head = input.head.trim();
@@ -714,6 +752,8 @@ export async function createBitbucketPull(
  *  200-file caps) — `parseGitDiff` tolerates a truncated unified diff either
  *  way (it just yields fewer/partial hunks). */
 export async function getBitbucketPullDiff(repo: ProviderRepoInfo, number: number): Promise<BitbucketDiffResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
 
@@ -955,6 +995,8 @@ export async function getBitbucketPullBlob(
   relPath: string,
   side: "old" | "new",
 ): Promise<BitbucketBlobResult> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError, status: 501 };
   if (!Number.isInteger(number) || number <= 0) {
     return { ok: false, error: "pull request number must be positive", status: 400 };
   }
@@ -1084,6 +1126,8 @@ export async function listBitbucketComments(
   number: number,
   kind: GitHubItemKind,
 ): Promise<BitbucketCommentsResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "item number must be positive" };
   const endpoint = kind === "pulls" ? "pullrequests" : "issues";
@@ -1123,6 +1167,8 @@ export async function createBitbucketComment(
   kind: GitHubItemKind,
   body: string,
 ): Promise<BitbucketCommentResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "item number must be positive" };
   const trimmed = body.trim();
@@ -1155,6 +1201,8 @@ export async function listBitbucketPullReviewComments(
   repo: ProviderRepoInfo,
   number: number,
 ): Promise<BitbucketPullReviewCommentsResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
   const url = new URL(`${BITBUCKET_API_BASE}${repoBasePath(repo)}/pullrequests/${number}/comments`);
@@ -1191,6 +1239,8 @@ export async function createBitbucketPullLineComment(
   number: number,
   input: CreateBitbucketPullLineCommentInput,
 ): Promise<BitbucketPullLineCommentResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
   const body = input.body.trim();
@@ -1229,6 +1279,8 @@ export async function replyBitbucketLineComment(
   commentId: number,
   body: string,
 ): Promise<BitbucketPullLineCommentResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
   if (!Number.isInteger(commentId) || commentId <= 0) return { ok: false, error: "review comment id must be positive" };
@@ -1257,6 +1309,8 @@ export async function replyBitbucketLineComment(
  *  purely to fill that field — same two-request shape as
  *  `getGitHubPullChecks`, just for a different reason. */
 export async function getBitbucketPullChecks(repo: ProviderRepoInfo, number: number): Promise<BitbucketChecksResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
 
@@ -1429,6 +1483,8 @@ export async function getBitbucketPullMergeability(
   repo: ProviderRepoInfo,
   number: number,
 ): Promise<BitbucketMergeabilityResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
   const creds = await bitbucketCreds(repo.remoteHost);
 
@@ -1454,6 +1510,8 @@ export async function getBitbucketPullMergeability(
  *  other adapter function — the facade (`git-host.ts`) stitches it on via
  *  `withSourcePath`. */
 export async function getBitbucketPullDetail(repo: ProviderRepoInfo, number: number): Promise<BitbucketIssueResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
   const creds = await bitbucketCreds(repo.remoteHost);
   const res = await fetchBitbucket(`${repoBasePath(repo)}/pullrequests/${number}`, creds, "application/json");
@@ -1482,6 +1540,8 @@ export async function mergeBitbucketPull(
   number: number,
   method: GitHubPullMergeMethod,
 ): Promise<BitbucketPullMergeResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
   const strategy = BITBUCKET_MERGE_STRATEGY[method];
@@ -1509,6 +1569,8 @@ export async function mergeBitbucketPull(
  *  the only terminal non-merge state a pull request can reach via the API,
  *  so this is what `closeGitHubPull`'s call sites map onto. */
 export async function closeBitbucketPull(repo: ProviderRepoInfo, number: number): Promise<BitbucketActionResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
   if (!creds) return { ok: false, error: "Bitbucket authentication required to decline a pull request" };
@@ -1530,7 +1592,9 @@ export async function closeBitbucketPull(repo: ProviderRepoInfo, number: number)
  *  GitHub (`reopenGitHubPull`, a plain `state: "closed"` → back to `"open"`
  *  PATCH), a decline is terminal. Always returns a friendly, actionable error
  *  rather than attempting a request that Bitbucket would reject anyway. */
-export async function reopenBitbucketPull(_repo: ProviderRepoInfo, _number: number): Promise<BitbucketActionResponse> {
+export async function reopenBitbucketPull(repo: ProviderRepoInfo, _number: number): Promise<BitbucketActionResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   return { ok: false, error: "declined pull requests cannot be reopened on Bitbucket" };
 }
 
@@ -1548,6 +1612,8 @@ export async function reviewBitbucketPull(
   verdict: GitHubPullReviewEvent,
   body?: string,
 ): Promise<BitbucketActionResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "pull request number must be positive" };
   const trimmedBody = body?.trim() ?? "";
@@ -1599,6 +1665,8 @@ export async function createBitbucketIssue(
   repo: ProviderRepoInfo,
   input: CreateBitbucketIssueInput,
 ): Promise<BitbucketIssueResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   const title = input.title.trim();
   if (!title) return { ok: false, error: "issue title required" };
@@ -1644,6 +1712,8 @@ export async function updateBitbucketIssue(
   number: number,
   patch: UpdateBitbucketIssueInput,
 ): Promise<BitbucketIssueResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "issue number must be positive" };
   if (patch.state && patch.state !== "open" && patch.state !== "closed") {
@@ -1699,6 +1769,8 @@ function bitbucketViewerAccessHint(status: number, message: string, repo: Provid
  *  means an anonymous "" login rather than an error, same no-token behavior
  *  as the GitHub counterpart). */
 export async function getBitbucketViewer(repo: ProviderRepoInfo): Promise<BitbucketViewerResponse> {
+  const serverError = bitbucketServerError(repo);
+  if (serverError) return { ok: false, error: serverError };
   const creds = await bitbucketCreds(repo.remoteHost);
   if (!creds) return { ok: true, login: "" };
   const res = await fetchBitbucket("/2.0/user", creds, "application/json");

--- a/src/bun/git-host.test.ts
+++ b/src/bun/git-host.test.ts
@@ -302,30 +302,49 @@ test("pullReopen on a bitbucket repo surfaces the 'cannot be reopened' error", a
 // pullBlob
 // ---------------------------------------------------------------------------
 
-test("pullBlob on a gitlab repo returns 501 unsupported without any fetch", async () => {
+test("pullBlob on a gitlab repo dispatches to getGitLabPullBlob and returns the file bytes", async () => {
   const dir = await makeRepo("https://gitlab.com/acme/app.git");
-  fetchMock = mockGitHubFetch([]); // gitlab/bitbucket previews aren't implemented — asserting no fetch happens
+  fetchMock = mockGitHubFetch([
+    {
+      match: "/api/v4/projects/acme%2Fapp/merge_requests/1",
+      json: {
+        iid: 1,
+        diff_refs: { base_sha: "base123", head_sha: "head456" },
+        source_project_id: 10,
+        target_project_id: 10,
+      },
+    },
+    {
+      match: /\/repository\/files\/.*\/raw\?ref=head456/,
+      text: "PNGDATA",
+      headers: { "content-type": "application/octet-stream" },
+    },
+  ]);
 
   const res = await pullBlob({ dir, number: 1, path: "assets/logo.png", side: "new" });
-  expect(res).toEqual({
-    ok: false,
-    status: 501,
-    error: "binary preview not supported for this provider yet",
-  });
-  expect(fetchMock.calls).toHaveLength(0);
+  expect(res.ok).toBe(true);
+  if (!res.ok) return;
+  expect(res.ref).toBe("head456");
+  expect(res.contentType).toBe("image/png");
+  expect(new TextDecoder().decode(res.bytes)).toBe("PNGDATA");
+  expect(fetchMock.calls.some((c) => c.url.includes("/merge_requests/1"))).toBe(true);
 });
 
-test("pullBlob on a bitbucket repo returns 501 unsupported without any fetch", async () => {
+// Bitbucket's `getBitbucketPullBlob` is implemented in bitbucket.ts (owned by
+// a sibling change) — this dispatch test doesn't assume its exact endpoint
+// shape, only that git-host.ts no longer short-circuits to 501 without
+// attempting a fetch. A catch-all route means whatever endpoint(s) the
+// Bitbucket adapter calls get *some* response instead of mockGitHubFetch
+// throwing "no route for ...".
+test("pullBlob on a bitbucket repo dispatches to the provider instead of returning 501", async () => {
   const dir = await makeRepo("https://bitbucket.org/acme/app.git");
-  fetchMock = mockGitHubFetch([]);
+  fetchMock = mockGitHubFetch([{ match: /.*/, status: 404, json: { error: { message: "not found" } } }]);
 
   const res = await pullBlob({ dir, number: 1, path: "assets/logo.png", side: "old" });
-  expect(res).toEqual({
-    ok: false,
-    status: 501,
-    error: "binary preview not supported for this provider yet",
-  });
-  expect(fetchMock.calls).toHaveLength(0);
+  expect(res.ok).toBe(false);
+  if (res.ok) return;
+  expect(res.status).not.toBe(501);
+  expect(fetchMock.calls.length).toBeGreaterThan(0);
 });
 
 test("pullBlob rejects an unsafe (path-traversal) filePath with 400 before dispatching to any provider — even github", async () => {

--- a/src/bun/git-host.test.ts
+++ b/src/bun/git-host.test.ts
@@ -8,6 +8,7 @@ import {
   pullDefaults,
   labels,
   pullReopen,
+  pullBlob,
 } from "./git-host.ts";
 import { makeGitHubRepo } from "./github-test-util.ts";
 import { mockGitHubFetch, type FetchMock } from "./github-test-util.ts";
@@ -294,5 +295,68 @@ test("pullReopen on a bitbucket repo surfaces the 'cannot be reopened' error", a
   expect(res.ok).toBe(false);
   if (res.ok) return;
   expect(res.error).toContain("cannot be reopened");
+  expect(fetchMock.calls).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// pullBlob
+// ---------------------------------------------------------------------------
+
+test("pullBlob on a gitlab repo returns 501 unsupported without any fetch", async () => {
+  const dir = await makeRepo("https://gitlab.com/acme/app.git");
+  fetchMock = mockGitHubFetch([]); // gitlab/bitbucket previews aren't implemented — asserting no fetch happens
+
+  const res = await pullBlob({ dir, number: 1, path: "assets/logo.png", side: "new" });
+  expect(res).toEqual({
+    ok: false,
+    status: 501,
+    error: "binary preview not supported for this provider yet",
+  });
+  expect(fetchMock.calls).toHaveLength(0);
+});
+
+test("pullBlob on a bitbucket repo returns 501 unsupported without any fetch", async () => {
+  const dir = await makeRepo("https://bitbucket.org/acme/app.git");
+  fetchMock = mockGitHubFetch([]);
+
+  const res = await pullBlob({ dir, number: 1, path: "assets/logo.png", side: "old" });
+  expect(res).toEqual({
+    ok: false,
+    status: 501,
+    error: "binary preview not supported for this provider yet",
+  });
+  expect(fetchMock.calls).toHaveLength(0);
+});
+
+test("pullBlob rejects an unsafe (path-traversal) filePath with 400 before dispatching to any provider — even github", async () => {
+  const dir = await makeGitHubRepo("acme", "app");
+  createdDirs.push(dir);
+  fetchMock = mockGitHubFetch([]); // a safe dispatch would fetch the Contents API — asserting it never gets there
+
+  const res = await pullBlob({ dir, number: 1, path: "../../etc/passwd", side: "new" });
+  expect(res).toEqual({ ok: false, status: 400, error: "invalid path" });
+  expect(fetchMock.calls).toHaveLength(0);
+});
+
+test("pullBlob rejects an absolute filePath with 400", async () => {
+  const dir = await makeGitHubRepo("acme", "app");
+  createdDirs.push(dir);
+  fetchMock = mockGitHubFetch([]);
+
+  const res = await pullBlob({ dir, number: 1, path: "/etc/passwd", side: "new" });
+  expect(res).toEqual({ ok: false, status: 400, error: "invalid path" });
+  expect(fetchMock.calls).toHaveLength(0);
+});
+
+test("pullBlob on a repo with no supported git remote returns 400 without a path/provider check", async () => {
+  const dir = await makeRepo("git@example.com:acme/app.git");
+  fetchMock = mockGitHubFetch([]);
+
+  const res = await pullBlob({ dir, number: 1, path: "assets/logo.png", side: "new" });
+  expect(res).toEqual({
+    ok: false,
+    status: 400,
+    error: "project does not have a supported git remote (GitHub, GitLab, or Bitbucket)",
+  });
   expect(fetchMock.calls).toHaveLength(0);
 });

--- a/src/bun/git-host.ts
+++ b/src/bun/git-host.ts
@@ -433,10 +433,20 @@ export async function pullBlob(input: PullBlobOpts): Promise<PullBlobResult> {
   if (!isSafeRelPath(input.path)) {
     return { ok: false, error: "invalid path", status: 400 };
   }
-  if (repoInfo.provider === "github") return getGitHubPullBlob(input);
-  return repoInfo.provider === "gitlab"
-    ? getGitLabPullBlob(repoInfo, input.number, input.path, input.side)
-    : getBitbucketPullBlob(repoInfo, input.number, input.path, input.side);
+  switch (repoInfo.provider) {
+    case "github":
+      return getGitHubPullBlob(input);
+    case "gitlab":
+      return getGitLabPullBlob(repoInfo, input.number, input.path, input.side);
+    case "bitbucket":
+      return getBitbucketPullBlob(repoInfo, input.number, input.path, input.side);
+    default: {
+      // Exhaustiveness check: a future fourth provider fails typecheck here
+      // instead of silently falling through to bitbucket.
+      const _exhaustive: never = repoInfo.provider;
+      return { ok: false, status: 501, error: "binary preview not supported for this provider yet" };
+    }
+  }
 }
 
 /**

--- a/src/bun/git-host.ts
+++ b/src/bun/git-host.ts
@@ -51,6 +51,7 @@ import {
   createGitLabIssue,
   createGitLabPull,
   createGitLabPullLineComment,
+  getGitLabPullBlob,
   getGitLabPullChecks,
   getGitLabPullDefaults,
   getGitLabPullDetail,
@@ -73,6 +74,7 @@ import {
   createBitbucketIssue,
   createBitbucketPull,
   createBitbucketPullLineComment,
+  getBitbucketPullBlob,
   getBitbucketPullChecks,
   getBitbucketPullDefaults,
   getBitbucketPullDetail,
@@ -413,10 +415,10 @@ export type PullBlobResult =
  * request's diff, for the binary-diff-preview UI (`BinaryFilePreview`).
  * GitHub is implemented (`getGitHubPullBlob` — resolves head/base repo and
  * anchors the old side at the PR's merge base, since the diff the UI shows
- * is merge-base-anchored, not `base.sha`-anchored). GitLab and Bitbucket
- * previews are deferred to a follow-up (see docs/plans/binary-diff-previews.md
- * §8) — both return `501 unsupported` rather than attempting a fetch, so the
- * UI's binary placeholder degrades gracefully instead of erroring.
+ * is merge-base-anchored, not `base.sha`-anchored). GitLab (`getGitLabPullBlob`
+ * — old side anchored at `diff_refs.base_sha`, GitLab's own merge base) and
+ * Bitbucket (`getBitbucketPullBlob`) are implemented the same way (see
+ * docs/plans/binary-diff-previews-providers.md).
  *
  * `input.path` is validated with `isSafeRelPath` (the same guard
  * `getTaskDiffBlob` applies to the task-diff blob route) before any
@@ -432,7 +434,9 @@ export async function pullBlob(input: PullBlobOpts): Promise<PullBlobResult> {
     return { ok: false, error: "invalid path", status: 400 };
   }
   if (repoInfo.provider === "github") return getGitHubPullBlob(input);
-  return { ok: false, status: 501, error: "binary preview not supported for this provider yet" };
+  return repoInfo.provider === "gitlab"
+    ? getGitLabPullBlob(repoInfo, input.number, input.path, input.side)
+    : getBitbucketPullBlob(repoInfo, input.number, input.path, input.side);
 }
 
 /**

--- a/src/bun/git-host.ts
+++ b/src/bun/git-host.ts
@@ -44,6 +44,7 @@ import {
   updateGitHubIssue,
 } from "./github.ts";
 import { providerRepoForDir } from "./git-provider.ts";
+import { isSafeRelPath } from "./worktree.ts";
 import {
   closeGitLabPull,
   createGitLabComment,
@@ -399,7 +400,11 @@ export interface PullBlobOpts {
 }
 
 export type PullBlobResult =
-  | { ok: true; bytes: Uint8Array; contentType: string }
+  // `ref` is the exact sha the bytes were fetched at (head sha for "new",
+  // the resolved merge-base sha for "old") — used by the server route to
+  // build a truly content-addressed ETag instead of one derived only from
+  // byte length + path.
+  | { ok: true; bytes: Uint8Array<ArrayBuffer>; contentType: string; ref: string }
   // status: 404 missing, 413 too large, 501 unsupported provider, 502 upstream
   | { ok: false; error: string; status?: number };
 
@@ -412,10 +417,20 @@ export type PullBlobResult =
  * previews are deferred to a follow-up (see docs/plans/binary-diff-previews.md
  * §8) — both return `501 unsupported` rather than attempting a fetch, so the
  * UI's binary placeholder degrades gracefully instead of erroring.
+ *
+ * `input.path` is validated with `isSafeRelPath` (the same guard
+ * `getTaskDiffBlob` applies to the task-diff blob route) before any
+ * provider is dispatched to — without it, a path like
+ * `../../../../repos/victim/priv/contents/secret` would pass the caller's
+ * extension gate and normalize into an arbitrary-repo Contents API read
+ * under the user's own token.
  */
 export async function pullBlob(input: PullBlobOpts): Promise<PullBlobResult> {
   const repoInfo = await providerRepoForDir(input.dir);
-  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR, status: 400 };
+  if (!isSafeRelPath(input.path)) {
+    return { ok: false, error: "invalid path", status: 400 };
+  }
   if (repoInfo.provider === "github") return getGitHubPullBlob(input);
   return { ok: false, status: 501, error: "binary preview not supported for this provider yet" };
 }

--- a/src/bun/git-host.ts
+++ b/src/bun/git-host.ts
@@ -24,6 +24,7 @@ import {
   createGitHubIssue,
   createGitHubPull,
   createGitHubPullLineComment,
+  getGitHubPullBlob,
   getGitHubPullChecks,
   getGitHubPullDefaults,
   getGitHubPullDetail,
@@ -384,6 +385,39 @@ export async function pullDiff(input: { dir: string; number: number }): Promise<
   if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
   if (repoInfo.provider === "github") return getGitHubPullDiff(input);
   return repoInfo.provider === "gitlab" ? getGitLabPullDiff(repoInfo, input.number) : getBitbucketPullDiff(repoInfo, input.number);
+}
+
+/** Same identifying fields `pullDiff` takes (`dir`, `number`), plus which
+ *  file and which side of the diff to fetch bytes for. `path` is
+ *  repo-relative, matching the `path` field on `TaskDiff`'s `DiffFile`
+ *  entries the UI already has in hand from a prior `pullDiff` call. */
+export interface PullBlobOpts {
+  dir: string;
+  number: number;
+  path: string;
+  side: "old" | "new";
+}
+
+export type PullBlobResult =
+  | { ok: true; bytes: Uint8Array; contentType: string }
+  // status: 404 missing, 413 too large, 501 unsupported provider, 502 upstream
+  | { ok: false; error: string; status?: number };
+
+/**
+ * Fetches the raw bytes of one side (old/new) of a binary file in a pull
+ * request's diff, for the binary-diff-preview UI (`BinaryFilePreview`).
+ * GitHub is implemented (`getGitHubPullBlob` — resolves head/base repo and
+ * anchors the old side at the PR's merge base, since the diff the UI shows
+ * is merge-base-anchored, not `base.sha`-anchored). GitLab and Bitbucket
+ * previews are deferred to a follow-up (see docs/plans/binary-diff-previews.md
+ * §8) — both return `501 unsupported` rather than attempting a fetch, so the
+ * UI's binary placeholder degrades gracefully instead of erroring.
+ */
+export async function pullBlob(input: PullBlobOpts): Promise<PullBlobResult> {
+  const repoInfo = await providerRepoForDir(input.dir);
+  if (!repoInfo) return { ok: false, error: NO_REMOTE_ERROR };
+  if (repoInfo.provider === "github") return getGitHubPullBlob(input);
+  return { ok: false, status: 501, error: "binary preview not supported for this provider yet" };
 }
 
 /**

--- a/src/bun/git-provider.test.ts
+++ b/src/bun/git-provider.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, beforeEach, afterEach, afterAll } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -9,6 +9,8 @@ import {
   __clearRemoteHostsCacheForTest,
   gitlabToken,
   bitbucketCreds,
+  apiHostForRemote,
+  __clearApiHostCacheForTest,
 } from "./git-provider.ts";
 import { setGitHubToken, tokenForHost } from "./github-tokens.ts";
 import { makeAliasGitHubRepo } from "./github-test-util.ts";
@@ -16,12 +18,13 @@ import { makeAliasGitHubRepo } from "./github-test-util.ts";
 // git-provider.ts resolves AGETOR_DATA_DIR lazily at call time (via
 // github-tokens.ts's resolveDataDir), so — like github-tokens.test.ts — it's
 // safe to swap the env var per-test. Each test gets its own mkdtemp token
-// store dir; GITLAB_TOKEN/BITBUCKET_TOKEN/BITBUCKET_EMAIL are saved/cleared
-// before every test and restored after so no test can leak env into another,
-// and so gitlabToken/bitbucketCreds's env-fallback tier only ever sees what a
-// given test explicitly sets.
+// store dir; GITLAB_TOKEN/BITBUCKET_TOKEN/BITBUCKET_EMAIL/AGETOR_SSH_BIN are
+// saved/cleared before every test and restored after so no test can leak env
+// into another, and so gitlabToken/bitbucketCreds's env-fallback tier and
+// apiHostForRemote's binary override only ever see what a given test
+// explicitly sets.
 const ORIGINAL_DATA_DIR = process.env.AGETOR_DATA_DIR;
-const ENV_KEYS = ["GITLAB_TOKEN", "BITBUCKET_TOKEN", "BITBUCKET_EMAIL"] as const;
+const ENV_KEYS = ["GITLAB_TOKEN", "BITBUCKET_TOKEN", "BITBUCKET_EMAIL", "AGETOR_SSH_BIN"] as const;
 let dataDir: string;
 let savedEnv: Record<string, string | undefined> = {};
 let createdDirs: string[] = [];
@@ -39,6 +42,11 @@ beforeEach(() => {
   // clearing up front keeps every test's cache behavior self-contained and
   // independent of suite run order.
   __clearRemoteHostsCacheForTest();
+  // Same reasoning for apiHostForRemote's cache, keyed by raw remoteHost —
+  // without this, a host string reused across tests (unlikely but not
+  // guaranteed unique) could read a stale resolution from an earlier test's
+  // stub instead of exercising the current test's.
+  __clearApiHostCacheForTest();
 });
 
 afterEach(() => {
@@ -333,6 +341,89 @@ test("bitbucketCreds: a stored github.com entry is not leaked to a bitbucket hos
 test("bitbucketCreds: null when nothing is stored and no env is set", async () => {
   expect(await bitbucketCreds("bitbucket-work.org")).toBeNull();
   expect(await bitbucketCreds(null)).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// apiHostForRemote — ssh-config-aware hostname resolution
+// (docs/plans/per-host-git-api-bases.md). Every test below points
+// AGETOR_SSH_BIN at a throwaway stub script instead of touching the real
+// `ssh` or any real ~/.ssh/config, so these are deterministic regardless of
+// the machine running them.
+// ---------------------------------------------------------------------------
+
+/** Writes an executable stub standing in for `ssh` and returns its path.
+ *  `apiHostForRemote` invokes it as `<stub> -G -- <host>`, so `$3` is the
+ *  (lowercase-trimmed) host argument when a stub cares to inspect it. */
+function writeSshStub(script: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-git-provider-ssh-stub-"));
+  createdDirs.push(dir);
+  const binPath = path.join(dir, "ssh");
+  writeFileSync(binPath, script, { mode: 0o755 });
+  return binPath;
+}
+
+test("apiHostForRemote: a host with no ssh-config alias echoes the input (identity)", () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub('#!/bin/sh\necho "hostname $3"\n');
+  expect(apiHostForRemote("gitlab.mycompany.com")).toBe("gitlab.mycompany.com");
+});
+
+test("apiHostForRemote: an ssh-config alias resolves to the aliased HostName, regardless of the raw input", () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname gitlab.com'\n");
+  expect(apiHostForRemote("gitlab-work")).toBe("gitlab.com");
+  expect(apiHostForRemote("some-other-alias.example")).toBe("gitlab.com");
+});
+
+test("apiHostForRemote: falls back to the input on ssh failure (non-zero exit)", () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\nexit 1\n");
+  expect(apiHostForRemote("gitlab-work.io")).toBe("gitlab-work.io");
+});
+
+test("apiHostForRemote: falls back to the input when the ssh binary itself can't be spawned", () => {
+  process.env.AGETOR_SSH_BIN = path.join(tmpdir(), "agetor-does-not-exist-ssh-binary-xyz");
+  expect(apiHostForRemote("gitlab-work.io")).toBe("gitlab-work.io");
+});
+
+test("apiHostForRemote: falls back to the input when ssh's output has no parseable hostname line", () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'user someone'\n");
+  expect(apiHostForRemote("gitlab-work.io")).toBe("gitlab-work.io");
+});
+
+test("apiHostForRemote caches by raw input: a second call for the same host reuses the first resolution even after the stub changes, and __clearApiHostCacheForTest() bypasses it", () => {
+  const stub = writeSshStub("#!/bin/sh\necho 'hostname first-resolved.example'\n");
+  process.env.AGETOR_SSH_BIN = stub;
+
+  const first = apiHostForRemote("gitlab-cache-test.example");
+  expect(first).toBe("first-resolved.example");
+
+  // Flip the stub's resolution after the first call. Within the cache, a
+  // second call for the exact same raw host must reuse the first result
+  // rather than re-spawning ssh.
+  writeFileSync(stub, "#!/bin/sh\necho 'hostname second-resolved.example'\n", { mode: 0o755 });
+  const second = apiHostForRemote("gitlab-cache-test.example");
+  expect(second).toBe("first-resolved.example");
+
+  // Bypassing the cache observes the stub's new resolution immediately.
+  __clearApiHostCacheForTest();
+  const third = apiHostForRemote("gitlab-cache-test.example");
+  expect(third).toBe("second-resolved.example");
+});
+
+test("apiHostForRemote: empty or option-injecting (leading '-') input is returned as-is without ever spawning ssh", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-git-provider-ssh-stub-"));
+  createdDirs.push(dir);
+  const marker = path.join(dir, "invoked");
+  const stub = path.join(dir, "ssh");
+  writeFileSync(
+    stub,
+    `#!/bin/sh\ntouch "${marker}"\necho 'hostname should-not-be-used.example'\n`,
+    { mode: 0o755 },
+  );
+  process.env.AGETOR_SSH_BIN = stub;
+
+  expect(apiHostForRemote("")).toBe("");
+  expect(apiHostForRemote("   ")).toBe("   ");
+  expect(apiHostForRemote("-oProxyCommand=touch /tmp/pwned")).toBe("-oProxyCommand=touch /tmp/pwned");
+  expect(existsSync(marker)).toBe(false);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/bun/git-provider.test.ts
+++ b/src/bun/git-provider.test.ts
@@ -228,20 +228,55 @@ test("remoteHostsForDirs processes every dir even when the dir count exceeds the
 
 // ---------------------------------------------------------------------------
 // gitlabToken
+//
+// gitlabToken now resolves credentials against `apiHostForRemote(remoteHost)`
+// (MF-2, docs/plans/per-host-git-api-bases.md §8.1b) rather than the raw
+// host, and scopes the resolution tiers differently for cloud vs
+// self-hosted. Every test below installs a deterministic `AGETOR_SSH_BIN`
+// stub (an identity stub unless the test specifically wants an
+// alias-resolves-to-gitlab.com scenario) so results never depend on the real
+// `ssh` binary or the machine's actual ~/.ssh/config — without this,
+// `apiHostForRemote`'s internal ssh spawn would make these tests
+// nondeterministic across machines the way they weren't before MF-2.
 // ---------------------------------------------------------------------------
 
-test("gitlabToken: a stored exact alias-host token wins", async () => {
+/** Identity ssh stub: echoes the input host back unchanged, matching real
+ *  ssh's default behavior for a host with no matching ~/.ssh/config entry —
+ *  i.e. simulates a genuine (non-aliased) self-hosted domain. */
+function identitySshStub(): string {
+  return writeSshStub('#!/bin/sh\necho "hostname $3"\n');
+}
+
+test("gitlabToken: a stored exact host-keyed token wins (self-hosted path)", async () => {
+  process.env.AGETOR_SSH_BIN = identitySshStub();
   setGitHubToken("gitlab-work.io", "alias-tok");
   setGitHubToken("gitlab.com", "default-tok");
   expect(await gitlabToken("gitlab-work.io")).toBe("alias-tok");
 });
 
-test("gitlabToken: falls back to a stored gitlab.com entry when there's no exact match", async () => {
+test("gitlabToken: cloud (resolves to gitlab.com) — falls back to a stored gitlab.com entry when there's no exact match; gitlab.com behavior is unchanged from before MF-2", async () => {
+  // Stub resolves any input to gitlab.com, simulating a real ssh-config
+  // alias whose HostName is gitlab.com — the cloud path, where the
+  // pre-MF-2 three-tier fallback still applies.
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname gitlab.com'\n");
   setGitHubToken("gitlab.com", "default-tok");
   expect(await gitlabToken("gitlab-other-alias.io")).toBe("default-tok");
 });
 
+test("gitlabToken: self-hosted resolved host does NOT fall back to a stored gitlab.com entry (credential-scoping guard, MF-2)", async () => {
+  process.env.AGETOR_SSH_BIN = identitySshStub();
+  setGitHubToken("gitlab.com", "default-tok");
+  const originalPath = process.env.PATH;
+  process.env.PATH = "/nonexistent-agetor-test-path"; // deny the glab last-tier shellout too
+  try {
+    expect(await gitlabToken("gitlab-other-alias.io")).toBeNull();
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});
+
 test("gitlabToken: a stored github.com entry is not leaked to a gitlab host (cross-provider leak guard)", async () => {
+  process.env.AGETOR_SSH_BIN = identitySshStub();
   setGitHubToken("github.com", "gh-tok");
   const originalPath = process.env.PATH;
   process.env.PATH = "/nonexistent-agetor-test-path";
@@ -252,21 +287,46 @@ test("gitlabToken: a stored github.com entry is not leaked to a gitlab host (cro
   }
 });
 
-test("gitlabToken: GITLAB_TOKEN env is used when the store is empty", async () => {
+test("gitlabToken: cloud (resolves to gitlab.com) — GITLAB_TOKEN env is used when the store is empty", async () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname gitlab.com'\n");
   process.env.GITLAB_TOKEN = "env-tok";
   expect(await gitlabToken("gitlab-work.io")).toBe("env-tok");
 });
 
+test("gitlabToken: self-hosted resolved host does NOT use GITLAB_TOKEN env (credential-scoping guard, MF-2)", async () => {
+  process.env.AGETOR_SSH_BIN = identitySshStub();
+  process.env.GITLAB_TOKEN = "env-tok";
+  const originalPath = process.env.PATH;
+  process.env.PATH = "/nonexistent-agetor-test-path"; // deny the glab last-tier shellout too
+  try {
+    expect(await gitlabToken("gitlab-work.io")).toBeNull();
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});
+
 test("gitlabToken: a stored token beats GITLAB_TOKEN env", async () => {
+  process.env.AGETOR_SSH_BIN = identitySshStub();
   setGitHubToken("gitlab-work.io", "stored-tok");
   process.env.GITLAB_TOKEN = "env-tok";
   expect(await gitlabToken("gitlab-work.io")).toBe("stored-tok");
 });
 
-test("gitlabToken: null when nothing is stored, no env, and the glab CLI is unavailable", async () => {
+test("gitlabToken: self-hosted also accepts a token stored under the RESOLVED host when it differs from the raw alias", async () => {
+  // The raw alias resolves (via the stub) to a genuine self-hosted domain
+  // distinct from the alias string itself; the token is stored under the
+  // resolved host, not the raw one, and must still be found (MF-2's second
+  // exact-match tier).
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname gitlab.selfhosted.example'\n");
+  setGitHubToken("gitlab.selfhosted.example", "resolved-host-tok");
+  expect(await gitlabToken("gitlab-alias")).toBe("resolved-host-tok");
+});
+
+test("gitlabToken: null when nothing is stored, no env, and the glab CLI is unavailable (self-hosted host and no remote in scope)", async () => {
   // Force the `glab` shellout to fail deterministically (ENOENT) rather than
   // depending on whether the real `glab` CLI happens to be installed and
   // authenticated on the machine running this test.
+  process.env.AGETOR_SSH_BIN = identitySshStub();
   const originalPath = process.env.PATH;
   process.env.PATH = "/nonexistent-agetor-test-path";
   try {
@@ -362,6 +422,19 @@ function writeSshStub(script: string): string {
   return binPath;
 }
 
+/** Writes an ssh stub that also touches a marker file on every invocation
+ *  (before running `body`), so a test can assert ssh was never spawned at
+ *  all — needed by the cloud-short-circuit and charset-guard tests below,
+ *  which must prove NO spawn happened, not just that the result matches. */
+function writeSshSpawnMarkerStub(body: string): { bin: string; marker: string } {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-git-provider-ssh-stub-"));
+  createdDirs.push(dir);
+  const marker = path.join(dir, "invoked");
+  const bin = path.join(dir, "ssh");
+  writeFileSync(bin, `#!/bin/sh\ntouch "${marker}"\n${body}`, { mode: 0o755 });
+  return { bin, marker };
+}
+
 test("apiHostForRemote: a host with no ssh-config alias echoes the input (identity)", () => {
   process.env.AGETOR_SSH_BIN = writeSshStub('#!/bin/sh\necho "hostname $3"\n');
   expect(apiHostForRemote("gitlab.mycompany.com")).toBe("gitlab.mycompany.com");
@@ -388,7 +461,12 @@ test("apiHostForRemote: falls back to the input when ssh's output has no parseab
   expect(apiHostForRemote("gitlab-work.io")).toBe("gitlab-work.io");
 });
 
-test("apiHostForRemote caches by raw input: a second call for the same host reuses the first resolution even after the stub changes, and __clearApiHostCacheForTest() bypasses it", () => {
+test("apiHostForRemote: normalizes mixed-case input to lowercase, including on ssh failure (NTH-6)", () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\nexit 1\n");
+  expect(apiHostForRemote("GitLab-Work.IO")).toBe("gitlab-work.io");
+});
+
+test("apiHostForRemote caches by normalized input: a second call for the same host, OR a different-case spelling of it, reuses the first resolution even after the stub changes, and __clearApiHostCacheForTest() bypasses it (NTH-6)", () => {
   const stub = writeSshStub("#!/bin/sh\necho 'hostname first-resolved.example'\n");
   process.env.AGETOR_SSH_BIN = stub;
 
@@ -397,10 +475,13 @@ test("apiHostForRemote caches by raw input: a second call for the same host reus
 
   // Flip the stub's resolution after the first call. Within the cache, a
   // second call for the exact same raw host must reuse the first result
-  // rather than re-spawning ssh.
+  // rather than re-spawning ssh — and so must a *different-case spelling*
+  // of the same host, since the cache is keyed by the normalized form.
   writeFileSync(stub, "#!/bin/sh\necho 'hostname second-resolved.example'\n", { mode: 0o755 });
   const second = apiHostForRemote("gitlab-cache-test.example");
   expect(second).toBe("first-resolved.example");
+  const secondMixedCase = apiHostForRemote("Gitlab-Cache-Test.EXAMPLE");
+  expect(secondMixedCase).toBe("first-resolved.example");
 
   // Bypassing the cache observes the stub's new resolution immediately.
   __clearApiHostCacheForTest();
@@ -408,22 +489,53 @@ test("apiHostForRemote caches by raw input: a second call for the same host reus
   expect(third).toBe("second-resolved.example");
 });
 
-test("apiHostForRemote: empty or option-injecting (leading '-') input is returned as-is without ever spawning ssh", () => {
-  const dir = mkdtempSync(path.join(tmpdir(), "agetor-git-provider-ssh-stub-"));
-  createdDirs.push(dir);
-  const marker = path.join(dir, "invoked");
-  const stub = path.join(dir, "ssh");
-  writeFileSync(
-    stub,
-    `#!/bin/sh\ntouch "${marker}"\necho 'hostname should-not-be-used.example'\n`,
-    { mode: 0o755 },
-  );
-  process.env.AGETOR_SSH_BIN = stub;
+test("apiHostForRemote: empty, whitespace-only, or option-injecting (leading '-') input returns the normalized (trimmed+lowercased) form without ever spawning ssh (NTH-6)", () => {
+  const { bin, marker } = writeSshSpawnMarkerStub("echo 'hostname should-not-be-used.example'\n");
+  process.env.AGETOR_SSH_BIN = bin;
 
   expect(apiHostForRemote("")).toBe("");
-  expect(apiHostForRemote("   ")).toBe("   ");
-  expect(apiHostForRemote("-oProxyCommand=touch /tmp/pwned")).toBe("-oProxyCommand=touch /tmp/pwned");
+  // The guard fires on the *normalized* (trimmed) form, so a whitespace-only
+  // raw input is NOT echoed back verbatim — it comes back as "".
+  expect(apiHostForRemote("   ")).toBe("");
+  // Likewise, a leading-dash input comes back lowercased, not raw-cased.
+  expect(apiHostForRemote("-oProxyCommand=touch /tmp/pwned")).toBe("-oproxycommand=touch /tmp/pwned");
   expect(existsSync(marker)).toBe(false);
+});
+
+test("apiHostForRemote: a hostname charset violation (embedded whitespace or a newline) returns the normalized form without ever spawning ssh (NTH-6)", () => {
+  const { bin, marker } = writeSshSpawnMarkerStub("echo 'hostname should-not-be-used.example'\n");
+  process.env.AGETOR_SSH_BIN = bin;
+
+  expect(apiHostForRemote("gitlab .com")).toBe("gitlab .com");
+  expect(apiHostForRemote("gitlab.com\nx")).toBe("gitlab.com\nx");
+  expect(existsSync(marker)).toBe(false);
+});
+
+test("apiHostForRemote: the three cloud hosts (github.com/gitlab.com/bitbucket.org) short-circuit to themselves before ever spawning ssh (MF-1)", () => {
+  // Stub would resolve EVERY input to a made-up host — if the short-circuit
+  // didn't fire before the spawn, a cloud host would come back wrong. This
+  // is exactly the altssh-workaround scenario MF-1 exists for: a user's real
+  // ~/.ssh/config for `Host gitlab.com` could plausibly set `HostName
+  // altssh.gitlab.com` for the SSH-over-443 workaround.
+  const { bin, marker } = writeSshSpawnMarkerStub("echo 'hostname altssh.gitlab.com'\n");
+  process.env.AGETOR_SSH_BIN = bin;
+
+  expect(apiHostForRemote("github.com")).toBe("github.com");
+  expect(apiHostForRemote("gitlab.com")).toBe("gitlab.com");
+  expect(apiHostForRemote("bitbucket.org")).toBe("bitbucket.org");
+  // Mixed-case cloud host input still short-circuits (post-normalization).
+  expect(apiHostForRemote("GitLab.COM")).toBe("gitlab.com");
+  expect(existsSync(marker)).toBe(false);
+});
+
+test("apiHostForRemote: an ssh alias resolving to the altssh.<cloud> SSH-over-443 transport endpoint maps to the real cloud API host (MF-1)", () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname altssh.gitlab.com'\n");
+  expect(apiHostForRemote("gitlab-work")).toBe("gitlab.com");
+});
+
+test("apiHostForRemote: an ssh alias resolving to the ssh.<cloud> transport endpoint also maps to the real cloud API host (MF-1)", () => {
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname ssh.github.com'\n");
+  expect(apiHostForRemote("github-work")).toBe("github.com");
 });
 
 // ---------------------------------------------------------------------------

--- a/src/bun/git-provider.ts
+++ b/src/bun/git-provider.ts
@@ -38,15 +38,51 @@ import { tokenForHost } from "./github-tokens.ts";
  */
 
 const GITLAB_FETCH_TIMEOUT_MS = 5_000;
-const SSH_RESOLVE_TIMEOUT_MS = 4_000;
+// The ssh -G fallback is correct-by-default (worst case: today's raw-host
+// behavior). An ssh config that takes longer than this to resolve isn't
+// worth blocking on — spawnSync is synchronous and blocks Bun's single event
+// loop for its entire duration, so this budget is deliberately tight rather
+// than generous.
+const SSH_RESOLVE_TIMEOUT_MS = 750;
 
-/** Module-level cache for `apiHostForRemote`, keyed by the raw (as-given)
- *  `remoteHost` argument — no TTL, unlike `remoteHostsCache` above.
- *  `remoteHostsCache` is TTL'd because its *source* (a project dir's git
- *  remotes) can change mid-session; `~/.ssh/config` for a fixed host
- *  effectively can't, so there's nothing to expire — a user hand-editing
- *  their ssh config mid-session and expecting agetor to notice without a
- *  restart isn't a supported flow. */
+/** The three cloud-forge hostnames `apiHostForRemote` short-circuits on
+ *  before ever spawning `ssh -G` — see the WHY block in `apiHostForRemote`
+ *  above its cloud-host guard. */
+const CLOUD_HOSTS = new Set(["github.com", "gitlab.com", "bitbucket.org"]);
+
+/** Maps an ssh-transport-only hostname (a vendor-documented "connect over
+ *  443 via ssh" endpoint — `altssh.gitlab.com`, `ssh.github.com`,
+ *  `altssh.bitbucket.org`, …) to the real cloud API host it's a transport
+ *  stand-in for. These are SSH transport overrides, not API hosts — none of
+ *  the three cloud forges serve a REST API from them. Built generically as
+ *  `altssh.<cloud>` and `ssh.<cloud>` for each cloud host rather than
+ *  hardcoding only the one pattern each vendor happens to document today, so
+ *  a raw host that RESOLVES (via `ssh -G`) to one of these still ends up at
+ *  the real cloud API host instead of a dead one. */
+const SSH_TRANSPORT_ALIASES = new Map<string, string>(
+  Array.from(CLOUD_HOSTS).flatMap((cloud) => [
+    [`altssh.${cloud}`, cloud],
+    [`ssh.${cloud}`, cloud],
+  ]),
+);
+
+/** Legal hostname charset, checked post-lowercase. Anything outside this
+ *  (embedded whitespace, control characters, a newline smuggling a second
+ *  "line" into the string, …) can't be a real hostname; guarding on it
+ *  before ever building a URL out of the value protects downstream `new
+ *  URL(...)` calls (gitlab.ts's `gitlabApiBase`, primarily) from malformed
+ *  input rather than letting them throw or silently misparse. */
+const HOSTNAME_CHARSET_RE = /^[a-z0-9.-]+$/;
+
+/** Module-level cache for `apiHostForRemote`, keyed by the NORMALIZED
+ *  (trimmed + lowercased) `remoteHost` argument (NTH-6 — this is what makes
+ *  two different-cased spellings of the same host share one resolution) —
+ *  no TTL, unlike `remoteHostsCache` above. `remoteHostsCache` is TTL'd
+ *  because its *source* (a project dir's git remotes) can change
+ *  mid-session; `~/.ssh/config` for a fixed host effectively can't, so
+ *  there's nothing to expire — a user hand-editing their ssh config
+ *  mid-session and expecting agetor to notice without a restart isn't a
+ *  supported flow. */
 const apiHostCache = new Map<string, string>();
 
 /** Test-only escape hatch: clears `apiHostForRemote`'s cache, mirroring
@@ -94,22 +130,51 @@ export function __clearApiHostCacheForTest(): void {
  * agents.ts) so tests can point at a stub script instead of the real `ssh`.
  */
 export function apiHostForRemote(remoteHost: string): string {
-  const cached = apiHostCache.get(remoteHost);
+  const normalized = remoteHost.trim().toLowerCase();
+
+  // Cache (and every guard/failure path below) is keyed by `normalized`, not
+  // the raw `remoteHost` argument — this is what makes two different-cased
+  // spellings of the same host share one resolution/cache slot, and what
+  // guarantees every return value (success or fallback) is consistently the
+  // normalized form rather than leaking raw casing/whitespace back out to a
+  // caller that may feed it straight into a `new URL(...)`.
+  const cached = apiHostCache.get(normalized);
   if (cached !== undefined) return cached;
 
-  const normalized = remoteHost.trim().toLowerCase();
-  // Guard rather than spawn: an empty host is nothing to resolve, and a
-  // leading "-" could otherwise be misread by ssh as an option. The `--`
-  // passed to ssh below is belt-and-suspenders for every other input; this
-  // guard is the cheap first line of defense that also sidesteps ever
+  // Cloud-host short-circuit, BEFORE any ssh -G spawn. WHY: several forges
+  // document an "ssh-over-443" transport workaround for users behind a
+  // firewall that blocks port 22 — e.g. GitLab's `Host gitlab.com` /
+  // `HostName altssh.gitlab.com`, GitHub's `ssh.github.com`. That's an SSH
+  // TRANSPORT override: it exists so `git clone git@gitlab.com:...`
+  // succeeds over port 443, and has nothing to do with which host serves
+  // the REST API. If we resolved a plain `gitlab.com` remote through the
+  // user's `~/.ssh/config` and that config happens to carry this (common,
+  // vendor-recommended) workaround, `ssh -G` would report `hostname
+  // altssh.gitlab.com` — and using that as the API host would redirect
+  // every API call to a host with no REST API at all. A raw remote host
+  // that already IS exactly one of the three cloud domains is unambiguous
+  // (there's no legitimate alias resolution that could improve on it), so
+  // short-circuit before ever spawning ssh.
+  if (CLOUD_HOSTS.has(normalized)) {
+    apiHostCache.set(normalized, normalized);
+    return normalized;
+  }
+
+  // Guard rather than spawn: an empty host is nothing to resolve, a leading
+  // "-" could otherwise be misread by ssh as an option, and a hostname
+  // charset violation (anything outside `[a-z0-9.-]` post-lowercase — e.g.
+  // embedded whitespace or a newline) can never be a real hostname and
+  // would otherwise reach a downstream `new URL(...)` call unguarded. The
+  // `--` passed to ssh below is belt-and-suspenders for every other input;
+  // this guard is the cheap first line of defense that also sidesteps ever
   // spawning a process for garbage input.
-  if (!normalized || normalized.startsWith("-")) {
-    apiHostCache.set(remoteHost, remoteHost);
-    return remoteHost;
+  if (!normalized || normalized.startsWith("-") || !HOSTNAME_CHARSET_RE.test(normalized)) {
+    apiHostCache.set(normalized, normalized);
+    return normalized;
   }
 
   const sshBin = process.env.AGETOR_SSH_BIN || "ssh";
-  let resolved = remoteHost;
+  let resolved = normalized;
   try {
     // No shell involved (argv array, not a command string) and `--` marks
     // the end of options, so `normalized` can't be reinterpreted as an ssh
@@ -123,10 +188,15 @@ export function apiHostForRemote(remoteHost: string): string {
       if (match && match[1]) resolved = match[1];
     }
   } catch {
-    // Missing binary, spawn error, etc. — resolved stays remoteHost.
+    // Missing binary, spawn error, etc. — resolved stays normalized.
   }
 
-  apiHostCache.set(remoteHost, resolved);
+  // An ssh alias can resolve to an SSH-over-443 transport endpoint rather
+  // than a real API host (see the cloud short-circuit's WHY above) — map it
+  // back to the cloud domain it's a transport stand-in for.
+  resolved = SSH_TRANSPORT_ALIASES.get(resolved) ?? resolved;
+
+  apiHostCache.set(normalized, resolved);
   return resolved;
 }
 
@@ -286,22 +356,74 @@ export async function remoteHostsForDirs(dirs: string[]): Promise<string[]> {
 /**
  * Resolve the token to authenticate a GitLab request with, for a repo whose
  * raw remote host is `remoteHost` (null when there's no repo in scope).
- * Resolution order mirrors `githubToken` in github.ts:
- *   1. A stored token for `remoteHost` (the raw-host-keyed store in
- *      `github-tokens.ts` — works for a gitlab alias host as-is, no schema
- *      change; falls back to a `gitlab.com`-labeled entry the same way
- *      `tokenForHost` falls back to `github.com` for GitHub).
- *   2. `GITLAB_TOKEN` env.
- *   3. Best-effort `glab config get token --host gitlab.com` shellout
- *      (5s timeout; any failure — missing binary, non-zero exit, timeout —
- *      swallowed to null, same as `githubToken`'s `gh auth token` fallback).
+ *
+ * Credential resolution is scoped to the **resolved** API host
+ * (`apiHostForRemote(remoteHost)`), not the raw host, and the two cases get
+ * different tiers:
+ *
+ *   - **Cloud** (`resolved === "gitlab.com"`, or `remoteHost === null` —
+ *     treated as cloud since that's `glab`'s own default `--host`): today's
+ *     three-tier order, unchanged — see `gitlabCloudToken` below.
+ *   - **Self-hosted** (`resolved` is anything else): exact host-keyed store
+ *     entry ONLY — see `gitlabSelfHostedToken` below for why the cloud
+ *     tiers (gitlab.com store fallback, `GITLAB_TOKEN` env, glab-cloud) must
+ *     NOT apply here.
+ *
+ * WHY the scoping matters (review finding, fix wave): before per-host API
+ * bases, every GitLab call's URL was hardcoded to `gitlab.com`, so a stored
+ * `gitlab.com` token (or `GITLAB_TOKEN`, or `glab`'s own cloud account)
+ * could only ever be sent to `gitlab.com` — falling back to it for an
+ * unrecognized host was harmless. Now that the API base is resolved
+ * per-host, the same fallback would transmit a `gitlab.com` personal-access
+ * token to an arbitrary third-party host whose name merely happens to
+ * contain "gitlab" — a credential-disclosure bug, not a convenience.
  */
 export async function gitlabToken(remoteHost: string | null): Promise<string | null> {
+  if (remoteHost === null) return gitlabCloudToken(null);
+  const resolved = apiHostForRemote(remoteHost);
+  if (resolved === "gitlab.com") return gitlabCloudToken(remoteHost);
+  return gitlabSelfHostedToken(remoteHost, resolved);
+}
+
+/** Cloud (gitlab.com) resolution order, unchanged from before per-host API
+ *  bases: stored token for `remoteHost` (falling back to a `gitlab.com`
+ *  -labeled store entry) → `GITLAB_TOKEN` env → best-effort `glab config get
+ *  token --host gitlab.com` shellout (5s timeout; any failure — missing
+ *  binary, non-zero exit, timeout — swallowed to null, same as
+ *  `githubToken`'s `gh auth token` fallback in github.ts). */
+async function gitlabCloudToken(remoteHost: string | null): Promise<string | null> {
   const stored = tokenForHost(remoteHost, "gitlab.com");
   if (stored) return stored;
   const envToken = process.env.GITLAB_TOKEN;
   if (envToken) return envToken;
   const glab = await run(["glab", "config", "get", "token", "--host", "gitlab.com"], undefined, GITLAB_FETCH_TIMEOUT_MS);
+  return glab.ok && glab.stdout ? glab.stdout : null;
+}
+
+/**
+ * Self-hosted resolution order — deliberately narrower than the cloud path
+ * (see the credential-disclosure WHY on `gitlabToken` above): only an EXACT
+ * host-keyed store entry, tried under both the raw remote host and (if it
+ * differs, e.g. an ssh alias resolving to a self-hosted domain) the resolved
+ * host. `tokenForHost(host, host)` — passing the host itself as the
+ * fallback — is how an exact-only lookup is expressed against a helper
+ * whose second parameter is normally a cross-host fallback: the exact-match
+ * branch already covers `host`, so the "fallback" branch degenerates to a
+ * no-op default-store leak. No `gitlab.com` store fallback, no
+ * `GITLAB_TOKEN` env, no glab-cloud-account shellout — none of those are
+ * scoped to this self-hosted target. As a last, still host-scoped tier,
+ * `glab config get token --host <resolved>` is attempted (glab supports
+ * `--host` for self-managed GitLab instances the same way it does for
+ * gitlab.com).
+ */
+async function gitlabSelfHostedToken(remoteHost: string, resolved: string): Promise<string | null> {
+  const byRemoteHost = tokenForHost(remoteHost, remoteHost);
+  if (byRemoteHost) return byRemoteHost;
+  if (resolved !== remoteHost) {
+    const byResolvedHost = tokenForHost(resolved, resolved);
+    if (byResolvedHost) return byResolvedHost;
+  }
+  const glab = await run(["glab", "config", "get", "token", "--host", resolved], undefined, GITLAB_FETCH_TIMEOUT_MS);
   return glab.ok && glab.stdout ? glab.stdout : null;
 }
 

--- a/src/bun/git-provider.ts
+++ b/src/bun/git-provider.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import type { GitProvider, ProviderRepoInfo } from "../shared/types.ts";
 import { canonicalGitHost, parseGitRemote, run } from "./github.ts";
@@ -37,6 +38,97 @@ import { tokenForHost } from "./github-tokens.ts";
  */
 
 const GITLAB_FETCH_TIMEOUT_MS = 5_000;
+const SSH_RESOLVE_TIMEOUT_MS = 4_000;
+
+/** Module-level cache for `apiHostForRemote`, keyed by the raw (as-given)
+ *  `remoteHost` argument — no TTL, unlike `remoteHostsCache` above.
+ *  `remoteHostsCache` is TTL'd because its *source* (a project dir's git
+ *  remotes) can change mid-session; `~/.ssh/config` for a fixed host
+ *  effectively can't, so there's nothing to expire — a user hand-editing
+ *  their ssh config mid-session and expecting agetor to notice without a
+ *  restart isn't a supported flow. */
+const apiHostCache = new Map<string, string>();
+
+/** Test-only escape hatch: clears `apiHostForRemote`'s cache, mirroring
+ *  `__clearRemoteHostsCacheForTest` below for the same reason (deterministic,
+ *  order-independent tests). */
+export function __clearApiHostCacheForTest(): void {
+  apiHostCache.clear();
+}
+
+/**
+ * Resolve the hostname API calls to a git-forge remote should target, given
+ * that remote's RAW host (`ProviderRepoInfo.remoteHost` /
+ * `parseGitRemote(...).rawHost` — see the module doc comment above).
+ *
+ * WHY this exists: a raw remote host is ambiguous. It's either a genuine
+ * self-hosted domain (`gitlab.mycompany.com`, used verbatim as the API host)
+ * or an `~/.ssh/config` multi-identity alias
+ * (docs/plans/github-remote-host-aliases.md) whose `HostName` is the
+ * provider's real cloud domain — e.g. `Host gitlab-work` / `HostName
+ * gitlab.com`, so the remote URL says `gitlab-work` but the API lives at
+ * `gitlab.com/api/v4`, not the nonexistent `gitlab-work/api/v4`. Nothing in
+ * the remote URL itself distinguishes the two cases: `ssh -G <host>` is the
+ * only local authority that can, because it performs the exact same
+ * Include/Match/Host-pattern resolution a real `ssh` invocation for that
+ * remote would, without opening a network connection (`-G` just prints the
+ * fully-resolved client configuration and exits).
+ *
+ * Parses the `hostname <value>` line `ssh -G` always emits: for an alias
+ * this is the resolved `HostName` (e.g. `gitlab.com`); for a plain domain
+ * with no matching config entry, ssh's default behavior is to echo the
+ * input back (lowercased — ssh lowercases hostnames during config
+ * resolution, which is harmless here since DNS/HTTP hostnames are
+ * case-insensitive).
+ *
+ * Never throws and never blocks longer than `SSH_RESOLVE_TIMEOUT_MS`: any
+ * failure (missing `ssh` binary, non-zero exit, timeout, unparseable
+ * output, empty resolved hostname) falls back to returning `remoteHost`
+ * unchanged — today's behavior. Synchronous and cached (see `apiHostCache`
+ * above) because this feeds `gitlabApiBase` (H2, gitlab.ts), which is called
+ * inline from ~25 template-literal call sites that have no reason to become
+ * async just for this.
+ *
+ * Binary overridable via `AGETOR_SSH_BIN` (house pattern — `AGETOR_TMUX_BIN`
+ * in tmux-resolution.ts, `AGETOR_CLAUDE_BIN`/`AGETOR_CODEX_BIN`/… in
+ * agents.ts) so tests can point at a stub script instead of the real `ssh`.
+ */
+export function apiHostForRemote(remoteHost: string): string {
+  const cached = apiHostCache.get(remoteHost);
+  if (cached !== undefined) return cached;
+
+  const normalized = remoteHost.trim().toLowerCase();
+  // Guard rather than spawn: an empty host is nothing to resolve, and a
+  // leading "-" could otherwise be misread by ssh as an option. The `--`
+  // passed to ssh below is belt-and-suspenders for every other input; this
+  // guard is the cheap first line of defense that also sidesteps ever
+  // spawning a process for garbage input.
+  if (!normalized || normalized.startsWith("-")) {
+    apiHostCache.set(remoteHost, remoteHost);
+    return remoteHost;
+  }
+
+  const sshBin = process.env.AGETOR_SSH_BIN || "ssh";
+  let resolved = remoteHost;
+  try {
+    // No shell involved (argv array, not a command string) and `--` marks
+    // the end of options, so `normalized` can't be reinterpreted as an ssh
+    // flag even if the leading-dash guard above were somehow bypassed.
+    const res = spawnSync(sshBin, ["-G", "--", normalized], {
+      encoding: "utf8",
+      timeout: SSH_RESOLVE_TIMEOUT_MS,
+    });
+    if (res.status === 0 && typeof res.stdout === "string") {
+      const match = res.stdout.match(/^hostname\s+(\S+)\s*$/m);
+      if (match && match[1]) resolved = match[1];
+    }
+  } catch {
+    // Missing binary, spawn error, etc. — resolved stays remoteHost.
+  }
+
+  apiHostCache.set(remoteHost, resolved);
+  return resolved;
+}
 
 /** Map a canonical provider host (as produced by `canonicalGitHost`) to the
  *  `GitProvider` it identifies, or null when it's none of the three supported

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -63,6 +63,7 @@ import type {
   TaskDiff,
 } from "../shared/types.ts";
 import { GIT_HOST_TOKENS_SECTION } from "../shared/types.ts";
+import { contentTypeForPreviewPath, MAX_BLOB_PREVIEW_BYTES } from "../shared/attachments.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
 import { tokenForHost } from "./github-tokens.ts";
 
@@ -1718,10 +1719,8 @@ interface GetGitHubPullBlobInput {
  *  consumer, not the source, of this module's types; TS's structural typing
  *  makes the two interchangeable at the `pullBlob` dispatch call site. */
 type GitHubBlobResult =
-  | { ok: true; bytes: Uint8Array; contentType: string }
+  | { ok: true; bytes: Uint8Array<ArrayBuffer>; contentType: string; ref: string }
   | { ok: false; error: string; status?: number };
-
-const GITHUB_BLOB_MAX_BYTES = 20_000_000;
 
 /** Merge-base sha cache for the "old" side of a PR blob fetch, keyed
  *  `${remoteHost}/${owner}/${name}#${number}@${headSha}` — the `.diff` media
@@ -1741,45 +1740,55 @@ function cacheMergeBase(key: string, sha: string): void {
   mergeBaseCache.set(key, sha);
 }
 
-/** Builds a `GitHubRepo` from a PR's `head.repo`/`base.repo` JSON object
- *  (`{ full_name: "owner/name" }`), reusing the *original* repo's
- *  `remoteHost` — the fork lives on the same git host, and tokens are
- *  stored per-host, not per-repo (see `githubToken`'s doc comment). Returns
- *  null when the embedded repo is absent (e.g. the fork was deleted), same
- *  as `normalizeMergeability`'s `headRepo` handling. */
-function repoFromPullSide(raw: unknown, host: string): GitHubRepo | null {
-  if (!raw || typeof raw !== "object") return null;
-  const fullName = (raw as Record<string, unknown>).full_name;
-  if (typeof fullName !== "string") return null;
+interface PullDetailCacheEntry {
+  headSha: string;
+  baseSha: string;
+  headRepoFullName: string | null;
+  baseRepoFullName: string | null;
+  fetchedAt: number;
+}
+
+/** Short-TTL cache of a PR's head/base sha + head/base repo full names,
+ *  keyed `${remoteHost}/${owner}/${name}#${number}` — without this, every
+ *  blob request (old side, then new side, or the user paging through
+ *  several binary files in the same PR) re-fetches `GET /pulls/:number`
+ *  from scratch even though the two sides of one preview session almost
+ *  always want the same PR detail. 60s TTL so a fresh push to the PR is
+ *  picked up reasonably promptly rather than serving a stale head sha for
+ *  the rest of the process's life. Same crude size-guard eviction style as
+ *  `mergeBaseCache` — not correctness-critical, just bounds memory. */
+const pullDetailCache = new Map<string, PullDetailCacheEntry>();
+const PULL_DETAIL_CACHE_LIMIT = 200;
+const PULL_DETAIL_CACHE_TTL_MS = 60_000;
+
+function cachePullDetail(key: string, entry: PullDetailCacheEntry): void {
+  if (pullDetailCache.size >= PULL_DETAIL_CACHE_LIMIT && !pullDetailCache.has(key)) {
+    pullDetailCache.clear();
+  }
+  pullDetailCache.set(key, entry);
+}
+
+/** Builds a `GitHubRepo` from a PR side's `full_name` (`"owner/name"`, as
+ *  read off `head.repo.full_name`/`base.repo.full_name` or the cached
+ *  `PullDetailCacheEntry`), reusing the *original* repo's `remoteHost` — the
+ *  fork lives on the same git host, and tokens are stored per-host, not
+ *  per-repo (see `githubToken`'s doc comment). Returns null when
+ *  `fullName` is null (e.g. the fork was deleted) or malformed. */
+function repoFromFullName(fullName: string | null, host: string): GitHubRepo | null {
+  if (!fullName) return null;
   const slash = fullName.indexOf("/");
   if (slash === -1) return null;
   return { owner: fullName.slice(0, slash), name: fullName.slice(slash + 1), remoteHost: host };
 }
 
-/** Extension → content-type for a binary diff preview. Deliberately doesn't
- *  trust GitHub's Contents API response content-type for known preview
- *  extensions (server-guessed types can be generic like
+/** Content-type for a binary diff preview, from the shared canonical
+ *  extension→MIME map (`../shared/attachments.ts`). Deliberately doesn't
+ *  trust GitHub's Contents API response content-type for a known preview
+ *  extension (server-guessed types can be generic like
  *  `application/octet-stream`) — only falls back to it when the extension
- *  isn't one of the previewable kinds `binaryPreviewKind` (shared/attachments.ts)
- *  recognizes. Pure. */
+ *  isn't one of the previewable kinds the shared map recognizes. Pure. */
 function contentTypeForBlobPath(path: string, fallback: string | null): string {
-  const base = path.split("/").pop() ?? "";
-  const dot = base.lastIndexOf(".");
-  const ext = dot === -1 ? "" : base.slice(dot + 1).toLowerCase();
-  const known: Record<string, string> = {
-    png: "image/png",
-    jpg: "image/jpeg",
-    jpeg: "image/jpeg",
-    gif: "image/gif",
-    webp: "image/webp",
-    svg: "image/svg+xml",
-    bmp: "image/bmp",
-    ico: "image/x-icon",
-    avif: "image/avif",
-    heic: "image/heic",
-    pdf: "application/pdf",
-  };
-  return known[ext] ?? fallback ?? "application/octet-stream";
+  return contentTypeForPreviewPath(path) ?? fallback ?? "application/octet-stream";
 }
 
 /** Fetches the raw bytes of a single file from one side (old/new) of a
@@ -1804,7 +1813,7 @@ function contentTypeForBlobPath(path: string, fallback: string | null): string {
  *  send a chunked response with no `content-length`). */
 export async function getGitHubPullBlob(input: GetGitHubPullBlobInput): Promise<GitHubBlobResult> {
   const repo = await repoForDir(input.dir);
-  if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
+  if (!repo) return { ok: false, error: "project does not have a GitHub remote", status: 400 };
   if (!Number.isInteger(input.number) || input.number <= 0) {
     return { ok: false, error: "pull request number must be positive", status: 400 };
   }
@@ -1812,28 +1821,53 @@ export async function getGitHubPullBlob(input: GetGitHubPullBlobInput): Promise<
   if (!relPath) return { ok: false, error: "file path is required", status: 400 };
 
   const token = await githubToken(repo.remoteHost ?? null);
-  const prUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
-  const prRes = await fetchGitHub(prUrl, token, "application/vnd.github+json");
-  if (!("status" in prRes)) return { ok: false, error: prRes.error, status: 502 };
-  const prJson = await prRes.json().catch(() => null);
-  if (!prRes.ok) {
-    return prRes.status === 404
-      ? { ok: false, error: "pull request not found", status: 404 }
-      : { ok: false, error: apiError(prJson, prRes.status, prRes.statusText), status: prRes.status };
-  }
-  const pr = prJson && typeof prJson === "object" ? (prJson as Record<string, unknown>) : {};
-  const head = pr.head && typeof pr.head === "object" ? pr.head as Record<string, unknown> : {};
-  const base = pr.base && typeof pr.base === "object" ? pr.base as Record<string, unknown> : {};
-  const headSha = typeof head.sha === "string" ? head.sha : null;
-  const baseSha = typeof base.sha === "string" ? base.sha : null;
-  if (!headSha || !baseSha) {
-    return { ok: false, error: "GitHub returned a pull request without head/base sha", status: 502 };
+
+  // PR detail (head/base sha + repo full names) is cached for a short TTL —
+  // see `pullDetailCache`'s doc comment. Avoids a redundant `GET
+  // /pulls/:number` for every blob request against the same PR.
+  const detailKey = `${repo.remoteHost}/${repoSlug(repo)}#${input.number}`;
+  const cachedDetail = pullDetailCache.get(detailKey);
+  let headSha: string;
+  let baseSha: string;
+  let headRepoFullName: string | null;
+  let baseRepoFullName: string | null;
+  if (cachedDetail && Date.now() - cachedDetail.fetchedAt < PULL_DETAIL_CACHE_TTL_MS) {
+    ({ headSha, baseSha, headRepoFullName, baseRepoFullName } = cachedDetail);
+  } else {
+    const prUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+    const prRes = await fetchGitHub(prUrl, token, "application/vnd.github+json");
+    if (!("status" in prRes)) return { ok: false, error: prRes.error, status: 502 };
+    const prJson = await prRes.json().catch(() => null);
+    if (!prRes.ok) {
+      return prRes.status === 404
+        ? { ok: false, error: "pull request not found", status: 404 }
+        : { ok: false, error: apiError(prJson, prRes.status, prRes.statusText), status: prRes.status };
+    }
+    const pr = prJson && typeof prJson === "object" ? (prJson as Record<string, unknown>) : {};
+    const head = pr.head && typeof pr.head === "object" ? pr.head as Record<string, unknown> : {};
+    const base = pr.base && typeof pr.base === "object" ? pr.base as Record<string, unknown> : {};
+    const resolvedHeadSha = typeof head.sha === "string" ? head.sha : null;
+    const resolvedBaseSha = typeof base.sha === "string" ? base.sha : null;
+    if (!resolvedHeadSha || !resolvedBaseSha) {
+      return { ok: false, error: "GitHub returned a pull request without head/base sha", status: 502 };
+    }
+    headSha = resolvedHeadSha;
+    baseSha = resolvedBaseSha;
+    headRepoFullName = head.repo && typeof head.repo === "object"
+      && typeof (head.repo as Record<string, unknown>).full_name === "string"
+      ? (head.repo as Record<string, unknown>).full_name as string
+      : null;
+    baseRepoFullName = base.repo && typeof base.repo === "object"
+      && typeof (base.repo as Record<string, unknown>).full_name === "string"
+      ? (base.repo as Record<string, unknown>).full_name as string
+      : null;
+    cachePullDetail(detailKey, { headSha, baseSha, headRepoFullName, baseRepoFullName, fetchedAt: Date.now() });
   }
 
   let blobRepo: GitHubRepo;
   let ref: string;
   if (input.side === "new") {
-    const headRepo = repoFromPullSide(head.repo, repo.remoteHost);
+    const headRepo = repoFromFullName(headRepoFullName, repo.remoteHost);
     if (!headRepo) {
       return {
         ok: false,
@@ -1844,7 +1878,7 @@ export async function getGitHubPullBlob(input: GetGitHubPullBlobInput): Promise<
     blobRepo = headRepo;
     ref = headSha;
   } else {
-    blobRepo = repoFromPullSide(base.repo, repo.remoteHost) ?? repo;
+    blobRepo = repoFromFullName(baseRepoFullName, repo.remoteHost) ?? repo;
     const cacheKey = `${repo.remoteHost}/${repoSlug(repo)}#${input.number}@${headSha}`;
     const cached = mergeBaseCache.get(cacheKey);
     if (cached) {
@@ -1888,12 +1922,12 @@ export async function getGitHubPullBlob(input: GetGitHubPullBlobInput): Promise<
   }
 
   const contentLength = Number(fileRes.headers.get("content-length") ?? 0);
-  if (contentLength > GITHUB_BLOB_MAX_BYTES) {
+  if (contentLength > MAX_BLOB_PREVIEW_BYTES) {
     return { ok: false, error: `File is too large to preview (${Math.ceil(contentLength / 1_000_000)} MB).`, status: 413 };
   }
   const buf = await fileRes.arrayBuffer().catch(() => null);
   if (!buf) return { ok: false, error: "GitHub returned an unreadable file response", status: 502 };
-  if (buf.byteLength > GITHUB_BLOB_MAX_BYTES) {
+  if (buf.byteLength > MAX_BLOB_PREVIEW_BYTES) {
     return { ok: false, error: `File is too large to preview (${Math.ceil(buf.byteLength / 1_000_000)} MB).`, status: 413 };
   }
 
@@ -1901,6 +1935,7 @@ export async function getGitHubPullBlob(input: GetGitHubPullBlobInput): Promise<
     ok: true,
     bytes: new Uint8Array(buf),
     contentType: contentTypeForBlobPath(relPath, fileRes.headers.get("content-type")),
+    ref,
   };
 }
 

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -1706,6 +1706,204 @@ export async function getGitHubPullDiff(input: GetGitHubPullDiffInput): Promise<
   };
 }
 
+interface GetGitHubPullBlobInput {
+  dir: string;
+  number: number;
+  path: string;
+  side: "old" | "new";
+}
+
+/** Structurally identical to `git-host.ts`'s `PullBlobResult` — kept as a
+ *  separate declaration (rather than imported) because `git-host.ts` is the
+ *  consumer, not the source, of this module's types; TS's structural typing
+ *  makes the two interchangeable at the `pullBlob` dispatch call site. */
+type GitHubBlobResult =
+  | { ok: true; bytes: Uint8Array; contentType: string }
+  | { ok: false; error: string; status?: number };
+
+const GITHUB_BLOB_MAX_BYTES = 20_000_000;
+
+/** Merge-base sha cache for the "old" side of a PR blob fetch, keyed
+ *  `${remoteHost}/${owner}/${name}#${number}@${headSha}` — the `.diff` media
+ *  type `getGitHubPullDiff` renders is a three-dot (merge-base-anchored)
+ *  diff, so the old side of a binary file must be read at the merge base,
+ *  not `base.sha` (which drifts if the base branch moves after the PR was
+ *  opened). Bounded with a crude size guard rather than an LRU — a single
+ *  workstation's Git Integration modal won't realistically open enough
+ *  distinct PRs in one process lifetime to make eviction policy matter. */
+const mergeBaseCache = new Map<string, string>();
+const MERGE_BASE_CACHE_LIMIT = 200;
+
+function cacheMergeBase(key: string, sha: string): void {
+  if (mergeBaseCache.size >= MERGE_BASE_CACHE_LIMIT && !mergeBaseCache.has(key)) {
+    mergeBaseCache.clear();
+  }
+  mergeBaseCache.set(key, sha);
+}
+
+/** Builds a `GitHubRepo` from a PR's `head.repo`/`base.repo` JSON object
+ *  (`{ full_name: "owner/name" }`), reusing the *original* repo's
+ *  `remoteHost` — the fork lives on the same git host, and tokens are
+ *  stored per-host, not per-repo (see `githubToken`'s doc comment). Returns
+ *  null when the embedded repo is absent (e.g. the fork was deleted), same
+ *  as `normalizeMergeability`'s `headRepo` handling. */
+function repoFromPullSide(raw: unknown, host: string): GitHubRepo | null {
+  if (!raw || typeof raw !== "object") return null;
+  const fullName = (raw as Record<string, unknown>).full_name;
+  if (typeof fullName !== "string") return null;
+  const slash = fullName.indexOf("/");
+  if (slash === -1) return null;
+  return { owner: fullName.slice(0, slash), name: fullName.slice(slash + 1), remoteHost: host };
+}
+
+/** Extension → content-type for a binary diff preview. Deliberately doesn't
+ *  trust GitHub's Contents API response content-type for known preview
+ *  extensions (server-guessed types can be generic like
+ *  `application/octet-stream`) — only falls back to it when the extension
+ *  isn't one of the previewable kinds `binaryPreviewKind` (shared/attachments.ts)
+ *  recognizes. Pure. */
+function contentTypeForBlobPath(path: string, fallback: string | null): string {
+  const base = path.split("/").pop() ?? "";
+  const dot = base.lastIndexOf(".");
+  const ext = dot === -1 ? "" : base.slice(dot + 1).toLowerCase();
+  const known: Record<string, string> = {
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    webp: "image/webp",
+    svg: "image/svg+xml",
+    bmp: "image/bmp",
+    ico: "image/x-icon",
+    avif: "image/avif",
+    heic: "image/heic",
+    pdf: "application/pdf",
+  };
+  return known[ext] ?? fallback ?? "application/octet-stream";
+}
+
+/** Fetches the raw bytes of a single file from one side (old/new) of a
+ *  GitHub pull request's diff, for the binary-preview UI. Dispatched through
+ *  `git-host.ts`'s `pullBlob` (the GitLab/Bitbucket branches there return
+ *  `501 unsupported` without reaching this module).
+ *
+ *  - `side: "new"` reads the file at `head.sha`, from the *head* repo (a
+ *    fork for a cross-repo PR).
+ *  - `side: "old"` reads the file at the PR's merge-base commit (resolved
+ *    via the compare API and cached — see `mergeBaseCache`), from the *base*
+ *    repo — `base.sha` would be wrong once the base branch has moved past
+ *    where the PR forked from it, and the UI's diff is merge-base-anchored
+ *    (`getGitHubPullDiff` fetches the three-dot `.diff` media type).
+ *
+ *  Bytes come from the Contents API's raw media type
+ *  (`Accept: application/vnd.github.raw`), which — unlike the default JSON+
+ *  base64 response — isn't capped at ~1MB, matching `MAX_BLOB_PREVIEW_BYTES`
+ *  intent on the caller side. Size is checked twice: from `content-length`
+ *  before reading the body (cheap rejection of an obviously-too-large file),
+ *  and again against the actual byte count after `arrayBuffer()` (GitHub can
+ *  send a chunked response with no `content-length`). */
+export async function getGitHubPullBlob(input: GetGitHubPullBlobInput): Promise<GitHubBlobResult> {
+  const repo = await repoForDir(input.dir);
+  if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
+  if (!Number.isInteger(input.number) || input.number <= 0) {
+    return { ok: false, error: "pull request number must be positive", status: 400 };
+  }
+  const relPath = input.path.trim().replace(/^\/+/, "");
+  if (!relPath) return { ok: false, error: "file path is required", status: 400 };
+
+  const token = await githubToken(repo.remoteHost ?? null);
+  const prUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+  const prRes = await fetchGitHub(prUrl, token, "application/vnd.github+json");
+  if (!("status" in prRes)) return { ok: false, error: prRes.error, status: 502 };
+  const prJson = await prRes.json().catch(() => null);
+  if (!prRes.ok) {
+    return prRes.status === 404
+      ? { ok: false, error: "pull request not found", status: 404 }
+      : { ok: false, error: apiError(prJson, prRes.status, prRes.statusText), status: prRes.status };
+  }
+  const pr = prJson && typeof prJson === "object" ? (prJson as Record<string, unknown>) : {};
+  const head = pr.head && typeof pr.head === "object" ? pr.head as Record<string, unknown> : {};
+  const base = pr.base && typeof pr.base === "object" ? pr.base as Record<string, unknown> : {};
+  const headSha = typeof head.sha === "string" ? head.sha : null;
+  const baseSha = typeof base.sha === "string" ? base.sha : null;
+  if (!headSha || !baseSha) {
+    return { ok: false, error: "GitHub returned a pull request without head/base sha", status: 502 };
+  }
+
+  let blobRepo: GitHubRepo;
+  let ref: string;
+  if (input.side === "new") {
+    const headRepo = repoFromPullSide(head.repo, repo.remoteHost);
+    if (!headRepo) {
+      return {
+        ok: false,
+        error: "the head repository for this pull request is unavailable (the fork may have been deleted)",
+        status: 404,
+      };
+    }
+    blobRepo = headRepo;
+    ref = headSha;
+  } else {
+    blobRepo = repoFromPullSide(base.repo, repo.remoteHost) ?? repo;
+    const cacheKey = `${repo.remoteHost}/${repoSlug(repo)}#${input.number}@${headSha}`;
+    const cached = mergeBaseCache.get(cacheKey);
+    if (cached) {
+      ref = cached;
+    } else {
+      const compareUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/compare/`
+        + `${encodeURIComponent(baseSha)}...${encodeURIComponent(headSha)}`;
+      const compareRes = await fetchGitHub(compareUrl, token, "application/vnd.github+json");
+      if (!("status" in compareRes)) return { ok: false, error: compareRes.error, status: 502 };
+      const compareJson = await compareRes.json().catch(() => null);
+      if (!compareRes.ok) {
+        return { ok: false, error: apiError(compareJson, compareRes.status, compareRes.statusText), status: compareRes.status };
+      }
+      const mergeBaseObj = compareJson && typeof compareJson === "object"
+        ? (compareJson as Record<string, unknown>).merge_base_commit
+        : null;
+      const mergeBaseSha = mergeBaseObj && typeof mergeBaseObj === "object"
+        && typeof (mergeBaseObj as Record<string, unknown>).sha === "string"
+        ? (mergeBaseObj as Record<string, unknown>).sha as string
+        : null;
+      if (!mergeBaseSha) {
+        return { ok: false, error: "GitHub did not return a merge base for this pull request", status: 502 };
+      }
+      ref = mergeBaseSha;
+      cacheMergeBase(cacheKey, ref);
+    }
+  }
+
+  const fileUrl = `${contentsUrl(blobRepo, relPath)}?ref=${encodeURIComponent(ref)}`;
+  const fileRes = await fetchGitHub(fileUrl, token, "application/vnd.github.raw");
+  if (!("status" in fileRes)) return { ok: false, error: fileRes.error, status: 502 };
+  if (fileRes.status === 404) return { ok: false, error: "file not present on this side", status: 404 };
+  if (!fileRes.ok) {
+    const raw = await fileRes.text().catch(() => "");
+    let msg = raw;
+    try {
+      const parsed = JSON.parse(raw) as { message?: unknown };
+      if (typeof parsed.message === "string") msg = parsed.message;
+    } catch { /* raw-media error bodies are sometimes plain text */ }
+    return { ok: false, error: msg || `${fileRes.status} ${fileRes.statusText}`, status: fileRes.status };
+  }
+
+  const contentLength = Number(fileRes.headers.get("content-length") ?? 0);
+  if (contentLength > GITHUB_BLOB_MAX_BYTES) {
+    return { ok: false, error: `File is too large to preview (${Math.ceil(contentLength / 1_000_000)} MB).`, status: 413 };
+  }
+  const buf = await fileRes.arrayBuffer().catch(() => null);
+  if (!buf) return { ok: false, error: "GitHub returned an unreadable file response", status: 502 };
+  if (buf.byteLength > GITHUB_BLOB_MAX_BYTES) {
+    return { ok: false, error: `File is too large to preview (${Math.ceil(buf.byteLength / 1_000_000)} MB).`, status: 413 };
+  }
+
+  return {
+    ok: true,
+    bytes: new Uint8Array(buf),
+    contentType: contentTypeForBlobPath(relPath, fileRes.headers.get("content-type")),
+  };
+}
+
 /** `GET /repos/:o/:r/pulls/:number` — a single pull request by number,
  *  normalized through the same `normalizeItem` mapper `reopenGitHubPull` and
  *  `listGitHubItems` use, so the UI's PR detail subpage renders an item

--- a/src/bun/gitlab-network.test.ts
+++ b/src/bun/gitlab-network.test.ts
@@ -5,14 +5,16 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
 import { gitlabMergeRequest, mockGitLabFetch, sampleRepo } from "./gitlab-test-util.ts";
 import {
+  __gitlabInternals,
   closeGitLabPull,
   createGitLabComment,
   createGitLabIssue,
   createGitLabPull,
   createGitLabPullLineComment,
+  getGitLabPullBlob,
   getGitLabPullChecks,
   getGitLabPullDefaults,
   getGitLabPullDiff,
@@ -30,6 +32,18 @@ import {
 } from "./gitlab.ts";
 
 const REPO = sampleRepo();
+
+// getGitLabPullBlob caches an MR's resolved base/head sha + source/target
+// project ids across calls (pullBlobDetailCache, 60s TTL) — bun test shares
+// one process across every *.test.ts file, and git-host.test.ts's own
+// pull-blob happy-path test primes that cache with gitlab.com/acme/app#1.
+// Reset before every test in this file (not just the getGitLabPullBlob
+// section) so no test here can observe a stale entry left by another file,
+// regardless of run order. The tests below also use MR numbers (21-27+)
+// distinct from git-host.test.ts's #1 as defense in depth.
+beforeEach(() => {
+  __gitlabInternals.resetGitLabPullBlobCaches();
+});
 
 // gitlab.ts resolves its token via github-tokens.ts's raw-host-keyed store
 // first, falling back to GITLAB_TOKEN env (see git-provider.ts's
@@ -281,6 +295,190 @@ test("getGitLabPullDiff hits raw_diffs and parses the plain-text unified diff in
     expect(res.ok).toBe(true);
     if (!res.ok) throw new Error(res.error);
     expect(res.files.map((f) => f.path)).toEqual(["foo.ts"]);
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// getGitLabPullBlob
+// ---------------------------------------------------------------------------
+
+test("getGitLabPullBlob old side: reads diff_refs.base_sha from the target project, encoding a subdir+space path as %2F/%20", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: /\/merge_requests\/21$/,
+      json: { iid: 21, diff_refs: { base_sha: "base-old-1", head_sha: "head-new-1" }, source_project_id: 55, target_project_id: 55 },
+    },
+    {
+      match: /\/projects\/acme%2Fapp\/repository\/files\/assets%2Fsub%2Fmy%20file\.png\/raw\?ref=base-old-1$/,
+      text: "OLDBYTES",
+      headers: { "content-type": "application/octet-stream" },
+    },
+  ]);
+  try {
+    const res = await getGitLabPullBlob(REPO, 21, "assets/sub/my file.png", "old");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.ref).toBe("base-old-1");
+    expect(res.contentType).toBe("image/png");
+    expect(new TextDecoder().decode(res.bytes)).toBe("OLDBYTES");
+    expect(mock.calls.some((c) => c.url.includes("/repository/files/assets%2Fsub%2Fmy%20file.png/raw?ref=base-old-1"))).toBe(true);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullBlob new side: reads diff_refs.head_sha", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: /\/merge_requests\/21$/,
+      json: { iid: 21, diff_refs: { base_sha: "base-old-1", head_sha: "head-new-1" }, source_project_id: 55, target_project_id: 55 },
+    },
+    {
+      match: /\/repository\/files\/assets%2Fsub%2Fmy%20file\.png\/raw\?ref=head-new-1$/,
+      text: "NEWBYTES",
+    },
+  ]);
+  try {
+    const res = await getGitLabPullBlob(REPO, 21, "assets/sub/my file.png", "new");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.ref).toBe("head-new-1");
+    expect(new TextDecoder().decode(res.bytes)).toBe("NEWBYTES");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullBlob falls back to /versions when diff_refs is missing, using the latest version's shas", async () => {
+  const mock = mockGitLabFetch([
+    { match: /\/merge_requests\/22$/, json: { iid: 22, source_project_id: 9, target_project_id: 9 } },
+    {
+      match: "/merge_requests/22/versions",
+      json: [
+        { base_commit_sha: "vbase-latest", head_commit_sha: "vhead-latest" },
+        { base_commit_sha: "vbase-older", head_commit_sha: "vhead-older" },
+      ],
+    },
+    { match: /\/raw\?ref=vbase-latest$/, text: "VERSIONED" },
+  ]);
+  try {
+    const res = await getGitLabPullBlob(REPO, 22, "readme.png", "old");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.ref).toBe("vbase-latest");
+    expect(mock.calls.some((c) => c.url.includes("/merge_requests/22/versions"))).toBe(true);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullBlob fork MR: new side fetches the numeric source_project_id, old side still fetches the target project", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: /\/merge_requests\/23$/,
+      json: { iid: 23, diff_refs: { base_sha: "fbase", head_sha: "fhead" }, source_project_id: 777, target_project_id: 888 },
+    },
+    { match: /\/projects\/777\/repository\/files\/.*\/raw\?ref=fhead$/, text: "FORKBYTES" },
+    { match: /\/projects\/acme%2Fapp\/repository\/files\/.*\/raw\?ref=fbase$/, text: "TARGETBYTES" },
+  ]);
+  try {
+    const newRes = await getGitLabPullBlob(REPO, 23, "img.png", "new");
+    expect(newRes.ok).toBe(true);
+    if (!newRes.ok) throw new Error(newRes.error);
+    expect(newRes.ref).toBe("fhead");
+    expect(mock.calls.some((c) => c.url.includes("/projects/777/repository/files/"))).toBe(true);
+
+    const oldRes = await getGitLabPullBlob(REPO, 23, "img.png", "old");
+    expect(oldRes.ok).toBe(true);
+    if (!oldRes.ok) throw new Error(oldRes.error);
+    expect(oldRes.ref).toBe("fbase");
+    expect(mock.calls.some((c) => c.url.includes("/projects/acme%2Fapp/repository/files/"))).toBe(true);
+
+    // Only one MR detail fetch across both calls — the detail cache is warm
+    // after the first call.
+    expect(mock.calls.filter((c) => /\/merge_requests\/23$/.test(c.url))).toHaveLength(1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullBlob fork 404 retry: a 404 on the fork's raw file is retried once against the target project", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: /\/merge_requests\/24$/,
+      json: { iid: 24, diff_refs: { base_sha: "fbase2", head_sha: "fhead2" }, source_project_id: 777, target_project_id: 888 },
+    },
+    { match: /\/projects\/777\/repository\/files\/.*\/raw\?ref=fhead2$/, status: 404, json: { message: "404 Project Not Found" } },
+    { match: /\/projects\/acme%2Fapp\/repository\/files\/.*\/raw\?ref=fhead2$/, text: "RETRIED_OK" },
+  ]);
+  try {
+    const res = await getGitLabPullBlob(REPO, 24, "img.png", "new");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.ref).toBe("fhead2");
+    expect(new TextDecoder().decode(res.bytes)).toBe("RETRIED_OK");
+    expect(mock.calls.some((c) => c.url.includes("/projects/777/repository/files/"))).toBe(true);
+    expect(mock.calls.some((c) => c.url.includes("/projects/acme%2Fapp/repository/files/"))).toBe(true);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullBlob detail-cache: two blob calls for the same MR only issue ONE detail fetch", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: /\/merge_requests\/25$/,
+      json: { iid: 25, diff_refs: { base_sha: "cbase", head_sha: "chead" }, source_project_id: 3, target_project_id: 3 },
+    },
+    { match: /\/raw\?ref=cbase$/, text: "A" },
+    { match: /\/raw\?ref=chead$/, text: "B" },
+  ]);
+  try {
+    const res1 = await getGitLabPullBlob(REPO, 25, "a.png", "old");
+    const res2 = await getGitLabPullBlob(REPO, 25, "a.png", "new");
+    expect(res1.ok).toBe(true);
+    expect(res2.ok).toBe(true);
+    expect(mock.calls.filter((c) => /\/merge_requests\/25$/.test(c.url))).toHaveLength(1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullBlob returns {ok:false, status:404} when the raw file is not present (non-fork)", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: /\/merge_requests\/26$/,
+      json: { iid: 26, diff_refs: { base_sha: "dbase", head_sha: "dhead" }, source_project_id: 4, target_project_id: 4 },
+    },
+    { match: /\/raw\?ref=dhead$/, status: 404, json: { message: "404 File Not Found" } },
+  ]);
+  try {
+    const res = await getGitLabPullBlob(REPO, 26, "missing.png", "new");
+    expect(res).toEqual({ ok: false, error: "file not present on this side", status: 404 });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("getGitLabPullBlob returns 413 from content-length alone, without needing to read a large body", async () => {
+  const mock = mockGitLabFetch([
+    {
+      match: /\/merge_requests\/27$/,
+      json: { iid: 27, diff_refs: { base_sha: "ebase", head_sha: "ehead" }, source_project_id: 6, target_project_id: 6 },
+    },
+    // The response body itself is tiny — the 413 must come purely from the
+    // content-length header check, before `.arrayBuffer()` is ever called.
+    { match: /\/raw\?ref=ehead$/, text: "x", headers: { "content-length": "21000000" } },
+  ]);
+  try {
+    const res = await getGitLabPullBlob(REPO, 27, "huge.png", "new");
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.status).toBe(413);
+    expect(res.error).toContain("21 MB");
+    expect(mock.calls.filter((c) => c.url.includes("/raw?ref=ehead"))).toHaveLength(1);
   } finally {
     mock.restore();
   }

--- a/src/bun/gitlab-network.test.ts
+++ b/src/bun/gitlab-network.test.ts
@@ -5,8 +5,9 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
-import { gitlabMergeRequest, mockGitLabFetch, sampleRepo } from "./gitlab-test-util.ts";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "bun:test";
+import { __clearApiHostCacheForTest } from "./git-provider.ts";
+import { gitlabMergeRequest, mockGitLabFetch, sampleAliasRepo, sampleRepo, sampleSelfHostedRepo, writeSshStub } from "./gitlab-test-util.ts";
 import {
   __gitlabInternals,
   closeGitLabPull,
@@ -41,8 +42,37 @@ const REPO = sampleRepo();
 // section) so no test here can observe a stale entry left by another file,
 // regardless of run order. The tests below also use MR numbers (21-27+)
 // distinct from git-host.test.ts's #1 as defense in depth.
+//
+// gitlabApiBase (docs/plans/per-host-git-api-bases.md) resolves every call's
+// host via apiHostForRemote (git-provider.ts), which spawns `ssh -G` unless
+// AGETOR_SSH_BIN points elsewhere and caches by raw remoteHost — same
+// process-sharing hazard as pullBlobDetailCache, plus a second one: an
+// un-stubbed `ssh -G -- gitlab.com` would depend on whatever real
+// ~/.ssh/config the machine running the suite happens to have. An identity
+// stub (echoes its input back as `hostname <input>`) is installed as the
+// default AGETOR_SSH_BIN for every test in this file — it reproduces
+// production's plain-domain behavior (no matching alias → echo) for every
+// existing test's `sampleRepo()`/`sampleSelfHostedRepo()` fixtures without
+// depending on the real `ssh` binary or config, and is overridden locally by
+// the alias-to-cloud regression test below, which needs a stub that resolves
+// to gitlab.com regardless of input. `__clearApiHostCacheForTest` is called
+// both before (so a previous test's resolution can't leak in) and after (so
+// this file's own resolutions can't leak into a later file — git-host.test.ts
+// primes gitlab caches too) each test, mirroring the pullBlobDetailCache
+// hygiene above. AGETOR_SSH_BIN itself is saved/restored per test for the
+// same cross-file reason.
+const ORIGINAL_SSH_BIN = process.env.AGETOR_SSH_BIN;
+
 beforeEach(() => {
   __gitlabInternals.resetGitLabPullBlobCaches();
+  __clearApiHostCacheForTest();
+  process.env.AGETOR_SSH_BIN = writeSshStub('#!/bin/sh\necho "hostname $3"\n');
+});
+
+afterEach(() => {
+  __clearApiHostCacheForTest();
+  if (ORIGINAL_SSH_BIN === undefined) delete process.env.AGETOR_SSH_BIN;
+  else process.env.AGETOR_SSH_BIN = ORIGINAL_SSH_BIN;
 });
 
 // gitlab.ts resolves its token via github-tokens.ts's raw-host-keyed store
@@ -1110,6 +1140,88 @@ test("normalizeGitLabMergeability: headSha falls back to the top-level sha when 
 test("normalizeGitLabMergeability: autoMerge:true from merge_when_pipeline_succeeds", () => {
   const result = normalizeGitLabMergeability(REPO, 5, gitlabMergeRequest({ merge_when_pipeline_succeeds: true }));
   expect(result?.autoMerge).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// gitlabApiBase — per-host routing (docs/plans/per-host-git-api-bases.md)
+// ---------------------------------------------------------------------------
+
+test("self-hosted GitLab: getGitLabPullDiff, getGitLabPullBlob, and getGitLabPullDefaults all hit https://gitlab.mycompany.com/api/v4/...", async () => {
+  const repo = sampleSelfHostedRepo();
+  // The file-wide beforeEach installs an identity AGETOR_SSH_BIN stub (echoes
+  // its input), so this self-hosted domain — no ssh alias involved — resolves
+  // to itself, exactly like production's fallback for an unrecognized host.
+
+  const diffMock = mockGitLabFetch([{ match: "/merge_requests/90/raw_diffs", text: "" }]);
+  try {
+    const res = await getGitLabPullDiff(repo, 90);
+    expect(res.ok).toBe(true);
+    expect(diffMock.calls).toHaveLength(1);
+    expect(diffMock.calls[0]!.url.startsWith("https://gitlab.mycompany.com/api/v4/")).toBe(true);
+  } finally {
+    diffMock.restore();
+  }
+
+  const defaultsMock = mockGitLabFetch([{ match: "/api/v4/projects/acme%2Fapp", json: { default_branch: "main" } }]);
+  try {
+    const res = await getGitLabPullDefaults(repo);
+    expect(res).toEqual({ ok: true, repo: "acme/app", head: "", base: "main" });
+    expect(defaultsMock.calls[0]!.url.startsWith("https://gitlab.mycompany.com/api/v4/")).toBe(true);
+  } finally {
+    defaultsMock.restore();
+  }
+
+  const blobMock = mockGitLabFetch([
+    {
+      match: /\/merge_requests\/91$/,
+      json: { iid: 91, diff_refs: { base_sha: "base-91", head_sha: "head-91" }, source_project_id: 55, target_project_id: 55 },
+    },
+    {
+      match: /\/repository\/files\/img\.png\/raw\?ref=head-91$/,
+      text: "BYTES",
+      headers: { "content-type": "application/octet-stream" },
+    },
+  ]);
+  try {
+    const res = await getGitLabPullBlob(repo, 91, "img.png", "new");
+    expect(res.ok).toBe(true);
+    for (const call of blobMock.calls) {
+      expect(call.url.startsWith("https://gitlab.mycompany.com/api/v4/")).toBe(true);
+    }
+  } finally {
+    blobMock.restore();
+  }
+});
+
+test("alias-to-cloud regression guard: an ssh alias whose HostName resolves to gitlab.com keeps hitting https://gitlab.com/api/v4/... (byte-identical to today)", async () => {
+  // Overrides the file-wide identity stub with one that always resolves to
+  // gitlab.com, regardless of the input host — modeling a `~/.ssh/config`
+  // multi-identity alias (`Host gitlab-work.io` / `HostName gitlab.com`).
+  process.env.AGETOR_SSH_BIN = writeSshStub("#!/bin/sh\necho 'hostname gitlab.com'\n");
+  __clearApiHostCacheForTest();
+  const repo = sampleAliasRepo("gitlab-work.io");
+
+  const mock = mockGitLabFetch([{ match: "/merge_requests/92/raw_diffs", text: "" }]);
+  try {
+    const res = await getGitLabPullDiff(repo, 92);
+    expect(res.ok).toBe(true);
+    expect(mock.calls[0]!.url.startsWith("https://gitlab.com/api/v4/")).toBe(true);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("self-hosted GitLab: listGitLabItems' synthesized webUrl uses the self-hosted host, not gitlab.com", async () => {
+  const repo = sampleSelfHostedRepo();
+  const mock = mockGitLabFetch([{ match: "merge_requests", json: [] }]);
+  try {
+    const res = await listGitLabItems(repo, { kind: "pulls", state: "open" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.webUrl).toBe("https://gitlab.mycompany.com/acme/app");
+  } finally {
+    mock.restore();
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/src/bun/gitlab-network.test.ts
+++ b/src/bun/gitlab-network.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "bun:test";
 import { __clearApiHostCacheForTest } from "./git-provider.ts";
-import { gitlabMergeRequest, mockGitLabFetch, sampleAliasRepo, sampleRepo, sampleSelfHostedRepo, writeSshStub } from "./gitlab-test-util.ts";
+import { cleanupSshStubs, gitlabMergeRequest, mockGitLabFetch, sampleAliasRepo, sampleRepo, sampleSelfHostedRepo, writeSshStub } from "./gitlab-test-util.ts";
 import {
   __gitlabInternals,
   closeGitLabPull,
@@ -71,6 +71,7 @@ beforeEach(() => {
 
 afterEach(() => {
   __clearApiHostCacheForTest();
+  cleanupSshStubs();
   if (ORIGINAL_SSH_BIN === undefined) delete process.env.AGETOR_SSH_BIN;
   else process.env.AGETOR_SSH_BIN = ORIGINAL_SSH_BIN;
 });

--- a/src/bun/gitlab-test-util.ts
+++ b/src/bun/gitlab-test-util.ts
@@ -10,7 +10,7 @@
 // `mockGitHubFetch` (github-test-util.ts) is host-agnostic — it just matches
 // on the request URL/method against a route table over `globalThis.fetch` —
 // so it is reused directly here rather than re-implemented.
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { ProviderRepoInfo } from "../shared/types.ts";
@@ -47,19 +47,36 @@ export function sampleSelfHostedRepo(selfHostedHost = "gitlab.mycompany.com", ov
   return sampleRepo({ host: selfHostedHost, remoteHost: selfHostedHost, ...overrides });
 }
 
+/** Every mkdtemp dir `writeSshStub` has created, in creation order — drained
+ *  by `cleanupSshStubs()`. Module-level (not per-call cleanup) because the
+ *  stub's path is handed to callers via `AGETOR_SSH_BIN` and may outlive the
+ *  call that created it for the rest of a test. */
+const createdSshStubDirs: string[] = [];
+
 /** Writes an executable stub standing in for `ssh`, for pointing
  *  `AGETOR_SSH_BIN` (git-provider.ts's `apiHostForRemote` override) at
  *  deterministic, network-free hostname resolution — mirrors
  *  git-provider.test.ts's own `writeSshStub`. `apiHostForRemote` invokes it
  *  as `<stub> -G -- <host>`, so `$3` is the (lowercased, trimmed) host
  *  argument when a stub cares to inspect it. Each call gets its own
- *  throwaway mkdtemp dir under the OS tmp root, which the OS reclaims —
- *  callers don't need to track it for cleanup. */
+ *  throwaway mkdtemp dir under the OS tmp root; the dir is tracked
+ *  module-internally and only removed when the caller invokes
+ *  `cleanupSshStubs()` (e.g. from an `afterEach`/`afterAll`) — mirroring
+ *  git-provider.test.ts's own `createdDirs` pattern. */
 export function writeSshStub(script: string): string {
   const dir = mkdtempSync(path.join(tmpdir(), "agetor-gitlab-ssh-stub-"));
+  createdSshStubDirs.push(dir);
   const binPath = path.join(dir, "ssh");
   writeFileSync(binPath, script, { mode: 0o755 });
   return binPath;
+}
+
+/** Removes every mkdtemp dir created by `writeSshStub` so far and clears the
+ *  tracking list. Consumers should call this from an `afterEach`/`afterAll`
+ *  to avoid leaking one throwaway dir per `writeSshStub` call. */
+export function cleanupSshStubs(): void {
+  for (const dir of createdSshStubDirs) rmSync(dir, { recursive: true, force: true });
+  createdSshStubDirs.length = 0;
 }
 
 /** A minimal-but-valid GitLab merge-request JSON object (REST v4 shape), as

--- a/src/bun/gitlab-test-util.ts
+++ b/src/bun/gitlab-test-util.ts
@@ -10,6 +10,9 @@
 // `mockGitHubFetch` (github-test-util.ts) is host-agnostic — it just matches
 // on the request URL/method against a route table over `globalThis.fetch` —
 // so it is reused directly here rather than re-implemented.
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { ProviderRepoInfo } from "../shared/types.ts";
 
 export { mockGitHubFetch as mockGitLabFetch } from "./github-test-util.ts";
@@ -34,6 +37,29 @@ export function sampleRepo(overrides: Partial<ProviderRepoInfo> = {}): ProviderR
  *  token-routing path the same way `makeAliasGitHubRepo` does for GitHub. */
 export function sampleAliasRepo(aliasHost = "gitlab-work.io", overrides: Partial<ProviderRepoInfo> = {}): ProviderRepoInfo {
   return sampleRepo({ remoteHost: aliasHost, ...overrides });
+}
+
+/** Same as `sampleRepo`, but pointed at a genuine self-hosted GitLab domain
+ *  (docs/plans/per-host-git-api-bases.md) — both `host` and `remoteHost` are
+ *  the self-hosted domain itself (no ssh alias involved), exercising
+ *  `gitlabApiBase`'s per-host routing in gitlab-network.test.ts. */
+export function sampleSelfHostedRepo(selfHostedHost = "gitlab.mycompany.com", overrides: Partial<ProviderRepoInfo> = {}): ProviderRepoInfo {
+  return sampleRepo({ host: selfHostedHost, remoteHost: selfHostedHost, ...overrides });
+}
+
+/** Writes an executable stub standing in for `ssh`, for pointing
+ *  `AGETOR_SSH_BIN` (git-provider.ts's `apiHostForRemote` override) at
+ *  deterministic, network-free hostname resolution — mirrors
+ *  git-provider.test.ts's own `writeSshStub`. `apiHostForRemote` invokes it
+ *  as `<stub> -G -- <host>`, so `$3` is the (lowercased, trimmed) host
+ *  argument when a stub cares to inspect it. Each call gets its own
+ *  throwaway mkdtemp dir under the OS tmp root, which the OS reclaims —
+ *  callers don't need to track it for cleanup. */
+export function writeSshStub(script: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "agetor-gitlab-ssh-stub-"));
+  const binPath = path.join(dir, "ssh");
+  writeFileSync(binPath, script, { mode: 0o755 });
+  return binPath;
 }
 
 /** A minimal-but-valid GitLab merge-request JSON object (REST v4 shape), as

--- a/src/bun/gitlab.ts
+++ b/src/bun/gitlab.ts
@@ -28,8 +28,10 @@ import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
 import { apiHostForRemote, gitlabToken } from "./git-provider.ts";
 
 /**
- * GitLab Cloud (gitlab.com, REST API v4) adapter (T2,
- * docs/plans/multi-provider-git-modal.md §4). Mirrors `src/bun/github.ts`'s
+ * GitLab adapter (T2, docs/plans/multi-provider-git-modal.md §4) — gitlab.com
+ * as well as self-hosted instances, both addressed via
+ * `apiHostForRemote`-derived `https://<host>/api/v4` (see
+ * docs/plans/per-host-git-api-bases.md). Mirrors `src/bun/github.ts`'s
  * conventions closely enough that the facade (`git-host.ts`, T4) can dispatch
  * to either module transparently: same `{ok:true}&Result | {ok:false,error}`
  * result-union style, a 30s AbortController fetch timeout, `user-agent:

--- a/src/bun/gitlab.ts
+++ b/src/bun/gitlab.ts
@@ -669,6 +669,14 @@ function cachePullBlobDetail(key: string, entry: GitLabPullBlobDetailCacheEntry)
   pullBlobDetailCache.set(key, entry);
 }
 
+/** Test-only: clears `pullBlobDetailCache`. bun test shares a process across
+ *  files, so a test that primes the cache (e.g. git-host.test.ts's happy-path
+ *  pull-blob test) would otherwise leak a stale entry into a later network
+ *  test in this module — network tests should call this from `beforeEach`. */
+function resetGitLabPullBlobCaches(): void {
+  pullBlobDetailCache.clear();
+}
+
 /** Content-type for a binary diff preview, from the shared canonical
  *  extension→MIME map — mirrors github.ts's `contentTypeForBlobPath`. Pure —
  *  unit-tested via `__gitlabInternals`. */
@@ -768,21 +776,34 @@ export async function getGitLabPullBlob(
 
   let ref: string;
   let blobProjectId: string;
+  let isFork = false;
   if (side === "new") {
     ref = headSha;
     // Fail closed to the target project (the one we have an owner/name slug
     // for) unless both ids are confirmed numbers and actually differ — an
     // unconfirmed id is not a safe basis for routing to a different project.
-    const isFork = sourceProjectId !== null && targetProjectId !== null && sourceProjectId !== targetProjectId;
+    isFork = sourceProjectId !== null && targetProjectId !== null && sourceProjectId !== targetProjectId;
     blobProjectId = isFork ? String(sourceProjectId) : projectId;
   } else {
     ref = baseSha;
     blobProjectId = projectId;
   }
 
-  const fileUrl = `${GITLAB_API_BASE}/projects/${blobProjectId}/repository/files/${encodeURIComponent(path)}/raw?ref=${encodeURIComponent(ref)}`;
-  const fileRes = await fetchGitLab(fileUrl, token, { accept: "*/*" });
+  const buildFileUrl = (pid: string): string =>
+    `${GITLAB_API_BASE}/projects/${pid}/repository/files/${encodeURIComponent(path)}/raw?ref=${encodeURIComponent(ref)}`;
+
+  let fileRes = await fetchGitLab(buildFileUrl(blobProjectId), token, { accept: "*/*" });
   if (!("status" in fileRes)) return { ok: false, error: fileRes.error, status: 502 };
+  if (fileRes.status === 404 && side === "new" && isFork) {
+    // A private/deleted fork can 404 on its own numeric project id even
+    // though the MR's head commit is still reachable — GitLab keeps a
+    // cross-project MR's head commit available in the *target* project via
+    // `refs/merge-requests/:iid/head`, so a same-`headSha` read against the
+    // target project usually succeeds where the fork read failed. Retry
+    // exactly once before giving up.
+    fileRes = await fetchGitLab(buildFileUrl(projectId), token, { accept: "*/*" });
+    if (!("status" in fileRes)) return { ok: false, error: fileRes.error, status: 502 };
+  }
   if (fileRes.status === 404) return { ok: false, error: "file not present on this side", status: 404 };
   if (!fileRes.ok) {
     const raw = await fileRes.text().catch(() => "");
@@ -1478,4 +1499,5 @@ export const __gitlabInternals = {
   sortItems,
   gitlabStateParams,
   contentTypeForGitLabBlobPath,
+  resetGitLabPullBlobCaches,
 };

--- a/src/bun/gitlab.ts
+++ b/src/bun/gitlab.ts
@@ -23,6 +23,7 @@ import type {
   TaskDiff,
 } from "../shared/types.ts";
 import { GIT_HOST_TOKENS_SECTION } from "../shared/types.ts";
+import { contentTypeForPreviewPath, MAX_BLOB_PREVIEW_BYTES } from "../shared/attachments.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
 import { gitlabToken } from "./git-provider.ts";
 
@@ -627,6 +628,187 @@ export async function getGitLabPullDiff(repo: ProviderRepoInfo, number: number):
     base: null,
     files,
     note: files.length === 0 ? "No diff returned for this merge request." : undefined,
+  };
+}
+
+/** Structurally identical to `git-host.ts`'s `PullBlobResult` — kept as a
+ *  separate declaration (rather than imported) for the same reason
+ *  `github.ts`'s `GitHubBlobResult` is: `git-host.ts` is the consumer, not
+ *  the source, of this module's types, and TS's structural typing makes the
+ *  two interchangeable at the `pullBlob` dispatch call site. */
+type GitLabBlobResult =
+  | { ok: true; bytes: Uint8Array<ArrayBuffer>; contentType: string; ref: string }
+  | { ok: false; error: string; status?: number };
+
+interface GitLabPullBlobDetailCacheEntry {
+  baseSha: string;
+  headSha: string;
+  /** Numeric project ids, present whenever GitLab reports them as numbers.
+   *  `null` means "couldn't confirm" — treated as same-repo (fails closed to
+   *  the project we already have an owner/name slug for, not to an
+   *  unconfirmed numeric id). */
+  sourceProjectId: number | null;
+  targetProjectId: number | null;
+  fetchedAt: number;
+}
+
+/** Short-TTL cache of an MR's resolved base/head sha + source/target project
+ *  ids, keyed `${remoteHost}/${owner}/${name}#${number}` — mirrors
+ *  github.ts's `pullDetailCache` exactly (60s TTL, 200-entry wholesale-clear
+ *  eviction) so paging through a binary file's old/new sides, or several
+ *  files in the same MR, doesn't re-fetch `GET /merge_requests/:iid` (and
+ *  possibly `/versions`) on every blob request. */
+const pullBlobDetailCache = new Map<string, GitLabPullBlobDetailCacheEntry>();
+const PULL_BLOB_DETAIL_CACHE_LIMIT = 200;
+const PULL_BLOB_DETAIL_CACHE_TTL_MS = 60_000;
+
+function cachePullBlobDetail(key: string, entry: GitLabPullBlobDetailCacheEntry): void {
+  if (pullBlobDetailCache.size >= PULL_BLOB_DETAIL_CACHE_LIMIT && !pullBlobDetailCache.has(key)) {
+    pullBlobDetailCache.clear();
+  }
+  pullBlobDetailCache.set(key, entry);
+}
+
+/** Content-type for a binary diff preview, from the shared canonical
+ *  extension→MIME map — mirrors github.ts's `contentTypeForBlobPath`. Pure —
+ *  unit-tested via `__gitlabInternals`. */
+function contentTypeForGitLabBlobPath(path: string, fallback: string | null): string {
+  return contentTypeForPreviewPath(path) ?? fallback ?? "application/octet-stream";
+}
+
+/** Fetches the raw bytes of a single file from one side (old/new) of a
+ *  GitLab merge request's diff, for the binary-preview UI. Dispatched
+ *  through `git-host.ts`'s `pullBlob`.
+ *
+ *  - `side: "old"` reads the file at `diff_refs.base_sha` — GitLab's own
+ *    merge-base sha (unlike GitHub's `base.sha`, this one doesn't drift once
+ *    the base branch moves, so no separate compare round-trip is needed) —
+ *    from the *target* project (`repo.owner`/`repo.name`).
+ *  - `side: "new"` reads the file at `diff_refs.head_sha`, from the *source*
+ *    project — the target project for a same-repo MR, or the fork's numeric
+ *    `source_project_id` for a cross-repo one (GitLab's MR payload carries no
+ *    owner/name for the source project, only its numeric id).
+ *
+ *  `diff_refs` populates asynchronously right after an MR is created/pushed
+ *  to, so a missing/incomplete `diff_refs` falls back to the latest diff
+ *  "version" (`GET .../versions`) the same way `createGitLabPullLineComment`
+ *  does. The resolved tuple is cached — see `pullBlobDetailCache`.
+ *
+ *  Bytes come from the repository-files raw endpoint (`GET
+ *  /projects/:id/repository/files/:path/raw?ref=<sha>`), requested with a
+ *  permissive `accept` (`fetchGitLab` defaults to `application/json`, which
+ *  would be wrong for arbitrary binary bytes). Size is checked twice: from
+ *  `content-length` before reading the body, and again against the actual
+ *  byte count after `arrayBuffer()` (a chunked response can omit
+ *  `content-length`) — matching `MAX_BLOB_PREVIEW_BYTES`, not the 8MB diff
+ *  cap `getGitLabPullDiff` uses. */
+export async function getGitLabPullBlob(
+  repo: ProviderRepoInfo,
+  number: number,
+  relPath: string,
+  side: "old" | "new",
+): Promise<GitLabBlobResult> {
+  if (!Number.isInteger(number) || number <= 0) {
+    return { ok: false, error: "merge request number must be positive", status: 400 };
+  }
+  const path = relPath.trim().replace(/^\/+/, "");
+  if (!path) return { ok: false, error: "file path is required", status: 400 };
+
+  const token = await gitlabToken(repo.remoteHost);
+  const projectId = encodeProjectId(repo.owner, repo.name);
+  const detailKey = `${repo.remoteHost}/${repo.owner}/${repo.name}#${number}`;
+
+  const cached = pullBlobDetailCache.get(detailKey);
+  let baseSha: string;
+  let headSha: string;
+  let sourceProjectId: number | null;
+  let targetProjectId: number | null;
+
+  if (cached && Date.now() - cached.fetchedAt < PULL_BLOB_DETAIL_CACHE_TTL_MS) {
+    ({ baseSha, headSha, sourceProjectId, targetProjectId } = cached);
+  } else {
+    const mrRes = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`, token);
+    if (!("status" in mrRes)) return { ok: false, error: mrRes.error, status: 502 };
+    const mrJson = await mrRes.json().catch(() => null);
+    if (!mrRes.ok) {
+      return mrRes.status === 404
+        ? { ok: false, error: "merge request not found", status: 404 }
+        : { ok: false, error: errorFrom(mrRes, mrJson, repo, !!token), status: mrRes.status };
+    }
+    const obj = mrJson && typeof mrJson === "object" ? mrJson as Record<string, unknown> : {};
+    const diffRefs = obj.diff_refs && typeof obj.diff_refs === "object" ? obj.diff_refs as Record<string, unknown> : null;
+    let resolvedBaseSha = diffRefs && typeof diffRefs.base_sha === "string" ? diffRefs.base_sha : null;
+    let resolvedHeadSha = diffRefs && typeof diffRefs.head_sha === "string" ? diffRefs.head_sha : null;
+    const resolvedSourceProjectId = typeof obj.source_project_id === "number" ? obj.source_project_id : null;
+    const resolvedTargetProjectId = typeof obj.target_project_id === "number" ? obj.target_project_id : null;
+
+    if (!resolvedBaseSha || !resolvedHeadSha) {
+      // diff_refs populates async after the MR is created/pushed to — fall
+      // back to the latest diff version, same as createGitLabPullLineComment.
+      const versionsRes = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/versions`, token);
+      if (!("status" in versionsRes)) return { ok: false, error: versionsRes.error, status: 502 };
+      const versions = await versionsRes.json().catch(() => null);
+      if (!versionsRes.ok) {
+        return { ok: false, error: errorFrom(versionsRes, versions, repo, !!token), status: versionsRes.status };
+      }
+      const latest = Array.isArray(versions) && versions.length > 0 ? versions[0] as Record<string, unknown> : null;
+      resolvedBaseSha = latest && typeof latest.base_commit_sha === "string" ? latest.base_commit_sha : null;
+      resolvedHeadSha = latest && typeof latest.head_commit_sha === "string" ? latest.head_commit_sha : null;
+      if (!resolvedBaseSha || !resolvedHeadSha) {
+        return { ok: false, error: "GitLab returned no base/head commit for this merge request", status: 502 };
+      }
+    }
+
+    baseSha = resolvedBaseSha;
+    headSha = resolvedHeadSha;
+    sourceProjectId = resolvedSourceProjectId;
+    targetProjectId = resolvedTargetProjectId;
+    cachePullBlobDetail(detailKey, { baseSha, headSha, sourceProjectId, targetProjectId, fetchedAt: Date.now() });
+  }
+
+  let ref: string;
+  let blobProjectId: string;
+  if (side === "new") {
+    ref = headSha;
+    // Fail closed to the target project (the one we have an owner/name slug
+    // for) unless both ids are confirmed numbers and actually differ — an
+    // unconfirmed id is not a safe basis for routing to a different project.
+    const isFork = sourceProjectId !== null && targetProjectId !== null && sourceProjectId !== targetProjectId;
+    blobProjectId = isFork ? String(sourceProjectId) : projectId;
+  } else {
+    ref = baseSha;
+    blobProjectId = projectId;
+  }
+
+  const fileUrl = `${GITLAB_API_BASE}/projects/${blobProjectId}/repository/files/${encodeURIComponent(path)}/raw?ref=${encodeURIComponent(ref)}`;
+  const fileRes = await fetchGitLab(fileUrl, token, { accept: "*/*" });
+  if (!("status" in fileRes)) return { ok: false, error: fileRes.error, status: 502 };
+  if (fileRes.status === 404) return { ok: false, error: "file not present on this side", status: 404 };
+  if (!fileRes.ok) {
+    const raw = await fileRes.text().catch(() => "");
+    let msg = raw;
+    try {
+      const parsed = JSON.parse(raw) as { message?: unknown };
+      if (typeof parsed.message === "string") msg = parsed.message;
+    } catch { /* raw-file error bodies are sometimes plain text */ }
+    return { ok: false, error: authHint(fileRes.status, msg || `${fileRes.status} ${fileRes.statusText}`, repo, !!token), status: fileRes.status };
+  }
+
+  const contentLength = Number(fileRes.headers.get("content-length") ?? 0);
+  if (contentLength > MAX_BLOB_PREVIEW_BYTES) {
+    return { ok: false, error: `File is too large to preview (${Math.ceil(contentLength / 1_000_000)} MB).`, status: 413 };
+  }
+  const buf = await fileRes.arrayBuffer().catch(() => null);
+  if (!buf) return { ok: false, error: "GitLab returned an unreadable file response", status: 502 };
+  if (buf.byteLength > MAX_BLOB_PREVIEW_BYTES) {
+    return { ok: false, error: `File is too large to preview (${Math.ceil(buf.byteLength / 1_000_000)} MB).`, status: 413 };
+  }
+
+  return {
+    ok: true,
+    bytes: new Uint8Array(buf),
+    contentType: contentTypeForGitLabBlobPath(path, fileRes.headers.get("content-type")),
+    ref,
   };
 }
 
@@ -1295,4 +1477,5 @@ export const __gitlabInternals = {
   normalizeRepoLabel,
   sortItems,
   gitlabStateParams,
+  contentTypeForGitLabBlobPath,
 };

--- a/src/bun/gitlab.ts
+++ b/src/bun/gitlab.ts
@@ -25,7 +25,7 @@ import type {
 import { GIT_HOST_TOKENS_SECTION } from "../shared/types.ts";
 import { contentTypeForPreviewPath, MAX_BLOB_PREVIEW_BYTES } from "../shared/attachments.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
-import { gitlabToken } from "./git-provider.ts";
+import { apiHostForRemote, gitlabToken } from "./git-provider.ts";
 
 /**
  * GitLab Cloud (gitlab.com, REST API v4) adapter (T2,
@@ -49,9 +49,38 @@ import { gitlabToken } from "./git-provider.ts";
  * a working directory (see its doc comment).
  */
 
-const GITLAB_API_BASE = "https://gitlab.com/api/v4";
+/** GitLab's cloud hostname — kept as a named constant for the handful of
+ *  display-only fallbacks (e.g. `authHint`'s `repo.remoteHost || GITLAB_CLOUD_HOST`)
+ *  that aren't API-base URLs. Every actual request/URL site derives its host
+ *  via `gitlabHost`/`gitlabApiBase` below, not this constant directly. */
+const GITLAB_CLOUD_HOST = "gitlab.com";
 const GITLAB_FETCH_TIMEOUT_MS = 30_000;
 const GITLAB_DIFF_BODY_CAP_BYTES = 8_000_000;
+
+/** Resolves the real host to address for `repo`'s GitLab API/web requests.
+ *  `repo.remoteHost` is the raw host from the git remote — often an
+ *  `~/.ssh/config` alias used to pin a per-identity SSH key (see
+ *  git-provider.ts's module doc comment), not necessarily the provider's
+ *  actual hostname. `apiHostForRemote` (git-provider.ts) resolves that alias
+ *  to its configured `HostName` via `ssh -G` (falling back to the input
+ *  verbatim on any failure), so a multi-identity alias whose HostName is
+ *  gitlab.com round-trips to gitlab.com, while a genuine self-hosted domain
+ *  (`gitlab.mycompany.com`, no matching alias) round-trips to itself. */
+function gitlabHost(repo: ProviderRepoInfo): string {
+  return apiHostForRemote(repo.remoteHost);
+}
+
+/** `https://<host>/api/v4` for `repo`'s real GitLab host (see `gitlabHost`).
+ *  For gitlab.com and any ssh alias whose HostName points at gitlab.com, this
+ *  reproduces the old hard-coded `https://gitlab.com/api/v4` constant
+ *  exactly — byte-identical behavior, zero regression. For a genuine
+ *  self-hosted domain, it targets that instance's own `/api/v4`, which is
+ *  what makes self-hosted GitLab work at all. Called once per exported
+ *  function (every call site has `repo` in scope) rather than memoized here —
+ *  `apiHostForRemote` already caches the ssh resolution itself. */
+function gitlabApiBase(repo: ProviderRepoInfo): string {
+  return `https://${gitlabHost(repo)}/api/v4`;
+}
 
 export interface GitLabError {
   ok: false;
@@ -80,8 +109,10 @@ function fetchErrorMessage(e: unknown): string {
 
 /** `PRIVATE-TOKEN` (GitLab's own auth header, not `Authorization: Bearer`) when
  *  a token is present; 30s abort; `user-agent: agetor` — same shape as
- *  `fetchGitHub` in github.ts. `url` must be an absolute `https://gitlab.com/api/v4/...`
- *  URL (every call site below builds one) so pagination helpers can re-derive
+ *  `fetchGitHub` in github.ts. `url` must be an absolute `https://<host>/api/v4/...`
+ *  URL (every call site below builds one via `gitlabApiBase(repo)`, so `<host>`
+ *  is gitlab.com for cloud/alias repos and the real domain for self-hosted
+ *  ones — see `gitlabHost`'s doc comment) so pagination helpers can re-derive
  *  a next-page URL without having to know a base path convention. */
 async function fetchGitLab(
   url: string,
@@ -134,7 +165,7 @@ function apiError(body: unknown, status: number, statusText: string): string {
  *  unit-tested via `__gitlabInternals`. */
 function authHint(status: number, message: string, repo: ProviderRepoInfo, hadToken: boolean): string {
   if (status !== 401 && status !== 404) return message;
-  const host = repo.remoteHost || "gitlab.com";
+  const host = repo.remoteHost || GITLAB_CLOUD_HOST;
   const base = `${repo.owner}/${repo.name} was not found on GitLab — if the project is private, add a token for ${host} in Settings → ${GIT_HOST_TOKENS_SECTION}`;
   return hadToken
     ? `${base} (the configured token cannot access it — check it belongs to the right account)`
@@ -261,7 +292,7 @@ function normalizeItem(kind: GitHubItemKind, raw: unknown, sourcePath: string | 
  *  doesn't carry its parent MR/issue iid. */
 function noteHtmlUrl(repo: ProviderRepoInfo, kind: GitHubItemKind, number: number, noteId: number): string {
   const seg = kind === "pulls" ? "merge_requests" : "issues";
-  return `https://gitlab.com/${repo.owner}/${repo.name}/-/${seg}/${number}#note_${noteId}`;
+  return `https://${gitlabHost(repo)}/${repo.owner}/${repo.name}/-/${seg}/${number}#note_${noteId}`;
 }
 
 function normalizeComment(raw: unknown, repo: ProviderRepoInfo, kind: GitHubItemKind, number: number): GitHubComment | null {
@@ -448,6 +479,7 @@ const GITLAB_PER_PAGE = 30;
  *  `closed` for issues) is a single direct request with normal pagination. */
 export async function listGitLabItems(repo: ProviderRepoInfo, opts: ListGitLabItemsOptions): Promise<GitLabListResponse> {
   const token = await gitlabToken(repo.remoteHost);
+  const apiBase = gitlabApiBase(repo);
   const projectId = encodeProjectId(repo.owner, repo.name);
   const endpoint = opts.kind === "pulls" ? "merge_requests" : "issues";
   const page = Number.isInteger(opts.page) && (opts.page as number) > 0 ? (opts.page as number) : 1;
@@ -457,7 +489,7 @@ export async function listGitLabItems(repo: ProviderRepoInfo, opts: ListGitLabIt
   const combinedClosed = states.length > 1;
 
   const buildUrl = (stateParam: string, sourcePage: number): string => {
-    const url = new URL(`${GITLAB_API_BASE}/projects/${projectId}/${endpoint}`);
+    const url = new URL(`${apiBase}/projects/${projectId}/${endpoint}`);
     // "all" is expressed by omitting `state` — the MR list documents
     // `state=all` but the issues list doesn't, and omission means "all"
     // uniformly on both endpoints.
@@ -500,7 +532,7 @@ export async function listGitLabItems(repo: ProviderRepoInfo, opts: ListGitLabIt
   return {
     ok: true,
     repo: `${repo.owner}/${repo.name}`,
-    webUrl: `https://gitlab.com/${repo.owner}/${repo.name}`,
+    webUrl: `https://${gitlabHost(repo)}/${repo.owner}/${repo.name}`,
     auth: token ? "token" : "none",
     items: sliced,
     page,
@@ -525,7 +557,7 @@ export async function listGitLabItems(repo: ProviderRepoInfo, opts: ListGitLabIt
 export async function getGitLabPullDefaults(repo: ProviderRepoInfo): Promise<GitLabPullDefaultsResponse> {
   const token = await gitlabToken(repo.remoteHost);
   const projectId = encodeProjectId(repo.owner, repo.name);
-  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}`, token);
+  const res = await fetchGitLab(`${gitlabApiBase(repo)}/projects/${projectId}`, token);
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
   if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!token) };
@@ -561,7 +593,7 @@ export async function createGitLabPull(repo: ProviderRepoInfo, input: CreateGitL
   if (!token) return { ok: false, error: "GitLab authentication required to create a merge request" };
   const projectId = encodeProjectId(repo.owner, repo.name);
   const finalTitle = input.draft ? `Draft: ${title}` : title;
-  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests`, token, {
+  const res = await fetchGitLab(`${gitlabApiBase(repo)}/projects/${projectId}/merge_requests`, token, {
     method: "POST",
     body: JSON.stringify({
       title: finalTitle,
@@ -590,7 +622,7 @@ export async function getGitLabPullDiff(repo: ProviderRepoInfo, number: number):
   const token = await gitlabToken(repo.remoteHost);
   const projectId = encodeProjectId(repo.owner, repo.name);
   const res = await fetchGitLab(
-    `${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/raw_diffs`,
+    `${gitlabApiBase(repo)}/projects/${projectId}/merge_requests/${number}/raw_diffs`,
     token,
     { accept: "text/plain" },
   );
@@ -723,6 +755,7 @@ export async function getGitLabPullBlob(
   if (!path) return { ok: false, error: "file path is required", status: 400 };
 
   const token = await gitlabToken(repo.remoteHost);
+  const apiBase = gitlabApiBase(repo);
   const projectId = encodeProjectId(repo.owner, repo.name);
   const detailKey = `${repo.remoteHost}/${repo.owner}/${repo.name}#${number}`;
 
@@ -735,7 +768,7 @@ export async function getGitLabPullBlob(
   if (cached && Date.now() - cached.fetchedAt < PULL_BLOB_DETAIL_CACHE_TTL_MS) {
     ({ baseSha, headSha, sourceProjectId, targetProjectId } = cached);
   } else {
-    const mrRes = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`, token);
+    const mrRes = await fetchGitLab(`${apiBase}/projects/${projectId}/merge_requests/${number}`, token);
     if (!("status" in mrRes)) return { ok: false, error: mrRes.error, status: 502 };
     const mrJson = await mrRes.json().catch(() => null);
     if (!mrRes.ok) {
@@ -753,7 +786,7 @@ export async function getGitLabPullBlob(
     if (!resolvedBaseSha || !resolvedHeadSha) {
       // diff_refs populates async after the MR is created/pushed to — fall
       // back to the latest diff version, same as createGitLabPullLineComment.
-      const versionsRes = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/versions`, token);
+      const versionsRes = await fetchGitLab(`${apiBase}/projects/${projectId}/merge_requests/${number}/versions`, token);
       if (!("status" in versionsRes)) return { ok: false, error: versionsRes.error, status: 502 };
       const versions = await versionsRes.json().catch(() => null);
       if (!versionsRes.ok) {
@@ -790,7 +823,7 @@ export async function getGitLabPullBlob(
   }
 
   const buildFileUrl = (pid: string): string =>
-    `${GITLAB_API_BASE}/projects/${pid}/repository/files/${encodeURIComponent(path)}/raw?ref=${encodeURIComponent(ref)}`;
+    `${apiBase}/projects/${pid}/repository/files/${encodeURIComponent(path)}/raw?ref=${encodeURIComponent(ref)}`;
 
   let fileRes = await fetchGitLab(buildFileUrl(blobProjectId), token, { accept: "*/*" });
   if (!("status" in fileRes)) return { ok: false, error: fileRes.error, status: 502 };
@@ -846,7 +879,7 @@ export async function listGitLabComments(repo: ProviderRepoInfo, number: number,
   const projectId = encodeProjectId(repo.owner, repo.name);
   const endpoint = kind === "pulls" ? "merge_requests" : "issues";
   const comments: GitHubComment[] = [];
-  let url: string | null = `${GITLAB_API_BASE}/projects/${projectId}/${endpoint}/${number}/notes?sort=asc&order_by=created_at&per_page=100`;
+  let url: string | null = `${gitlabApiBase(repo)}/projects/${projectId}/${endpoint}/${number}/notes?sort=asc&order_by=created_at&per_page=100`;
   for (let page = 0; url && page < 5; page++) {
     const res = await fetchGitLab(url, token);
     if (!("status" in res)) return res;
@@ -871,7 +904,7 @@ export async function createGitLabComment(repo: ProviderRepoInfo, number: number
   if (!token) return { ok: false, error: "GitLab authentication required to comment" };
   const projectId = encodeProjectId(repo.owner, repo.name);
   const endpoint = kind === "pulls" ? "merge_requests" : "issues";
-  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/${endpoint}/${number}/notes`, token, {
+  const res = await fetchGitLab(`${gitlabApiBase(repo)}/projects/${projectId}/${endpoint}/${number}/notes`, token, {
     method: "POST",
     body: JSON.stringify({ body: text }),
   });
@@ -896,7 +929,7 @@ export async function listGitLabPullReviewComments(repo: ProviderRepoInfo, numbe
   const token = await gitlabToken(repo.remoteHost);
   const projectId = encodeProjectId(repo.owner, repo.name);
   const comments: GitHubPullLineComment[] = [];
-  let url: string | null = `${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/discussions?per_page=100`;
+  let url: string | null = `${gitlabApiBase(repo)}/projects/${projectId}/merge_requests/${number}/discussions?per_page=100`;
   for (let page = 0; url && page < 5; page++) {
     const res = await fetchGitLab(url, token);
     if (!("status" in res)) return res;
@@ -944,9 +977,10 @@ export async function createGitLabPullLineComment(
 
   const token = await gitlabToken(repo.remoteHost);
   if (!token) return { ok: false, error: "GitLab authentication required to comment on a line" };
+  const apiBase = gitlabApiBase(repo);
   const projectId = encodeProjectId(repo.owner, repo.name);
 
-  const versionsRes = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/versions`, token);
+  const versionsRes = await fetchGitLab(`${apiBase}/projects/${projectId}/merge_requests/${number}/versions`, token);
   if (!("status" in versionsRes)) return versionsRes;
   const versions = await versionsRes.json().catch(() => null);
   if (!versionsRes.ok) return { ok: false, error: errorFrom(versionsRes, versions, repo, !!token) };
@@ -971,7 +1005,7 @@ export async function createGitLabPullLineComment(
   if (input.side === "RIGHT") position.new_line = input.line;
   else position.old_line = input.line;
 
-  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/discussions`, token, {
+  const res = await fetchGitLab(`${apiBase}/projects/${projectId}/merge_requests/${number}/discussions`, token, {
     method: "POST",
     body: JSON.stringify({ body, position }),
   });
@@ -998,7 +1032,7 @@ async function findDiscussionIdForNote(
   token: string | null,
 ): Promise<{ ok: true; id: string | null } | GitLabError> {
   const projectId = encodeProjectId(repo.owner, repo.name);
-  let url: string | null = `${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/discussions?per_page=100`;
+  let url: string | null = `${gitlabApiBase(repo)}/projects/${projectId}/merge_requests/${number}/discussions?per_page=100`;
   for (let page = 0; url && page < 5; page++) {
     const res = await fetchGitLab(url, token);
     if (!("status" in res)) return res;
@@ -1031,7 +1065,7 @@ export async function replyGitLabLineComment(repo: ProviderRepoInfo, number: num
   if (!discussion.id) return { ok: false, error: "Could not find the discussion for that comment." };
 
   const res = await fetchGitLab(
-    `${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/discussions/${discussion.id}/notes`,
+    `${gitlabApiBase(repo)}/projects/${projectId}/merge_requests/${number}/discussions/${discussion.id}/notes`,
     token,
     { method: "POST", body: JSON.stringify({ body: text }) },
   );
@@ -1156,7 +1190,7 @@ export async function getGitLabPullMergeability(repo: ProviderRepoInfo, number: 
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
   const token = await gitlabToken(repo.remoteHost);
   const projectId = encodeProjectId(repo.owner, repo.name);
-  const url = `${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`;
+  const url = `${gitlabApiBase(repo)}/projects/${projectId}/merge_requests/${number}`;
 
   let last: GitHubPullMergeability | null = null;
   for (let attempt = 0; attempt < 3; attempt++) {
@@ -1184,9 +1218,10 @@ export async function getGitLabPullMergeability(repo: ProviderRepoInfo, number: 
 export async function getGitLabPullChecks(repo: ProviderRepoInfo, number: number): Promise<GitLabChecksResponse> {
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
   const token = await gitlabToken(repo.remoteHost);
+  const apiBase = gitlabApiBase(repo);
   const projectId = encodeProjectId(repo.owner, repo.name);
 
-  const mrRes = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`, token);
+  const mrRes = await fetchGitLab(`${apiBase}/projects/${projectId}/merge_requests/${number}`, token);
   if (!("status" in mrRes)) return mrRes;
   const mr = await mrRes.json().catch(() => null);
   if (!mrRes.ok) return { ok: false, error: errorFrom(mrRes, mr, repo, !!token) };
@@ -1195,7 +1230,7 @@ export async function getGitLabPullChecks(repo: ProviderRepoInfo, number: number
   if (!sha) return { ok: false, error: "GitLab returned a merge request without a head sha" };
   const pipeline = obj.head_pipeline && typeof obj.head_pipeline === "object" ? obj.head_pipeline as Record<string, unknown> : null;
 
-  const statusesRes = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/repository/commits/${sha}/statuses?per_page=100`, token);
+  const statusesRes = await fetchGitLab(`${apiBase}/projects/${projectId}/repository/commits/${sha}/statuses?per_page=100`, token);
   if (!("status" in statusesRes)) return statusesRes;
   const statuses = await statusesRes.json().catch(() => null);
   if (!statusesRes.ok) return { ok: false, error: errorFrom(statusesRes, statuses, repo, !!token) };
@@ -1217,7 +1252,7 @@ export async function getGitLabPullDetail(repo: ProviderRepoInfo, number: number
   if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "merge request number must be positive" };
   const token = await gitlabToken(repo.remoteHost);
   const projectId = encodeProjectId(repo.owner, repo.name);
-  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`, token);
+  const res = await fetchGitLab(`${gitlabApiBase(repo)}/projects/${projectId}/merge_requests/${number}`, token);
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
   if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!token) };
@@ -1239,7 +1274,7 @@ export async function mergeGitLabPull(repo: ProviderRepoInfo, number: number, me
   const token = await gitlabToken(repo.remoteHost);
   if (!token) return { ok: false, error: "GitLab authentication required to merge" };
   const projectId = encodeProjectId(repo.owner, repo.name);
-  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/merge`, token, {
+  const res = await fetchGitLab(`${gitlabApiBase(repo)}/projects/${projectId}/merge_requests/${number}/merge`, token, {
     method: "PUT",
     body: JSON.stringify({ squash: method === "squash" }),
   });
@@ -1275,7 +1310,7 @@ export async function closeGitLabPull(repo: ProviderRepoInfo, number: number): P
   const token = await gitlabToken(repo.remoteHost);
   if (!token) return { ok: false, error: "GitLab authentication required to close a merge request" };
   const projectId = encodeProjectId(repo.owner, repo.name);
-  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`, token, {
+  const res = await fetchGitLab(`${gitlabApiBase(repo)}/projects/${projectId}/merge_requests/${number}`, token, {
     method: "PUT",
     body: JSON.stringify({ state_event: "close" }),
   });
@@ -1292,7 +1327,7 @@ export async function reopenGitLabPull(repo: ProviderRepoInfo, number: number): 
   const token = await gitlabToken(repo.remoteHost);
   if (!token) return { ok: false, error: "GitLab authentication required to reopen a merge request" };
   const projectId = encodeProjectId(repo.owner, repo.name);
-  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}`, token, {
+  const res = await fetchGitLab(`${gitlabApiBase(repo)}/projects/${projectId}/merge_requests/${number}`, token, {
     method: "PUT",
     body: JSON.stringify({ state_event: "reopen" }),
   });
@@ -1322,7 +1357,7 @@ export async function reviewGitLabPull(repo: ProviderRepoInfo, number: number, v
   const text = body?.trim() ?? "";
 
   if (verdict === "APPROVE") {
-    const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/merge_requests/${number}/approve`, token, {
+    const res = await fetchGitLab(`${gitlabApiBase(repo)}/projects/${projectId}/merge_requests/${number}/approve`, token, {
       method: "POST",
       body: "{}",
     });
@@ -1351,12 +1386,12 @@ export async function reviewGitLabPull(repo: ProviderRepoInfo, number: number, v
  *  per the plan's decision — the alternative (rejecting the entire
  *  create/update over one bad assignee) is worse UX for a field the user
  *  likely won't double-check immediately. */
-async function resolveAssigneeIds(projectId: string, usernames: string[], token: string | null): Promise<number[]> {
+async function resolveAssigneeIds(apiBase: string, projectId: string, usernames: string[], token: string | null): Promise<number[]> {
   const trimmed = usernames.map((s) => s.trim()).filter(Boolean);
   if (trimmed.length === 0) return [];
   const ids: number[] = [];
   for (const username of trimmed) {
-    const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/users?search=${encodeURIComponent(username)}`, token);
+    const res = await fetchGitLab(`${apiBase}/projects/${projectId}/users?search=${encodeURIComponent(username)}`, token);
     if (!("status" in res) || !res.ok) continue;
     const body = await res.json().catch(() => null);
     if (!Array.isArray(body)) continue;
@@ -1378,11 +1413,12 @@ export async function createGitLabIssue(repo: ProviderRepoInfo, input: CreateGit
   if (!title) return { ok: false, error: "issue title required" };
   const token = await gitlabToken(repo.remoteHost);
   if (!token) return { ok: false, error: "GitLab authentication required to create an issue" };
+  const apiBase = gitlabApiBase(repo);
   const projectId = encodeProjectId(repo.owner, repo.name);
   const labels = input.labels?.map((s) => s.trim()).filter(Boolean) ?? [];
-  const assigneeIds = await resolveAssigneeIds(projectId, input.assignees ?? [], token);
+  const assigneeIds = await resolveAssigneeIds(apiBase, projectId, input.assignees ?? [], token);
 
-  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/issues`, token, {
+  const res = await fetchGitLab(`${apiBase}/projects/${projectId}/issues`, token, {
     method: "POST",
     body: JSON.stringify({
       title,
@@ -1418,6 +1454,7 @@ export async function updateGitLabIssue(repo: ProviderRepoInfo, number: number, 
   const kind: GitHubItemKind = input.kind === "pulls" ? "pulls" : "issues";
   const endpoint = kind === "pulls" ? "merge_requests" : "issues";
   const noun = kind === "pulls" ? "merge request" : "issue";
+  const apiBase = gitlabApiBase(repo);
   const projectId = encodeProjectId(repo.owner, repo.name);
 
   const patch: Record<string, unknown> = {};
@@ -1426,9 +1463,9 @@ export async function updateGitLabIssue(repo: ProviderRepoInfo, number: number, 
   if (input.state === "closed") patch.state_event = "close";
   else if (input.state === "open") patch.state_event = "reopen";
   if (input.labels) patch.labels = input.labels.map((s) => s.trim()).filter(Boolean).join(",");
-  if (input.assignees) patch.assignee_ids = await resolveAssigneeIds(projectId, input.assignees, token);
+  if (input.assignees) patch.assignee_ids = await resolveAssigneeIds(apiBase, projectId, input.assignees, token);
 
-  const res = await fetchGitLab(`${GITLAB_API_BASE}/projects/${projectId}/${endpoint}/${number}`, token, {
+  const res = await fetchGitLab(`${apiBase}/projects/${projectId}/${endpoint}/${number}`, token, {
     method: "PUT",
     body: JSON.stringify(patch),
   });
@@ -1445,7 +1482,7 @@ export async function updateGitLabIssue(repo: ProviderRepoInfo, number: number, 
 export async function getGitLabViewer(repo: ProviderRepoInfo): Promise<GitLabViewerResponse> {
   const token = await gitlabToken(repo.remoteHost);
   if (!token) return { ok: true, login: "" };
-  const res = await fetchGitLab(`${GITLAB_API_BASE}/user`, token);
+  const res = await fetchGitLab(`${gitlabApiBase(repo)}/user`, token);
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
   if (!res.ok) return { ok: false, error: errorFrom(res, json, repo, !!token) };
@@ -1461,7 +1498,7 @@ export async function listGitLabLabels(repo: ProviderRepoInfo): Promise<GitLabLa
   const token = await gitlabToken(repo.remoteHost);
   const projectId = encodeProjectId(repo.owner, repo.name);
   const labels: GitHubRepoLabel[] = [];
-  let url: string | null = `${GITLAB_API_BASE}/projects/${projectId}/labels?per_page=100`;
+  let url: string | null = `${gitlabApiBase(repo)}/projects/${projectId}/labels?per_page=100`;
   for (let page = 0; url && page < 3; page++) {
     const res = await fetchGitLab(url, token);
     if (!("status" in res)) return res;
@@ -1482,6 +1519,8 @@ export async function listGitLabLabels(repo: ProviderRepoInfo): Promise<GitLabLa
  *  `gitlab.test.ts`) — mirrors github.ts's `__githubInternals`. */
 export const __gitlabInternals = {
   encodeProjectId,
+  gitlabHost,
+  gitlabApiBase,
   apiError,
   authHint,
   pageLinks,

--- a/src/bun/server-blob.test.ts
+++ b/src/bun/server-blob.test.ts
@@ -1,0 +1,207 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import type { Task } from "../shared/types.ts";
+
+// Set AGETOR_DATA_DIR BEFORE importing db.ts (which captures it at top-level
+// import) — same convention as worktree.test.ts / task-events.test.ts.
+const DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-server-blob-data-"));
+process.env.AGETOR_DATA_DIR = DATA_DIR;
+// Unique port, distinct from every other *.test.ts file's AGETOR_API_PORT
+// (files-preview-endpoint.test.ts uses 4441; see its header comment for the
+// convention).
+process.env.AGETOR_API_PORT = "4551";
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+}
+
+async function makeRepo(): Promise<string> {
+  const repo = mkdtempSync(path.join(tmpdir(), "agetor-server-blob-repo-"));
+  await git(["init", "-b", "main"], repo);
+  await git(["config", "user.email", "test@example.com"], repo);
+  await git(["config", "user.name", "test"], repo);
+  writeFileSync(path.join(repo, "README"), "hi\n");
+  await git(["add", "."], repo);
+  await git(["commit", "-m", "init"], repo);
+  return repo;
+}
+
+function fakeTask(overrides: Partial<Task> & { workdir: string }): Task {
+  return {
+    id: randomUUID(),
+    title: "Fix the thing",
+    prompt: "p",
+    column: "ready",
+    agent: "claude-code",
+    isolation: "worktree",
+    taskType: "task",
+    branch: null,
+    branchSource: "created",
+    worktreePath: null,
+    baseRef: null,
+    prUrl: null,
+    mode: null,
+    model: null,
+    effort: null,
+    fast: false,
+    maxMode: false,
+    references: [],
+    backlog: [],
+    plans: [],
+    draft: null,
+    runId: null,
+    hasOpenableRun: false,
+    pendingInteractionCount: 0,
+    openTerminalCount: 0,
+    archivedAt: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PNG_BYTES = Buffer.concat([PNG_MAGIC, Buffer.from("preview-fixture")]);
+// Not a real PDF — the route only cares about the extension/content-type
+// mapping, never parses the bytes.
+const PDF_BYTES = Buffer.from("%PDF-1.4 fixture bytes");
+
+let server: { stop: () => void };
+let token: string;
+
+// A single shared task with a real worktree, reused (read-only) across the
+// happy-path tests below: a committed PNG (for old-side/etag coverage), a
+// committed PDF, a committed .txt (non-previewable), and a working-tree
+// modification to the PNG (so "new" and "old" bytes genuinely differ).
+let task: Task;
+
+beforeAll(async () => {
+  const { tasks } = await import("./db.ts");
+  const { startApiServer, API_TOKEN } = await import("./server.ts");
+  server = startApiServer() as unknown as { stop: () => void };
+  token = API_TOKEN;
+
+  const { prepareWorkdir, resolveRef } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  writeFileSync(path.join(repo, "logo.png"), PNG_BYTES);
+  writeFileSync(path.join(repo, "doc.pdf"), PDF_BYTES);
+  writeFileSync(path.join(repo, "notes.txt"), "hello");
+  await git(["add", "."], repo);
+  await git(["commit", "-m", "add fixtures"], repo);
+  const base = await resolveRef(repo, "HEAD");
+
+  const draft = fakeTask({ workdir: repo, baseRef: base });
+  const prepared = await prepareWorkdir(draft);
+  if ("error" in prepared) throw new Error(prepared.error);
+
+  // Working-tree modification so old-side vs new-side bytes genuinely
+  // differ (exercises the ETag round-trip meaningfully).
+  writeFileSync(path.join(prepared.cwd, "logo.png"), Buffer.concat([PNG_MAGIC, Buffer.from("modified")]));
+
+  task = { ...draft, worktreePath: prepared.worktreePath, branch: prepared.branch };
+  tasks.insert(task);
+});
+
+afterAll(() => {
+  server?.stop?.();
+});
+
+const BASE_URL = "http://127.0.0.1:4551";
+const blobUrl = (taskId: string, p: string, side: string) =>
+  `${BASE_URL}/tasks/${taskId}/diff/blob?path=${encodeURIComponent(p)}&side=${side}`;
+
+const withHeader = (url: string) => fetch(url, { headers: { authorization: `Bearer ${token}` } });
+const withQueryToken = (url: string) => fetch(`${url}&token=${token}`);
+
+test("/tasks/:id/diff/blob requires a token", async () => {
+  const res = await fetch(blobUrl(task.id, "logo.png", "new"));
+  expect(res.status).toBe(401);
+});
+
+test("/tasks/:id/diff/blob accepts a ?token= query param", async () => {
+  const res = await withQueryToken(blobUrl(task.id, "logo.png", "new"));
+  expect(res.status).toBe(200);
+});
+
+test("/tasks/:id/diff/blob 404s for an unknown task", async () => {
+  const res = await withHeader(blobUrl(randomUUID(), "logo.png", "new"));
+  expect(res.status).toBe(404);
+});
+
+test("/tasks/:id/diff/blob 400s when path is missing", async () => {
+  const res = await withHeader(`${BASE_URL}/tasks/${task.id}/diff/blob?side=new`);
+  expect(res.status).toBe(400);
+});
+
+test("/tasks/:id/diff/blob 400s when side is missing or invalid", async () => {
+  const missing = await withHeader(`${BASE_URL}/tasks/${task.id}/diff/blob?path=logo.png`);
+  expect(missing.status).toBe(400);
+
+  const bad = await withHeader(`${BASE_URL}/tasks/${task.id}/diff/blob?path=logo.png&side=sideways`);
+  expect(bad.status).toBe(400);
+});
+
+test("/tasks/:id/diff/blob 415s a non-previewable extension", async () => {
+  const res = await withHeader(blobUrl(task.id, "notes.txt", "new"));
+  expect(res.status).toBe(415);
+});
+
+test("/tasks/:id/diff/blob 200s the new side with matching bytes, content-type, and cache headers", async () => {
+  const res = await withHeader(blobUrl(task.id, "logo.png", "new"));
+  expect(res.status).toBe(200);
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  expect(Buffer.from(bytes)).toEqual(Buffer.concat([PNG_MAGIC, Buffer.from("modified")]));
+  expect(res.headers.get("content-type")).toBe("image/png");
+  expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+  expect(res.headers.get("cache-control") ?? "").toContain("must-revalidate");
+  expect(res.headers.get("etag")).toBeTruthy();
+});
+
+test("/tasks/:id/diff/blob 200s the old side with the committed bytes, distinct from the new side", async () => {
+  const res = await withHeader(blobUrl(task.id, "logo.png", "old"));
+  expect(res.status).toBe(200);
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  expect(Buffer.from(bytes)).toEqual(PNG_BYTES);
+  expect(res.headers.get("content-type")).toBe("image/png");
+  expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+  expect(res.headers.get("cache-control") ?? "").toContain("must-revalidate");
+  expect(res.headers.get("etag")).toBeTruthy();
+});
+
+test("/tasks/:id/diff/blob 200s a PDF with application/pdf content-type", async () => {
+  const res = await withHeader(blobUrl(task.id, "doc.pdf", "new"));
+  expect(res.status).toBe(200);
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  expect(Buffer.from(bytes)).toEqual(PDF_BYTES);
+  expect(res.headers.get("content-type")).toBe("application/pdf");
+});
+
+test("/tasks/:id/diff/blob 304s on a matching If-None-Match with an empty body (new side)", async () => {
+  const first = await withHeader(blobUrl(task.id, "logo.png", "new"));
+  const etag = first.headers.get("etag");
+  expect(etag).toBeTruthy();
+
+  const second = await fetch(blobUrl(task.id, "logo.png", "new"), {
+    headers: { authorization: `Bearer ${token}`, "if-none-match": etag as string },
+  });
+  expect(second.status).toBe(304);
+  const body = await second.arrayBuffer();
+  expect(body.byteLength).toBe(0);
+});
+
+test("/tasks/:id/diff/blob 304s on a matching If-None-Match with an empty body (old side)", async () => {
+  const first = await withHeader(blobUrl(task.id, "logo.png", "old"));
+  const etag = first.headers.get("etag");
+  expect(etag).toBeTruthy();
+
+  const second = await fetch(blobUrl(task.id, "logo.png", "old"), {
+    headers: { authorization: `Bearer ${token}`, "if-none-match": etag as string },
+  });
+  expect(second.status).toBe(304);
+  const body = await second.arrayBuffer();
+  expect(body.byteLength).toBe(0);
+});

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -176,7 +176,7 @@ import type {
 } from "../shared/types.ts";
 import { armForceQuit, broadcastAppEvent, subscribeAppEvents } from "./quit-guard.ts";
 import { consumePendingOpenTask } from "./pending-open.ts";
-import { binaryPreviewKind, isImagePath } from "../shared/attachments.ts";
+import { binaryPreviewKind, contentTypeForPreviewPath, isImagePath } from "../shared/attachments.ts";
 
 // Re-export so existing call sites (index.ts → webview URL) keep working.
 // `API_PORT` is a module-load snapshot for index.ts's BrowserWindow URL.
@@ -208,27 +208,14 @@ const json = (data: unknown, init?: ResponseInit) =>
     status: init?.status,
   });
 
-// Content-type map for GET /files/preview and the binary-diff-blob routes
-// below. Module-scope so it isn't reallocated on every request. `pdf` is
-// used by the blob routes only (/files/preview is image-only, gated by
-// isImagePath) — the extension→mimetype fallback below (`image/<ext>`)
-// only ever applies to image kinds, so pdf must be listed explicitly.
-const PREVIEW_CONTENT_TYPES: Record<string, string> = {
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  svg: "image/svg+xml",
-  ico: "image/x-icon",
-  pdf: "application/pdf",
-};
-
-// Content-type for a binary-diff-blob response (/tasks/:id/diff/blob,
-// /github/pull-blob). `kind` comes from `binaryPreviewKind`'s allowlist, so
-// the `image/<ext>` fallback below only ever applies to an image extension
-// — never to `pdf`, which is always the explicit map entry.
+// Content-type for the /tasks/:id/diff/blob response, from the shared
+// canonical extension→MIME map (`../shared/attachments.ts`, also used by
+// /files/preview below and by github.ts's pull-blob path — one map, no more
+// drift between the three). `relPath` has already passed `binaryPreviewKind`
+// by the time this is called, so the shared map always matches; the
+// fallback is defense-in-depth only.
 function blobContentType(relPath: string, kind: "image" | "pdf"): string {
-  const ext = relPath.slice(relPath.lastIndexOf(".") + 1).toLowerCase();
-  if (kind === "pdf") return PREVIEW_CONTENT_TYPES.pdf ?? "application/pdf";
-  return PREVIEW_CONTENT_TYPES[ext] ?? `image/${ext}`;
+  return contentTypeForPreviewPath(relPath) ?? (kind === "pdf" ? "application/pdf" : "application/octet-stream");
 }
 
 // Derived, never-persisted count of this task's still-`running` subagent
@@ -901,26 +888,27 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             return json({ error: result.error }, { status: result.status ?? 502, headers: corsHeaders(req) });
           }
 
-          // pullBlob's result carries bytes + contentType but no etag of its
-          // own — synthesize a weak one from byte length + path, stable
-          // enough for the modal-scoped 1h cache below (a PR blob at a given
-          // sha doesn't change; the merge-base can move, hence "weak" and a
-          // short ttl rather than the task-diff route's immutable one).
-          const etag = `W/"${result.bytes.byteLength}-${createHash("sha1").update(filePath).digest("hex").slice(0, 16)}"`;
+          // Strong ETag from the resolved `ref` (the exact sha the bytes were
+          // fetched at) + path — content-addressed, unlike the old weak etag
+          // (byte length + path only), which could collide/miss across two
+          // different shas of the same size. By the time we know `ref` the
+          // upstream GitHub fetch has already happened (pullBlob resolves
+          // after fetching), so a 304 here only saves the localhost transfer
+          // back to the browser, not the GitHub round trip — still worth it
+          // for a modal where the user pages back and forth between files.
+          const etag = `"${createHash("sha1").update(`${result.ref}:${filePath}`).digest("hex")}"`;
           if (req.headers.get("if-none-match") === etag) {
             return new Response(null, { status: 304, headers: { ...corsHeaders(req), etag } });
           }
-          // `new Uint8Array(bytes)` (copy, not a re-view) resolves the type
-          // to `Uint8Array<ArrayBuffer>` — `pullBlob`'s unparametrized
-          // `Uint8Array` return type defaults to `Uint8Array<ArrayBufferLike>`
-          // under TS 5.7+, which `BodyInit`'s `ArrayBufferView<ArrayBuffer>`
-          // constraint rejects.
-          return new Response(new Uint8Array(result.bytes), {
+          // Not content-addressed by URL (PR number, not a pinned sha) — the
+          // merge-base can move between requests, so revalidate every time;
+          // the ETag above makes that a cheap 304.
+          return new Response(result.bytes, {
             headers: {
               ...corsHeaders(req),
               "content-type": result.contentType,
               "x-content-type-options": "nosniff",
-              "cache-control": "private, max-age=3600",
+              "cache-control": "private, max-age=0, must-revalidate",
               etag,
             },
           });
@@ -3488,8 +3476,9 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       // textual diff" placeholder. Same trust posture as /files/preview:
       // token-gated + loopback-only is the real boundary, the extension
       // allowlist (`binaryPreviewKind`) just keeps this from doubling as a
-      // generic blob reader, and `getTaskDiffBlob` independently rejects any
-      // path that would escape the task's cwd.
+      // generic blob reader, and `getTaskDiffBlob` rejects any path that
+      // would lexically escape the task's cwd (symlink containment is not
+      // enforced, consistent with /files/preview's trust posture).
       "/tasks/:id/diff/blob": {
         GET: authed(async (req) => {
           const t = tasks.get(req.params.id);
@@ -3525,12 +3514,14 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
               ...corsHeaders(req),
               "content-type": blobContentType(relPath, kind),
               "x-content-type-options": "nosniff",
-              // "new" is the working tree — it can change under the user's
-              // feet, so revalidate every time. "old" is pinned to a resolved
-              // commit sha, so it never changes for a given etag.
-              "cache-control": side === "new"
-                ? "private, max-age=0, must-revalidate"
-                : "private, max-age=31536000, immutable",
+              // Neither side is content-addressed by URL: "new" is the
+              // working tree (can change under the user's feet), and "old"
+              // is pinned to `task.baseRef` which itself isn't stable — an
+              // isolation=none task's base is literally "HEAD" (moves with
+              // every commit), and a worktree task's baseRef can be null.
+              // Both sides revalidate on every request; the ETag (content
+              // hash for "old", size+mtime for "new") makes that a cheap 304.
+              "cache-control": "private, max-age=0, must-revalidate",
               etag: result.etag,
             },
           });
@@ -3892,7 +3883,11 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             return json({ error: `not found: ${raw}` }, { status: 404, headers: corsHeaders(req) });
           }
           const ext = raw.slice(raw.lastIndexOf(".") + 1).toLowerCase();
-          const contentType = PREVIEW_CONTENT_TYPES[ext] ?? `image/${ext}`;
+          // Shared canonical map (../shared/attachments.ts) — behavior is
+          // unchanged from the old inline map + `image/<ext>` fallback: every
+          // extension reachable here already passed `isImagePath`, so the
+          // shared lookup always hits and the fallback is never exercised.
+          const contentType = contentTypeForPreviewPath(raw) ?? `image/${ext}`;
           // ETag derived from size+mtime so a re-saved file at the same path
           // (e.g. a screenshot overwritten in place) is detected as changed.
           const etag = `"${st.size}-${st.mtimeMs}"`;

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import path from "node:path";
 import type { WebSocketHandler } from "bun";
@@ -56,6 +57,7 @@ import { planAskAnswers } from "./claude-questions.ts";
 import {
   getAheadCount,
   getTaskDiff,
+  getTaskDiffBlob,
   gitFetch,
   gitPull,
   gitPush,
@@ -174,7 +176,7 @@ import type {
 } from "../shared/types.ts";
 import { armForceQuit, broadcastAppEvent, subscribeAppEvents } from "./quit-guard.ts";
 import { consumePendingOpenTask } from "./pending-open.ts";
-import { isImagePath } from "../shared/attachments.ts";
+import { binaryPreviewKind, isImagePath } from "../shared/attachments.ts";
 
 // Re-export so existing call sites (index.ts → webview URL) keep working.
 // `API_PORT` is a module-load snapshot for index.ts's BrowserWindow URL.
@@ -206,14 +208,28 @@ const json = (data: unknown, init?: ResponseInit) =>
     status: init?.status,
   });
 
-// Content-type map for GET /files/preview. Module-scope so it isn't
-// reallocated on every request.
+// Content-type map for GET /files/preview and the binary-diff-blob routes
+// below. Module-scope so it isn't reallocated on every request. `pdf` is
+// used by the blob routes only (/files/preview is image-only, gated by
+// isImagePath) — the extension→mimetype fallback below (`image/<ext>`)
+// only ever applies to image kinds, so pdf must be listed explicitly.
 const PREVIEW_CONTENT_TYPES: Record<string, string> = {
   jpg: "image/jpeg",
   jpeg: "image/jpeg",
   svg: "image/svg+xml",
   ico: "image/x-icon",
+  pdf: "application/pdf",
 };
+
+// Content-type for a binary-diff-blob response (/tasks/:id/diff/blob,
+// /github/pull-blob). `kind` comes from `binaryPreviewKind`'s allowlist, so
+// the `image/<ext>` fallback below only ever applies to an image extension
+// — never to `pdf`, which is always the explicit map entry.
+function blobContentType(relPath: string, kind: "image" | "pdf"): string {
+  const ext = relPath.slice(relPath.lastIndexOf(".") + 1).toLowerCase();
+  if (kind === "pdf") return PREVIEW_CONTENT_TYPES.pdf ?? "application/pdf";
+  return PREVIEW_CONTENT_TYPES[ext] ?? `image/${ext}`;
+}
 
 // Derived, never-persisted count of this task's still-`running` subagent
 // rows — drives the kanban card's "N background agents" badge. Single-task
@@ -840,6 +856,74 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
             return json({ error: result.error }, { status: 400, headers: corsHeaders(req) });
           }
           return json(result, { headers: corsHeaders(req) });
+        }),
+      },
+
+      // Serve the raw bytes of one file, on one side of a PR's diff, for the
+      // Git Integration modal's binary (image/PDF) preview. Mirrors
+      // /github/pull-diff's identifying params (`path` = the local repo dir
+      // used to resolve host/repo/number, `number` = the PR number) — the
+      // *blob's* repo-relative path is a distinct concept from that `path`
+      // param, so it's carried as `filePath` here to avoid a name collision
+      // with pull-diff's `path` (a deviation from the plan's literal
+      // `?path=<repo-rel>` shape, which would have shadowed the existing
+      // `path` meaning). Dispatches through git-host.ts's `pullBlob`, which
+      // resolves the PR's head/merge-base and fetches blob bytes via the
+      // provider's Contents API; unsupported providers (GitLab/Bitbucket in
+      // v1) return `{ ok: false, status: 501 }` from `pullBlob` itself.
+      "/github/pull-blob": {
+        GET: authed(async (req) => {
+          const url = new URL(req.url);
+          const dir = url.searchParams.get("path");
+          const number = Number(url.searchParams.get("number"));
+          const filePath = url.searchParams.get("filePath") ?? "";
+          const side = url.searchParams.get("side");
+          if (!dir) return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
+          if (typeof number !== "number" || !Number.isInteger(number) || number <= 0) {
+            return json({ error: "valid pull request number required" }, { status: 400, headers: corsHeaders(req) });
+          }
+          if (!filePath) {
+            return json({ error: "filePath required" }, { status: 400, headers: corsHeaders(req) });
+          }
+          if (side !== "old" && side !== "new") {
+            return json({ error: "side must be 'old' or 'new'" }, { status: 400, headers: corsHeaders(req) });
+          }
+          const kind = binaryPreviewKind(filePath);
+          if (!kind) {
+            return json(
+              { error: `no preview available for: ${filePath}` },
+              { status: 415, headers: corsHeaders(req) },
+            );
+          }
+
+          const result = await gitHost.pullBlob({ dir, number, path: filePath, side });
+          if (!result.ok) {
+            return json({ error: result.error }, { status: result.status ?? 502, headers: corsHeaders(req) });
+          }
+
+          // pullBlob's result carries bytes + contentType but no etag of its
+          // own — synthesize a weak one from byte length + path, stable
+          // enough for the modal-scoped 1h cache below (a PR blob at a given
+          // sha doesn't change; the merge-base can move, hence "weak" and a
+          // short ttl rather than the task-diff route's immutable one).
+          const etag = `W/"${result.bytes.byteLength}-${createHash("sha1").update(filePath).digest("hex").slice(0, 16)}"`;
+          if (req.headers.get("if-none-match") === etag) {
+            return new Response(null, { status: 304, headers: { ...corsHeaders(req), etag } });
+          }
+          // `new Uint8Array(bytes)` (copy, not a re-view) resolves the type
+          // to `Uint8Array<ArrayBuffer>` — `pullBlob`'s unparametrized
+          // `Uint8Array` return type defaults to `Uint8Array<ArrayBufferLike>`
+          // under TS 5.7+, which `BodyInit`'s `ArrayBufferView<ArrayBuffer>`
+          // constraint rejects.
+          return new Response(new Uint8Array(result.bytes), {
+            headers: {
+              ...corsHeaders(req),
+              "content-type": result.contentType,
+              "x-content-type-options": "nosniff",
+              "cache-control": "private, max-age=3600",
+              etag,
+            },
+          });
         }),
       },
 
@@ -3395,6 +3479,61 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           const t = tasks.get(req.params.id);
           if (!t) return json({ error: "not found" }, { status: 404, headers: corsHeaders(req) });
           return json(await getTaskDiff(t), { headers: corsHeaders(req) });
+        }),
+      },
+
+      // Serve the raw bytes of one file, on one side of a task's diff, so the
+      // Diff Modal can render an old-vs-new preview for binary files it knows
+      // how to display (images, PDFs) instead of the plain "binary file — no
+      // textual diff" placeholder. Same trust posture as /files/preview:
+      // token-gated + loopback-only is the real boundary, the extension
+      // allowlist (`binaryPreviewKind`) just keeps this from doubling as a
+      // generic blob reader, and `getTaskDiffBlob` independently rejects any
+      // path that would escape the task's cwd.
+      "/tasks/:id/diff/blob": {
+        GET: authed(async (req) => {
+          const t = tasks.get(req.params.id);
+          if (!t) return json({ error: "not found" }, { status: 404, headers: corsHeaders(req) });
+
+          const url = new URL(req.url);
+          const relPath = url.searchParams.get("path") ?? "";
+          const side = url.searchParams.get("side");
+          if (!relPath) {
+            return json({ error: "path required" }, { status: 400, headers: corsHeaders(req) });
+          }
+          if (side !== "old" && side !== "new") {
+            return json({ error: "side must be 'old' or 'new'" }, { status: 400, headers: corsHeaders(req) });
+          }
+          const kind = binaryPreviewKind(relPath);
+          if (!kind) {
+            return json(
+              { error: `no preview available for: ${relPath}` },
+              { status: 415, headers: corsHeaders(req) },
+            );
+          }
+
+          const result = await getTaskDiffBlob(t, relPath, side);
+          if (!result.ok) {
+            return json({ error: result.error }, { status: result.status, headers: corsHeaders(req) });
+          }
+
+          if (req.headers.get("if-none-match") === result.etag) {
+            return new Response(null, { status: 304, headers: { ...corsHeaders(req), etag: result.etag } });
+          }
+          return new Response(result.bytes, {
+            headers: {
+              ...corsHeaders(req),
+              "content-type": blobContentType(relPath, kind),
+              "x-content-type-options": "nosniff",
+              // "new" is the working tree — it can change under the user's
+              // feet, so revalidate every time. "old" is pinned to a resolved
+              // commit sha, so it never changes for a given etag.
+              "cache-control": side === "new"
+                ? "private, max-age=0, must-revalidate"
+                : "private, max-age=31536000, immutable",
+              etag: result.etag,
+            },
+          });
         }),
       },
 

--- a/src/bun/worktree.test.ts
+++ b/src/bun/worktree.test.ts
@@ -455,6 +455,20 @@ test("getTaskDiff surfaces workdir changes for isolation=none tasks", async () =
   expect(fresh!.hunks).toContain("brand new");
 });
 
+test("getTaskDiff emits an unchanged (unprefixed) path for an untracked file when the workdir IS the repo root", async () => {
+  // The overwhelmingly common case — no `path.relative(root, cwd)` prefix to
+  // apply since root === cwd. Guards against the normalization accidentally
+  // adding a "./"-style prefix or otherwise mangling the common path.
+  const { getTaskDiff } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  writeFileSync(path.join(repo, "fresh.txt"), "brand new\n");
+
+  const diff = await getTaskDiff(fakeTask({ workdir: repo, isolation: "none" }));
+  const fresh = diff.files.find((f) => f.path === "fresh.txt");
+  expect(fresh).toBeDefined();
+  expect(fresh!.status).toBe("added");
+});
+
 test("getTaskDiff reports a friendly note when isolation=none workdir isn't a git repo", async () => {
   const { getTaskDiff } = await import("./worktree.ts");
   const dir = mkdtempSync(path.join(tmpdir(), "agetor-wt-nongit-diff-"));
@@ -704,6 +718,38 @@ test("getTaskDiffBlob: isolation=none task whose workdir is a repo SUBDIRECTORY 
   expect(result.ok).toBe(true);
   if (!result.ok) return;
   expect(Buffer.from(result.bytes)).toEqual(BLOB_V1);
+});
+
+test("getTaskDiff normalizes an UNTRACKED file's path to repo-root-relative for a subdir workdir, and getTaskDiffBlob resolves it at that same path", async () => {
+  // Regression pairing with the tracked-file subdir test above: `git
+  // ls-files --others` (unlike `git diff <base>`) runs in `cwd` and reports
+  // paths relative to IT, not the repo root — so for an isolation=none task
+  // whose workdir is `<repo>/sub`, the raw listing would say `assets/new.bin`
+  // while every tracked entry in the same TaskDiff says `sub/...`. getTaskDiff
+  // must prefix the subdirectory itself so the emitted DiffFile.path is
+  // root-relative like everything else, and getTaskDiffBlob must resolve
+  // that same root-relative path back to bytes.
+  const { getTaskDiff, getTaskDiffBlob } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  const assetsDir = path.join(repo, "sub", "assets");
+  mkdirSync(assetsDir, { recursive: true });
+  writeFileSync(path.join(assetsDir, "new.bin"), BLOB_V1);
+  // Deliberately never `git add`ed — this is the untracked path.
+
+  const task = fakeTask({ workdir: path.join(repo, "sub"), isolation: "none" });
+  const diff = await getTaskDiff(task);
+
+  const file = diff.files.find((f) => f.path === "sub/assets/new.bin");
+  expect(file).toBeDefined();
+  expect(file!.status).toBe("added");
+  // Not the cwd-relative shape a naive `git ls-files --others` listing would
+  // have produced.
+  expect(diff.files.some((f) => f.path === "assets/new.bin")).toBe(false);
+
+  const blob = await getTaskDiffBlob(task, "sub/assets/new.bin", "new");
+  expect(blob.ok).toBe(true);
+  if (!blob.ok) return;
+  expect(Buffer.from(blob.bytes)).toEqual(BLOB_V1);
 });
 
 describe("getTaskDiffBlob: path traversal rejections", () => {

--- a/src/bun/worktree.test.ts
+++ b/src/bun/worktree.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, beforeAll, describe } from "bun:test";
-import { mkdtempSync, existsSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, existsSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
@@ -550,6 +550,226 @@ test("parseGitDiff keeps the path for binary-only file sections", async () => {
   expect(files[0]?.path).toBe("assets/logo.png");
   expect(files[0]?.binary).toBe(true);
 });
+
+// ---------------------------------------------------------------------------
+// getTaskDiffBlob
+// ---------------------------------------------------------------------------
+
+// Two distinct "binary" fixtures (PNG magic + filler bytes) — content only
+// needs to differ byte-for-byte between "old" (committed at base) and "new"
+// (working tree); getTaskDiffBlob never interprets the bytes.
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const BLOB_V1 = Buffer.concat([PNG_MAGIC, Buffer.from("version-one-content")]);
+const BLOB_V2 = Buffer.concat([PNG_MAGIC, Buffer.from("version-two-content-different")]);
+
+// Old-side etags are a sha1 hex digest of "<resolved-sha>:<relPath>",
+// quoted — 40 hex chars. New-side etags are `"<size>-<mtimeMs>"` — a
+// completely different shape, since the "new" side isn't content-addressed
+// (it's the live working tree).
+const OLD_ETAG_RE = /^"[0-9a-f]{40}"$/;
+const NEW_ETAG_RE = /^"\d+-\d+(\.\d+)?"$/;
+
+test("getTaskDiffBlob: modified binary — old side reads the committed blob, new side reads the working-tree file, etags differ in shape", async () => {
+  const { prepareWorkdir, getTaskDiffBlob, resolveRef } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  writeFileSync(path.join(repo, "logo.png"), BLOB_V1);
+  await git(["add", "."], repo);
+  await git(["commit", "-m", "add logo"], repo);
+  const base = await resolveRef(repo, "HEAD");
+
+  const task = fakeTask({ workdir: repo, baseRef: base });
+  const prepared = await prepareWorkdir(task);
+  if ("error" in prepared) throw new Error(prepared.error);
+
+  // Uncommitted working-tree modification — this is exactly what `git diff
+  // <base>` would show as the binary file's "new" side.
+  writeFileSync(path.join(prepared.cwd, "logo.png"), BLOB_V2);
+
+  const live = { ...task, worktreePath: prepared.worktreePath, branch: prepared.branch };
+
+  const oldSide = await getTaskDiffBlob(live, "logo.png", "old");
+  expect(oldSide.ok).toBe(true);
+  if (!oldSide.ok) return;
+  expect(Buffer.from(oldSide.bytes)).toEqual(BLOB_V1);
+  expect(oldSide.etag).toMatch(OLD_ETAG_RE);
+
+  const newSide = await getTaskDiffBlob(live, "logo.png", "new");
+  expect(newSide.ok).toBe(true);
+  if (!newSide.ok) return;
+  expect(Buffer.from(newSide.bytes)).toEqual(BLOB_V2);
+  expect(newSide.etag).toMatch(NEW_ETAG_RE);
+
+  expect(oldSide.etag).not.toBe(newSide.etag);
+});
+
+test("getTaskDiffBlob: added (untracked) file — new side ok, old side 404", async () => {
+  const { prepareWorkdir, getTaskDiffBlob, resolveRef } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  const base = await resolveRef(repo, "HEAD");
+  const task = fakeTask({ workdir: repo, baseRef: base });
+  const prepared = await prepareWorkdir(task);
+  if ("error" in prepared) throw new Error(prepared.error);
+
+  // Untracked — never added, never committed, on either side of the base.
+  writeFileSync(path.join(prepared.cwd, "fresh.png"), BLOB_V1);
+
+  const live = { ...task, worktreePath: prepared.worktreePath, branch: prepared.branch };
+
+  const newSide = await getTaskDiffBlob(live, "fresh.png", "new");
+  expect(newSide.ok).toBe(true);
+  if (!newSide.ok) return;
+  expect(Buffer.from(newSide.bytes)).toEqual(BLOB_V1);
+
+  const oldSide = await getTaskDiffBlob(live, "fresh.png", "old");
+  expect(oldSide).toMatchObject({ ok: false, status: 404 });
+});
+
+test("getTaskDiffBlob: deleted file — old side ok, new side 404", async () => {
+  const { prepareWorkdir, getTaskDiffBlob, resolveRef } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  writeFileSync(path.join(repo, "gone.png"), BLOB_V1);
+  await git(["add", "."], repo);
+  await git(["commit", "-m", "add gone.png"], repo);
+  const base = await resolveRef(repo, "HEAD");
+
+  const task = fakeTask({ workdir: repo, baseRef: base });
+  const prepared = await prepareWorkdir(task);
+  if ("error" in prepared) throw new Error(prepared.error);
+
+  // Delete from the working tree without committing — same shape `getTaskDiff`
+  // would report as a "deleted" file vs base.
+  rmSync(path.join(prepared.cwd, "gone.png"));
+
+  const live = { ...task, worktreePath: prepared.worktreePath, branch: prepared.branch };
+
+  const oldSide = await getTaskDiffBlob(live, "gone.png", "old");
+  expect(oldSide.ok).toBe(true);
+  if (!oldSide.ok) return;
+  expect(Buffer.from(oldSide.bytes)).toEqual(BLOB_V1);
+
+  const newSide = await getTaskDiffBlob(live, "gone.png", "new");
+  expect(newSide).toMatchObject({ ok: false, status: 404 });
+});
+
+test("getTaskDiffBlob: renamed file — old side is still served at the pre-rename (oldPath) path; new side only resolves at the new path", async () => {
+  const { prepareWorkdir, getTaskDiffBlob, resolveRef } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  writeFileSync(path.join(repo, "before.png"), BLOB_V1);
+  await git(["add", "."], repo);
+  await git(["commit", "-m", "add before.png"], repo);
+  const base = await resolveRef(repo, "HEAD");
+
+  const task = fakeTask({ workdir: repo, baseRef: base });
+  const prepared = await prepareWorkdir(task);
+  if ("error" in prepared) throw new Error(prepared.error);
+
+  // Rename in the working tree (uncommitted) — old content lives only at the
+  // base commit's `before.png`; the working tree now only has `after.png`.
+  await git(["mv", "before.png", "after.png"], prepared.cwd);
+
+  const live = { ...task, worktreePath: prepared.worktreePath, branch: prepared.branch };
+
+  const oldSide = await getTaskDiffBlob(live, "before.png", "old");
+  expect(oldSide.ok).toBe(true);
+  if (!oldSide.ok) return;
+  expect(Buffer.from(oldSide.bytes)).toEqual(BLOB_V1);
+
+  const newAtNewPath = await getTaskDiffBlob(live, "after.png", "new");
+  expect(newAtNewPath.ok).toBe(true);
+  if (!newAtNewPath.ok) return;
+  expect(Buffer.from(newAtNewPath.bytes)).toEqual(BLOB_V1);
+
+  const newAtOldPath = await getTaskDiffBlob(live, "before.png", "new");
+  expect(newAtOldPath).toMatchObject({ ok: false, status: 404 });
+});
+
+test("getTaskDiffBlob: isolation=none task whose workdir is a repo SUBDIRECTORY resolves the new side via the repo root, not cwd + relPath", async () => {
+  // Regression test: `git diff`/`git ls-files` report paths root-relative,
+  // not cwd-relative. A naive `path.join(task.workdir, relPath)` for an
+  // isolation=none task whose workdir is `<repo>/sub` would double-prefix
+  // the subdirectory (`<repo>/sub/sub/assets/x.bin`) and 404.
+  const { getTaskDiffBlob } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  const assetsDir = path.join(repo, "sub", "assets");
+  mkdirSync(assetsDir, { recursive: true });
+  writeFileSync(path.join(assetsDir, "x.bin"), BLOB_V1);
+  await git(["add", "."], repo);
+  await git(["commit", "-m", "add sub/assets/x.bin"], repo);
+
+  const task = fakeTask({ workdir: path.join(repo, "sub"), isolation: "none" });
+
+  // Root-relative, exactly as `git diff` (run from the subdirectory) would
+  // report it — NOT relative to task.workdir.
+  const result = await getTaskDiffBlob(task, "sub/assets/x.bin", "new");
+  expect(result.ok).toBe(true);
+  if (!result.ok) return;
+  expect(Buffer.from(result.bytes)).toEqual(BLOB_V1);
+});
+
+describe("getTaskDiffBlob: path traversal rejections", () => {
+  test("rejects a '../' escaping relative path with 400", async () => {
+    const { prepareWorkdir, getTaskDiffBlob, resolveRef } = await import("./worktree.ts");
+    const repo = await makeRepo();
+    const base = await resolveRef(repo, "HEAD");
+    const task = fakeTask({ workdir: repo, baseRef: base });
+    const prepared = await prepareWorkdir(task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    const live = { ...task, worktreePath: prepared.worktreePath, branch: prepared.branch };
+
+    const result = await getTaskDiffBlob(live, "../x.png", "new");
+    expect(result).toMatchObject({ ok: false, status: 400 });
+  });
+
+  test("rejects an absolute path with 400", async () => {
+    const { prepareWorkdir, getTaskDiffBlob, resolveRef } = await import("./worktree.ts");
+    const repo = await makeRepo();
+    const base = await resolveRef(repo, "HEAD");
+    const task = fakeTask({ workdir: repo, baseRef: base });
+    const prepared = await prepareWorkdir(task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    const live = { ...task, worktreePath: prepared.worktreePath, branch: prepared.branch };
+
+    const result = await getTaskDiffBlob(live, "/etc/passwd.png", "new");
+    expect(result).toMatchObject({ ok: false, status: 400 });
+  });
+
+  test("rejects a path containing a null byte with 400", async () => {
+    const { prepareWorkdir, getTaskDiffBlob, resolveRef } = await import("./worktree.ts");
+    const repo = await makeRepo();
+    const base = await resolveRef(repo, "HEAD");
+    const task = fakeTask({ workdir: repo, baseRef: base });
+    const prepared = await prepareWorkdir(task);
+    if ("error" in prepared) throw new Error(prepared.error);
+    const live = { ...task, worktreePath: prepared.worktreePath, branch: prepared.branch };
+
+    const result = await getTaskDiffBlob(live, "a\0b.png", "new");
+    expect(result).toMatchObject({ ok: false, status: 400 });
+  });
+});
+
+test("getTaskDiffBlob: a new-side file over MAX_BLOB_PREVIEW_BYTES 413s instead of being read into memory", async () => {
+  const { prepareWorkdir, getTaskDiffBlob, resolveRef, MAX_BLOB_PREVIEW_BYTES } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  const base = await resolveRef(repo, "HEAD");
+  const task = fakeTask({ workdir: repo, baseRef: base });
+  const prepared = await prepareWorkdir(task);
+  if ("error" in prepared) throw new Error(prepared.error);
+
+  // Working-tree file (untracked is fine — the "new" side is a plain stat +
+  // read of whatever's on disk, no git involved) just over the cap.
+  const big = new Uint8Array(MAX_BLOB_PREVIEW_BYTES + 1);
+  await Bun.write(path.join(prepared.cwd, "huge.png"), big);
+
+  const live = { ...task, worktreePath: prepared.worktreePath, branch: prepared.branch };
+  const result = await getTaskDiffBlob(live, "huge.png", "new");
+  expect(result).toMatchObject({ ok: false, status: 413 });
+
+  // Old-side 413 would require committing a >20MB blob into the temp repo's
+  // history — noticeably slower for marginal extra coverage of the same
+  // `size > MAX_BLOB_PREVIEW_BYTES` check (the old-side code path applies
+  // the identical cap, just sourced from `git cat-file -s` instead of
+  // `fs.statSync`). Skipped here; the check itself is exercised above.
+}, 20_000);
 
 test("removeWorktree tears down both the worktree and the branch", async () => {
   const { prepareWorkdir, removeWorktree } = await import("./worktree.ts");

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -920,6 +920,7 @@ export async function getTaskDiff(task: Task): Promise<TaskDiff> {
   // full additions via --no-index (which exits 1 when content differs).
   const listed = await git(["ls-files", "--others", "--exclude-standard", "-z"], cwd);
   if (listed.ok) {
+    const rels = listed.stdout.split("\0").filter(Boolean).slice(0, MAX_UNTRACKED);
     // `ls-files` (and the `--no-index` diff below) run in `cwd`, so `rel` is
     // CWD-relative — but tracked entries from `git diff <base>` above are
     // repo-ROOT-relative. For an isolation=none task whose workdir is a repo
@@ -928,20 +929,33 @@ export async function getTaskDiff(task: Task): Promise<TaskDiff> {
     // Normalize by prefixing the root→cwd path segment onto the emitted
     // DiffFile.path only; the `--no-index` invocation itself keeps using the
     // cwd-relative `rel`, since that's what exists relative to the cwd git
-    // runs in. `path.relative` already returns forward-slash segments on
-    // POSIX (this app is macOS-only per CLAUDE.md), so no join-separator
-    // normalization is needed beyond a defensive backslash guard.
+    // runs in. `path.sep` is "/" here (this app is macOS-only per
+    // CLAUDE.md), so the split/join below is a no-op — kept only for
+    // symmetry with the `path.relative` call it normalizes, not because it
+    // does any actual backslash conversion (a backslash is a legal macOS
+    // filename char, so it must never be rewritten).
     //
     // `repoRoot` reports git's canonicalized path (symlinks resolved, e.g.
     // `/tmp` → `/private/tmp` on macOS — see `gitWritableRootsSync`'s doc
     // comment for the same gotcha), so diffing it against a non-canonical
     // `cwd` would spuriously produce a non-empty prefix even when cwd IS the
-    // root. Realpath `cwd` first to compare like-for-like.
-    const root = await repoRoot(cwd);
-    let realCwd = cwd;
-    try { realCwd = realpathSync(cwd); } catch { /* cwd missing — compare as-is */ }
-    const prefix = root ? path.relative(root, realCwd).split(path.sep).join("/") : "";
-    const rels = listed.stdout.split("\0").filter(Boolean).slice(0, MAX_UNTRACKED);
+    // root. Realpath `cwd` first to compare like-for-like. Skipped entirely
+    // when there are no untracked files to prefix — avoids paying a git
+    // spawn + realpathSync in the common zero-untracked case.
+    let prefix = "";
+    if (rels.length > 0) {
+      const root = await repoRoot(cwd);
+      let realCwd = cwd;
+      try { realCwd = realpathSync(cwd); } catch { /* cwd missing — compare as-is */ }
+      const rawPrefix = root ? path.relative(root, realCwd).split(path.sep).join("/") : "";
+      // GIT_WORK_TREE/bind-mount exotics can leave git's toplevel not a
+      // prefix of realpath(cwd), in which case `path.relative` returns a
+      // `..`-leading escape. A `../`-prefixed DiffFile.path would be
+      // rejected by isSafeRelPath downstream and permanently break that
+      // file's preview with no diagnostic — fall back to the old no-prefix
+      // behavior instead of emitting an escaping path.
+      prefix = rawPrefix.startsWith("..") ? "" : rawPrefix;
+    }
     for (const rel of rels) {
       const res = await git(["diff", "--no-color", "--no-index", "--", "/dev/null", rel], cwd);
       if (res.exitCode !== 0 && res.exitCode !== 1) continue;

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -7,6 +7,7 @@ import { dataDir } from "./db.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
 import { LEGACY_BRANCH_PREFIX } from "../shared/types.ts";
 import type { BranchInfo, Task, TaskDiff, WorktreeTeardownResult } from "../shared/types.ts";
+import { MAX_BLOB_PREVIEW_BYTES } from "../shared/attachments.ts";
 
 export type { BranchInfo };
 
@@ -947,21 +948,25 @@ export async function getTaskDiff(task: Task): Promise<TaskDiff> {
   return { base: shortBase, files };
 }
 
-// Above this many bytes, a diff-preview blob (image/PDF) is refused rather
-// than read into memory whole — these routes serve the webview's inline
-// old-vs-new preview, not a general-purpose file reader.
-export const MAX_BLOB_PREVIEW_BYTES = 20_000_000;
+// Re-exported so existing/future importers of `MAX_BLOB_PREVIEW_BYTES` from
+// this module keep working; `../shared/attachments.ts` is now the canonical
+// definition (shared with `github.ts`'s GitHub pull-blob route).
+export { MAX_BLOB_PREVIEW_BYTES };
 
 /**
  * True iff `relPath` is safe to `path.join` onto a trusted `cwd`: non-empty,
  * free of null bytes, not itself absolute, and whose normalized form
  * doesn't escape `cwd` (no leading `..` segment once normalized). This is a
  * stricter contract than `/files/preview`'s (which trusts an already-
- * absolute, already-existing path) — `getTaskDiffBlob` takes a
+ * absolute, already-existing path) — `getTaskDiffBlob` (and, via
+ * `git-host.ts`'s `pullBlob`, the GitHub pull-blob route) take a
  * repo-relative path from the client, so traversal must be rejected before
- * it ever touches the filesystem or a `git` invocation.
+ * it ever touches the filesystem or a `git`/API invocation. Rejects
+ * lexically-escaping paths only; symlink containment is not enforced,
+ * consistent with `/files/preview`'s trust posture (this app has no
+ * sandbox — see the repo's CLAUDE.md).
  */
-function isSafeRelPath(relPath: string): boolean {
+export function isSafeRelPath(relPath: string): boolean {
   if (!relPath) return false;
   if (relPath.includes("\0")) return false;
   if (path.isAbsolute(relPath)) return false;
@@ -1017,12 +1022,37 @@ export async function getTaskDiffBlob(
   }
 
   if (side === "new") {
-    const abs = path.join(cwd, relPath);
+    // `git diff`/`git ls-files` report tracked paths relative to the repo
+    // ROOT, not necessarily `cwd` — for an isolation=none task whose workdir
+    // is a subdirectory of the repo, joining `relPath` onto `cwd` directly
+    // double-prefixes it and 404s. (The "old" side below is unaffected:
+    // `git show <sha>:<relPath>` is root-relative by construction, same as
+    // the diff itself.) Resolve the repo root once and join there instead.
+    //
+    // Caveat: untracked files surfaced via `git ls-files --others`
+    // (getTaskDiff's synthetic "added" entries) are CWD-relative, not
+    // root-relative — so such a file's path may only resolve under the
+    // cwd-relative join. Try the root-relative path first (the common case —
+    // tracked diffs are root-relative), and fall back to the cwd-relative
+    // join only when the root-relative stat misses and the two differ.
+    const root = await repoRoot(cwd);
+    const rootAbs = root ? path.join(root, relPath) : null;
+    const cwdAbs = path.join(cwd, relPath);
+    let abs = rootAbs ?? cwdAbs;
     let st;
     try {
       st = statSync(abs);
     } catch {
-      return { ok: false, error: "not found", status: 404 };
+      if (rootAbs && rootAbs !== cwdAbs) {
+        try {
+          st = statSync(cwdAbs);
+          abs = cwdAbs;
+        } catch {
+          return { ok: false, error: "not found", status: 404 };
+        }
+      } else {
+        return { ok: false, error: "not found", status: 404 };
+      }
     }
     // Only regular files: a FIFO/device named `*.png` would otherwise hang
     // the read forever (same guard as /files/preview).
@@ -1049,7 +1079,15 @@ export async function getTaskDiffBlob(
     return { ok: false, error: "not present at base", status: 404 };
   }
   const size = Number(sizeRes.stdout);
-  if (Number.isFinite(size) && size > MAX_BLOB_PREVIEW_BYTES) {
+  // Fail CLOSED on an unparsable size: `cat-file -s` exited 0 (handled
+  // above) but printed something we can't read as a number is "can't
+  // confirm this is safe to read into memory," not "assume it's small
+  // enough." Two separate branches (rather than one combined condition) so
+  // each gets its own clear error/status.
+  if (!Number.isFinite(size)) {
+    return { ok: false, error: "could not determine blob size", status: 404 };
+  }
+  if (size > MAX_BLOB_PREVIEW_BYTES) {
     return { ok: false, error: "too large to preview", status: 413 };
   }
 

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -920,15 +920,37 @@ export async function getTaskDiff(task: Task): Promise<TaskDiff> {
   // full additions via --no-index (which exits 1 when content differs).
   const listed = await git(["ls-files", "--others", "--exclude-standard", "-z"], cwd);
   if (listed.ok) {
+    // `ls-files` (and the `--no-index` diff below) run in `cwd`, so `rel` is
+    // CWD-relative — but tracked entries from `git diff <base>` above are
+    // repo-ROOT-relative. For an isolation=none task whose workdir is a repo
+    // subdirectory, mixing the two namespaces in one TaskDiff is wrong (it's
+    // exactly what getTaskDiffBlob's cwd-fallback exists to paper over).
+    // Normalize by prefixing the root→cwd path segment onto the emitted
+    // DiffFile.path only; the `--no-index` invocation itself keeps using the
+    // cwd-relative `rel`, since that's what exists relative to the cwd git
+    // runs in. `path.relative` already returns forward-slash segments on
+    // POSIX (this app is macOS-only per CLAUDE.md), so no join-separator
+    // normalization is needed beyond a defensive backslash guard.
+    //
+    // `repoRoot` reports git's canonicalized path (symlinks resolved, e.g.
+    // `/tmp` → `/private/tmp` on macOS — see `gitWritableRootsSync`'s doc
+    // comment for the same gotcha), so diffing it against a non-canonical
+    // `cwd` would spuriously produce a non-empty prefix even when cwd IS the
+    // root. Realpath `cwd` first to compare like-for-like.
+    const root = await repoRoot(cwd);
+    let realCwd = cwd;
+    try { realCwd = realpathSync(cwd); } catch { /* cwd missing — compare as-is */ }
+    const prefix = root ? path.relative(root, realCwd).split(path.sep).join("/") : "";
     const rels = listed.stdout.split("\0").filter(Boolean).slice(0, MAX_UNTRACKED);
     for (const rel of rels) {
       const res = await git(["diff", "--no-color", "--no-index", "--", "/dev/null", rel], cwd);
       if (res.exitCode !== 0 && res.exitCode !== 1) continue;
       const [parsed] = parseGitDiff(res.stdout);
+      const emittedPath = prefix ? `${prefix}/${rel}` : rel;
       files.push(
         parsed
-          ? { ...parsed, status: "added", path: rel, oldPath: null }
-          : { path: rel, oldPath: null, status: "added", additions: 0, deletions: 0, binary: false, hunks: "", truncated: false },
+          ? { ...parsed, status: "added", path: emittedPath, oldPath: null }
+          : { path: emittedPath, oldPath: null, status: "added", additions: 0, deletions: 0, binary: false, hunks: "", truncated: false },
       );
     }
   }
@@ -1029,12 +1051,14 @@ export async function getTaskDiffBlob(
     // `git show <sha>:<relPath>` is root-relative by construction, same as
     // the diff itself.) Resolve the repo root once and join there instead.
     //
-    // Caveat: untracked files surfaced via `git ls-files --others`
-    // (getTaskDiff's synthetic "added" entries) are CWD-relative, not
-    // root-relative — so such a file's path may only resolve under the
-    // cwd-relative join. Try the root-relative path first (the common case —
-    // tracked diffs are root-relative), and fall back to the cwd-relative
-    // join only when the root-relative stat misses and the two differ.
+    // The cwd-relative fallback below exists for untracked files surfaced via
+    // `git ls-files --others` — getTaskDiff's synthetic "added" entries used
+    // to emit those CWD-relative, which only resolved under this fallback
+    // join. getTaskDiff now normalizes those to root-relative paths at the
+    // source, so for any freshly-generated diff the root-relative join above
+    // always hits and this fallback is vestigial. It stays anyway: a stale
+    // client (open DiffDialog tab, cached response) may still hold a
+    // pre-normalization cwd-relative path, and falling back is free.
     const root = await repoRoot(cwd);
     const rootAbs = root ? path.join(root, relPath) : null;
     const cwdAbs = path.join(cwd, relPath);

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -1,6 +1,7 @@
-import { existsSync, mkdirSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { dataDir } from "./db.ts";
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
@@ -43,6 +44,38 @@ async function git(args: string[], cwd: string, timeoutMs = GIT_TIMEOUT_MS): Pro
       proc.exited,
     ]);
     return { ok: exitCode === 0, stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Like `git`, but for reading raw blob bytes (e.g. `git show <sha>:<path>`)
+ * whose content may not be valid UTF-8 — images and PDFs, in particular.
+ * `git`'s `text()` collection would mangle those bytes via replacement-
+ * character substitution, so this variant collects stdout as an
+ * `ArrayBuffer` instead. Same never-throws contract and 30s default timeout
+ * as `git`.
+ */
+async function gitRaw(
+  args: string[],
+  cwd: string,
+  timeoutMs = GIT_TIMEOUT_MS,
+): Promise<{ ok: boolean; exitCode: number; bytes: Uint8Array<ArrayBuffer>; stderr: string }> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const timer = setTimeout(() => proc.kill(), timeoutMs);
+  try {
+    const [buf, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).arrayBuffer(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { ok: exitCode === 0, exitCode, bytes: new Uint8Array(buf), stderr: stderr.trim() };
   } finally {
     clearTimeout(timer);
   }
@@ -912,6 +945,123 @@ export async function getTaskDiff(task: Task): Promise<TaskDiff> {
     };
   }
   return { base: shortBase, files };
+}
+
+// Above this many bytes, a diff-preview blob (image/PDF) is refused rather
+// than read into memory whole — these routes serve the webview's inline
+// old-vs-new preview, not a general-purpose file reader.
+export const MAX_BLOB_PREVIEW_BYTES = 20_000_000;
+
+/**
+ * True iff `relPath` is safe to `path.join` onto a trusted `cwd`: non-empty,
+ * free of null bytes, not itself absolute, and whose normalized form
+ * doesn't escape `cwd` (no leading `..` segment once normalized). This is a
+ * stricter contract than `/files/preview`'s (which trusts an already-
+ * absolute, already-existing path) — `getTaskDiffBlob` takes a
+ * repo-relative path from the client, so traversal must be rejected before
+ * it ever touches the filesystem or a `git` invocation.
+ */
+function isSafeRelPath(relPath: string): boolean {
+  if (!relPath) return false;
+  if (relPath.includes("\0")) return false;
+  if (path.isAbsolute(relPath)) return false;
+  const normalized = path.normalize(relPath);
+  if (path.isAbsolute(normalized)) return false;
+  if (normalized === ".." || normalized.startsWith(`..${path.sep}`)) return false;
+  return true;
+}
+
+/**
+ * Read the raw bytes of one file, on one side of a task's diff, for the
+ * binary-preview UI (images/PDFs get an old-vs-new inline preview instead of
+ * the plain "binary file — no textual diff" placeholder). Mirrors
+ * `getTaskDiff`'s cwd/base selection exactly, so "old"/"new" here are
+ * literally the two sides `git diff <base>` compared:
+ *
+ *  - "new" reads the on-disk file in the task's cwd (the working tree).
+ *  - "old" resolves `base` to a commit sha and reads the blob via
+ *    `git show <sha>:<relPath>` — raw bytes (`gitRaw`), never text, since
+ *    images/PDFs aren't valid UTF-8 and must never round-trip through a
+ *    string.
+ *
+ * Never throws. `relPath` must pass `isSafeRelPath` — this route is
+ * repo-dir-relative, not an arbitrary-path reader like `/files/preview`.
+ * Renamed files: the caller is responsible for passing whichever path
+ * applies to the requested side (e.g. `oldPath` for `side: "old"` on a
+ * rename) — this function has no rename awareness of its own.
+ */
+export async function getTaskDiffBlob(
+  task: Task,
+  relPath: string,
+  side: "old" | "new",
+): Promise<{ ok: true; bytes: Uint8Array<ArrayBuffer>; etag: string } | { ok: false; error: string; status: number }> {
+  let cwd: string;
+  let base: string;
+
+  if (task.isolation === "worktree") {
+    if (!task.worktreePath || !existsSync(task.worktreePath)) {
+      return { ok: false, error: "this task hasn't created a worktree yet", status: 404 };
+    }
+    cwd = task.worktreePath;
+    base = task.baseRef ?? "HEAD";
+  } else {
+    if (!existsSync(task.workdir) || !(await isGitRepo(task.workdir))) {
+      return { ok: false, error: "the task's workdir isn't a git repo", status: 404 };
+    }
+    cwd = task.workdir;
+    base = "HEAD";
+  }
+
+  if (!isSafeRelPath(relPath)) {
+    return { ok: false, error: "invalid path", status: 400 };
+  }
+
+  if (side === "new") {
+    const abs = path.join(cwd, relPath);
+    let st;
+    try {
+      st = statSync(abs);
+    } catch {
+      return { ok: false, error: "not found", status: 404 };
+    }
+    // Only regular files: a FIFO/device named `*.png` would otherwise hang
+    // the read forever (same guard as /files/preview).
+    if (!st.isFile()) {
+      return { ok: false, error: "not found", status: 404 };
+    }
+    if (st.size > MAX_BLOB_PREVIEW_BYTES) {
+      return { ok: false, error: "too large to preview", status: 413 };
+    }
+    const bytes = new Uint8Array(await Bun.file(abs).arrayBuffer());
+    return { ok: true, bytes, etag: `"${st.size}-${st.mtimeMs}"` };
+  }
+
+  // side === "old"
+  const rev = await git(["rev-parse", "--verify", `${base}^{commit}`], cwd, 10_000);
+  if (!rev.ok || !rev.stdout) {
+    return { ok: false, error: "could not resolve base", status: 404 };
+  }
+  const sha = rev.stdout;
+
+  // Check the blob's size before reading it whole into memory.
+  const sizeRes = await git(["cat-file", "-s", `${sha}:${relPath}`], cwd, 10_000);
+  if (!sizeRes.ok) {
+    return { ok: false, error: "not present at base", status: 404 };
+  }
+  const size = Number(sizeRes.stdout);
+  if (Number.isFinite(size) && size > MAX_BLOB_PREVIEW_BYTES) {
+    return { ok: false, error: "too large to preview", status: 413 };
+  }
+
+  const blob = await gitRaw(["show", `${sha}:${relPath}`], cwd);
+  if (!blob.ok) {
+    return { ok: false, error: "not present at base", status: 404 };
+  }
+  // Stable hash (not Bun.hash — see claude-tmux.ts's note on its algorithm
+  // not being a cross-version stability contract) of the resolved sha+path,
+  // so this etag stays valid for the lifetime of the pinned base.
+  const etag = `"${createHash("sha1").update(`${sha}:${relPath}`).digest("hex")}"`;
+  return { ok: true, bytes: blob.bytes, etag };
 }
 
 /**

--- a/src/mainview/components/kanban/BinaryFilePreview.tsx
+++ b/src/mainview/components/kanban/BinaryFilePreview.tsx
@@ -1,13 +1,15 @@
 import {
-  useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent,
+  useCallback, useEffect, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent,
 } from "react";
 import { AlertTriangle, ChevronLeft, ChevronRight, FileWarning, ImageOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { api } from "@/lib/api";
-import { loadPdfDocument, type PdfDoc } from "@/lib/pdf";
+import { loadPdfDocument, isRenderCancelledError, type PdfDoc } from "@/lib/pdf";
+import { MAX_BLOB_PREVIEW_BYTES } from "../../../shared/attachments.ts";
+import type { DiffFile } from "../../../shared/types.ts";
 
-export type BinaryPreviewFileStatus = "added" | "modified" | "deleted" | "renamed";
+export type BinaryPreviewFileStatus = DiffFile["status"];
 
 export interface BinaryFilePreviewProps {
   kind: "image" | "pdf";
@@ -22,7 +24,29 @@ export interface BinaryFilePreviewProps {
   fileName?: string;
 }
 
-type Side = "old" | "new";
+export type Side = "old" | "new";
+
+/** Build the `{ oldUrl, newUrl }` pair `BinaryFilePreview` wants from a diff
+ *  file entry, applying the same added/deleted-side-is-null rule and rename
+ *  (`oldPath ?? path`) handling both DiffDialog's and GitHubDialog's binary
+ *  preview wrappers need. `urlFor` is the caller's one-line closure over
+ *  whichever blob-URL builder applies (`api.taskDiffBlobUrl` for a task
+ *  diff, `api.pullBlobUrl` for a GitHub PR diff). */
+export function binaryPreviewSides(
+  file: Pick<DiffFile, "path" | "oldPath" | "status">,
+  urlFor: (path: string, side: Side) => string,
+): { oldUrl: string | null; newUrl: string | null } {
+  return {
+    oldUrl: file.status === "added" ? null : urlFor(file.oldPath ?? file.path, "old"),
+    newUrl: file.status === "deleted" ? null : urlFor(file.path, "new"),
+  };
+}
+
+/** `file.path` is always the NEW-state path (renames included), so this is
+ *  the right basename for both preview panes' alt text / labels. */
+export function binaryFileBasename(path: string): string {
+  return path.slice(path.lastIndexOf("/") + 1);
+}
 
 /** Two-layer CSS checkerboard behind image panes, so transparent PNG/SVG
  *  content is visually distinguishable from an opaque white/black area.
@@ -71,30 +95,57 @@ function Pane({ side, status, children }: { side: Side; status: BinaryPreviewFil
 
 function EmptyPane({ side, status }: { side: Side; status: BinaryPreviewFileStatus }) {
   return (
-    <div className="flex h-40 items-center justify-center rounded-md border border-dashed border-border/60 bg-muted/20 p-2 text-center text-[11px] italic text-muted-foreground">
+    <div className="flex h-56 items-center justify-center rounded-md border border-dashed border-border/60 bg-muted/20 p-2 text-center text-[11px] italic text-muted-foreground">
       {emptySideCopy(side, status)}
     </div>
   );
 }
 
+/** Size cap in whole MB, for the too-large copy below — derived from the
+ *  shared constant rather than hardcoded so the image and PDF panes (and
+ *  the server-side limit they mirror) can't drift apart. */
+const MAX_BLOB_PREVIEW_MB = Math.round(MAX_BLOB_PREVIEW_BYTES / 1_000_000);
+
 /* ------------------------------- Images -------------------------------- */
+
+type ImageErrorKind = "too-large" | "missing" | "generic";
+
+const IMAGE_ERROR_COPY: Record<ImageErrorKind, string> = {
+  "too-large": `Too large to preview — ${MAX_BLOB_PREVIEW_MB} MB limit`,
+  "missing": "Not present on this side",
+  "generic": "Couldn't load image",
+};
 
 function ImagePane({ side, status, url, fileName }: { side: Side; status: BinaryPreviewFileStatus; url: string | null; fileName?: string }) {
   const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
-  const [errored, setErrored] = useState(false);
+  const [errorKind, setErrorKind] = useState<ImageErrorKind | null>(null);
 
   useEffect(() => {
     setDims(null);
-    setErrored(false);
+    setErrorKind(null);
+  }, [url]);
+
+  // SF-10: a bare 404/413 both surface through `onError` as the same
+  // generic broken-image icon — the browser gives no status code to an
+  // `<img>` load failure. Re-probe the URL (status only, body cancelled
+  // unread — see `api.probeBlobStatus`) so the pane can distinguish "too
+  // large to preview" and "not present on this side" from a genuine
+  // decode/network failure. Only runs on error, so no steady-state cost.
+  const handleError = useCallback(() => {
+    setErrorKind("generic");
+    if (!url) return;
+    void api.probeBlobStatus(url).then((kind) => {
+      setErrorKind(kind === "too-large" ? "too-large" : kind === "missing" ? "missing" : "generic");
+    });
   }, [url]);
 
   if (!url) return <EmptyPane side={side} status={status} />;
 
-  if (errored) {
+  if (errorKind) {
     return (
-      <div className="flex h-40 flex-col items-center justify-center gap-1.5 rounded-md border border-warning/40 bg-warning/10 p-2 text-center">
+      <div className="flex h-56 flex-col items-center justify-center gap-1.5 rounded-md border border-warning/40 bg-warning/10 p-2 text-center">
         <ImageOff className="size-4 shrink-0 text-warning" />
-        <span className="text-[11px] text-warning">Couldn't load image</span>
+        <span className="text-[11px] text-warning">{IMAGE_ERROR_COPY[errorKind]}</span>
       </div>
     );
   }
@@ -103,7 +154,7 @@ function ImagePane({ side, status, url, fileName }: { side: Side; status: Binary
   return (
     <div className="flex flex-col gap-1">
       <div
-        className="flex h-40 items-center justify-center overflow-hidden rounded-md border border-border/60 p-2"
+        className="flex h-56 items-center justify-center overflow-hidden rounded-md border border-border/60 p-2"
         style={CHECKERBOARD_STYLE}
       >
         <img
@@ -111,9 +162,9 @@ function ImagePane({ side, status, url, fileName }: { side: Side; status: Binary
           alt={`${label} version of ${fileName ?? "file"}`}
           loading="lazy"
           decoding="async"
-          className="max-h-72 max-w-full object-contain"
+          className="max-h-full max-w-full object-contain"
           onLoad={(e) => setDims({ w: e.currentTarget.naturalWidth, h: e.currentTarget.naturalHeight })}
-          onError={() => setErrored(true)}
+          onError={handleError}
         />
       </div>
       <span className="text-center font-mono text-[11px] tabular-nums text-muted-foreground">
@@ -127,18 +178,33 @@ function ImagePane({ side, status, url, fileName }: { side: Side; status: Binary
 
 type PdfSideState =
   | { status: "idle" }
+  // A url exists but we're deliberately not fetching it yet (SF-7: waiting
+  // for the pane to scroll into view) — rendered identically to "loading"
+  // below so there's no misleading "no version" flash for a side that in
+  // fact has content, just not-yet-fetched content.
+  | { status: "deferred" }
   | { status: "loading" }
   | { status: "ready"; doc: PdfDoc; numPages: number }
   | { status: "error"; kind: "too-large" | "missing" | "generic" };
 
-function usePdfSide(url: string | null, fetchBytes: (url: string) => Promise<ArrayBuffer>): PdfSideState {
-  const [state, setState] = useState<PdfSideState>(() => (url ? { status: "loading" } : { status: "idle" }));
+function usePdfSide(
+  url: string | null,
+  active: boolean,
+  fetchBytes: (url: string) => Promise<ArrayBuffer>,
+): PdfSideState {
+  const [state, setState] = useState<PdfSideState>(
+    () => (!url ? { status: "idle" } : active ? { status: "loading" } : { status: "deferred" }),
+  );
   const docRef = useRef<PdfDoc | null>(null);
 
   useEffect(() => {
     docRef.current = null;
     if (!url) {
       setState({ status: "idle" });
+      return;
+    }
+    if (!active) {
+      setState({ status: "deferred" });
       return;
     }
     let cancelled = false;
@@ -167,17 +233,23 @@ function usePdfSide(url: string | null, fetchBytes: (url: string) => Promise<Arr
         docRef.current = null;
       }
     };
-  }, [url, fetchBytes]);
+  }, [url, active, fetchBytes]);
 
   return state;
 }
 
-function useElementWidth<T extends HTMLElement>(): [React.RefObject<T | null>, number] {
-  const ref = useRef<T | null>(null);
+/** Tracks an element's content-box width across mount/branch-swaps via a
+ *  ref callback (React 19's ref-cleanup form) instead of a `[]`
+ *  `useLayoutEffect` over a `useRef` — the latter only ever observes
+ *  whichever node was mounted at first render, so a later render that swaps
+ *  in a differently-branched element sharing this ref (as `PdfPane`'s
+ *  idle/loading/ready/error returns do) silently stops tracking width
+ *  (NTH-12). A callback ref re-fires on every attach/detach, so the
+ *  observed node always matches what's actually on screen. */
+function useElementWidth<T extends HTMLElement>(): [(el: T | null) => void, number] {
   const [width, setWidth] = useState(0);
 
-  useLayoutEffect(() => {
-    const el = ref.current;
+  const setRef = useCallback((el: T | null) => {
     if (!el) return;
     const ro = new ResizeObserver((entries) => {
       const w = entries[0]?.contentRect.width;
@@ -188,11 +260,42 @@ function useElementWidth<T extends HTMLElement>(): [React.RefObject<T | null>, n
     return () => ro.disconnect();
   }, []);
 
-  return [ref, width];
+  return [setRef, width];
+}
+
+/** Fires once when its attached element first enters the viewport, then
+ *  disconnects (SF-7) — gates PDF byte-fetching so a diff with many binary
+ *  blocks (every block defaults open) doesn't pull every PDF on both sides
+ *  down at once. Images don't need this: `<img loading="lazy">` already
+ *  defers them natively. */
+function useVisibleOnce<T extends HTMLElement>(): [(el: T | null) => void, boolean] {
+  const [visible, setVisible] = useState(false);
+  const seenRef = useRef(false);
+
+  const setRef = useCallback((el: T | null) => {
+    if (!el || seenRef.current) return;
+    if (typeof IntersectionObserver === "undefined") {
+      // No IO support (non-browser test runtime) — fetch eagerly rather
+      // than never rendering a preview at all.
+      seenRef.current = true;
+      setVisible(true);
+      return;
+    }
+    const io = new IntersectionObserver((entries) => {
+      if (!entries.some((e) => e.isIntersecting)) return;
+      seenRef.current = true;
+      setVisible(true);
+      io.disconnect();
+    });
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return [setRef, visible];
 }
 
 const PDF_ERROR_COPY: Record<"too-large" | "missing" | "generic", string> = {
-  "too-large": "Too large to preview — 20 MB limit",
+  "too-large": `Too large to preview — ${MAX_BLOB_PREVIEW_MB} MB limit`,
   "missing": "File not found",
   "generic": "Couldn't load PDF",
 };
@@ -205,29 +308,39 @@ function PdfPane({
   state: PdfSideState;
   page: number;
   width: number;
-  containerRef: React.RefObject<HTMLDivElement | null>;
+  containerRef: (el: HTMLDivElement | null) => void;
 }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  // Render failures distinct from a document-level load error (state.error)
+  // — a corrupt page on an otherwise-valid doc, surfaced instead of the
+  // old silent `.catch(() => {})` that left the canvas permanently blank.
+  const [renderError, setRenderError] = useState(false);
 
   useEffect(() => {
+    setRenderError(false);
     if (state.status !== "ready" || !canvasRef.current || !width) return;
     if (page > state.numPages) return;
-    let cancelled = false;
-    void state.doc.renderPage(page, canvasRef.current, Math.max(1, Math.floor(width))).catch(() => {
-      if (!cancelled) {
-        // Render failures on a valid doc are rare (corrupt page); leave the
-        // canvas as-is rather than tearing down the whole pane state.
-      }
+    // MF-1: a page render mid-flight when this effect re-fires (double
+    // click, or a ResizeObserver width change racing the first render)
+    // would otherwise collide with pdf.js's "Cannot use the same canvas
+    // during multiple render() operations" and leave the pane permanently
+    // blank. `renderPage` now returns a cancellable handle — cancel the
+    // in-flight render on cleanup and only swallow the resulting (expected)
+    // cancellation; any other render failure surfaces to `renderError`.
+    const task = state.doc.renderPage(page, canvasRef.current, Math.max(1, Math.floor(width)));
+    task.result.catch((err) => {
+      if (isRenderCancelledError(err)) return;
+      setRenderError(true);
     });
     return () => {
-      cancelled = true;
+      task.cancel();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state, page, width]);
 
   if (state.status === "idle") return <EmptyPane side={side} status={status} />;
 
-  if (state.status === "loading") {
+  if (state.status === "loading" || state.status === "deferred") {
     return (
       <div ref={containerRef} className="flex h-72 w-full animate-pulse items-center justify-center rounded-md border border-border/60 bg-muted/40" />
     );
@@ -251,6 +364,15 @@ function PdfPane({
     );
   }
 
+  if (renderError) {
+    return (
+      <div ref={containerRef} className="flex h-40 flex-col items-center justify-center gap-1.5 rounded-md border border-border/60 bg-muted/20 p-2 text-center">
+        <AlertTriangle className="size-4 shrink-0 text-muted-foreground" />
+        <span className="text-[11px] italic text-muted-foreground">Couldn't render page {page}</span>
+      </div>
+    );
+  }
+
   return (
     <div ref={containerRef} className="flex items-center justify-center overflow-hidden rounded-md border border-border/60 bg-muted/10 p-1">
       <canvas ref={canvasRef} className="max-w-full" />
@@ -264,8 +386,12 @@ export function BinaryFilePreview({ kind, status, oldUrl, newUrl, fetchBytes, fi
   const doFetch = fetchBytes ?? api.fetchBlobBytes;
   const [page, setPage] = useState(1);
 
-  const oldState = usePdfSide(kind === "pdf" ? oldUrl : null, doFetch);
-  const newState = usePdfSide(kind === "pdf" ? newUrl : null, doFetch);
+  // SF-7: every binary block defaults open, so gate the (potentially
+  // 20MB-per-side) PDF byte fetch on the pane actually being scrolled into
+  // view rather than firing for every PDF in the diff on mount.
+  const [pdfRootRef, pdfVisible] = useVisibleOnce<HTMLDivElement>();
+  const oldState = usePdfSide(kind === "pdf" ? oldUrl : null, pdfVisible, doFetch);
+  const newState = usePdfSide(kind === "pdf" ? newUrl : null, pdfVisible, doFetch);
 
   const [oldRef, oldWidth] = useElementWidth<HTMLDivElement>();
   const [newRef, newWidth] = useElementWidth<HTMLDivElement>();
@@ -304,7 +430,7 @@ export function BinaryFilePreview({ kind, status, oldUrl, newUrl, fetchBytes, fi
   const showPager = (oldUrl !== null || newUrl !== null) && totalPages > 1;
 
   return (
-    <div className="flex flex-col gap-2">
+    <div ref={pdfRootRef} className="flex flex-col gap-2">
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <Pane side="old" status={status}>
           <PdfPane side="old" status={status} state={oldState} page={page} width={oldWidth} containerRef={oldRef} />

--- a/src/mainview/components/kanban/BinaryFilePreview.tsx
+++ b/src/mainview/components/kanban/BinaryFilePreview.tsx
@@ -1,0 +1,349 @@
+import {
+  useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent,
+} from "react";
+import { AlertTriangle, ChevronLeft, ChevronRight, FileWarning, ImageOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { api } from "@/lib/api";
+import { loadPdfDocument, type PdfDoc } from "@/lib/pdf";
+
+export type BinaryPreviewFileStatus = "added" | "modified" | "deleted" | "renamed";
+
+export interface BinaryFilePreviewProps {
+  kind: "image" | "pdf";
+  status: BinaryPreviewFileStatus;
+  /** null = this side doesn't exist (added → oldUrl null; deleted → newUrl null). */
+  oldUrl: string | null;
+  newUrl: string | null;
+  /** Injected for PDF panes, which fetch bytes via `fetch` rather than an
+   *  `<img>` tag. Defaults to `api.fetchBlobBytes`; overridable for tests. */
+  fetchBytes?: (url: string) => Promise<ArrayBuffer>;
+  /** Used in alt text / placeholder copy. */
+  fileName?: string;
+}
+
+type Side = "old" | "new";
+
+/** Two-layer CSS checkerboard behind image panes, so transparent PNG/SVG
+ *  content is visually distinguishable from an opaque white/black area.
+ *  Built from `--muted-foreground` at low alpha via the raw
+ *  `hsl(var(--x) / <alpha>)` syntax (the CSS vars in index.css already
+ *  store bare "H S% L%" triples), so it reads correctly in both themes
+ *  without a bespoke token. */
+const CHECKERBOARD_STYLE: CSSProperties = {
+  backgroundImage: [
+    "linear-gradient(45deg, hsl(var(--muted-foreground) / 0.14) 25%, transparent 25%)",
+    "linear-gradient(-45deg, hsl(var(--muted-foreground) / 0.14) 25%, transparent 25%)",
+    "linear-gradient(45deg, transparent 75%, hsl(var(--muted-foreground) / 0.14) 75%)",
+    "linear-gradient(-45deg, transparent 75%, hsl(var(--muted-foreground) / 0.14) 75%)",
+  ].join(", "),
+  backgroundSize: "16px 16px",
+  backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
+};
+
+function paneLabel(side: Side): { text: string; cls: string } {
+  return side === "old"
+    ? { text: "Before", cls: "border-danger/30 bg-danger/10 text-danger" }
+    : { text: "After", cls: "border-success/30 bg-success/10 text-success" };
+}
+
+function emptySideCopy(side: Side, status: BinaryPreviewFileStatus): string {
+  if (side === "old") return status === "added" ? "Added — no previous version" : "No previous version";
+  return status === "deleted" ? "Deleted — no new version" : "No new version";
+}
+
+function Pane({ side, status, children }: { side: Side; status: BinaryPreviewFileStatus; children: React.ReactNode }) {
+  const label = paneLabel(side);
+  return (
+    <div className="flex min-w-0 flex-col gap-1.5">
+      <span
+        className={cn(
+          "inline-flex w-fit items-center rounded-md border px-1.5 py-0.5 text-[11px] font-medium",
+          label.cls,
+        )}
+      >
+        {label.text}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+function EmptyPane({ side, status }: { side: Side; status: BinaryPreviewFileStatus }) {
+  return (
+    <div className="flex h-40 items-center justify-center rounded-md border border-dashed border-border/60 bg-muted/20 p-2 text-center text-[11px] italic text-muted-foreground">
+      {emptySideCopy(side, status)}
+    </div>
+  );
+}
+
+/* ------------------------------- Images -------------------------------- */
+
+function ImagePane({ side, status, url, fileName }: { side: Side; status: BinaryPreviewFileStatus; url: string | null; fileName?: string }) {
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+  const [errored, setErrored] = useState(false);
+
+  useEffect(() => {
+    setDims(null);
+    setErrored(false);
+  }, [url]);
+
+  if (!url) return <EmptyPane side={side} status={status} />;
+
+  if (errored) {
+    return (
+      <div className="flex h-40 flex-col items-center justify-center gap-1.5 rounded-md border border-warning/40 bg-warning/10 p-2 text-center">
+        <ImageOff className="size-4 shrink-0 text-warning" />
+        <span className="text-[11px] text-warning">Couldn't load image</span>
+      </div>
+    );
+  }
+
+  const label = side === "old" ? "previous" : "current";
+  return (
+    <div className="flex flex-col gap-1">
+      <div
+        className="flex h-40 items-center justify-center overflow-hidden rounded-md border border-border/60 p-2"
+        style={CHECKERBOARD_STYLE}
+      >
+        <img
+          src={url}
+          alt={`${label} version of ${fileName ?? "file"}`}
+          loading="lazy"
+          decoding="async"
+          className="max-h-72 max-w-full object-contain"
+          onLoad={(e) => setDims({ w: e.currentTarget.naturalWidth, h: e.currentTarget.naturalHeight })}
+          onError={() => setErrored(true)}
+        />
+      </div>
+      <span className="text-center font-mono text-[11px] tabular-nums text-muted-foreground">
+        {dims ? `${dims.w} × ${dims.h} px` : " "}
+      </span>
+    </div>
+  );
+}
+
+/* -------------------------------- PDFs ---------------------------------- */
+
+type PdfSideState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; doc: PdfDoc; numPages: number }
+  | { status: "error"; kind: "too-large" | "missing" | "generic" };
+
+function usePdfSide(url: string | null, fetchBytes: (url: string) => Promise<ArrayBuffer>): PdfSideState {
+  const [state, setState] = useState<PdfSideState>(() => (url ? { status: "loading" } : { status: "idle" }));
+  const docRef = useRef<PdfDoc | null>(null);
+
+  useEffect(() => {
+    docRef.current = null;
+    if (!url) {
+      setState({ status: "idle" });
+      return;
+    }
+    let cancelled = false;
+    setState({ status: "loading" });
+    (async () => {
+      try {
+        const bytes = await fetchBytes(url);
+        const doc = await loadPdfDocument(bytes);
+        if (cancelled) {
+          void doc.destroy();
+          return;
+        }
+        docRef.current = doc;
+        setState({ status: "ready", doc, numPages: doc.numPages });
+      } catch (err) {
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : "";
+        const kind = msg === "too-large" ? "too-large" : msg === "missing" ? "missing" : "generic";
+        setState({ status: "error", kind });
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (docRef.current) {
+        void docRef.current.destroy();
+        docRef.current = null;
+      }
+    };
+  }, [url, fetchBytes]);
+
+  return state;
+}
+
+function useElementWidth<T extends HTMLElement>(): [React.RefObject<T | null>, number] {
+  const ref = useRef<T | null>(null);
+  const [width, setWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (w) setWidth(w);
+    });
+    ro.observe(el);
+    setWidth(el.clientWidth);
+    return () => ro.disconnect();
+  }, []);
+
+  return [ref, width];
+}
+
+const PDF_ERROR_COPY: Record<"too-large" | "missing" | "generic", string> = {
+  "too-large": "Too large to preview — 20 MB limit",
+  "missing": "File not found",
+  "generic": "Couldn't load PDF",
+};
+
+function PdfPane({
+  side, status, state, page, width, containerRef,
+}: {
+  side: Side;
+  status: BinaryPreviewFileStatus;
+  state: PdfSideState;
+  page: number;
+  width: number;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    if (state.status !== "ready" || !canvasRef.current || !width) return;
+    if (page > state.numPages) return;
+    let cancelled = false;
+    void state.doc.renderPage(page, canvasRef.current, Math.max(1, Math.floor(width))).catch(() => {
+      if (!cancelled) {
+        // Render failures on a valid doc are rare (corrupt page); leave the
+        // canvas as-is rather than tearing down the whole pane state.
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state, page, width]);
+
+  if (state.status === "idle") return <EmptyPane side={side} status={status} />;
+
+  if (state.status === "loading") {
+    return (
+      <div ref={containerRef} className="flex h-72 w-full animate-pulse items-center justify-center rounded-md border border-border/60 bg-muted/40" />
+    );
+  }
+
+  if (state.status === "error") {
+    const Icon = state.kind === "too-large" ? FileWarning : AlertTriangle;
+    return (
+      <div ref={containerRef} className="flex h-40 flex-col items-center justify-center gap-1.5 rounded-md border border-border/60 bg-muted/20 p-2 text-center">
+        <Icon className="size-4 shrink-0 text-muted-foreground" />
+        <span className="text-[11px] italic text-muted-foreground">{PDF_ERROR_COPY[state.kind]}</span>
+      </div>
+    );
+  }
+
+  if (page > state.numPages) {
+    return (
+      <div ref={containerRef} className="flex h-40 items-center justify-center rounded-md border border-border/60 bg-muted/20 p-2 text-center text-[11px] italic text-muted-foreground">
+        No page {page}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="flex items-center justify-center overflow-hidden rounded-md border border-border/60 bg-muted/10 p-1">
+      <canvas ref={canvasRef} className="max-w-full" />
+    </div>
+  );
+}
+
+/* ------------------------------ Component -------------------------------- */
+
+export function BinaryFilePreview({ kind, status, oldUrl, newUrl, fetchBytes, fileName }: BinaryFilePreviewProps) {
+  const doFetch = fetchBytes ?? api.fetchBlobBytes;
+  const [page, setPage] = useState(1);
+
+  const oldState = usePdfSide(kind === "pdf" ? oldUrl : null, doFetch);
+  const newState = usePdfSide(kind === "pdf" ? newUrl : null, doFetch);
+
+  const [oldRef, oldWidth] = useElementWidth<HTMLDivElement>();
+  const [newRef, newWidth] = useElementWidth<HTMLDivElement>();
+
+  const oldPages = oldState.status === "ready" ? oldState.numPages : 0;
+  const newPages = newState.status === "ready" ? newState.numPages : 0;
+  const totalPages = Math.max(1, oldPages, newPages);
+
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages);
+  }, [page, totalPages]);
+
+  const goPrev = useCallback((e: ReactMouseEvent) => {
+    e.stopPropagation();
+    setPage((p) => Math.max(1, p - 1));
+  }, []);
+  const goNext = useCallback((e: ReactMouseEvent) => {
+    e.stopPropagation();
+    setPage((p) => Math.min(totalPages, p + 1));
+  }, [totalPages]);
+  const stopMouseDown = useCallback((e: ReactMouseEvent) => e.stopPropagation(), []);
+
+  if (kind === "image") {
+    return (
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Pane side="old" status={status}>
+          <ImagePane side="old" status={status} url={oldUrl} fileName={fileName} />
+        </Pane>
+        <Pane side="new" status={status}>
+          <ImagePane side="new" status={status} url={newUrl} fileName={fileName} />
+        </Pane>
+      </div>
+    );
+  }
+
+  const showPager = (oldUrl !== null || newUrl !== null) && totalPages > 1;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Pane side="old" status={status}>
+          <PdfPane side="old" status={status} state={oldState} page={page} width={oldWidth} containerRef={oldRef} />
+        </Pane>
+        <Pane side="new" status={status}>
+          <PdfPane side="new" status={status} state={newState} page={page} width={newWidth} containerRef={newRef} />
+        </Pane>
+      </div>
+      {showPager && (
+        <div className="flex items-center justify-center gap-2" onMouseDown={stopMouseDown}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            disabled={page <= 1}
+            onMouseDown={stopMouseDown}
+            onClick={goPrev}
+            aria-label="Previous page"
+          >
+            <ChevronLeft className="size-3.5" />
+          </Button>
+          <span className="min-w-[5.5rem] text-center font-mono text-[11px] tabular-nums text-muted-foreground">
+            Page {page} / {totalPages}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            disabled={page >= totalPages}
+            onMouseDown={stopMouseDown}
+            onClick={goNext}
+            aria-label="Next page"
+          >
+            <ChevronRight className="size-3.5" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/mainview/components/kanban/DiffDialog.tsx
+++ b/src/mainview/components/kanban/DiffDialog.tsx
@@ -13,7 +13,7 @@ import {
   addRangeToSelection, composeDiffMessage, groupSelectedRows, isRowInDragRange, isSelectableKind,
   type DiffDragRange, type DiffSelectionBlock,
 } from "@/lib/diff-selection";
-import { BinaryFilePreview } from "./BinaryFilePreview";
+import { BinaryFilePreview, binaryFileBasename, binaryPreviewSides } from "./BinaryFilePreview";
 import { binaryPreviewKind } from "../../../shared/attachments.ts";
 import type { AgentKind, DiffFile, Harness, Run, Task, TaskDiff } from "../../../shared/types.ts";
 
@@ -863,21 +863,18 @@ function FileBlock({
  *  row machinery — no `data-diff-path`/`data-diff-index`, no selection. */
 function BinaryDiffPreview({ taskId, file }: { taskId: string | null; file: DiffFile }) {
   const kind = binaryPreviewKind(file.path);
-  if (kind === null) {
+  if (kind === null || !taskId) {
     return <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file — no textual diff.</div>;
   }
-  if (!taskId) {
-    return <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file — no textual diff.</div>;
-  }
-  const fileName = file.path.slice(file.path.lastIndexOf("/") + 1);
+  const { oldUrl, newUrl } = binaryPreviewSides(file, (path, side) => api.taskDiffBlobUrl(taskId, path, side));
   return (
     <div className="px-3 py-2">
       <BinaryFilePreview
         kind={kind}
         status={file.status}
-        fileName={fileName}
-        oldUrl={file.status === "added" ? null : api.taskDiffBlobUrl(taskId, file.oldPath ?? file.path, "old")}
-        newUrl={file.status === "deleted" ? null : api.taskDiffBlobUrl(taskId, file.path, "new")}
+        fileName={binaryFileBasename(file.path)}
+        oldUrl={oldUrl}
+        newUrl={newUrl}
       />
     </div>
   );

--- a/src/mainview/components/kanban/DiffDialog.tsx
+++ b/src/mainview/components/kanban/DiffDialog.tsx
@@ -13,6 +13,8 @@ import {
   addRangeToSelection, composeDiffMessage, groupSelectedRows, isRowInDragRange, isSelectableKind,
   type DiffDragRange, type DiffSelectionBlock,
 } from "@/lib/diff-selection";
+import { BinaryFilePreview } from "./BinaryFilePreview";
+import { binaryPreviewKind } from "../../../shared/attachments.ts";
 import type { AgentKind, DiffFile, Harness, Run, Task, TaskDiff } from "../../../shared/types.ts";
 
 interface Props {
@@ -682,6 +684,7 @@ export function DiffDialog({ open, task, onClose }: Props) {
             {diff.files.map((f) => (
               <FileBlock
                 key={f.path}
+                taskId={taskId}
                 file={f}
                 open={openFiles.has(f.path)}
                 onToggle={() => toggle(f.path)}
@@ -787,6 +790,7 @@ type RowMouseDownHandler = (
 ) => void;
 
 function FileBlock({
+  taskId,
   file,
   open,
   onToggle,
@@ -796,6 +800,7 @@ function FileBlock({
   dragRange,
   registerBody,
 }: {
+  taskId: string | null;
   file: DiffFile;
   open: boolean;
   onToggle: () => void;
@@ -826,7 +831,7 @@ function FileBlock({
       </button>
       {open && (
         file.binary ? (
-          <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file — no textual diff.</div>
+          <BinaryDiffPreview taskId={taskId} file={file} />
         ) : (
           <>
             <DiffBody
@@ -846,6 +851,34 @@ function FileBlock({
           </>
         )
       )}
+    </div>
+  );
+}
+
+/** Binary-file branch of a `FileBlock` — renders an old/new image or PDF
+ *  preview when `file.path` is a kind `BinaryFilePreview` knows how to
+ *  render, else falls back to the plain placeholder. `file.path` is always
+ *  the file's NEW-state path (per `DiffFile`'s doc comment), so it's already
+ *  the right side to classify for a rename. Deliberately outside `DiffBody`'s
+ *  row machinery — no `data-diff-path`/`data-diff-index`, no selection. */
+function BinaryDiffPreview({ taskId, file }: { taskId: string | null; file: DiffFile }) {
+  const kind = binaryPreviewKind(file.path);
+  if (kind === null) {
+    return <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file — no textual diff.</div>;
+  }
+  if (!taskId) {
+    return <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file — no textual diff.</div>;
+  }
+  const fileName = file.path.slice(file.path.lastIndexOf("/") + 1);
+  return (
+    <div className="px-3 py-2">
+      <BinaryFilePreview
+        kind={kind}
+        status={file.status}
+        fileName={fileName}
+        oldUrl={file.status === "added" ? null : api.taskDiffBlobUrl(taskId, file.oldPath ?? file.path, "old")}
+        newUrl={file.status === "deleted" ? null : api.taskDiffBlobUrl(taskId, file.path, "new")}
+      />
     </div>
   );
 }

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -6592,11 +6592,13 @@ function GitHubItemDetail({
   // labels/milestones, reviewers, auto-merge) stay on `canPush` alone.
   const canModifyOwn = canPush || (!!viewerLogin && item.author?.login === viewerLogin);
   // Identifies the (repo dir, PR number) a binary diff blob request needs.
-  // Null gates PullDiff back to the plain placeholder for a non-PR item or a
-  // non-GitHub provider — GitLab/Bitbucket blob fetch is unsupported in v1
-  // (git-host.ts `pullBlob` returns 501 for them).
+  // Null gates PullDiff back to the plain placeholder for a non-PR item, or
+  // when `provider` isn't a single concrete provider (`"mixed"` — a batch
+  // view spanning repos on different hosts — or `null`, not yet resolved).
+  // All three git hosts (github/gitlab/bitbucket) are supported here:
+  // git-host.ts `pullBlob` dispatches by the repo dir's remote.
   const blobCtx = useMemo(
-    () => (provider === "github" && item.kind === "pulls" ? { repoDir: itemPath, number: item.number } : null),
+    () => (provider !== "mixed" && provider !== null && item.kind === "pulls" ? { repoDir: itemPath, number: item.number } : null),
     [provider, item.kind, item.number, itemPath],
   );
   return (
@@ -8931,10 +8933,10 @@ function Reactions({
 }
 
 /** Binary-file branch of a `DiffFileBlock` — renders an old/new image or PDF
- *  preview for a GitHub PR when `file.path` is a kind `BinaryFilePreview`
- *  knows how to render, else falls back to the plain placeholder.
- *  `blobCtx === null` (non-GitHub provider, or the item isn't a PR) also
- *  falls back to the placeholder — `/github/pull-blob` is GitHub-only in v1.
+ *  preview for a github/gitlab/bitbucket PR when `file.path` is a kind
+ *  `BinaryFilePreview` knows how to render, else falls back to the plain
+ *  placeholder. `blobCtx === null` (a `"mixed"`/unresolved provider, or the
+ *  item isn't a PR) also falls back to the placeholder.
  *  Deliberately outside `DiffBody`'s row machinery — no
  *  `data-diff-path`/`data-diff-index`, no selection. */
 function PullBinaryPreview({ blobCtx, file }: { blobCtx: { repoDir: string; number: number } | null; file: DiffFile }) {

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -69,6 +69,8 @@ import { cn } from "@/lib/utils";
 import { toRows, type DiffRow } from "@/lib/diff-rows";
 import { mergeabilityView, type MergeTone } from "@/lib/mergeability";
 import { isCredentialError } from "@/lib/credential-error";
+import { BinaryFilePreview } from "./BinaryFilePreview";
+import { binaryPreviewKind } from "../../../shared/attachments.ts";
 import { ResolveConflictsDialog, type ResolveConflictsContext } from "./ResolveConflictsDialog";
 import {
   backToList,
@@ -6589,6 +6591,14 @@ function GitHubItemDetail({
   // wider flag, while genuinely push-only actions (merge, lock, pin, transfer,
   // labels/milestones, reviewers, auto-merge) stay on `canPush` alone.
   const canModifyOwn = canPush || (!!viewerLogin && item.author?.login === viewerLogin);
+  // Identifies the (repo dir, PR number) a binary diff blob request needs.
+  // Null gates PullDiff back to the plain placeholder for a non-PR item or a
+  // non-GitHub provider — GitLab/Bitbucket blob fetch is unsupported in v1
+  // (git-host.ts `pullBlob` returns 501 for them).
+  const blobCtx = useMemo(
+    () => (provider === "github" && item.kind === "pulls" ? { repoDir: itemPath, number: item.number } : null),
+    [provider, item.kind, item.number, itemPath],
+  );
   return (
     <div>
       <div className="mb-2 flex items-center justify-between gap-2">
@@ -6698,7 +6708,7 @@ function GitHubItemDetail({
             <CommitStatus status={commitStatus} loading={commitStatusLoading} error={commitStatusError} onRetry={onRetryCommitStatus} onRefresh={onRefreshCommitStatus} />
           )}
           <PullCommits commits={commits} loading={commitsLoading} error={commitsError} onRetry={onRetryCommits} />
-          <PullDiff diff={diff} loading={diffLoading} error={diffError} onRetry={onRetryDiff} onRefresh={onRefreshDiff} onLineComment={onLineComment} onAddToReview={onAddToReview} pending={pendingReview} allowBatchReview={provider === "github"} />
+          <PullDiff diff={diff} loading={diffLoading} error={diffError} onRetry={onRetryDiff} onRefresh={onRefreshDiff} onLineComment={onLineComment} onAddToReview={onAddToReview} pending={pendingReview} allowBatchReview={provider === "github"} blobCtx={blobCtx} />
           {provider === "github" && (
             <PendingReview comments={pendingReview} stale={pendingStale} onRemove={onRemovePendingReview} />
           )}
@@ -8027,6 +8037,7 @@ function PullDiff({
   onAddToReview,
   pending,
   allowBatchReview,
+  blobCtx,
 }: {
   diff?: TaskDiff;
   loading: boolean;
@@ -8043,6 +8054,9 @@ function PullDiff({
   // Hide the batch affordance entirely on those providers; a single inline
   // comment still posts immediately via `onLineComment`.
   allowBatchReview: boolean;
+  // (repo dir, PR number) for binary-blob preview requests; null keeps the
+  // plain placeholder (non-GitHub provider or a non-PR item).
+  blobCtx: { repoDir: string; number: number } | null;
 }) {
   const totals = useMemo(() => {
     const files = diff?.files ?? [];
@@ -8117,6 +8131,7 @@ function PullDiff({
               onAddToReview={onAddToReview}
               queuedKeys={queuedKeys}
               allowBatchReview={allowBatchReview}
+              blobCtx={blobCtx}
             />
           ))}
         </div>
@@ -8915,18 +8930,46 @@ function Reactions({
   );
 }
 
+/** Binary-file branch of a `DiffFileBlock` — renders an old/new image or PDF
+ *  preview for a GitHub PR when `file.path` is a kind `BinaryFilePreview`
+ *  knows how to render, else falls back to the plain placeholder.
+ *  `blobCtx === null` (non-GitHub provider, or the item isn't a PR) also
+ *  falls back to the placeholder — `/github/pull-blob` is GitHub-only in v1.
+ *  Deliberately outside `DiffBody`'s row machinery — no
+ *  `data-diff-path`/`data-diff-index`, no selection. */
+function PullBinaryPreview({ blobCtx, file }: { blobCtx: { repoDir: string; number: number } | null; file: DiffFile }) {
+  const kind = binaryPreviewKind(file.path);
+  if (kind === null || !blobCtx) {
+    return <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file, no textual diff.</div>;
+  }
+  const fileName = file.path.slice(file.path.lastIndexOf("/") + 1);
+  return (
+    <div className="px-3 py-2">
+      <BinaryFilePreview
+        kind={kind}
+        status={file.status}
+        fileName={fileName}
+        oldUrl={file.status === "added" ? null : api.pullBlobUrl({ path: blobCtx.repoDir, number: blobCtx.number, filePath: file.oldPath ?? file.path, side: "old" })}
+        newUrl={file.status === "deleted" ? null : api.pullBlobUrl({ path: blobCtx.repoDir, number: blobCtx.number, filePath: file.path, side: "new" })}
+      />
+    </div>
+  );
+}
+
 function DiffFileBlock({
   file,
   onLineComment,
   onAddToReview,
   queuedKeys,
   allowBatchReview,
+  blobCtx,
 }: {
   file: DiffFile;
   onLineComment: (target: LineCommentTarget) => Promise<void>;
   onAddToReview: (target: LineCommentTarget) => void;
   queuedKeys: Set<string>;
   allowBatchReview: boolean;
+  blobCtx: { repoDir: string; number: number } | null;
 }) {
   const meta = STATUS_META[file.status];
   const Icon = meta.icon;
@@ -8963,7 +9006,7 @@ function DiffFileBlock({
       {open && (
         <div id={bodyId}>
           {file.binary ? (
-            <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file, no textual diff.</div>
+            <PullBinaryPreview blobCtx={blobCtx} file={file} />
           ) : (
             <>
               <DiffBody file={file} hunks={file.hunks} onLineComment={onLineComment} onAddToReview={onAddToReview} queuedKeys={queuedKeys} allowBatchReview={allowBatchReview} />

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -69,7 +69,7 @@ import { cn } from "@/lib/utils";
 import { toRows, type DiffRow } from "@/lib/diff-rows";
 import { mergeabilityView, type MergeTone } from "@/lib/mergeability";
 import { isCredentialError } from "@/lib/credential-error";
-import { BinaryFilePreview } from "./BinaryFilePreview";
+import { BinaryFilePreview, binaryFileBasename, binaryPreviewSides } from "./BinaryFilePreview";
 import { binaryPreviewKind } from "../../../shared/attachments.ts";
 import { ResolveConflictsDialog, type ResolveConflictsContext } from "./ResolveConflictsDialog";
 import {
@@ -8940,17 +8940,18 @@ function Reactions({
 function PullBinaryPreview({ blobCtx, file }: { blobCtx: { repoDir: string; number: number } | null; file: DiffFile }) {
   const kind = binaryPreviewKind(file.path);
   if (kind === null || !blobCtx) {
-    return <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file, no textual diff.</div>;
+    return <div className="px-3 py-2 text-xs italic text-muted-foreground">Binary file — no textual diff.</div>;
   }
-  const fileName = file.path.slice(file.path.lastIndexOf("/") + 1);
+  const { oldUrl, newUrl } = binaryPreviewSides(file, (path, side) =>
+    api.pullBlobUrl({ path: blobCtx.repoDir, number: blobCtx.number, filePath: path, side }));
   return (
     <div className="px-3 py-2">
       <BinaryFilePreview
         kind={kind}
         status={file.status}
-        fileName={fileName}
-        oldUrl={file.status === "added" ? null : api.pullBlobUrl({ path: blobCtx.repoDir, number: blobCtx.number, filePath: file.oldPath ?? file.path, side: "old" })}
-        newUrl={file.status === "deleted" ? null : api.pullBlobUrl({ path: blobCtx.repoDir, number: blobCtx.number, filePath: file.path, side: "new" })}
+        fileName={binaryFileBasename(file.path)}
+        oldUrl={oldUrl}
+        newUrl={newUrl}
       />
     </div>
   );

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -1337,12 +1337,17 @@ export const api = {
     return `${BASE}/github/pull-blob?${q.toString()}`;
   },
 
-  /** Fetch binary blob bytes via `Authorization: Bearer` (no token in the
-   *  URL — used for PDF panes, which go through `fetch`/pdf.js rather than
-   *  an `<img>` tag). Throws an `Error` whose message distinguishes a
-   *  missing blob ("missing", 404) from one over the server's size cap
-   *  ("too-large", 413) from any other failure, so callers can render a
-   *  matching empty state. */
+  /** Fetch binary blob bytes via an `Authorization: Bearer` header — used
+   *  for PDF panes, which go through `fetch`/pdf.js rather than an `<img>`
+   *  tag. This function always authenticates via the header, same as every
+   *  other `api.*` call; it doesn't rely on (or care about) a `?token=` in
+   *  `url` even though `url` is typically one of `taskDiffBlobUrl`'s /
+   *  `pullBlobUrl`'s outputs, which DO append one — those builders are
+   *  shared with `<img src>` consumers, which can't set headers at all, so
+   *  their URLs carry a token unconditionally. Throws an `Error` whose
+   *  message distinguishes a missing blob ("missing", 404) from one over
+   *  the server's size cap ("too-large", 413) from any other failure, so
+   *  callers can render a matching empty state. */
   fetchBlobBytes: async (url: string): Promise<ArrayBuffer> => {
     const res = await fetch(url, {
       headers: { "authorization": `Bearer ${API_TOKEN}` },
@@ -1353,6 +1358,24 @@ export const api = {
       throw new Error(`${res.status} ${res.statusText}`);
     }
     return res.arrayBuffer();
+  },
+  /** Lightweight status probe for a blob URL, used to classify an `<img>`
+   *  `onError` (SF-10) without downloading the — possibly large — body the
+   *  way `fetchBlobBytes` does: the response is read only for its status,
+   *  then its body is cancelled unread. Same three-way classification as
+   *  `fetchBlobBytes`, as a return value instead of a thrown error since
+   *  this is a best-effort classification, not a load path a caller awaits
+   *  before rendering. */
+  probeBlobStatus: async (url: string): Promise<"missing" | "too-large" | "ok" | "error"> => {
+    try {
+      const res = await fetch(url, { headers: { "authorization": `Bearer ${API_TOKEN}` } });
+      void res.body?.cancel();
+      if (res.status === 404) return "missing";
+      if (res.status === 413) return "too-large";
+      return res.ok ? "ok" : "error";
+    } catch {
+      return "error";
+    }
   },
 
   /** Persist an in-memory image (clipboard paste or macOS floating-thumbnail

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -1308,6 +1308,53 @@ export const api = {
   filePreviewUrl: (path: string): string =>
     `${BASE}/files/preview?path=${encodeURIComponent(path)}&token=${encodeURIComponent(API_TOKEN)}`,
 
+  /** Absolute URL for a task's worktree-diff binary blob (old or new side of
+   *  a binary file), for `<img src>` use in `BinaryFilePreview`. Same
+   *  `?token=` pattern as `filePreviewUrl` — `<img>` can't set an
+   *  `Authorization` header. Backed by `GET /tasks/:id/diff/blob`, which
+   *  resolves `side: "old"` via `git show <baseRef>:<path>` and `side:
+   *  "new"` from the on-disk file in the task's cwd (worktree or workdir),
+   *  mirroring what `getTaskDiff`'s underlying `git diff` compared. */
+  taskDiffBlobUrl: (taskId: string, path: string, side: "old" | "new"): string =>
+    `${BASE}/tasks/${taskId}/diff/blob?path=${encodeURIComponent(path)}&side=${side}&token=${encodeURIComponent(API_TOKEN)}`,
+
+  /** Absolute URL for a GitHub PR's binary blob (old or new side), for
+   *  `<img src>` use in `BinaryFilePreview`. Identifying params mirror
+   *  `getGitHubPullDiff` (`path`, `number`) exactly, plus the blob-specific
+   *  `filePath` (repo-relative file path — carried as a distinct param name
+   *  from `path`, which is the local repo dir used to resolve the GitHub
+   *  remote) and `side`. Backed by `GET /github/pull-blob`: the old side
+   *  anchors at the PR's merge base (the `.diff` shown is a three-dot
+   *  diff), the new side at the PR head sha. */
+  pullBlobUrl: (opts: { path: string; number: number; filePath: string; side: "old" | "new" }): string => {
+    const q = new URLSearchParams({
+      path: opts.path,
+      number: String(opts.number),
+      filePath: opts.filePath,
+      side: opts.side,
+      token: API_TOKEN,
+    });
+    return `${BASE}/github/pull-blob?${q.toString()}`;
+  },
+
+  /** Fetch binary blob bytes via `Authorization: Bearer` (no token in the
+   *  URL — used for PDF panes, which go through `fetch`/pdf.js rather than
+   *  an `<img>` tag). Throws an `Error` whose message distinguishes a
+   *  missing blob ("missing", 404) from one over the server's size cap
+   *  ("too-large", 413) from any other failure, so callers can render a
+   *  matching empty state. */
+  fetchBlobBytes: async (url: string): Promise<ArrayBuffer> => {
+    const res = await fetch(url, {
+      headers: { "authorization": `Bearer ${API_TOKEN}` },
+    });
+    if (!res.ok) {
+      if (res.status === 404) throw new Error("missing");
+      if (res.status === 413) throw new Error("too-large");
+      throw new Error(`${res.status} ${res.statusText}`);
+    }
+    return res.arrayBuffer();
+  },
+
   /** Persist an in-memory image (clipboard paste or macOS floating-thumbnail
    *  drag) to disk and get back its absolute path. Bypasses `j()` because the
    *  body is raw bytes, not JSON. */

--- a/src/mainview/lib/pdf.ts
+++ b/src/mainview/lib/pdf.ts
@@ -1,0 +1,79 @@
+/**
+ * Lazy pdf.js loader for binary-diff PDF previews.
+ *
+ * Nothing pdf.js-related may load at board startup — `loadPdfDocument` does
+ * a dynamic `import("pdfjs-dist")` so the ~1MB library + worker only enter
+ * the bundle graph as a separate Vite chunk, fetched the first time a PDF
+ * preview pane actually mounts (BinaryFilePreview.tsx).
+ *
+ * Worker wiring: the worker script itself (`pdf.worker.min.mjs`) is a
+ * separate file pdf.js `postMessage`s work to. We resolve its URL via the
+ * `new URL(<bare-specifier>, import.meta.url)` pattern, which is Vite's
+ * documented way to get an asset URL for a package-relative path — Vite's
+ * import-analysis plugin statically recognizes this exact call shape and
+ * rewrites it to a hashed asset URL at build time, without needing an
+ * ambient `*.mjs?url` module declaration (this repo has no `vite/client`
+ * types reference, so a `?url`-suffixed static import wouldn't type-check).
+ * Confirmed against the installed pdfjs-dist version's `build/` layout
+ * (`node_modules/pdfjs-dist/build/pdf.worker.min.mjs` — pdfjs-dist@6.2.108).
+ */
+
+export interface PdfPageSize {
+  width: number;
+  height: number;
+}
+
+export interface PdfDoc {
+  numPages: number;
+  /** Render `pageNo` (1-based) into `canvas`, fitted to `maxWidth` CSS
+   *  pixels and scaled for the device pixel ratio so the canvas stays
+   *  crisp on HiDPI displays. Resolves with the rendered CSS size. */
+  renderPage(pageNo: number, canvas: HTMLCanvasElement, maxWidth: number): Promise<PdfPageSize>;
+  /** Release the underlying pdf.js document (and its worker-side state).
+   *  Call on unmount / before loading a different document. */
+  destroy(): Promise<void>;
+}
+
+let workerConfigured = false;
+
+export async function loadPdfDocument(data: ArrayBuffer): Promise<PdfDoc> {
+  const pdfjs = await import("pdfjs-dist");
+
+  if (!workerConfigured) {
+    const workerUrl = new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url);
+    pdfjs.GlobalWorkerOptions.workerSrc = workerUrl.toString();
+    workerConfigured = true;
+  }
+
+  // pdf.js detaches/consumes the ArrayBuffer it's handed; callers may want
+  // to keep the original bytes around, so hand over a copy. `destroy()`
+  // lives on the loading task, not the resolved PDFDocumentProxy — keep
+  // both.
+  const loadingTask = pdfjs.getDocument({ data: data.slice(0) });
+  const doc = await loadingTask.promise;
+
+  return {
+    numPages: doc.numPages,
+    async renderPage(pageNo, canvas, maxWidth) {
+      const page = await doc.getPage(pageNo);
+      const unscaled = page.getViewport({ scale: 1 });
+      const dpr = typeof window !== "undefined" ? (window.devicePixelRatio || 1) : 1;
+      const cssScale = maxWidth / unscaled.width;
+      const viewport = page.getViewport({ scale: cssScale * dpr });
+
+      canvas.width = Math.max(1, Math.round(viewport.width));
+      canvas.height = Math.max(1, Math.round(viewport.height));
+      canvas.style.width = `${Math.round(viewport.width / dpr)}px`;
+      canvas.style.height = `${Math.round(viewport.height / dpr)}px`;
+
+      if (!canvas.getContext("2d")) throw new Error("Canvas 2D context unavailable");
+
+      await page.render({ canvas, viewport }).promise;
+
+      return { width: Math.round(viewport.width / dpr), height: Math.round(viewport.height / dpr) };
+    },
+    async destroy() {
+      await loadingTask.destroy();
+    },
+  };
+}

--- a/src/mainview/lib/pdf.ts
+++ b/src/mainview/lib/pdf.ts
@@ -23,12 +23,39 @@ export interface PdfPageSize {
   height: number;
 }
 
+/** Name pdf.js stamps on the error a render rejects with when it's
+ *  cancelled via `RenderTask.cancel()` (confirmed against the installed
+ *  pdfjs-dist@6.2.108's `RenderingCancelledException`, which extends its
+ *  `BaseException` and sets `this.name = "RenderingCancelledException"` in
+ *  the base constructor). Exported so callers can distinguish an expected
+ *  cancellation (overlapping renders, unmount) from a real render failure
+ *  without importing pdf.js themselves. */
+export const RENDERING_CANCELLED_NAME = "RenderingCancelledException";
+
+export function isRenderCancelledError(err: unknown): boolean {
+  return !!err && typeof err === "object" && "name" in err && err.name === RENDERING_CANCELLED_NAME;
+}
+
+/** A single `renderPage` call in flight. `result` settles once (resolve on
+ *  success, reject on cancellation or a real render error); `cancel()` is
+ *  idempotent and safe to call at any point, including before pdf.js's own
+ *  `RenderTask` exists yet (the async gap while awaiting `getPage`) and
+ *  after `result` has already settled (no-op). */
+export interface PdfRenderTask {
+  result: Promise<PdfPageSize>;
+  cancel(): void;
+}
+
 export interface PdfDoc {
   numPages: number;
   /** Render `pageNo` (1-based) into `canvas`, fitted to `maxWidth` CSS
    *  pixels and scaled for the device pixel ratio so the canvas stays
-   *  crisp on HiDPI displays. Resolves with the rendered CSS size. */
-  renderPage(pageNo: number, canvas: HTMLCanvasElement, maxWidth: number): Promise<PdfPageSize>;
+   *  crisp on HiDPI displays. Returns a cancellable handle rather than a
+   *  bare promise — pdf.js refuses to run two `render()` calls against the
+   *  same canvas concurrently, so a caller that might re-invoke this before
+   *  the previous call finished (a double-click, or a ResizeObserver width
+   *  change mid-render) MUST cancel the stale call first. */
+  renderPage(pageNo: number, canvas: HTMLCanvasElement, maxWidth: number): PdfRenderTask;
   /** Release the underlying pdf.js document (and its worker-side state).
    *  Call on unmount / before loading a different document. */
   destroy(): Promise<void>;
@@ -45,32 +72,67 @@ export async function loadPdfDocument(data: ArrayBuffer): Promise<PdfDoc> {
     workerConfigured = true;
   }
 
-  // pdf.js detaches/consumes the ArrayBuffer it's handed; callers may want
-  // to keep the original bytes around, so hand over a copy. `destroy()`
-  // lives on the loading task, not the resolved PDFDocumentProxy — keep
-  // both.
-  const loadingTask = pdfjs.getDocument({ data: data.slice(0) });
+  // pdf.js detaches/consumes the ArrayBuffer it's handed. The only caller
+  // (usePdfSide in BinaryFilePreview.tsx) fetches fresh bytes per doc load
+  // and discards its own reference afterwards, so there's no one left who
+  // needs the original buffer preserved — hand it over directly rather than
+  // copying. `destroy()` lives on the loading task, not the resolved
+  // PDFDocumentProxy — keep both.
+  const loadingTask = pdfjs.getDocument({ data });
   const doc = await loadingTask.promise;
 
   return {
     numPages: doc.numPages,
-    async renderPage(pageNo, canvas, maxWidth) {
-      const page = await doc.getPage(pageNo);
-      const unscaled = page.getViewport({ scale: 1 });
-      const dpr = typeof window !== "undefined" ? (window.devicePixelRatio || 1) : 1;
-      const cssScale = maxWidth / unscaled.width;
-      const viewport = page.getViewport({ scale: cssScale * dpr });
+    renderPage(pageNo, canvas, maxWidth) {
+      let cancelled = false;
+      // pdf.js's own RenderTask, once `page.render()` has actually been
+      // called — undefined during the async gap while awaiting `getPage`.
+      let renderTask: { cancel(): void } | null = null;
 
-      canvas.width = Math.max(1, Math.round(viewport.width));
-      canvas.height = Math.max(1, Math.round(viewport.height));
-      canvas.style.width = `${Math.round(viewport.width / dpr)}px`;
-      canvas.style.height = `${Math.round(viewport.height / dpr)}px`;
+      function cancelledError(): Error {
+        const e = new Error(`Rendering cancelled, page ${pageNo}`);
+        e.name = RENDERING_CANCELLED_NAME;
+        return e;
+      }
 
-      if (!canvas.getContext("2d")) throw new Error("Canvas 2D context unavailable");
+      const result = (async (): Promise<PdfPageSize> => {
+        const page = await doc.getPage(pageNo);
+        if (cancelled) throw cancelledError();
 
-      await page.render({ canvas, viewport }).promise;
+        const unscaled = page.getViewport({ scale: 1 });
+        const dpr = typeof window !== "undefined" ? (window.devicePixelRatio || 1) : 1;
+        const cssScale = maxWidth / unscaled.width;
+        const viewport = page.getViewport({ scale: cssScale * dpr });
 
-      return { width: Math.round(viewport.width / dpr), height: Math.round(viewport.height / dpr) };
+        if (!canvas.getContext("2d")) throw new Error("Canvas 2D context unavailable");
+
+        // Mutating the canvas is gated behind this second cancellation
+        // check (cancel() can fire during the `getPage` await above, before
+        // `renderTask` exists to cancel) so a cancelled render can't clear
+        // dimensions a newer, still-live render already painted into.
+        if (cancelled) throw cancelledError();
+
+        canvas.width = Math.max(1, Math.round(viewport.width));
+        canvas.height = Math.max(1, Math.round(viewport.height));
+        canvas.style.width = `${Math.round(viewport.width / dpr)}px`;
+        canvas.style.height = `${Math.round(viewport.height / dpr)}px`;
+
+        const task = page.render({ canvas, viewport });
+        renderTask = task;
+        if (cancelled) task.cancel();
+        await task.promise;
+
+        return { width: Math.round(viewport.width / dpr), height: Math.round(viewport.height / dpr) };
+      })();
+
+      return {
+        result,
+        cancel() {
+          if (cancelled) return;
+          cancelled = true;
+          renderTask?.cancel();
+        },
+      };
     },
     async destroy() {
       await loadingTask.destroy();

--- a/src/shared/attachments.test.ts
+++ b/src/shared/attachments.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
+  binaryPreviewKind,
   canonicalizeAttachmentText,
+  contentTypeForPreviewPath,
   imageSourceMetaPath,
   isImagePath,
   isImageSourceMetaBreadcrumb,
+  isPdfPath,
+  MAX_BLOB_PREVIEW_BYTES,
   stripImagePlaceholders,
 } from "./attachments.ts";
 
@@ -53,6 +57,114 @@ describe("isImagePath", () => {
   test("a non-image extension does not match", () => {
     expect(isImagePath("/a/b/file.ts")).toBe(false);
     expect(isImagePath("/a/b/README.md")).toBe(false);
+  });
+});
+
+describe("isPdfPath", () => {
+  test("matches .pdf case-insensitively", () => {
+    expect(isPdfPath("/a/b/report.pdf")).toBe(true);
+    expect(isPdfPath("/a/b/report.PDF")).toBe(true);
+    expect(isPdfPath("/a/b/report.Pdf")).toBe(true);
+  });
+
+  test("bare filename with no directory still matches", () => {
+    expect(isPdfPath("report.pdf")).toBe(true);
+  });
+
+  test("a directory path (trailing slash) is never a pdf, even with a pdf-like name", () => {
+    expect(isPdfPath("/a/b/foo.pdf/")).toBe(false);
+  });
+
+  test("a non-pdf extension does not match", () => {
+    expect(isPdfPath("/a/b/file.png")).toBe(false);
+    expect(isPdfPath("/a/b/README.md")).toBe(false);
+  });
+
+  test("extension-less path does not match", () => {
+    expect(isPdfPath("/a/b/README")).toBe(false);
+  });
+});
+
+describe("binaryPreviewKind", () => {
+  test("every canonical image extension classifies as 'image', case-insensitively", () => {
+    for (const ext of ["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico", "avif", "heic"]) {
+      expect(binaryPreviewKind(`/a/file.${ext}`)).toBe("image");
+      expect(binaryPreviewKind(`/a/file.${ext.toUpperCase()}`)).toBe("image");
+    }
+  });
+
+  test("pdf classifies as 'pdf', case-insensitively", () => {
+    expect(binaryPreviewKind("/a/doc.pdf")).toBe("pdf");
+    expect(binaryPreviewKind("/a/doc.PDF")).toBe("pdf");
+  });
+
+  test("a non-previewable binary extension classifies as null", () => {
+    expect(binaryPreviewKind("/a/archive.zip")).toBeNull();
+    expect(binaryPreviewKind("/a/data.bin")).toBeNull();
+  });
+
+  test("a textual extension classifies as null", () => {
+    expect(binaryPreviewKind("/a/file.ts")).toBeNull();
+  });
+
+  test("an extension-less path classifies as null", () => {
+    expect(binaryPreviewKind("/a/README")).toBeNull();
+  });
+
+  test("a directory path (trailing slash) classifies as null even with an image-like name", () => {
+    expect(binaryPreviewKind("/a/foo.png/")).toBeNull();
+  });
+});
+
+describe("contentTypeForPreviewPath", () => {
+  test("png maps to image/png", () => {
+    expect(contentTypeForPreviewPath("/a/shot.png")).toBe("image/png");
+  });
+
+  test("svg maps to image/svg+xml", () => {
+    expect(contentTypeForPreviewPath("/a/icon.svg")).toBe("image/svg+xml");
+  });
+
+  test("pdf maps to application/pdf", () => {
+    expect(contentTypeForPreviewPath("/a/report.pdf")).toBe("application/pdf");
+  });
+
+  test("every canonical image extension has a mapped content-type", () => {
+    const expected: Record<string, string> = {
+      png: "image/png",
+      jpg: "image/jpeg",
+      jpeg: "image/jpeg",
+      gif: "image/gif",
+      webp: "image/webp",
+      svg: "image/svg+xml",
+      bmp: "image/bmp",
+      ico: "image/x-icon",
+      avif: "image/avif",
+      heic: "image/heic",
+    };
+    for (const [ext, mime] of Object.entries(expected)) {
+      expect(contentTypeForPreviewPath(`/a/file.${ext}`)).toBe(mime);
+    }
+  });
+
+  test("case-insensitive on the extension", () => {
+    expect(contentTypeForPreviewPath("/a/shot.PNG")).toBe("image/png");
+    expect(contentTypeForPreviewPath("/a/report.PDF")).toBe("application/pdf");
+  });
+
+  test("an unrecognized extension maps to null", () => {
+    expect(contentTypeForPreviewPath("/a/archive.zip")).toBeNull();
+    expect(contentTypeForPreviewPath("/a/notes.txt")).toBeNull();
+  });
+
+  test("an extension-less path maps to null", () => {
+    expect(contentTypeForPreviewPath("/a/README")).toBeNull();
+  });
+});
+
+describe("MAX_BLOB_PREVIEW_BYTES", () => {
+  test("is exported as the documented 20MB cap", () => {
+    expect(MAX_BLOB_PREVIEW_BYTES).toBe(20_000_000);
   });
 });
 

--- a/src/shared/attachments.ts
+++ b/src/shared/attachments.ts
@@ -83,6 +83,49 @@ export function binaryPreviewKind(path: string): BinaryPreviewKind | null {
   return null;
 }
 
+/** Single canonical extension → MIME map for every binary-preview kind this
+ *  module recognizes (the `IMAGE_EXTENSIONS` above, plus `pdf`). Was
+ *  previously duplicated across `server.ts` (`PREVIEW_CONTENT_TYPES` +
+ *  `blobContentType`) and `github.ts` (`contentTypeForBlobPath`'s inline
+ *  `known` map) — kept here as the one source of truth so the three don't
+ *  drift. Extend this map (and `IMAGE_EXTENSIONS` above, for image kinds)
+ *  together when adding a previewable kind. */
+const PREVIEW_CONTENT_TYPES: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
+  avif: "image/avif",
+  heic: "image/heic",
+  pdf: "application/pdf",
+};
+
+/** MIME type for `p`'s extension (basename-only, case-insensitive — same
+ *  path-parsing rule as `isImagePath`/`isPdfPath`), or `null` when `p` isn't
+ *  one of the binary-preview kinds `binaryPreviewKind` recognizes. Callers
+ *  that want a best-effort guess for an unrecognized extension (e.g. trust
+ *  a host API's own reported content-type) should `??` the result
+ *  themselves — this function never guesses beyond the canonical map. */
+export function contentTypeForPreviewPath(p: string): string | null {
+  const base = basename(p);
+  const dot = base.lastIndexOf(".");
+  if (dot === -1) return null;
+  const ext = base.slice(dot + 1).toLowerCase();
+  return PREVIEW_CONTENT_TYPES[ext] ?? null;
+}
+
+/** Above this many bytes, a diff/file-preview blob (image/PDF) is refused
+ *  rather than read into memory whole — these routes serve an inline
+ *  old-vs-new (or single-file) preview, not a general-purpose file reader.
+ *  Shared cap for every blob-preview route: the task-diff blob route
+ *  (`worktree.ts`'s `getTaskDiffBlob`) and the GitHub pull-blob route
+ *  (`github.ts`'s `getGitHubPullBlob`). */
+export const MAX_BLOB_PREVIEW_BYTES = 20_000_000;
+
 /** Matches claude's `[Image #<digits>]` placeholder token. `N` is a
  *  session-wide attachment counter, not a per-message index — don't attempt
  *  to correlate the number to anything positional. Module-private — callers

--- a/src/shared/attachments.ts
+++ b/src/shared/attachments.ts
@@ -59,6 +59,30 @@ export function isImagePath(path: string): boolean {
   return IMAGE_EXT_RE.test(basename(path));
 }
 
+const PDF_EXT_RE = /\.pdf$/i;
+
+/** True iff `path`'s basename ends in `.pdf` (case-insensitive). Same
+ *  path-parsing rule as `isImagePath` — a path ending in `/` is a directory
+ *  ref and is never a PDF, regardless of what precedes the trailing slash. */
+export function isPdfPath(path: string): boolean {
+  if (path.endsWith("/")) return false;
+  return PDF_EXT_RE.test(basename(path));
+}
+
+/** Binary file kinds the diff-preview UI knows how to render inline
+ *  (old-vs-new side by side) instead of the plain "binary file — no textual
+ *  diff" placeholder. */
+export type BinaryPreviewKind = "image" | "pdf";
+
+/** Classify `path` for the binary-diff-preview UI, or `null` if it's a
+ *  binary kind we don't have a preview renderer for (falls back to the
+ *  placeholder). */
+export function binaryPreviewKind(path: string): BinaryPreviewKind | null {
+  if (isImagePath(path)) return "image";
+  if (isPdfPath(path)) return "pdf";
+  return null;
+}
+
 /** Matches claude's `[Image #<digits>]` placeholder token. `N` is a
  *  session-wide attachment counter, not a per-message index — don't attempt
  *  to correlate the number to anything positional. Module-private — callers


### PR DESCRIPTION
## What

Binary files in diffs now render as real previews instead of the inert *"Binary file — no textual diff."* placeholder, in both diff surfaces:

- **Task Details Diff Modal** — worktree diffs (old = pinned base ref via `git show`, new = working tree).
- **Git Integration modal PR diffs** — GitHub, GitLab, and Bitbucket Cloud.

**Images** render GitHub-style 2-up: Before/After chips, checkerboard behind transparency, `width × height` captions, one-sided panes for added/deleted files, and distinct "too large (20 MB limit)" / "missing" error states.

**PDFs** render as side-by-side paged canvases via lazily-loaded pdf.js (`pdfjs-dist@6.2.108`, separate Vite chunk — zero board-startup cost), with a single synced `‹ Page n / N ›` pager and visibility-gated fetching.

As groundwork for the provider blobs, GitLab/Bitbucket API routing was also fixed properly:

- **Self-hosted GitLab now works module-wide** — every API call derives `https://<host>/api/v4` from the repo's real host instead of hard-coded `gitlab.com`.
- **Bitbucket Server/DC gets an explicit, actionable error** (it speaks a different REST API) instead of silently-wrong calls to `api.bitbucket.org`.

## How

### Blob serving (Bun side)
- `GET /tasks/:id/diff/blob?path&side` — old side from `git show <base>:<path>` (raw-bytes git helper; binary never round-trips through strings), new side from disk. Mirrors `/files/preview`'s guardrails: token-gated, extension-allowlisted, traversal-rejected, 20 MB cap, `nosniff`, ETag/304.
- `GET /github/pull-blob?path=<repoDir>&number&filePath&side` — dispatched by the repo dir's remote through `git-host.pullBlob` for all three providers:
  - **GitHub**: old side anchored at the **merge base** (compare API, cached) — `base.sha` would drift when the base branch moves; bytes via Contents API raw media type. Fork-aware on both sides.
  - **GitLab**: merge base comes free from `diff_refs.base_sha` (with `/versions` fallback for the async-population gap); fork MRs route the new side via numeric `source_project_id`, with a target-project retry (fork heads stay reachable via `refs/merge-requests/:iid/head`).
  - **Bitbucket**: merge base via the official `merge-base/{sha1..sha2}` endpoint, destination-tip fallback, cache invalidation + retry on 404.

### Rendering (webview)
- One shared `BinaryFilePreview` component consumed by both dialogs (which previously duplicated the placeholder). Renders entirely outside the diff row/selection machinery — compose-from-diff drag-select is untouched.
- Cancellable pdf.js render tasks (no blank-canvas races), DPR-aware canvases, semantic theme tokens throughout (correct in light and dark).

### Per-host API bases
- `apiHostForRemote()` resolves a remote host through `ssh -G` to distinguish genuine self-hosted domains from `~/.ssh/config` multi-identity aliases (`HostName gitlab.com`). Canonical cloud hosts short-circuit before any spawn, so the vendor-documented `altssh` SSH-over-443 workaround can't redirect API traffic. 750 ms cap, cached, `AGETOR_SSH_BIN`-overridable for tests.
- **Credential scoping**: with a derived base, GitLab token fallbacks (gitlab.com store entry / `GITLAB_TOKEN` / `glab`) would have shipped a cloud PAT to any host whose name contains "gitlab". Self-hosted hosts now resolve exact host-keyed credentials only.
- Bitbucket rejects only on positive evidence (dotted non-cloud resolved host); dotless aliases pass through unchanged, and the error suggests the exact `~/.ssh/config` fix when relevant.

### Also fixed along the way
- `getTaskDiff` untracked-file paths are now repo-root-relative (previously cwd-relative, so subdir-workdir diffs mixed two path namespaces), including the `realpath`-vs-`git rev-parse --show-toplevel` symlink pitfall on macOS.

## Testing

- **Unit**: 2678 pass / 0 fail — blob helpers and routes (auth, allowlist, traversal, caps, ETag/304), network-mocked GitLab/Bitbucket blob fetches (merge-base resolution, fork routing/retries, caches, 404/413 contract), `apiHostForRemote` (short-circuit, alias mapping, charset guard, token scoping).
- **e2e (Playwright)**: 19/19 — includes new specs asserting the image 2-up actually serves different old/new bytes (dimension captions), one-sided untracked previews, the textual-diff negative guard, and a 2-page PDF with a working pager.
- `tsc --noEmit` clean.

## Notes & limitations

- Plan docs with logged decisions/assumptions: `docs/plans/binary-diff-previews.md`, `docs/plans/binary-diff-previews-providers.md`, `docs/plans/per-host-git-api-bases.md`.
- Self-hosted GitLab assumes https, default port, standard `/api/v4`; provider detection still requires the hostname to contain "gitlab"/"bitbucket".
- GitHub Enterprise remains hard-coded (larger surface, different GraphQL URL shape) — candidate follow-up.
- e2e covers Chromium; a quick manual look at a PDF diff in the packaged app (WKWebView) is recommended before release.