### PR TITLE
feature: add Mythos 5, GPT-5.6 Cyber, and Gemini 3.7 Flash to the model pickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Add a harness from **Settings → Harnesses**. Templates pre-fill common pattern
 Each task picks:
 
 - a **mode** — how much permission the agent has (`auto`, `ask`, `acceptEdits`, `plan`, `bypass` — exposed per agent),
-- a **model** — Opus / Sonnet / Haiku for Claude, GPT-5.6 Sol / Terra / Luna and earlier GPT-5 options for Codex,
+- a **model** — Opus / Sonnet / Haiku for Claude, GPT-5.6 Sol / Terra / Luna (plus the access-gated GPT-5.6 Cyber) and earlier GPT-5 options for Codex,
 - an **effort** level — reasoning depth, where the model supports it.
 
 The picker filters incompatible combinations (e.g. effort is hidden on Haiku 4.5 because Anthropic's API doesn't accept it there).

--- a/docs/plans/add-gemini-3-7-flash.md
+++ b/docs/plans/add-gemini-3-7-flash.md
@@ -1,0 +1,97 @@
+# Plan — Add Gemini 3.7 Flash to the gemini model picker
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-13 |
+| Source | /implement — "also add Gemini 3.7 Flash for Gemini CLI, they just announced it" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/add-mythos-5 (continuing the user's active task branch) |
+| Base SHA | 450a708 (GPT-5.6 Cyber commit) |
+| Mode | **Autonomous** — grill and plan-approval gates bypassed; assumptions in §8 |
+
+## 1. Objective & success criteria
+
+`gemini-3.7-flash` selectable for gemini tasks; runs launch `gemini -m
+gemini-3.7-flash`; effort picker stays collapsed (gemini has no effort flag);
+default stays `gemini-3-pro-preview`; typecheck + tests green.
+
+## 2. Context & constraints (grounded)
+
+Web research (verified 2026-08-13, announcement day):
+- Model id **`gemini-3.7-flash`** — confirmed on the official Gemini API models
+  table (ai.google.dev/gemini-api/docs/models), listed **Stable** ("New
+  Stable"), no preview suffix — unlike `gemini-3-pro-preview`/`gemini-3.1-pro-preview`.
+- Positioning: Google's "latest and most capable Flash" — coding/agentic
+  workhorse tier, intro pricing $0.75/$3.75 per MTok through end of 2026.
+- Caveat: the gemini-cli repo has no `gemini-3.7-flash` references yet (0 code
+  hits on announcement day) — the CLI picker may lag, but agetor passes the id
+  verbatim via `-m`, so it works as soon as the CLI/API accepts it.
+
+Local sync points (verified):
+- `src/shared/types.ts` `AGENT_OPTIONS.gemini.models` (~1590): 3-pro-preview
+  (recommended default) → 3.1-pro-preview → 2.5-pro → 3.5-flash → 2.5-flash.
+- `src/shared/types.ts` `MODEL_EFFORT_SUPPORT.gemini` (~1471): every entry `[]`
+  — gemini has no per-invocation effort flag (settings.json-only, verified on
+  CLI 0.54.0 per existing comments); empty list collapses the effort picker.
+- `src/bun/agents.ts:493-496`: gemini model is passed verbatim via `-m`;
+  `opts.effort` is intentionally ignored on the gemini branch. **No change.**
+- `MODEL_MODE_DENY.gemini` = `{}` — no entry needed.
+- README has no gemini model enumeration (only a roadmap mention) — no change.
+- Tests: `src/bun/agents.test.ts:725+` gemini argv tests (use the default model;
+  none are order-sensitive); no existing per-model gemini assertions in
+  `effort-support.test.ts`.
+
+## 3. Approach & key decisions
+
+- **Position: first Flash entry** — above `gemini-3.5-flash`, below the Pro
+  tiers. The user didn't say "on top" this time; the list's existing order is
+  capability-tiered (Pros first, then Flashes, newest first within tier), and
+  3.7 Flash is a Flash-tier model, so it slots in as the newest Flash (A1).
+- **Hint reflects official positioning**: latest/most-capable Flash, strong on
+  coding/agentic work. No gating language — it's GA.
+- **Effort entry `[]`** — matches every sibling; keeps the picker collapsed.
+- **DEFAULT_MODEL.gemini unchanged** (`gemini-3-pro-preview`): repo policy pins
+  the flagship Pro as default (root CLAUDE.md "best available model"); 3.7
+  Flash is the top Flash, not the flagship.
+- No agents.ts change (verbatim `-m` passthrough is the tested contract).
+
+## 4. Work breakdown — implementation
+
+**IMPL-1**: add the model entry + effort-support entry.
+- Owns: `src/shared/types.ts` only.
+- Acceptance: `gemini-3.7-flash` between `gemini-2.5-pro` and
+  `gemini-3.5-flash` in `AGENT_OPTIONS.gemini.models` with the positioning
+  hint; `MODEL_EFFORT_SUPPORT.gemini["gemini-3.7-flash"] = []`; nothing else.
+
+## 5. Work breakdown — tests
+
+**TEST-1**: minimal coverage mirroring the suites' conventions.
+- Owns: `src/bun/agents.test.ts`, `src/bun/effort-support.test.ts`.
+- Acceptance: an agents.test.ts test asserting `-m gemini-3.7-flash` verbatim
+  argv emission (mirroring the existing gemini argv tests); an
+  effort-support.test.ts test asserting `supportedEfforts("gemini",
+  "gemini-3.7-flash")` is empty (picker collapses).
+
+**E2e: not applicable** — registry addition, same rationale as the two prior
+model-addition plans on this branch.
+
+## 6. Execution waves
+
+Wave 1: IMPL-1 (sonnet) → review (opus) → Wave 2: TEST-1 (sonnet) → run
+(haiku: `bun run typecheck` + `bun test`; node_modules present).
+
+## 7. Blast radius & risks
+
+- `supportedEfforts` unknown-id fallback for gemini already yields `[]`
+  (default model's set), so even a missed entry is behavior-neutral.
+- Users on a gemini CLI build predating 3.7 Flash get a CLI/API model error at
+  run time — pre-existing risk class, verbatim-passthrough design accepts it.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+- **A1**: placement = newest Flash slot (above 3.5 Flash), NOT top of the whole
+  list — the user didn't request top placement and the default/flagship is the
+  Pro preview. One-line reorder if they wanted it elsewhere.
+- **A2**: no Cursor catalog change — Cursor hosts its own separately-named
+  gemini entries (`gemini-3.6-flash` etc. in CURSOR_MODEL_SPECS); adding
+  Cursor's 3.7 Flash when Cursor ships it is a separate change.

--- a/docs/plans/add-gpt-5-6-cyber.md
+++ b/docs/plans/add-gpt-5-6-cyber.md
@@ -1,0 +1,98 @@
+# Plan — Add GPT-5.6 Cyber to the codex model picker
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-12 |
+| Source | /implement — "also add GPT 5.6 Cyber for Codex, on top of 5.6 Sol, even though not available for all" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/add-mythos-5 (continuing the user's active task branch) |
+| Base SHA | db8bbf0 (Mythos 5 commit) |
+| Mode | **Autonomous** — grill and plan-approval gates bypassed; assumptions in §8 |
+
+## 1. Objective & success criteria
+
+Users with GPT-5.6 Cyber access can pick it for codex tasks. Success:
+`gpt-5.6-cyber` appears first in the codex model picker (above Sol), runs pass
+it through as `--model gpt-5.6-cyber`, the effort picker offers the GPT-5.6
+family surface, default stays `gpt-5.6-sol`, typecheck + tests green.
+
+## 2. Context & constraints (grounded)
+
+Web research (official OpenAI docs, verified 2026-08-12):
+- Model id **`gpt-5.6-cyber`** — confirmed at developers.openai.com/api/docs/models/gpt-5.6-cyber.
+  An alias for OpenAI's cybersecurity-purpose-trained models built on GPT-5.6 Sol.
+  400K context / 128K output; $12.50/$75 per MTok.
+- **Access-gated**: requires approval + provisioning through OpenAI's Daybreak
+  program (Daybreak Red tier) — not unlocked by standard ChatGPT/API plans.
+- Effort levels: not enumerated for Cyber specifically; the GPT-5.6 family
+  supports none→max (assumption A1 mirrors Sol's set).
+
+Local sync points (verified against current code; simpler than the claude-code
+recipe because codex has no flag table):
+- `src/shared/types.ts` — `AGENT_OPTIONS.codex.models` (~1560; order = picker
+  order, `gpt-5.6-sol` currently first) and
+  `MODEL_EFFORT_SUPPORT.codex` (~1449; sol/terra/luna = `["max","xhigh","high","medium","low","none"]`).
+- `src/bun/agents.ts` — codex model ids pass through **verbatim** as `--model <id>`; no entry needed.
+- `MODEL_MODE_DENY.codex` is `{}` — no entry needed.
+- `README.md:238` enumerates the codex model examples.
+- Tests: `src/bun/effort-support.test.ts:89-99` — family-effort loop and a
+  **picker-order test asserting `ids.slice(0, 3)` = sol/terra/luna, which must
+  be updated** when cyber is inserted at position 0; `src/bun/agents.test.ts:478`
+  — verbatim `--model` passthrough test pattern.
+
+## 3. Approach & key decisions
+
+- **Position 0, above Sol** — the user's explicit ask ("on top of 5.6 Sol"),
+  consistent with Mythos 5's placement on the claude-code list.
+- **Hint carries the access gate** ("requires OpenAI Daybreak approval") so
+  non-approved users understand why a run would fail; agetor cannot probe access.
+- **Effort set mirrors Sol** (`max/xhigh/high/medium/low/none`) — A1. Agetor's
+  codex family entries deliberately omit `minimal` (Cursor-only in this repo);
+  keep that convention.
+- **No DEFAULT_MODEL change**; no MODE_DENY entry; no agents.ts change (verbatim
+  passthrough is the tested contract).
+- README example list gains Cyber to stay true to the picker.
+
+## 4. Work breakdown — implementation
+
+**IMPL-1**: add the model entry + effort support + README mention.
+- Owns: `src/shared/types.ts`, `README.md`.
+- Acceptance: `gpt-5.6-cyber` first in `AGENT_OPTIONS.codex.models` with an
+  access-gate hint; `MODEL_EFFORT_SUPPORT.codex["gpt-5.6-cyber"]` = Sol's set;
+  README line 238 mentions Cyber; nothing else edited.
+
+## 5. Work breakdown — tests
+
+**TEST-1**: extend/update codex model tests.
+- Owns: `src/bun/effort-support.test.ts`, `src/bun/agents.test.ts`.
+- Acceptance: family-effort loop includes `gpt-5.6-cyber`; picker-order test
+  updated to expect cyber at position 0 followed by sol/terra/luna; an
+  agents.test.ts verbatim-passthrough test for `gpt-5.6-cyber`.
+
+**E2e: not applicable** — registry addition with no new flow (same rationale as
+the prior GPT-5.6 family plan and the Mythos 5 plan).
+
+## 6. Execution waves
+
+Wave 1: IMPL-1 (sonnet) → review (opus) → Wave 2: TEST-1 (sonnet) → run (haiku:
+`bun run typecheck` + `bun test`; node_modules already installed).
+
+## 7. Blast radius & risks
+
+- Unknown-id fallback in `supportedEfforts` already resolves to Sol's set, so
+  even map drift degrades gracefully.
+- Users without Daybreak access selecting Cyber get a codex CLI error at run
+  time (same accepted trade-off as Mythos 5; hint mitigates).
+- Codex CLI versions predating Cyber will reject the id — same pre-existing
+  risk class as the GPT-5.6 family addition.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+- **A1**: Cyber's effort surface = Sol's (`max/xhigh/high/medium/low/none`).
+  Official docs don't enumerate Cyber-specific levels; family docs include the
+  full range. Fallback behavior makes a mismatch non-breaking.
+- **A2**: "on top of 5.6 Sol" = literal picker position 0 (same reading the
+  user confirmed implicitly by re-using the phrasing from the Mythos request).
+- **A3**: continuing on `feature/add-mythos-5` — this worktree/branch is the
+  user's active agetor task; a separate branch would fight agetor's
+  worktree-per-task model.

--- a/docs/plans/add-mythos-5.md
+++ b/docs/plans/add-mythos-5.md
@@ -1,0 +1,106 @@
+# Plan — Add Claude Mythos 5 to the claude-code model picker
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-12 |
+| Source | /implement — "add Mythos 5 in Agetor as an available option, on top of Fable 5" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/add-mythos-5 |
+| Base SHA | 2a4f1a1f3eb8a88aae8bd9581592a5c109d87a85 |
+| Mode | **Autonomous** — grill and plan-approval gates bypassed; assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+Users whose Anthropic org has Claude Mythos 5 access (Project Glasswing) can pick
+"Mythos 5" in agetor's claude-code model picker and run tasks on it. Success:
+
+- `mythos-5` appears in the New Task form and the RunPanel model picker for claude-code.
+- Runs launch `claude --model claude-mythos-5`.
+- Effort picker offers max/xhigh/high/medium/low (same surface as Fable 5).
+- Default model stays `opus-5`; nothing changes for existing tasks.
+- `bun run typecheck` and `bun test` green.
+
+## 2. Context & constraints (grounded)
+
+Model facts (verified via the claude-api reference skill, cached 2026-06-24):
+Mythos 5 id is `claude-mythos-5`; same underlying model, capabilities, pricing
+($10/$50 per MTok = 2x Opus), and API surface as Fable 5 (`claude-fable-5`);
+availability is restricted to orgs in Project Glasswing. Effort support:
+low/medium/high/xhigh/max — identical to Fable 5.
+
+Adding a claude-code model touches exactly these sync points (fleet knowledge
+from the Fable 5 / Opus 5 / Sonnet 5 additions, re-verified against current code):
+
+1. `src/shared/types.ts:1531` — `AGENT_OPTIONS["claude-code"].models` (list order = picker order; `fable-5` is currently first).
+2. `src/shared/types.ts:1432` — `MODEL_EFFORT_SUPPORT["claude-code"]`.
+3. `src/shared/types.ts:1501` — `MODEL_MODE_DENY["claude-code"]` (all `[]` today).
+4. `src/bun/agents.ts:116` — `CLAUDE_MODEL_FLAG` friendly-id → `--model` string.
+5. `src/mainview/components/kanban/NewTaskForm.tsx:944` — contextual helper line shown when `model === "fable-5"` (2x-usage warning); Mythos gets the analogous treatment.
+
+Tests that hard-assert these maps: `src/bun/agents.test.ts` (`--model` mapping),
+`src/bun/effort-support.test.ts` (per-model effort + DEFAULT_MODEL). Both UI
+pickers read AGENT_OPTIONS, so no other UI change is needed.
+
+Fresh worktree has no `node_modules` — run `bun install` before typecheck/test.
+
+## 3. Approach & key decisions
+
+- **Position: top of the picker, above Fable 5.** "On top of Fable 5" read
+  literally, matching the precedent of Fable 5 being added above Opus 4.8 at the
+  top. Rests on assumption A1.
+- **Hint flags restricted access**: users without Project Glasswing access would
+  otherwise hit an opaque CLI error. Hint: capability parity with Fable + 2x
+  Opus usage + approved-org requirement.
+- **Default stays `opus-5`.** Mythos is access-gated; defaulting to it would
+  break first runs for nearly all users. No DB migration (DEFAULT_MODEL only
+  seeds the new-task form).
+- **Effort/mode maps mirror `fable-5`** — same underlying model, evidence above.
+- **No Cursor/codex/gemini changes.** Cursor's model list is a separate,
+  cursor-hosted catalog; no evidence Cursor serves Mythos. Out of scope (A2).
+- **`CLAUDE_MODEL_FLAG` entry is required**, not optional: without it the
+  friendly id `mythos-5` would pass through verbatim to `--model mythos-5`,
+  which the claude CLI doesn't accept.
+
+## 4. Work breakdown — implementation
+
+**IMPL-1** (single task — files are small, tightly coupled edits):
+Add Mythos 5 to the claude-code model surface.
+- Owns: `src/shared/types.ts`, `src/bun/agents.ts`, `src/mainview/components/kanban/NewTaskForm.tsx`.
+- Acceptance: entries described in §2 items 1–5 added; `mythos-5` first in the
+  models list; comments follow surrounding style; nothing else edited.
+
+## 5. Work breakdown — tests
+
+**TEST-1**: extend the two hard-assert test files (covers IMPL-1).
+- Owns: `src/bun/agents.test.ts`, `src/bun/effort-support.test.ts`.
+- Acceptance: a `mythos-5 → --model claude-mythos-5` mapping test mirroring the
+  fable-5 one; a mythos-5 effort-support test (max/xhigh/high/medium/low);
+  existing DEFAULT_MODEL assertions untouched.
+
+**E2e: not applicable.** This is a data-table addition; the pickers render from
+AGENT_OPTIONS generically and are already covered by the existing e2e harness's
+task-creation flows. No new user flow is introduced, and running Mythos for real
+requires org access agetor's CI doesn't have.
+
+## 6. Execution waves
+
+- Wave 1: IMPL-1 (implementation runner: claude sonnet).
+- Review: opus, diff vs base SHA.
+- Wave 2: TEST-1 (tests runner: sonnet) — file-disjoint from IMPL-1.
+- Test run: haiku — `bun install`, `bun run typecheck`, `bun test`.
+
+## 7. Blast radius & risks
+
+- `MODEL_EFFORT_SUPPORT` unknown-id fallback means even a missed entry degrades
+  gracefully (falls back to opus-5's set) — low risk.
+- Users without Mythos access selecting it will get a CLI-side model error at
+  run time; mitigated by the hint text. Agetor has no way to probe org access.
+- No schema/migration changes; no server route changes.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+- **A1**: "on top of Fable 5" = literally above Fable 5 (picker position 0).
+  If the intent was merely "in addition to", the fix is a one-line reorder.
+- **A2**: scope is the claude-code agent only; Cursor's catalog untouched.
+- **A3**: helper line under the picker mirrors Fable's, mentioning 2x usage and
+  approved-org access, shown only when mythos-5 is selected.

--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -734,6 +734,18 @@ test("gemini with defaults emits -m + stream-json + --yolo + --skip-trust, promp
   ]);
 });
 
+test("gemini-3.7-flash model id is emitted verbatim via -m", () => {
+  const { cmd } = buildCommand(builtin("gemini"), "hi", { ...geminiDefaults, model: "gemini-3.7-flash" });
+  expect(cmd).toEqual([
+    "gemini",
+    "-m", "gemini-3.7-flash",
+    "--output-format", "stream-json",
+    "--yolo",
+    "--skip-trust",
+    "-p", "hi",
+  ]);
+});
+
 test("gemini 'ask' mode uses --approval-mode plan instead of --yolo", () => {
   const { cmd } = buildCommand(builtin("gemini"), "hi", { ...geminiDefaults, mode: "ask" });
   expect(cmd).not.toContain("--yolo");

--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -487,6 +487,18 @@ test("codex model 'gpt-5.6-sol' passes through verbatim as --model", () => {
   ]);
 });
 
+test("codex model 'gpt-5.6-cyber' passes through verbatim as --model", () => {
+  const { cmd } = buildCommand(builtin("codex"), "hi", { ...codexDefaults, model: "gpt-5.6-cyber", mode: "auto" });
+  expect(cmd).toEqual([
+    "codex", "exec",
+    "--model", "gpt-5.6-cyber",
+    "-c", "model_reasoning_effort=high",
+    "--json", "--color", "never", "--skip-git-repo-check",
+    "--sandbox", "workspace-write",
+    "-",
+  ]);
+});
+
 test("codex model 'gpt-5' adds --model gpt-5", () => {
   const { cmd } = buildCommand(builtin("codex"), "hi", { ...codexDefaults, model: "gpt-5", mode: "auto" });
   expect(cmd).toEqual([

--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -213,6 +213,16 @@ test("claude-code 'fable-5' maps to --model claude-fable-5", () => {
   ]);
 });
 
+test("claude-code 'mythos-5' maps to --model claude-mythos-5", () => {
+  const { cmd } = buildCommand(builtin("claude-code"), "do thing", { ...claudeDefaults, model: "mythos-5", mode: "auto" });
+  expect(cmd).toEqual([
+    "claude",
+    "--model", "claude-mythos-5",
+    "--permission-mode", "auto",
+    "--", "do thing",
+  ]);
+});
+
 test("claude-code 'sonnet-5' maps to --model claude-sonnet-5", () => {
   const { cmd } = buildCommand(builtin("claude-code"), "do thing", { ...claudeDefaults, model: "sonnet-5", mode: "auto" });
   expect(cmd).toEqual([

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -114,6 +114,7 @@ export interface AgentRunOptions {
 // curated list doesn't know about yet). Codex accepts the friendly ids as-is
 // so it doesn't need a translation table.
 const CLAUDE_MODEL_FLAG: Record<string, string> = {
+  "mythos-5": "claude-mythos-5",
   "fable-5": "claude-fable-5",
   "opus-5": "claude-opus-5",
   "opus-4.8": "claude-opus-4-8",

--- a/src/bun/effort-support.test.ts
+++ b/src/bun/effort-support.test.ts
@@ -87,7 +87,7 @@ test("codex DEFAULT_MODEL is GPT-5.6 Sol", () => {
 });
 
 test("codex GPT-5.6 family supports none through max", () => {
-  for (const model of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+  for (const model of ["gpt-5.6-cyber", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
     const ids = supportedEfforts("codex", model).map((o) => o.id);
     expect(ids).toEqual(["max", "xhigh", "high", "medium", "low", "none"]);
   }
@@ -95,7 +95,7 @@ test("codex GPT-5.6 family supports none through max", () => {
 
 test("codex model picker includes the GPT-5.6 family", () => {
   const ids = AGENT_OPTIONS.codex.models.map((m) => m.id);
-  expect(ids.slice(0, 3)).toEqual(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
+  expect(ids.slice(0, 4)).toEqual(["gpt-5.6-cyber", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
 });
 
 test("codex gpt-5.5 supports xhigh but not max", () => {

--- a/src/bun/effort-support.test.ts
+++ b/src/bun/effort-support.test.ts
@@ -76,6 +76,12 @@ test("claude fable-5 supports xhigh + max", () => {
   expect(ids).toContain("max");
 });
 
+test("claude mythos-5 supports xhigh + max", () => {
+  const ids = supportedEfforts("claude-code", "mythos-5").map((o) => o.id);
+  expect(ids).toContain("xhigh");
+  expect(ids).toContain("max");
+});
+
 test("codex DEFAULT_MODEL is GPT-5.6 Sol", () => {
   expect(DEFAULT_MODEL.codex).toBe("gpt-5.6-sol");
 });

--- a/src/bun/effort-support.test.ts
+++ b/src/bun/effort-support.test.ts
@@ -127,6 +127,13 @@ test("ordered highest → lowest (no placeholder at the top)", () => {
   expect(ids).toEqual(filteredExpected);
 });
 
+// --- gemini: no per-invocation effort flag -------------------------------------
+
+test("gemini gemini-3.7-flash exposes no effort options (no effort flag on the CLI)", () => {
+  const ids = supportedEfforts("gemini", "gemini-3.7-flash").map((o) => o.id);
+  expect(ids).toEqual([]);
+});
+
 // --- cursor: model thinking modes + fast variants -----------------------------
 
 test("cursor DEFAULT_MODEL is 'auto' (cursor-agent's own 'let the CLI pick' default)", () => {

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -947,6 +947,14 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
                 </div>
               )}
 
+              {/* Mythos 5 is Fable 5's access-gated twin — same 2x usage, plus the
+                  Project Glasswing requirement, so both need calling out here. */}
+              {kind === "claude-code" && model === "mythos-5" && (
+                <div className="text-[11px] text-muted-foreground">
+                  Mythos 5 uses 2x the usage of Opus and requires approved-org (Project Glasswing) access.
+                </div>
+              )}
+
               {/* Surfacing a missing-agent error inline so the user sees install
                   guidance before they hit Create and get a delayed failure. */}
               {selectedStatus && !selectedStatus.available && (

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1472,6 +1472,7 @@ export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> =
     "gemini-3-pro-preview": [],
     "gemini-3.1-pro-preview": [],
     "gemini-2.5-pro": [],
+    "gemini-3.7-flash": [],
     "gemini-3.5-flash": [],
     "gemini-2.5-flash": [],
   },
@@ -1588,12 +1589,14 @@ export const AGENT_OPTIONS: Record<AgentKind, AgentOptions> = {
     efforts: EFFORT_OPTIONS,
   },
   gemini: {
+    // Pro tier first, then Flash tier; newest first within each tier.
     models: [
       { id: "gemini-3-pro-preview", label: "Gemini 3 Pro (preview)", hint: "Recommended default — current flagship." },
       { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro (preview)", hint: "Newer preview tier." },
       { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", hint: "Prior stable flagship." },
-      { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", hint: "Fast, lower cost." },
-      { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", hint: "Fast, lower cost, prior generation." },
+      { id: "gemini-3.7-flash", label: "Gemini 3.7 Flash", hint: "Latest and most capable Flash — strong on coding and agentic work at Flash cost." },
+      { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", hint: "Fast, lower cost — prior Flash generation." },
+      { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", hint: "Fast, lower cost, earlier generation." },
     ],
     modes: [
       { id: "auto", label: "Auto (yolo)", hint: "Edit files without approval prompts (--yolo)." },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1028,8 +1028,9 @@ export interface CursorModelSpec {
  */
 export const DEFAULT_MODEL: Record<AgentKind, string> = {
   // Default to Opus 5 — the most-capable Opus, priced identically to Opus 4.8
-  // ($5/$25 per MTok). Fable 5 sits above it in the picker but costs 2x the
-  // usage, so the default stays on the most-capable non-premium tier.
+  // ($5/$25 per MTok). Mythos 5 and Fable 5 sit above it in the picker but
+  // cost 2x the usage, so the default stays on the most-capable non-premium
+  // tier.
   "claude-code": "opus-5",
   "codex": "gpt-5.6-sol",
   // Cursor's own "let cursor-agent pick" model — matches its CLI default.
@@ -1397,7 +1398,7 @@ export const CODE_PLAN_MODE: Record<AgentKind, { code: string; plan: string }> =
  */
 export const EFFORT_OPTIONS: AgentOption[] = [
   { id: "max", label: "Max thinking", hint: "Absolute maximum reasoning effort. Separate from Cursor Max Mode context." },
-  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Fable 5 / Opus 5 / 4.8 / 4.7 / 4.6 / Sonnet 5 / codex." },
+  { id: "xhigh", label: "Extra high", hint: "Extended capability for long-horizon work. Fable 5 / Mythos 5 / Opus 5 / 4.8 / 4.7 / 4.6 / Sonnet 5 / codex." },
   { id: "high", label: "High", hint: "Deep reasoning. The API default where supported." },
   { id: "medium", label: "Medium", hint: "Balanced speed vs. capability." },
   { id: "low", label: "Low", hint: "Most efficient. Best for simple tasks." },
@@ -1423,13 +1424,15 @@ export const EFFORT_OPTIONS: AgentOption[] = [
  */
 export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> = {
   // Per https://platform.claude.com/docs/en/build-with-claude/effort the
-  // effort parameter is API-supported on Fable 5 / Opus 5 / 4.8 / 4.7 / 4.6 /
-  // Sonnet 5 / Sonnet 4.6 / Opus 4.5 (xhigh is Fable-5-, Opus-, and Sonnet-5-only;
-  // Sonnet 4.6 has no xhigh; Haiku 4.5 doesn't support effort at all). The
-  // `/effort` CLI command accepts more
+  // effort parameter is API-supported on Fable 5 / Mythos 5 / Opus 5 / 4.8 /
+  // 4.7 / 4.6 / Sonnet 5 / Sonnet 4.6 / Opus 4.5 (xhigh is Fable-5-, Mythos-5-,
+  // Opus-, and Sonnet-5-only; Sonnet 4.6 has no xhigh; Haiku 4.5 doesn't
+  // support effort at all). The `/effort` CLI command accepts more
   // levels but the underlying API request would fail for unsupported pairs,
   // so we filter at the picker rather than letting the user fire bad runs.
   "claude-code": {
+    // Mythos 5 shares Fable 5's request surface (same underlying model).
+    "mythos-5": ["max", "xhigh", "high", "medium", "low"],
     // Fable 5 shares Opus 4.7/4.8's request surface (effort low→max, xhigh).
     "fable-5": ["max", "xhigh", "high", "medium", "low"],
     // Opus 5 supports the full effort ladder incl. xhigh (per claude-api skill).
@@ -1500,6 +1503,7 @@ export function supportedEfforts(agent: AgentKind, model: string | null): AgentO
  */
 const MODEL_MODE_DENY: Record<AgentKind, Record<string, string[]>> = {
   "claude-code": {
+    "mythos-5": [],
     "fable-5": [],
     "opus-5": [],
     "opus-4.8": [],
@@ -1529,6 +1533,7 @@ export function supportedModes(agent: AgentKind, model: string | null): AgentOpt
 export const AGENT_OPTIONS: Record<AgentKind, AgentOptions> = {
   "claude-code": {
     models: [
+      { id: "mythos-5", label: "Mythos 5", hint: "Fable 5's twin — same capability and cost; requires approved-org (Project Glasswing) access. Uses 2x the usage of Opus." },
       { id: "fable-5", label: "Fable 5", hint: "Most powerful tier — above Opus. Uses 2x the usage of Opus." },
       { id: "opus-5", label: "Opus 5", hint: "Most capable Opus; same usage cost as 4.8." },
       { id: "opus-4.8", label: "Opus 4.8", hint: "Prior Opus flagship." },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1448,6 +1448,9 @@ export const MODEL_EFFORT_SUPPORT: Record<AgentKind, Record<string, string[]>> =
     "haiku-4.5": [],
   },
   codex: {
+    // Cyber's own model page doesn't enumerate efforts; assume the GPT-5.6
+    // family surface (the set Sol documents). Revisit if codex rejects none/max.
+    "gpt-5.6-cyber": ["max", "xhigh", "high", "medium", "low", "none"],
     "gpt-5.6-sol": ["max", "xhigh", "high", "medium", "low", "none"],
     "gpt-5.6-terra": ["max", "xhigh", "high", "medium", "low", "none"],
     "gpt-5.6-luna": ["max", "xhigh", "high", "medium", "low", "none"],
@@ -1558,6 +1561,7 @@ export const AGENT_OPTIONS: Record<AgentKind, AgentOptions> = {
   },
   codex: {
     models: [
+      { id: "gpt-5.6-cyber", label: "GPT-5.6 Cyber", hint: "Cybersecurity-tuned GPT-5.6. Requires OpenAI Daybreak approval on an API-key account; rejected on ChatGPT plans." },
       { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", hint: "Recommended default — flagship GPT-5.6 capability." },
       { id: "gpt-5.6-terra", label: "GPT-5.6 Terra", hint: "Balanced GPT-5.6 model for strong performance at lower cost." },
       { id: "gpt-5.6-luna", label: "GPT-5.6 Luna", hint: "Efficient GPT-5.6 model for high-volume workloads." },


### PR DESCRIPTION
## What

Adds three newly released models to the model pickers, one per agent kind:

| Agent | Model | Picker id | CLI id | Placement |
| --- | --- | --- | --- | --- |
| claude-code | Claude Mythos 5 | `mythos-5` | `claude-mythos-5` | Top, above Fable 5 |
| codex | GPT-5.6 Cyber | `gpt-5.6-cyber` | `gpt-5.6-cyber` (verbatim) | Top, above Sol |
| gemini | Gemini 3.7 Flash | `gemini-3.7-flash` | `gemini-3.7-flash` (verbatim) | Newest Flash entry (Pro tier stays on top) |

No defaults change: new tasks still default to Opus 5 (claude-code), GPT-5.6 Sol (codex), and Gemini 3 Pro preview (gemini).

## Why

All three models were just released and users with access should be able to run them through Agetor. Two of them are access-gated — Mythos 5 requires approved-org access (Project Glasswing) and GPT-5.6 Cyber requires OpenAI Daybreak-program approval — so their picker hints state the gating explicitly, and the defaults deliberately stay on generally-available models. Gemini 3.7 Flash is GA (Stable on the Gemini API models table).

## Details per commit

- **`db8bbf0` Mythos 5** — full claude-code recipe: `AGENT_OPTIONS` entry, `MODEL_EFFORT_SUPPORT` (same max→low surface as Fable 5, its capability twin), `MODEL_MODE_DENY`, `CLAUDE_MODEL_FLAG["mythos-5"] = "claude-mythos-5"` (required — verbatim passthrough would emit an invalid `--model mythos-5`), and a NewTaskForm helper noting the 2x-Opus usage + access requirement. Also refreshed the `xhigh` effort-hint enumeration and the `DEFAULT_MODEL` comment.
- **`450a708` GPT-5.6 Cyber** — codex additions are lighter by design: `AGENT_OPTIONS` entry + `MODEL_EFFORT_SUPPORT` (GPT-5.6 family surface incl. `none`; Cyber's own docs don't enumerate levels, noted in a comment). Codex passes model ids through verbatim so no `agents.ts` change. README's codex enumeration mentions Cyber as access-gated. The order-sensitive picker test was updated for the new first entry.
- **`150f653` Gemini 3.7 Flash** — the lightest: `AGENT_OPTIONS` entry + empty `MODEL_EFFORT_SUPPORT` entry (gemini has no per-run effort flag; picker collapses). The gemini list's tiering rule (Pro first, then Flash, newest first within tier) is now documented in a comment, and the superseded Flash entries' hints were re-tiered.

Model facts were verified against primary sources before implementation (Anthropic model reference for `claude-mythos-5`; `developers.openai.com/api/docs/models/gpt-5.6-cyber`; `ai.google.dev/gemini-api/docs/models` on announcement day).

## Testing

- `bun run typecheck` — clean
- `bun test` — **2595 pass / 3 skip / 0 fail** (159 files)
- New tests: `--model` flag mapping for `mythos-5`, verbatim passthrough for `gpt-5.6-cyber` and `gemini-3.7-flash`, effort-support assertions for all three; codex picker-order test updated.

## Notes for review

- Selecting a gated model without access fails at the CLI at run time — Agetor has no way to probe org entitlements; the hints are the mitigation.
- The Gemini CLI had no `gemini-3.7-flash` references on announcement day; since Agetor passes `-m` verbatim, it works as soon as the installed CLI accepts the id.
- Each addition has a plan under `docs/plans/` (`add-mythos-5.md`, `add-gpt-5-6-cyber.md`, `add-gemini-3-7-flash.md`) with logged assumptions — notably that "on top of X" was read as literal top-of-picker placement for the two gated models.