### PR TITLE
feature: add Cursor Grok 4.6 to the model catalog and make it the Cursor default

### DIFF
--- a/docs/plans/cursor-grok-4-6-default.md
+++ b/docs/plans/cursor-grok-4-6-default.md
@@ -1,0 +1,88 @@
+# Plan — Cursor Grok 4.6 in the model picker + new Cursor default
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-12 |
+| Source | /implement request — "make Grok 4.6 available in the options and the default for Cursor" (ref: https://x.ai/news/grok-4-6) |
+| Config | AGENTS_CONFIG.yml (balanced) — run collapsed to inline execution (see §6) |
+| Branch | feature/add-grok-4-6 |
+| Base SHA | 2a4f1a1f3eb8a88aae8bd9581592a5c109d87a85 |
+| Mode | Autonomous — grill + plan-approval gates self-approved; assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+Grok 4.6 appears in the Cursor model picker with its full effort/fast surface, and a new
+Cursor task defaults to it (instead of `auto`). `bun run typecheck` and `bun test` green.
+
+## 2. Context & constraints (grounded)
+
+- **Verified live** via `~/.local/bin/cursor-agent models` (CLI `2026.08.11-e8db854`):
+  Grok 4.6 is exposed as `cursor-grok-4.6-low|medium|high|xhigh` plus `-fast` variants of
+  all four tiers. There is **no bare `cursor-grok-4.6` id**, no `max` tier, and no 1M-context
+  ("Max Mode") variant — same shape as `cursor-grok-4.5` but with an added `xhigh` tier.
+  The unsuffixed label ("Cursor Grok 4.6") belongs to the `-high` variant, matching 4.5.
+- The Cursor picker, `MODEL_EFFORT_SUPPORT.cursor`, and `--model` composition all derive
+  from `CURSOR_MODEL_SPECS` (`src/shared/types.ts:1058`, consumed at 1455 and 1570 and by
+  `cursorModelArg` at 1327) — one spec entry lights up everything.
+- `DEFAULT_MODEL.cursor` (`src/shared/types.ts:1036`) is what the New Task form pre-selects,
+  what `orchestrator.createTask` backfills when a request omits `model`
+  (`src/bun/orchestrator.ts:2378`), what the CLI `add` command pre-highlights, and the
+  fallback key for `supportedEfforts` / `cursorModelSupportsFast` / `cursorModelSupportsMaxMode`.
+- `DEFAULT_EFFORT.cursor` is already `"high"`; grok-4.6 has a `high` variant, so omitted
+  effort resolves cleanly (`orchestrator.ts:2381-2383` picks `high` because the support
+  list is non-empty).
+
+## 3. Approach & key decisions
+
+- **Catalog key `cursor-grok-4.6`** with `effortIds` for xhigh/high/medium/low and
+  `fastEfforts` for all four — mirrors the 4.5 entry; ids rest on the live CLI listing
+  (measured, not inferred). No `supportsMaxMode` (no 1M variant exists).
+- **Default flips from `auto` to `cursor-grok-4.6`** — per the explicit request. Side
+  effect (accepted): unknown/pasted cursor model ids now fall back to grok-4.6's effort
+  set (xhigh/high/medium/low) in the picker instead of collapsing to none; this matches
+  how codex already treats unknown ids.
+- **Picker placement: first entry, before `auto`** — codex and gemini both list their
+  recommended default first; the default model topping the list is the house pattern.
+- Legacy rows are untouched: existing tasks carry explicit `model` values; only new
+  tasks (or API calls omitting `model`) get the new default.
+
+## 4. Work breakdown — implementation
+
+- **T1** (`src/shared/types.ts`): add the `cursor-grok-4.6` spec (first entry in
+  `CURSOR_MODEL_SPECS`); set `DEFAULT_MODEL.cursor = "cursor-grok-4.6"`; refresh the
+  stale comments on `DEFAULT_MODEL.cursor` and `DEFAULT_EFFORT.cursor` (both currently
+  say the default is `auto`/declines effort).
+
+## 5. Work breakdown — tests
+
+- **T2** (`src/bun/effort-support.test.ts`): update the three assertions that pin the old
+  default (`DEFAULT_MODEL.cursor === "auto"`; `supportedEfforts("cursor", null)` /
+  unknown-id fallback returning `[]`); add coverage: catalog contains `cursor-grok-4.6`,
+  its effort surface is xhigh/high/medium/low with no max, `cursorModelArg` composes
+  `cursor-grok-4.6-high` for default effort and `-xhigh-fast` for fast xhigh, and no
+  Max-Mode support.
+- **e2e: not applicable** — pure catalog/constants change in shared types; no new UI
+  surface or flow (the picker rows are data-driven). Existing unit suite exercises the
+  full derivation chain.
+
+## 6. Execution waves
+
+Single wave, executed inline by the orchestrator — a two-file change is below the
+threshold where sub-agent fan-out pays for itself (per the skill's "Adapting to reality").
+
+## 7. Blast radius & risks
+
+- New-task defaults change for Cursor only; claude-code/codex/gemini untouched.
+- `supportedEfforts` fallback behavior change for unknown cursor ids (see §3) — benign;
+  `cursorModelArg` passes unknown ids through verbatim regardless.
+- Existing tasks/runs unaffected (explicit model persisted per row).
+
+## 8. Open questions / assumptions (autonomous mode)
+
+- **A1:** "Grok 4.6" = Cursor's `cursor-grok-4.6-*` family (the only 4.6 Grok ids the CLI
+  exposes). Confidence: high — verified against the live CLI.
+- **A2:** Default effort stays `high` (repo-wide `DEFAULT_EFFORT.cursor`), i.e. a new
+  Cursor task runs `cursor-grok-4.6-high`. The CLI's own unsuffixed "Cursor Grok 4.6"
+  label is the high tier, so this matches Cursor's presentation.
+- **A3:** Picker label "Cursor Grok 4.6" (CLI's own label), not "Grok 4.6" — consistent
+  with the existing "Cursor Grok 4.5" row.

--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -70,10 +70,9 @@ function alias(kind: AgentKind, opts: { home?: string; bin?: string; env?: Recor
 // will now always pass at runtime.
 const claudeDefaults = { mode: "auto", model: "opus-4.7", effort: "high" } as const;
 const codexDefaults = { mode: "auto", model: "gpt-5.6-sol", effort: "high" } as const;
-// Cursor has no effort knob — omitted from the defaults object entirely
-// (unlike claude/codex, `buildCommand`'s cursor branch never inspects
-// `opts.effort`, so leaving it unset is the realistic runtime shape).
-const cursorDefaults = { mode: "auto", model: "auto" } as const;
+// Cursor's effort rides inside the --model id (`cursorModelArg` composes
+// model + effort + fast into one string), not a separate flag.
+const cursorDefaults = { mode: "auto", model: "cursor-grok-4.6", effort: "high" } as const;
 // Gemini has no effort flag at all (see MODEL_EFFORT_SUPPORT.gemini in
 // shared/types.ts) — buildCommand's gemini branch never reads opts.effort.
 const geminiDefaults = { mode: "auto", model: "gemini-3-pro-preview" } as const;
@@ -560,12 +559,12 @@ test("codex throws when effort is missing for a model that supports it", () => {
 // spawn time via its own injection-safe quoting. `buildCommand`'s job is just
 // the flags: -p stream-json, --model, the auto/ask force+sandbox posture, and
 // --resume. Cursor effort/Fast/Max Mode are composed into the --model id.
-test("cursor with defaults emits -p --output-format stream-json --model auto --force --sandbox disabled", () => {
+test("cursor with defaults emits -p --output-format stream-json --model cursor-grok-4.6-high --force --sandbox disabled", () => {
   const { cmd } = buildCommand(builtin("cursor"), "hi", { ...cursorDefaults });
   expect(cmd).toEqual([
     "cursor-agent",
     "-p", "--output-format", "stream-json",
-    "--model", "auto",
+    "--model", "cursor-grok-4.6-high",
     "--force", "--sandbox", "disabled",
   ]);
 });
@@ -575,7 +574,7 @@ test("cursor 'ask' mode emits no --force / --sandbox flags (propose-only — cur
   expect(cmd).toEqual([
     "cursor-agent",
     "-p", "--output-format", "stream-json",
-    "--model", "auto",
+    "--model", "cursor-grok-4.6-high",
   ]);
   expect(cmd).not.toContain("--force");
   expect(cmd).not.toContain("--sandbox");
@@ -691,7 +690,7 @@ test("AGETOR_CURSOR_ARGS extra args land after the mode flags and before --resum
   expect(cmd).toEqual([
     "cursor-agent",
     "-p", "--output-format", "stream-json",
-    "--model", "auto",
+    "--model", "cursor-grok-4.6-high",
     "--force", "--sandbox", "disabled",
     "--verbose", "--foo",
     "--resume", "sess-1",

--- a/src/bun/effort-support.test.ts
+++ b/src/bun/effort-support.test.ts
@@ -123,8 +123,8 @@ test("ordered highest → lowest (no placeholder at the top)", () => {
 
 // --- cursor: model thinking modes + fast variants -----------------------------
 
-test("cursor DEFAULT_MODEL is 'auto' (cursor-agent's own 'let the CLI pick' default)", () => {
-  expect(DEFAULT_MODEL.cursor).toBe("auto");
+test("cursor DEFAULT_MODEL is Grok 4.6 (explicit flagship pin, not cursor-agent's 'auto')", () => {
+  expect(DEFAULT_MODEL.cursor).toBe("cursor-grok-4.6");
 });
 
 test("cursor DEFAULT_EFFORT is high for parameterized non-Auto models", () => {
@@ -133,7 +133,9 @@ test("cursor DEFAULT_EFFORT is high for parameterized non-Auto models", () => {
 
 test("cursor model catalog includes the screenshot/default surface", () => {
   const ids = AGENT_OPTIONS.cursor.models.map((m) => m.id);
-  expect(ids[0]).toBe("auto");
+  // The recommended default tops the list (same convention as codex/gemini).
+  expect(ids[0]).toBe("cursor-grok-4.6");
+  expect(ids).toContain("auto");
   expect(ids).toContain("gpt-5.3-codex");
   expect(ids).toContain("cursor-grok-4.5");
   expect(ids).toContain("composer-2.5");
@@ -146,8 +148,17 @@ test("cursor model catalog includes the screenshot/default surface", () => {
 });
 
 test("cursor Auto model reports zero efforts", () => {
-  expect(supportedEfforts("cursor", null)).toEqual([]);
   expect(supportedEfforts("cursor", "auto")).toEqual([]);
+});
+
+test("cursor null model resolves to the Grok 4.6 default effort surface", () => {
+  expect(supportedEfforts("cursor", null).map((o) => o.id)).toEqual(["xhigh", "high", "medium", "low"]);
+});
+
+test("cursor Grok 4.6 exposes Extra High but no Max (ids verified via `cursor-agent models`)", () => {
+  const ids = supportedEfforts("cursor", "cursor-grok-4.6").map((o) => o.id);
+  expect(ids).toEqual(["xhigh", "high", "medium", "low"]);
+  expect(cursorModelSupportsMaxMode("cursor-grok-4.6")).toBe(false);
 });
 
 test("cursor Opus 4.8 and GPT-5.6 Sol expose Max", () => {
@@ -165,7 +176,7 @@ test("cursor Gemini 3.6 Flash exposes Minimal", () => {
   expect(supportedEfforts("cursor", "gemini-3.6-flash").map((o) => o.id)).toContain("minimal");
 });
 
-test("cursor unknown model id falls back to DEFAULT_MODEL support set (Auto, no efforts)", () => {
+test("cursor unknown model id reports zero efforts (effort rides in the id, so a pick would be inert)", () => {
   expect(supportedEfforts("cursor", "cursor-mystery-9000")).toEqual([]);
 });
 
@@ -191,6 +202,11 @@ test("cursorModelArg composes known model, effort, and fast variants", () => {
   expect(cursorModelArg("gpt-5.6-sol", "high", true, true)).toBe("gpt-5.6-sol[context=1m,effort=high,fast=true]");
   expect(cursorModelArg("gpt-5.6-sol", "high", false, true)).toBe("gpt-5.6-sol[context=1m,effort=high,fast=false]");
   expect(cursorModelArg("unknown-model", "max", true)).toBe("unknown-model");
+  // Grok 4.6: DEFAULT_EFFORT ("high") fills a null effort; fast suffixes apply
+  // across the whole ladder; no Max-Mode bracket syntax (no 1M variant).
+  expect(cursorModelArg("cursor-grok-4.6", null, false)).toBe("cursor-grok-4.6-high");
+  expect(cursorModelArg("cursor-grok-4.6", "xhigh", true)).toBe("cursor-grok-4.6-xhigh-fast");
+  expect(cursorModelArg("cursor-grok-4.6", "low", false)).toBe("cursor-grok-4.6-low");
 });
 
 test("cursor supportedModes returns the auto/ask pair (no per-model mode carve-outs)", () => {

--- a/src/bun/orchestrator-cursor.test.ts
+++ b/src/bun/orchestrator-cursor.test.ts
@@ -22,7 +22,7 @@ async function settle(ms = 80) {
   await new Promise((r) => setTimeout(r, ms));
 }
 
-test("createTask (cursor) defaults model to auto and lands in backlog", async () => {
+test("createTask (cursor) defaults model to Grok 4.6 at high effort and lands in backlog", async () => {
   const { createTask } = await import("./orchestrator.ts");
 
   const created = await createTask({
@@ -36,7 +36,8 @@ test("createTask (cursor) defaults model to auto and lands in backlog", async ()
   if ("error" in created) throw new Error(created.error);
 
   expect(created.task.agent).toBe("cursor");
-  expect(created.task.model).toBe("auto");
+  expect(created.task.model).toBe("cursor-grok-4.6");
+  expect(created.task.effort).toBe("high");
   expect(created.task.column).toBe("backlog");
 });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1032,8 +1032,9 @@ export const DEFAULT_MODEL: Record<AgentKind, string> = {
   // usage, so the default stays on the most-capable non-premium tier.
   "claude-code": "opus-5",
   "codex": "gpt-5.6-sol",
-  // Cursor's own "let cursor-agent pick" model — matches its CLI default.
-  "cursor": "auto",
+  // Grok 4.6 (high effort via DEFAULT_EFFORT) — replaces cursor-agent's own
+  // "auto" as agetor's default so new tasks pin an explicit flagship model.
+  "cursor": "cursor-grok-4.6",
   // gemini-3-pro-preview is the current flagship per google-gemini/gemini-cli
   // docs (verified 2026-08-06). Deliberately NOT the "auto" alias — a spike
   // showed "auto" internally routes across mixed pro/flash-lite models even
@@ -1044,8 +1045,10 @@ export const DEFAULT_MODEL: Record<AgentKind, string> = {
 export const DEFAULT_EFFORT: Record<AgentKind, string> = {
   "claude-code": "high",
   "codex": "high",
-  // Cursor's default model is still "auto", which declines effort and stores
-  // NULL. When the user chooses a parameterized Cursor model, default to High.
+  // Models with `effortIds` default to High where they expose it (else their
+  // first available level — e.g. claude-4.6-sonnet only exposes medium).
+  // Models without `effortIds` ("auto", composer-2.5, the Gemini rows, …)
+  // decline effort and store NULL.
   "cursor": "high",
   // Gemini has no per-invocation effort/thinking-budget flag (verified via
   // `gemini --help` on CLI 0.54.0 — thinkingBudget/thinkingLevel are
@@ -1056,6 +1059,21 @@ export const DEFAULT_EFFORT: Record<AgentKind, string> = {
 };
 
 export const CURSOR_MODEL_SPECS: Record<string, CursorModelSpec> = {
+  // Ids verified against `cursor-agent models` (CLI 2026.08.11): grok 4.6 ships
+  // as cursor-grok-4.6-{low,medium,high,xhigh} plus -fast variants of all four —
+  // no bare id, no max tier, no 1M/Max-Mode variant. The unsuffixed "Cursor
+  // Grok 4.6" label is the high tier, same convention as 4.5.
+  "cursor-grok-4.6": {
+    label: "Cursor Grok 4.6",
+    hint: "Recommended default — Cursor-hosted Grok 4.6.",
+    effortIds: {
+      xhigh: "cursor-grok-4.6-xhigh",
+      high: "cursor-grok-4.6-high",
+      medium: "cursor-grok-4.6-medium",
+      low: "cursor-grok-4.6-low",
+    },
+    fastEfforts: ["xhigh", "high", "medium", "low"],
+  },
   "auto": { label: "Auto", hint: "Cursor picks the model." },
   "gpt-5.3-codex": {
     label: "Codex 5.3",
@@ -1475,10 +1493,14 @@ export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> =
  * Effort options the picker should show for a given (agent, model). Returns
  * an empty list when the model doesn't accept the effort flag (Haiku 4.5).
  * Unknown model ids fall back to the agent's `DEFAULT_MODEL` support set so a
- * user-pasted future model still gets a sensible picker. Returned in the
- * EFFORT_OPTIONS order (highest → lowest).
+ * user-pasted future model still gets a sensible picker — except for cursor,
+ * where effort is encoded in the model id itself (`cursorModelArg`): an
+ * unknown cursor id passes through verbatim, so any effort picked for it
+ * would silently never reach the CLI. Those report no efforts instead.
+ * Returned in the EFFORT_OPTIONS order (highest → lowest).
  */
 export function supportedEfforts(agent: AgentKind, model: string | null): AgentOption[] {
+  if (agent === "cursor" && model !== null && !(model in MODEL_EFFORT_SUPPORT.cursor)) return [];
   const key = model ?? DEFAULT_MODEL[agent];
   const ids =
     MODEL_EFFORT_SUPPORT[agent][key]


### PR DESCRIPTION
## What

- Adds **Cursor Grok 4.6** to the Cursor model picker as a new `cursor-grok-4.6` entry in `CURSOR_MODEL_SPECS`, placed first in the list (the recommended-default-tops-the-list convention codex/gemini already follow).
- Flips `DEFAULT_MODEL.cursor` from `"auto"` to `"cursor-grok-4.6"` — a new Cursor task (UI, CLI `add`, or API call omitting `model`) now runs `cursor-grok-4.6-high` (`DEFAULT_EFFORT.cursor` is `high`). Existing tasks keep their stored model.
- Guards `supportedEfforts` for unknown cursor model ids: they now report **zero efforts** instead of inheriting the default model's list.

## Why

Grok 4.6 launched (https://x.ai/news/grok-4-6) and is available in the Cursor harness. Model ids were **verified against the live CLI** (`cursor-agent models`, 2026.08.11): Grok 4.6 ships as `cursor-grok-4.6-{low,medium,high,xhigh}` plus `-fast` variants of all four — no bare id, no `max` tier, no 1M/Max-Mode variant. The unsuffixed "Cursor Grok 4.6" label is the high tier, so the spec mirrors the existing `cursor-grok-4.5` entry (plus the new `xhigh` tier 4.5 lacks).

The `supportedEfforts` guard fixes a regression the default flip would otherwise introduce: cursor encodes effort *inside* the model id (`cursorModelArg` passes unknown ids through verbatim), so with a non-`auto` default, a user-pasted unknown cursor id would render a four-option effort dropdown whose choice never reaches the CLI — and RunPanel would silently `PATCH effort: "high"` onto such tasks just from opening task details. Unknown cursor ids now collapse the picker, restoring the pre-change behavior.

## Changes

- `src/shared/types.ts` — new catalog entry; `DEFAULT_MODEL.cursor`; `supportedEfforts` cursor guard; refreshed stale comments on `DEFAULT_MODEL.cursor` / `DEFAULT_EFFORT.cursor`.
- `src/bun/effort-support.test.ts` — updated default/fallback assertions; new Grok 4.6 coverage (effort surface, no Max Mode, `cursorModelArg` composition incl. `-fast`).
- `src/bun/orchestrator-cursor.test.ts` — `createTask` default now asserted as `cursor-grok-4.6` + `high`.
- `src/bun/agents.test.ts` — `cursorDefaults` fixture now mirrors the real runtime defaults (`--model cursor-grok-4.6-high` argv expectations).
- `docs/plans/cursor-grok-4-6-default.md` — plan/decision record.

## Verification

- `bun run typecheck` — green.
- `bun test` — 2592 pass / 0 fail.

## Known follow-up (deferred, pre-existing)

The CLI `add` command's `mergeModels` and `ResolveConflictsDialog` don't filter catalog-covered raw ids, so CLI-discovered variants (e.g. `cursor-grok-4.6-high-fast`) can show as duplicate picker rows in those two surfaces — same gap already exists for grok-4.5.