### PR TITLE
feature: readable message rhythm in Task Details — heading margins, real paragraph spacing

### DIFF
--- a/docs/plans/task-details-message-readability.md
+++ b/docs/plans/task-details-message-readability.md
@@ -1,0 +1,94 @@
+# Plan — Task Details message readability QoL
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-12 |
+| Source | `/implement` — "more space between the paragraphs and add some margin to the titles in the messages of Task Details… and other QoL UI improvements to make the messages better readable" |
+| Config | AGENTS_CONFIG.yml (balanced, v1 schema) |
+| Branch | feature/some-minor-ui-improvements-for-text |
+| Base SHA | 2a4f1a1f3eb8a88aae8bd9581592a5c109d87a85 |
+| Mode | **Autonomous** — no live owner; grill + plan-approval gates self-resolved, assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+Make agent/user message markdown in the Task Details stream easier to read:
+- Headings ("titles") get visible breathing room — clearly more space above a heading than between two paragraphs, snug space below (heading binds to its own section).
+- Paragraph-to-paragraph spacing loosens modestly.
+- Related small QoL: slightly roomier list items, `hr` spacing consistent with the new rhythm, slightly more generous line-height.
+- No perf regression (no new inline objects in the react-markdown component maps), no theme breakage, values stay in `rem`.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- All block typography for message markdown lives in the global `.agetor-md` class, `src/mainview/index.css:134-185` — **not** in `USER_MD_COMPONENTS`/`ASSISTANT_MD_COMPONENTS` (`src/mainview/components/kanban/md-components.tsx:129-142`, which only override `a`/`code`/`pre`). The CSS class is the whole change surface.
+- Current rules: container `line-height: 1.55`; the only inter-block spacing is the lobotomized-owl `> * + * { margin-top: 0.5rem }`; `p { margin: 0 }`; headings have size/weight (h1 `1.05rem` … h4–h6 `0.875rem`, weight 600, `line-height: 1.3`) but **no margins of their own**; `li { margin: 0.125rem 0 }`; `hr { margin: 0.5rem 0 }`.
+- The comment at `index.css:134-136` documents the tightness as intentional (messages shouldn't dwarf adjacent 12px tool-call rows) → changes must be modest, not a full "prose" treatment.
+- **Shared class — blast radius**: `.agetor-md` also styles PlanDialog plan bodies (`PlanDialog.tsx:330`) and all GitHubDialog PR/issue markdown (`GitHubDialog.tsx:6115` etc.). Those surfaces get the same improvement; dense GitHub bodies are the reason to stay modest.
+- **rem only**: commit `2a4f1a1` (#170) added an app-wide font-size control that scales `documentElement.style.fontSize`; `px` values would break scaling.
+- Semantic color tokens only (repo convention); no color changes planned anyway.
+- No Tailwind typography plugin (`tailwind.config.js:97` → `plugins: []`); do not add one.
+- ThinkingBlock and RawText are plain `pre-wrap` text, not markdown — out of scope (see §8).
+- Perf constraint from prior fleet work: component maps stay module consts; block components stay memo'd. A CSS-only change satisfies this trivially.
+
+## 3. Approach & key decisions
+
+**CSS-only change to `.agetor-md` in `src/mainview/index.css`** (single file), keeping the margin-top-only owl pattern so margin-collapsing never enters the picture:
+
+```css
+.agetor-md { line-height: 1.6; }                      /* was 1.55 */
+.agetor-md > * + * { margin-top: 0.625rem; }          /* was 0.5rem — paragraph rhythm */
+/* headings: clear space above (wins over the owl by specificity)… */
+.agetor-md h1, … h6 { margin-top: 1.125rem; }
+/* …snug space below (placed AFTER the heading rules so consecutive headings stay snug) */
+.agetor-md h1 + *, … h6 + * { margin-top: 0.375rem; }
+/* guard: first child never gets pushed down (heading-first messages) */
+.agetor-md > :first-child { margin-top: 0; }
+.agetor-md li { margin: 0.1875rem 0; }                /* was 0.125rem */
+.agetor-md hr { margin: 0.75rem 0; }                  /* was 0.5rem */
+/* optional, small: h1 1.125rem / h2 1.0625rem / h3 1rem for a touch more hierarchy */
+```
+
+Alternatives considered:
+- *Tailwind `@tailwindcss/typography` (`prose`)* — rejected: heavyweight, fights the intentional density, new plugin dependency.
+- *Per-element overrides in the MD component maps* — rejected: wrong layer (styling is CSS-driven by design; maps exist only for `a`/`code`/`pre` behavior), and would triple-maintain across USER/ASSISTANT/GH maps.
+- *Scoping changes to RunPanel only via a modifier class* — rejected: PlanDialog and GitHubDialog benefit equally from the fix; a modest global improvement beats a fork of the type ramp. Revisit only if GitHub bodies look too airy (see risk in §7).
+
+Decisions rest on Phase 1 code reading (file:line verified); no spikes needed — pure CSS with well-understood cascade behavior (specificity: `.agetor-md h1` (0,1,1) beats `.agetor-md > * + *` (0,1,0); `.agetor-md > :first-child` (0,2,0) beats the heading rule).
+
+## 4. Work breakdown — implementation
+
+| ID | Goal | Files owned | Deps | Acceptance |
+| --- | --- | --- | --- | --- |
+| I1 | Apply the `.agetor-md` spacing/typography changes from §3 | `src/mainview/index.css` | — | Rules match §3 semantics; rem-only; comment at 134-136 updated to describe the new rhythm; `bun run typecheck` green; `bunx vite build` green |
+
+Single wave, single task — nothing to partition.
+
+## 5. Work breakdown — tests
+
+| ID | Goal | Files owned | Covers | Acceptance |
+| --- | --- | --- | --- | --- |
+| T1 | Playwright spec asserting the reading rhythm on a rendered assistant message | `e2e/markdown-readability.spec.ts` | I1 | Renders a message containing `## heading` + two paragraphs + a list via the existing per-worker-backend fixtures (`e2e/fixtures.ts`, follow `quote.spec.ts` patterns); asserts computed styles **structurally** (heading margin-top > paragraph gap > 0; first child margin-top = 0) rather than exact px, so the spec survives future tuning and the font-size control |
+
+**E2e applies**: the change is user-visible rendering in the webview; the repo has a parallel-safe Playwright harness (`playwright.config.ts`, worker-scoped isolated Bun backends per `docs/plans/e2e-per-worker-backends.md`). Run recipe: `bunx playwright test` (harness auto-manages the shared Vite server + per-worker backends). Unit tests don't apply — no logic changed; no unit test renders RunPanel.
+
+## 6. Execution waves
+
+1. Wave 1: I1 (implementation, sonnet)
+2. Review (opus) on the diff vs base
+3. Wave 2: T1 (tests creation, sonnet)
+4. Test run: `bun test` + `bun run typecheck` + `bunx playwright test` (haiku runner)
+5. Fixes if needed (sonnet), re-run to green
+
+## 7. Blast radius & risks
+
+- `.agetor-md` is shared: RunPanel messages, PlanDialog, GitHubDialog PR/issue bodies all shift. Mitigation: modest deltas (+0.125rem paragraph gap, headings +~0.6rem above). Rollback = revert one CSS block.
+- Consecutive headings (`h2` directly followed by `h3`) get the snug 0.375rem gap by source order — accepted (a heading directly under its parent heading *should* bind tightly).
+- Headings nested inside blockquotes/list items get `margin-top: 1.125rem` without the owl context — rare in agent output; accepted.
+- The rAF-batched stream and memo'd blocks are untouched — no perf risk.
+
+## 8. Open questions / assumptions (autonomous mode log)
+
+- **A1**: "Titles" = markdown headings inside message bodies (not the panel section headers, which were just fixed in #164). Confidence: high, from the wording "titles in the messages".
+- **A2**: The shared `.agetor-md` surfaces (PlanDialog, GitHubDialog) should receive the same improvement rather than be shielded with a scoped class. If GitHub PR bodies feel too loose afterwards, add a density modifier class there in a follow-up.
+- **A3**: ThinkingBlock rendering literal `#`/`-` (it's plain text, not markdown) is a separate feature, out of scope here.
+- **A4**: Exact values (0.625/1.125/0.375 rem) are my design call within the "modest" constraint; they're one-line tunables.
+- Gates bypassed: Phase 2 grill and Phase 3 approval were self-resolved because the session runs unattended (agetor-orchestrated).

--- a/e2e/markdown-readability.spec.ts
+++ b/e2e/markdown-readability.spec.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { test, expect, type APIRequestContext, type E2EBackend, type Locator, type Page } from "./fixtures";
+import { gotoApp } from "./helpers";
+
+/**
+ * E2E coverage for the message-markdown reading rhythm inside the Task
+ * Details stream's `.agetor-md` class (src/mainview/index.css). Modeled
+ * directly on e2e/quote.spec.ts's harness (real Chromium against the real
+ * webview + a per-worker headless Bun backend, no mocked fetches) and
+ * e2e/font-size.spec.ts's style-assertion conventions (computed-style
+ * assertions rather than screenshots/pixel constants — a user font-size
+ * control tunes the rem-based values these rules use, so any pixel constant
+ * would fall out of sync).
+ *
+ * Producing a real `.agetor-md` block with arbitrary, test-authored markdown:
+ * the fake claude driver (`AGETOR_CLAUDE_DRIVER=fake`, set by the `backend`
+ * fixture) only emits a *fixed* canned reply ("fake response to: <prompt>")
+ * on the `stdout` stream, which the run panel renders through the generic
+ * `RawText` block — plain text, not markdown (see quote.spec.ts's header
+ * comment). There is no test hook to control the fake driver's `assistant`-
+ * stream text. What orchestrator.ts *does* do unconditionally on every
+ * `startTask` is echo the task's own prompt back as a `user` stream event
+ * (orchestrator.ts, "Echo the initial prompt as a 'user' event so the panel
+ * renders it") — and the "you" bubble that renders (`RunPanel.tsx`) feeds
+ * that prompt straight through `ReactMarkdown` inside a `className="agetor-md
+ * ..."` wrapper, using `USER_MD_COMPONENTS`. That components map only
+ * overrides `a`/`code`/`pre` (`md-components.tsx`) — headings, paragraphs,
+ * and lists render as plain default tags, identical to what
+ * `ASSISTANT_MD_COMPONENTS` would produce for the same markdown — so seeding
+ * the *prompt* with our test markdown exercises exactly the same `.agetor-md`
+ * CSS rules the assistant stream would, without needing a real/controllable
+ * assistant reply.
+ */
+
+test.describe.configure({ mode: "serial" });
+
+interface TaskRow {
+  id: string;
+  title: string;
+}
+
+/** Create a task (isolation "none", a plain non-git temp dir as workdir — the
+ *  fake driver never touches the filesystem) with a distinct title/prompt and
+ *  start it, so orchestrator.ts's prompt-echo puts `prompt` on the `user`
+ *  stream as a real `.agetor-md`-rendered block. Fails loudly via `expect`
+ *  rather than leaving a silent 400 for a later step to trip on. */
+async function createAndStartTask(
+  request: APIRequestContext,
+  backend: E2EBackend,
+  title: string,
+  prompt: string,
+): Promise<TaskRow> {
+  const auth = { authorization: `Bearer ${backend.apiToken}` };
+  const createRes = await request.post(`${backend.apiBase}/tasks`, {
+    headers: auth,
+    data: { title, prompt, isolation: "none", workdir: tmpdir() },
+  });
+  expect(createRes.ok(), `POST /tasks -> ${createRes.status()}: ${await createRes.text()}`).toBeTruthy();
+  const task = (await createRes.json()) as TaskRow;
+
+  const startRes = await request.post(`${backend.apiBase}/tasks/${task.id}/start`, {
+    headers: auth,
+  });
+  expect(
+    startRes.ok(),
+    `POST /tasks/${task.id}/start -> ${startRes.status()}: ${await startRes.text()}`,
+  ).toBeTruthy();
+
+  return task;
+}
+
+/** The run panel's slide-over `<aside>` — see quote.spec.ts's identical
+ *  helper for why `.last()` is the right pick (RunPanel mounts after
+ *  NewTaskForm's own always-present `<aside>` sidebar). */
+function runPanel(page: Page) {
+  return page.locator("aside").last();
+}
+
+/** Click a task card by its exact title and wait for the composer textarea
+ *  to mount as proof the run panel is open. */
+async function openTask(page: Page, title: string) {
+  await page.getByText(title, { exact: true }).first().click();
+  const panel = runPanel(page);
+  await expect(panel.locator("textarea")).toBeVisible();
+  return panel;
+}
+
+/** Computed `margin-top`, in px, as a number — `getComputedStyle` via
+ *  `locator.evaluate`, per the task's structural-assertion requirement
+ *  (never a hardcoded pixel constant; only relative/zero comparisons). */
+async function marginTopPx(locator: Locator): Promise<number> {
+  const value = await locator.evaluate((el) => getComputedStyle(el).marginTop);
+  return Number.parseFloat(value);
+}
+
+test.describe("markdown readability", () => {
+  test("message markdown block follows the .agetor-md reading rhythm: heading/paragraph/list spacing", async ({
+    page,
+    request,
+    backend,
+  }) => {
+    const marker = randomUUID();
+    const title = `markdown-e2e ${marker}`;
+    // First-child heading, a paragraph, a second paragraph, another heading,
+    // then a list — exactly the shape the rhythm rules key off of.
+    const prompt =
+      `## Reading Rhythm ${marker}\n\n` +
+      `para one line\n\n` +
+      `para two line\n\n` +
+      `### Section ${marker}\n\n` +
+      `- item a\n- item b`;
+
+    await createAndStartTask(request, backend, title, prompt);
+
+    await gotoApp(page, backend.bootBase);
+    const panel = await openTask(page, title);
+
+    // Exactly one `.agetor-md` block should exist in the panel: the "you"
+    // bubble rendering our seeded prompt. The fake driver's canned assistant
+    // reply renders as plain `RawText`, not markdown, so it contributes none.
+    const blocks = panel.locator(".agetor-md");
+    await expect(blocks).toHaveCount(1);
+    const container = blocks.first();
+
+    // Wait for the whole markdown tree to have committed in one shot
+    // (ReactMarkdown renders synchronously, not streamed piecemeal) before
+    // taking any measurements — two `<li>`s is a reliable proxy for "the
+    // headings and paragraphs above it are there too."
+    await expect(container.locator("li")).toHaveCount(2);
+    await expect(container.locator("p")).toHaveCount(2);
+    await expect(container.locator("h3")).toHaveCount(1);
+    await expect(container.locator("ul")).toHaveCount(1);
+
+    const firstChild = container.locator("> :first-child");
+    const paragraphs = container.locator("p");
+    const secondHeading = container.locator("h3");
+    const list = container.locator("ul");
+
+    // --- first child: no leading gap above the block's own first line ----
+    expect(await marginTopPx(firstChild)).toBe(0);
+
+    // --- paragraph -> paragraph gap: the owl (`> * + *`) rhythm reaches
+    //     paragraphs now that the old `p { margin: 0 }` reset is gone -------
+    const secondParagraphMarginTop = await marginTopPx(paragraphs.nth(1));
+    expect(secondParagraphMarginTop).toBeGreaterThan(0);
+
+    // --- heading prominence: a non-first heading gets more top margin than
+    //     an ordinary paragraph ------------------------------------------
+    const headingMarginTop = await marginTopPx(secondHeading);
+    expect(headingMarginTop).toBeGreaterThan(secondParagraphMarginTop);
+
+    // --- snug-below: the element right after a heading sits closer than
+    //     the heading's own top margin, so the heading reads as attached to
+    //     what follows it -------------------------------------------------
+    const afterHeadingMarginTop = await marginTopPx(list);
+    expect(afterHeadingMarginTop).toBeLessThan(headingMarginTop);
+  });
+});

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -4119,7 +4119,7 @@ const UserMessageBlock = memo(function UserMessageBlock({ text, taskId }: { text
 
   const collapseClassName = cn(
     "agetor-md",
-    expanded ? "max-h-[40vh] overflow-y-auto" : "max-h-[4.5rem] overflow-hidden",
+    expanded ? "max-h-[40vh] overflow-y-auto" : "max-h-[4.8rem] overflow-hidden",
   );
 
   return (

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -132,27 +132,34 @@
 }
 
 /* Markdown rendering for assistant messages in the run panel. Sized to sit
-   well next to the surrounding 12px event rows; spacing is tight so a multi-
-   paragraph reply doesn't dwarf adjacent tool calls. */
-.agetor-md { line-height: 1.55; }
-.agetor-md > * + * { margin-top: 0.5rem; }
+   well next to the surrounding 12px event rows; still compact by design, but
+   headings get clear space above and snug space below (margin-top-only, so
+   a heading binds to the content that follows it) while paragraph-to-
+   paragraph rhythm loosens modestly. */
+.agetor-md { line-height: 1.6; }
+.agetor-md > * + * { margin-top: 0.625rem; }
 .agetor-md p { margin: 0; }
 .agetor-md h1, .agetor-md h2, .agetor-md h3, .agetor-md h4, .agetor-md h5, .agetor-md h6 {
   font-weight: 600;
   line-height: 1.3;
   color: hsl(var(--foreground));
+  margin-top: 1.125rem;
 }
-.agetor-md h1 { font-size: 1.05rem; }
-.agetor-md h2 { font-size: 1rem; }
-.agetor-md h3 { font-size: 0.95rem; }
+.agetor-md h1 { font-size: 1.125rem; }
+.agetor-md h2 { font-size: 1.0625rem; }
+.agetor-md h3 { font-size: 1rem; }
 .agetor-md h4, .agetor-md h5, .agetor-md h6 { font-size: 0.875rem; }
+.agetor-md h1 + *, .agetor-md h2 + *, .agetor-md h3 + *, .agetor-md h4 + *, .agetor-md h5 + *, .agetor-md h6 + * {
+  margin-top: 0.375rem;
+}
+.agetor-md > :first-child { margin-top: 0; }
 .agetor-md strong { font-weight: 600; color: hsl(var(--foreground)); }
 .agetor-md em { font-style: italic; }
 .agetor-md del { text-decoration: line-through; opacity: 0.7; }
 .agetor-md ul, .agetor-md ol { padding-left: 1.25rem; margin: 0; }
 .agetor-md ul { list-style: disc; }
 .agetor-md ol { list-style: decimal; }
-.agetor-md li { margin: 0.125rem 0; }
+.agetor-md li { margin: 0.1875rem 0; }
 .agetor-md li > ul, .agetor-md li > ol { margin-top: 0.125rem; }
 .agetor-md li > p { display: inline; }
 .agetor-md blockquote {
@@ -164,7 +171,7 @@
 .agetor-md hr {
   border: 0;
   border-top: 1px solid hsl(var(--border));
-  margin: 0.5rem 0;
+  margin: 0.75rem 0;
 }
 .agetor-md table {
   width: 100%;

--- a/src/mainview/index.css
+++ b/src/mainview/index.css
@@ -135,10 +135,11 @@
    well next to the surrounding 12px event rows; still compact by design, but
    headings get clear space above and snug space below (margin-top-only, so
    a heading binds to the content that follows it) while paragraph-to-
-   paragraph rhythm loosens modestly. */
+   paragraph rhythm loosens modestly via the owl selector below — Tailwind
+   Preflight already zeroes p/ul/ol margins, so no redundant reset here would
+   just fight the owl at equal-or-higher specificity. */
 .agetor-md { line-height: 1.6; }
 .agetor-md > * + * { margin-top: 0.625rem; }
-.agetor-md p { margin: 0; }
 .agetor-md h1, .agetor-md h2, .agetor-md h3, .agetor-md h4, .agetor-md h5, .agetor-md h6 {
   font-weight: 600;
   line-height: 1.3;
@@ -152,11 +153,13 @@
 .agetor-md h1 + *, .agetor-md h2 + *, .agetor-md h3 + *, .agetor-md h4 + *, .agetor-md h5 + *, .agetor-md h6 + * {
   margin-top: 0.375rem;
 }
-.agetor-md > :first-child { margin-top: 0; }
+.agetor-md > :first-child,
+.agetor-md blockquote > :first-child,
+.agetor-md li > :first-child { margin-top: 0; }
 .agetor-md strong { font-weight: 600; color: hsl(var(--foreground)); }
 .agetor-md em { font-style: italic; }
 .agetor-md del { text-decoration: line-through; opacity: 0.7; }
-.agetor-md ul, .agetor-md ol { padding-left: 1.25rem; margin: 0; }
+.agetor-md ul, .agetor-md ol { padding-left: 1.25rem; }
 .agetor-md ul { list-style: disc; }
 .agetor-md ol { list-style: decimal; }
 .agetor-md li { margin: 0.1875rem 0; }


### PR DESCRIPTION
## What

Improves readability of message markdown in the Task Details stream (and every other surface styled by the shared `.agetor-md` class: PlanDialog plan bodies, GitHubDialog PR/issue markdown):

- **Headings get breathing room**: `margin-top: 1.125rem` above, snug `0.375rem` below (so a title binds to its own section), with first-child guards (`.agetor-md > :first-child`, `blockquote > :first-child`, `li > :first-child`) so heading-first content isn't pushed down.
- **Paragraph spacing actually works now**: the `> * + *` owl gap (bumped 0.5 → 0.625rem) was being silently defeated by `.agetor-md p { margin: 0 }` — specificity (0,1,1) beats the owl's (0,1,0) — so paragraph-to-paragraph gaps were **0px**. Removed the redundant per-element `margin: 0` resets (Tailwind Preflight already zeroes them in `@layer base`, and unlayered `.agetor-md` rules win over Preflight), letting the owl reach paragraphs and lists.
- Small QoL: line-height 1.55 → 1.6, roomier list items (`li` margin 0.125 → 0.1875rem), `hr` margin matched to the new rhythm (0.75rem), slightly stronger heading hierarchy (h1/h2/h3 → 1.125/1.0625/1rem).
- **Regression fix caught in review**: at line-height 1.6 the collapsed user-bubble preview (`max-h-[4.5rem]`) clipped the 4th line's descenders mid-glyph; resized to `max-h-[4.8rem]` — exactly four line boxes (4 × 0.75rem × 1.6).

All values stay in `rem` so the app-wide Cmd+/Cmd− font-size control keeps scaling correctly. No color changes; no typography plugin added.

## Why

Multi-paragraph agent replies rendered as a cramped wall of text: zero gap between paragraphs and headings that only differed by font size, with no margins separating them from surrounding prose.

## Tests

- New `e2e/markdown-readability.spec.ts`: renders markdown through `.agetor-md` in the run panel (seeded via the task prompt echo, since the fake driver's reply is plain text) and asserts the rhythm **structurally** via computed styles — paragraph gap > 0, heading margin > paragraph gap, snug-below < heading margin, first child = 0 — no pixel constants, so it survives font-size scaling and future tuning. Verified parallel-safe (`--repeat-each=3`).
- `bun run typecheck` green; full Playwright suite 18/18 green.
- `bun test`: 2589 pass, 1 fail — the known pre-existing `claude-tmux-queue` timing flake (`<500ms` bound missed under load), unrelated to this diff (no Bun-side code touched).

## Notes

- Plan doc: `docs/plans/task-details-message-readability.md`.
- Deferred follow-up: an `em`-based heading ramp would fix PlanDialog's inverted h4–h6 hierarchy (headings render smaller than its 16px body) but would shrink h2/h3 in the RunPanel — the surface this PR targets — so it's left for a per-surface density modifier later.