### PR TITLE
feature: first-run onboarding — welcome dialog + live getting-started checklist

### DIFF
--- a/docs/plans/onboarding-first-run.md
+++ b/docs/plans/onboarding-first-run.md
@@ -1,0 +1,127 @@
+# Plan — First-run onboarding (welcome + live Getting Started checklist)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-12 |
+| Source | /implement request + GitHub issue "New users don't know what to do first" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Branch | feature/onboarding-process |
+| Base SHA | 2a4f1a1f3eb8a88aae8bd9581592a5c109d87a85 (tree clean apart from this plan) |
+
+## 1. Objective & success criteria
+
+A brand-new agetor user (fresh data dir, zero tasks) opens the app and immediately understands what agetor is and what to do first. Concretely:
+
+- A **welcome dialog** appears once on first run, explaining the workflow in a few sentences (task = prompt + project + harness; cards move Backlog → Ready → Running → Review/Done).
+- A **"Getting started" checklist card** fills the empty board area with 4 live steps, each auto-checked from real state and offering a one-click action:
+  1. **Harness ready** — done when ≥1 enabled harness probe reports `available`. Otherwise shows per-harness status (installed/missing/disabled) with install hints, login guidance ("Open in Terminal" + the exact login command), and a deep link to Settings → Harnesses.
+  2. **Add a project** — done when ≥1 registered project exists.
+  3. **Create your first task** — done when ≥1 task exists. Action expands/focuses the New Task panel.
+  4. **Run it** — done when any task has ever left backlog/ready (column ∈ running/review/done/blocked).
+- Dismissable ("I know my way around"), auto-completes when all steps are done, **never shows for existing users** (data with completed steps ⇒ silently marked dismissed).
+- Replayable from Settings → General ("Show getting started guide").
+- A short **workflow explainer** (InfoTip) near the New Task panel header addresses the issue's "12 unexplained fields" complaint.
+- While onboarding is visible, empty kanban columns show a one-line muted hint of what each column means.
+
+Success = e2e spec proves: fresh backend shows welcome + checklist; steps check off as harness/project/task/run land; dismissal persists across reload; replay works. `bun run typecheck`, `bun test`, `bunx playwright test` all green.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- **No empty state exists**: `Column.tsx:35-70` renders a bare list; `App.tsx:780-784` shows "0 tasks". Onboarding is greenfield — no prior attempt in git history or docs/plans.
+- **Board layout**: `App.tsx:814-902` — `NewTaskForm` sidebar + `<main>` with columns. Tasks polled 2s (`App.tsx:240-300`), harness statuses (`api.listHarnesses()` → `HarnessStatus[]`) polled 15s (`App.tsx:250-256, 301`).
+- **Harness probe is install-only**: `agent-status.ts:72-121` returns `{ available, path, version, reason, installHint }` per harness row; login state is NOT detectable (decision: guidance only, no new probes). `INSTALL_HINTS` per kind at `agent-status.ts:10-15`. Manual login flow exists: `api.openHarnessTerminal(id)` → POST `/harnesses/:id/open-terminal` (native; 501 headless), with per-kind login copy precedent in `HARNESS_HOME_COPY` (`SettingsDialog.tsx:135-156`).
+- **Projects**: GET `/projects` (`server.ts:546-`), consumed by `ProjectPicker`. Registered-projects count is the step-2 signal.
+- **Preferences KV**: `preferences` table (migration 011), GET `/preferences` + PUT `/preferences/:key` (string values). Keys like `theme`, `fontSize`, `defaultHarness`. **No migration needed** for the new key. Reads are always best-effort (`.catch` keep-defaults idiom).
+- **Settings dialog**: sidebar sections from `settings-dialog-view.ts:4-9` (`general|harnesses|git|prompts`); no deep-link prop today — `open` effect resets to General (`SettingsDialog.tsx:257-264`). App holds only `settingsOpen: boolean` (`App.tsx:163`).
+- **Reusable primitives**: `Dialog`, `Card`, `Button`, `Badge`, `InfoTip` (`components/ui/`), `panel-collapse.ts` localStorage util (`NEW_TASK_PANEL_COLLAPSED_KEY`), `TmuxMissingBanner`/`TmuxInstallDialog` guided-fix precedents, `GitHubSetupDialog` numbered `GuideStep[]` pattern.
+- **Theming rule**: semantic tokens only (`text-success`, `bg-info/10`, …); any new token must land in `index.css` **and** `tailwind.config.js` together (no new tokens planned — reuse existing).
+- **Churn warning**: `NewTaskForm.tsx` and `SettingsDialog.tsx` change weekly — no pixel/label anchors; use props/`data-*` markers.
+- **Delivery conventions**: pure logic in `src/mainview/lib/*.ts` with colocated bun unit tests (no DOM test harness exists); e2e via per-worker backend fixtures (`e2e/fixtures.ts`, fake claude driver `AGETOR_CLAUDE_DRIVER=fake`, seed via authed POSTs); run with `bunx playwright test` (no package.json script); squash PR titled `feature: … (#NNN)`.
+- **Codex + Cursor ship disabled by default** (migrations 016/024) — deliberate; onboarding must not auto-enable (decision: show "disabled — enable in Settings" + deep link).
+
+## 3. Approach & key decisions
+
+- **Shape** (owner decision): welcome dialog + live checklist card; no blocking wizard, no spotlight tour (churn risk).
+- **Login** (owner decision): guidance only — surface install status, exact login command per kind, "Open in Terminal". No auth-state probing.
+- **Disabled harnesses** (owner decision): visible with deep link to Settings → Harnesses; never auto-enabled.
+- **Multi-account** (owner decision): one sentence pointing at Settings → Harnesses → Add; no dedicated step.
+- **Persistence**: server preference key **`onboardingDismissed`** (`"true"`/`"false"`; absent = never dismissed). Server-side, cross-session, no migration. Not paint-blocking, so the async preferences path is fine (unlike theme/collapse). Replay = write `"false"`.
+- **Existing users**: on first evaluation after data loads, if the pref is unset and all steps already derive as done, silently write `"true"` — upgrading users never see onboarding. Welcome *dialog* additionally requires `tasks.length === 0`.
+- **All logic is pure and unit-tested** in `src/mainview/lib/onboarding.ts`; components stay thin (no DOM test harness exists).
+- **No server changes at all** — the entire feature is webview-side + one new preference key.
+
+## 4. Work breakdown — implementation tasks
+
+Shared contracts (pinned so parallel tasks can't drift):
+
+- `src/mainview/lib/onboarding.ts` exports:
+  - `type OnboardingStepId = "harness" | "project" | "task" | "run"`
+  - `type OnboardingStep = { id: OnboardingStepId; done: boolean }`
+  - `deriveOnboardingSteps(input: { statuses: HarnessStatus[]; enabledHarnessIds: Set<string> | null; projectCount: number; tasks: Pick<Task, "column">[] }): OnboardingStep[]`
+  - `type OnboardingVisibility = { showWelcome: boolean; showChecklist: boolean; autoDismiss: boolean }`
+  - `resolveOnboardingVisibility(input: { dismissedPref: string | undefined; loaded: boolean; steps: OnboardingStep[]; taskCount: number; welcomeAcknowledged: boolean }): OnboardingVisibility`
+  - `ONBOARDING_DISMISSED_PREF = "onboardingDismissed"`
+- `SettingsDialog` gains prop `initialSection?: SettingsSectionId` (applied in the existing `open` effect; default unchanged).
+- `NewTaskForm` gains prop `focusNonce?: number` — when it increments: expand the panel (reuse `writeCollapsed`), focus the Title input, brief highlight.
+- `App.tsx` replaces `settingsOpen: boolean` with `settingsOpen` + `settingsInitialSection` (or a single `SettingsSectionId | null` state) and passes both new props down.
+
+### Wave 1 (parallel, disjoint)
+
+- **T1 — onboarding logic lib**
+  Files: `src/mainview/lib/onboarding.ts` (new), `src/mainview/lib/onboarding.test.ts` (new).
+  Implements the contracts above. Step rules: harness done ⇔ some status is `available` AND (enabledHarnessIds is null OR contains its harnessId); project done ⇔ `projectCount > 0`; task done ⇔ `tasks.length > 0`; run done ⇔ some task column ∈ {running, review, done, blocked}. Visibility rules per §3 (incl. `autoDismiss` when pref unset + all done + loaded). Unit tests cover every rule + existing-user auto-dismiss + replay (`"false"` after `"true"`).
+  Acceptance: `bun test src/mainview/lib/onboarding.test.ts` green; no imports from components.
+
+- **T2 — Settings deep-link + replay button**
+  Files: `src/mainview/components/settings/SettingsDialog.tsx`, `src/mainview/lib/settings-dialog-view.ts` (only if a helper is genuinely needed).
+  Adds `initialSection?: SettingsSectionId` prop honored when the dialog opens; adds a "Getting started" row in **General** with a "Show getting started guide" button that writes `onboardingDismissed="false"` via `api.setPreference` and closes the dialog. Must respect the PR #150 overflow contract.
+  Acceptance: typecheck green; opening with `initialSection="harnesses"` lands on Harnesses; button writes the pref.
+
+### Wave 2 (parallel, disjoint; depends on Wave 1)
+
+- **T3 — onboarding components + App wiring + column hints**
+  Files: `src/mainview/components/onboarding/WelcomeDialog.tsx` (new), `src/mainview/components/onboarding/OnboardingChecklist.tsx` (new), `src/mainview/App.tsx`, `src/mainview/components/kanban/Column.tsx`.
+  - `WelcomeDialog`: Dialog-based, copy seeded from README "Getting started" + the issue's suggested copy; "Get started" (ack → checklist) and "Skip — I know my way around" (writes dismissed pref).
+  - `OnboardingChecklist`: full-size centered card when `tasks.length === 0`, compact strip above the board otherwise. Step rows with done/pending icons (semantic tokens only). Harness step detail: per-harness dot + version, install hint for missing, "disabled — Enable in Settings" deep link, login guidance block (per-kind login command + "Open in Terminal" via `api.openHarnessTerminal`, error-toasted if 501), one-line multi-account pointer. Project step: point at New Task panel's Project picker (fires `focusNonce`). Task step: fires `focusNonce`. Run step: informational copy. Dismiss link writes pref. `data-testid` markers for e2e (`onboarding-welcome`, `onboarding-checklist`, `onboarding-step-<id>`).
+  - `App.tsx`: derive steps/visibility from existing polled state (`tasks`, `agents`, projects list — add a lightweight projects fetch if none exists in App), fetch prefs once (already done for fontSize), implement `autoDismiss` write-once effect, render dialog + card, thread `settingsInitialSection` and `focusNonce`.
+  - `Column.tsx`: optional `emptyHint?: string` shown muted when the column has no tasks — passed by App only while checklist is visible. Hints: Backlog "Ideas you haven't queued yet" / Ready "Waiting for you to press Run" / Running "Agents working right now" / Blocked "Needs your attention".
+  Acceptance: typecheck green; zero-state renders welcome + card; no render when pref `"true"`.
+
+- **T4 — New Task panel affordances**
+  Files: `src/mainview/components/kanban/NewTaskForm.tsx`.
+  - `focusNonce?: number` prop: on increment, expand (reuse existing collapse state + `writeCollapsed`), focus Title, transient ring highlight (~1.5s, semantic token).
+  - Workflow InfoTip beside the "New task" header: 3–4 sentences on how the fields fit together (Type/Title/Prompt = what to do; Project/Branch/Isolate = where; Harness/Mode/Model/Effort = which agent and how). Reuses `InfoTip`.
+  Acceptance: typecheck green; no change to submit behavior or field defaults.
+
+## 5. Work breakdown — test tasks
+
+- **TT1 — unit tests** land with T1 (colocated, per repo convention). Any gaps found later: extend `onboarding.test.ts`.
+- **TT2 — e2e spec** `e2e/onboarding.spec.ts` (new file; may touch `e2e/helpers.ts` only to add small shared helpers):
+  1. Fresh backend → welcome dialog + checklist visible; harness step already done (fake driver reports available).
+  2. Skip → nothing shown after reload (pref persisted server-side).
+  3. Fresh backend: register project via authed POST `/projects` → step 2 checks off; create task (POST `/tasks`, isolation "none") → step 3; start it (fake driver) → step 4 after settle; checklist auto-completes/disappears; pref now `"true"`.
+  4. Replay: Settings → General → "Show getting started guide" → checklist visible again.
+  5. Existing-user guard: seed a done-state backend (project + task run) before first page load → onboarding never appears, pref auto-set.
+  **e2e applies** (user-visible flow, harness exists). Run recipe: shared Vite via Playwright `webServer`, per-worker headless backend fixture (`e2e/fixtures.ts`) with fake driver env; command `bunx playwright test e2e/onboarding.spec.ts`.
+
+## 6. Execution waves
+
+- Wave 1: T1 ∥ T2 → checkpoint (typecheck + bun test + commit).
+- Wave 2: T3 ∥ T4 → checkpoint (typecheck + bun test + commit). (T3/T4 are file-disjoint; the `focusNonce` contract is pinned in §4 so both sides compile after the wave completes.)
+- Phase 5 review → Phase 6: TT2 (single agent) → Phase 7 full run (bun test + typecheck + playwright) → Phase 8 fixes if needed.
+
+## 7. Blast radius & risks
+
+- `App.tsx` is the app shell — wiring errors break everything; mitigated by typecheck + e2e boot assertions in existing specs (`theme.spec.ts` exercises boot).
+- `Column.tsx` renders every column — the hint must not disturb drag-and-drop (dnd-kit) drop zones; hint goes inside the existing empty list container, non-interactive.
+- `NewTaskForm` focus effect must not steal focus outside onboarding actions (only fires on nonce increment, never on mount).
+- Settings `initialSection` must not regress the existing reset-to-General behavior when opened normally.
+- `openHarnessTerminal` is 501 under headless — checklist must degrade (toast, guidance text still useful). e2e must not click it.
+- Existing e2e specs assume no unexpected overlays: welcome dialog appears on fresh backends, which every worker gets. **TT2/T3 must ensure existing specs keep passing** — simplest: existing helpers' `gotoApp` flows through a backend that has no tasks, so the welcome dialog WILL appear and could block clicks in theme/font-size/quote specs. Mitigation (pinned): `e2e/fixtures.ts` or `helpers.ts` seeds `onboardingDismissed="true"` via `putPreference` in `gotoApp` by default, with an opt-out used only by `onboarding.spec.ts`. This is a required part of TT2 (and must be validated in Phase 7 by running the whole suite).
+- No server/DB changes; rollback = revert the squash commit.
+
+## 8. Open questions / assumptions
+
+- Copy is drafted by the implementer seeded from README + the GitHub issue; owner may reword at review.
+- Assumes `HarnessStatus` rows for disabled harnesses are distinguishable client-side (join with the Settings harness listing if the status payload lacks `enabled`); T3 resolves against actual API shape.
+- The GitHub issue's suggested empty-state copy is folded into the checklist card rather than a separate bare "No tasks yet" block.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -143,7 +143,163 @@ async function killGracefully(child: ChildProcess): Promise<void> {
   }
 }
 
-export const test = base.extend<{}, { backend: E2EBackend }>({
+/**
+ * Spawns one `headless.ts` backend on `apiPort`/`apiToken`, waits for it to
+ * become healthy, hands it to `use()`, and tears it down afterward. Shared by
+ * both `backend` (worker-scoped — one long-lived instance reused by every
+ * test in a worker) and `freshBackend` (test-scoped — a brand-new instance
+ * per test; see that fixture's doc comment for why it exists) below.
+ * `logLabel` only affects log/error messages (e.g. "worker 2" vs a test
+ * title) so a startup failure or mid-suite-death report points at the right
+ * instance.
+ */
+async function provisionBackend(
+  apiPort: number,
+  apiToken: string,
+  logLabel: string,
+  use: (backend: E2EBackend) => Promise<void>,
+): Promise<void> {
+  const apiBase = `http://127.0.0.1:${apiPort}`;
+
+  await assertPortFree(apiBase, apiPort);
+
+  const dataDir = await mkdtemp(path.join(tmpdir(), "agetor-e2e-"));
+  const logFile = path.join(dataDir, "backend.log");
+  const daemonLogFile = path.join(dataDir, "daemon.log");
+
+  const logStream: WriteStream = createWriteStream(logFile);
+  await new Promise<void>((resolve, reject) => {
+    logStream.once("open", () => resolve());
+    logStream.once("error", reject);
+  });
+
+  const child = spawn("bun", ["src/bun/headless.ts"], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      AGETOR_DATA_DIR: dataDir,
+      AGETOR_API_PORT: String(apiPort),
+      AGETOR_API_TOKEN: apiToken,
+      // 10 min, not disabled (0): the idle-shutdown loop in headless.ts
+      // only fires once there's been no running run AND no attached
+      // client for the whole timeout, so it can't trip during an active
+      // suite. What it buys us: if this fixture's own teardown ever
+      // fails to kill the child (crash, bug), the backend self-reaps
+      // instead of squatting on its port forever.
+      AGETOR_DAEMON_IDLE_MS: "600000",
+      // Same fake-driver combo orchestrator.test.ts uses: with
+      // AGETOR_CLAUDE_DRIVER=fake, spawnAgent's claude-code branch
+      // returns an in-process fake agent instead of shelling out to
+      // tmux. checkHarness (the start-task pre-flight) is a separate
+      // code path that doesn't know about the driver override — it
+      // still resolves a claude-shaped binary AND a tmux binary
+      // regardless — so AGETOR_CLAUDE_BIN/AGETOR_TMUX_BIN point both at
+      // `/bin/echo` (always present) purely to satisfy that probe;
+      // AGETOR_CLAUDE_ARGS is cleared so buildCommand's argv (recorded
+      // by the fake but never executed) isn't polluted by an inherited
+      // shell override. Required by quote.spec.ts; inert for the other
+      // specs, which never start a run.
+      AGETOR_CLAUDE_DRIVER: "fake",
+      AGETOR_CLAUDE_BIN: "/bin/echo",
+      AGETOR_TMUX_BIN: "/bin/echo",
+      AGETOR_CLAUDE_ARGS: "",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout?.pipe(logStream);
+  child.stderr?.pipe(logStream);
+
+  // Surfaces a backend that dies mid-suite (crash, OOM, someone `kill`s
+  // it by hand) instead of leaving it silent — later tests would just
+  // see ECONNREFUSED and point at the wrong thing. Guarded by
+  // `tearingDown` so our own intentional kill in the teardown path below
+  // isn't misreported as a mid-suite death.
+  let tearingDown = false;
+  // Boxed in an object (rather than a bare reassigned `let`) so TS
+  // doesn't narrow the read below back to `null` across the intervening
+  // `await use(backend)` — a plain closure-mutated `let` loses that
+  // narrowing.
+  const deathReport: { info: { code: number | null; signal: NodeJS.Signals | null } | null } = {
+    info: null,
+  };
+  child.on("exit", (code, signal) => {
+    if (!tearingDown) deathReport.info = { code, signal };
+  });
+
+  // Race the health poll against an early exit/spawn failure (e.g. `bun`
+  // not on PATH, or headless.ts throwing before it binds) so a
+  // misconfigured child fails fast with a useful error instead of
+  // burning the full health-poll timeout. `.catch(() => {})` on the
+  // standalone reference keeps a late rejection (the child exiting
+  // normally during teardown, well after the race has already resolved)
+  // from surfacing as an unhandled rejection.
+  const spawnError = new Promise<never>((_, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      reject(new Error(`headless backend exited early (code=${code}, signal=${signal})`));
+    });
+  });
+  spawnError.catch(() => {});
+
+  try {
+    await Promise.race([waitForHealth(apiBase), spawnError]);
+    // `/health` answered, but confirm it was actually *our* child that
+    // answered it and not some other process that raced in and bound
+    // the port after assertPortFree's pre-flight check but before (or
+    // during) our own spawn — e.g. our child crashed immediately after
+    // binding and something else grabbed the now-free port before this
+    // check ran.
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        `${apiBase}/health answered but our child (pid ${child.pid}) had already exited ` +
+          `(code=${child.exitCode}, signal=${child.signalCode}) — another process owns that port.`,
+      );
+    }
+  } catch (err) {
+    const tails = await formatLogTails(logFile, daemonLogFile);
+    tearingDown = true;
+    await killGracefully(child);
+    logStream.end();
+    await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+    throw new Error(`${(err as Error).message}\n${tails}`);
+  }
+
+  const backend: E2EBackend = {
+    apiPort,
+    apiToken,
+    apiBase,
+    bootBase: `${E2E_BASE_URL}/#api=${apiPort}&token=${apiToken}`,
+    dataDir,
+  };
+
+  await use(backend);
+
+  if (deathReport.info) {
+    const tails = await formatLogTails(logFile, daemonLogFile);
+    // eslint-disable-next-line no-console -- deliberate loud stderr so the
+    // report points at infrastructure, not a flaky test.
+    console.error(
+      `[e2e] backend for ${logLabel} died mid-suite: ` +
+        `code=${deathReport.info.code} signal=${deathReport.info.signal}\n${tails}`,
+    );
+  }
+
+  tearingDown = true;
+  await killGracefully(child);
+  logStream.end();
+  if (process.env.E2E_KEEP_DATA_DIR) {
+    console.log(`[e2e] E2E_KEEP_DATA_DIR set — keeping ${dataDir}`);
+  } else {
+    await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+// Disjoint from BASE_API_PORT's worker range (4600 + up to ~workers) with a
+// wide gap — `freshBackend` below is test-scoped, so at most a handful of
+// these run concurrently even on a many-worker machine.
+const FRESH_BASE_API_PORT = 4700;
+
+export const test = base.extend<{ freshBackend: E2EBackend }, { backend: E2EBackend }>({
   backend: [
     async ({}, use, workerInfo) => {
       // `parallelIndex` is the stable 0..(workers-1) slot this worker
@@ -159,140 +315,28 @@ export const test = base.extend<{}, { backend: E2EBackend }>({
       // raced it. A random token makes any such impostor fail auth loudly
       // instead.
       const apiToken = `e2e-w${workerInfo.parallelIndex}-${randomUUID()}`;
-      const apiBase = `http://127.0.0.1:${apiPort}`;
-
-      await assertPortFree(apiBase, apiPort);
-
-      const dataDir = await mkdtemp(path.join(tmpdir(), "agetor-e2e-"));
-      const logFile = path.join(dataDir, "backend.log");
-      const daemonLogFile = path.join(dataDir, "daemon.log");
-
-      const logStream: WriteStream = createWriteStream(logFile);
-      await new Promise<void>((resolve, reject) => {
-        logStream.once("open", () => resolve());
-        logStream.once("error", reject);
-      });
-
-      const child = spawn("bun", ["src/bun/headless.ts"], {
-        cwd: REPO_ROOT,
-        env: {
-          ...process.env,
-          AGETOR_DATA_DIR: dataDir,
-          AGETOR_API_PORT: String(apiPort),
-          AGETOR_API_TOKEN: apiToken,
-          // 10 min, not disabled (0): the idle-shutdown loop in headless.ts
-          // only fires once there's been no running run AND no attached
-          // client for the whole timeout, so it can't trip during an active
-          // suite. What it buys us: if this fixture's own teardown ever
-          // fails to kill the child (crash, bug), the backend self-reaps
-          // instead of squatting on its port forever.
-          AGETOR_DAEMON_IDLE_MS: "600000",
-          // Same fake-driver combo orchestrator.test.ts uses: with
-          // AGETOR_CLAUDE_DRIVER=fake, spawnAgent's claude-code branch
-          // returns an in-process fake agent instead of shelling out to
-          // tmux. checkHarness (the start-task pre-flight) is a separate
-          // code path that doesn't know about the driver override — it
-          // still resolves a claude-shaped binary AND a tmux binary
-          // regardless — so AGETOR_CLAUDE_BIN/AGETOR_TMUX_BIN point both at
-          // `/bin/echo` (always present) purely to satisfy that probe;
-          // AGETOR_CLAUDE_ARGS is cleared so buildCommand's argv (recorded
-          // by the fake but never executed) isn't polluted by an inherited
-          // shell override. Required by quote.spec.ts; inert for the other
-          // specs, which never start a run.
-          AGETOR_CLAUDE_DRIVER: "fake",
-          AGETOR_CLAUDE_BIN: "/bin/echo",
-          AGETOR_TMUX_BIN: "/bin/echo",
-          AGETOR_CLAUDE_ARGS: "",
-        },
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-      child.stdout?.pipe(logStream);
-      child.stderr?.pipe(logStream);
-
-      // Surfaces a backend that dies mid-suite (crash, OOM, someone `kill`s
-      // it by hand) instead of leaving it silent — later tests would just
-      // see ECONNREFUSED and point at the wrong thing. Guarded by
-      // `tearingDown` so our own intentional kill in the teardown path below
-      // isn't misreported as a mid-suite death.
-      let tearingDown = false;
-      // Boxed in an object (rather than a bare reassigned `let`) so TS
-      // doesn't narrow the read below back to `null` across the intervening
-      // `await use(backend)` — a plain closure-mutated `let` loses that
-      // narrowing.
-      const deathReport: { info: { code: number | null; signal: NodeJS.Signals | null } | null } = {
-        info: null,
-      };
-      child.on("exit", (code, signal) => {
-        if (!tearingDown) deathReport.info = { code, signal };
-      });
-
-      // Race the health poll against an early exit/spawn failure (e.g. `bun`
-      // not on PATH, or headless.ts throwing before it binds) so a
-      // misconfigured child fails fast with a useful error instead of
-      // burning the full health-poll timeout. `.catch(() => {})` on the
-      // standalone reference keeps a late rejection (the child exiting
-      // normally during teardown, well after the race has already resolved)
-      // from surfacing as an unhandled rejection.
-      const spawnError = new Promise<never>((_, reject) => {
-        child.once("error", reject);
-        child.once("exit", (code, signal) => {
-          reject(new Error(`headless backend exited early (code=${code}, signal=${signal})`));
-        });
-      });
-      spawnError.catch(() => {});
-
-      try {
-        await Promise.race([waitForHealth(apiBase), spawnError]);
-        // `/health` answered, but confirm it was actually *our* child that
-        // answered it and not some other process that raced in and bound
-        // the port after assertPortFree's pre-flight check but before (or
-        // during) our own spawn — e.g. our child crashed immediately after
-        // binding and something else grabbed the now-free port before this
-        // check ran.
-        if (child.exitCode !== null || child.signalCode !== null) {
-          throw new Error(
-            `${apiBase}/health answered but our child (pid ${child.pid}) had already exited ` +
-              `(code=${child.exitCode}, signal=${child.signalCode}) — another process owns that port.`,
-          );
-        }
-      } catch (err) {
-        const tails = await formatLogTails(logFile, daemonLogFile);
-        tearingDown = true;
-        await killGracefully(child);
-        logStream.end();
-        await rm(dataDir, { recursive: true, force: true }).catch(() => {});
-        throw new Error(`${(err as Error).message}\n${tails}`);
-      }
-
-      const backend: E2EBackend = {
-        apiPort,
-        apiToken,
-        apiBase,
-        bootBase: `${E2E_BASE_URL}/#api=${apiPort}&token=${apiToken}`,
-        dataDir,
-      };
-
-      await use(backend);
-
-      if (deathReport.info) {
-        const tails = await formatLogTails(logFile, daemonLogFile);
-        // eslint-disable-next-line no-console -- deliberate loud stderr so the
-        // report points at infrastructure, not a flaky test.
-        console.error(
-          `[e2e] backend for worker ${workerInfo.parallelIndex} died mid-suite: ` +
-            `code=${deathReport.info.code} signal=${deathReport.info.signal}\n${tails}`,
-        );
-      }
-
-      tearingDown = true;
-      await killGracefully(child);
-      logStream.end();
-      if (process.env.E2E_KEEP_DATA_DIR) {
-        console.log(`[e2e] E2E_KEEP_DATA_DIR set — keeping ${dataDir}`);
-      } else {
-        await rm(dataDir, { recursive: true, force: true }).catch(() => {});
-      }
+      await provisionBackend(apiPort, apiToken, `worker ${workerInfo.parallelIndex}`, use);
     },
     { scope: "worker" },
   ],
+
+  // Test-scoped: a brand-new headless backend + SQLite DB spawned for this
+  // one test and torn down right after, unlike `backend` above (worker-
+  // scoped, shared by every test in the file). theme/font-size/quote reset
+  // the one preference they care about before each test and are fine sharing
+  // a DB. Onboarding can't do that: `resolveOnboardingVisibility` (src/
+  // mainview/lib/onboarding.ts) branches on whether `onboardingDismissed` has
+  // *ever* been written (`dismissedPref === undefined`), and there is no
+  // "unset preference" API — once any test writes that key (directly, via
+  // Skip/Dismiss, or via the auto-dismiss-when-all-steps-done effect), no
+  // later test sharing that DB could ever observe the "never evaluated"
+  // state again. Several onboarding.spec.ts cases need exactly that state
+  // independently (fresh welcome dialog, skip-then-persist, existing-user
+  // auto-dismiss), so each gets its own virgin backend instead of fighting
+  // over one shared DB.
+  freshBackend: async ({}, use, testInfo) => {
+    const apiPort = FRESH_BASE_API_PORT + testInfo.parallelIndex;
+    const apiToken = `e2e-fresh-w${testInfo.parallelIndex}-${randomUUID()}`;
+    await provisionBackend(apiPort, apiToken, `test "${testInfo.title}"`, use);
+  },
 });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -8,11 +8,65 @@ import type { E2EBackend } from "./fixtures";
  * backend, so there is no single fixed port/token pair to close over.
  */
 
+export interface GotoAppOptions {
+  /**
+   * Defaults to `true`: before navigating, seeds `onboardingDismissed="true"`
+   * directly against the backend this `url` points at, so the first-run
+   * welcome dialog / "Getting started" checklist (docs/plans/onboarding-
+   * first-run.md) never appears for a spec that isn't testing it. Every
+   * fresh per-worker backend (e2e/fixtures.ts's `backend`) starts with that
+   * preference absent — which is exactly the "show onboarding" state — so
+   * without this default, theme/font-size/quote specs would get a welcome
+   * dialog overlay blocking their first click. Only e2e/onboarding.spec.ts
+   * needs the real first-run state, via `{ seedOnboardingDismissed: false }`.
+   */
+  seedOnboardingDismissed?: boolean;
+}
+
+/** Preference key onboarding's visibility logic reads
+ *  (`ONBOARDING_DISMISSED_PREF` in src/mainview/lib/onboarding.ts) — kept as
+ *  a literal here rather than imported so this file has no dependency on
+ *  mainview source. */
+const ONBOARDING_DISMISSED_KEY = "onboardingDismissed";
+
+/** Pulls `apiBase`/`token` out of a boot URL's `#api=<port>&token=<token>`
+ *  hash. Used so `gotoApp` can seed a preference through `page.request`
+ *  (available on `Page` without a separate `request` fixture) without
+ *  widening its signature to take a full `E2EBackend` object — every
+ *  existing caller already builds a plain url string (some, like font-
+ *  size.spec.ts, append extra hash params of their own), so keeping `url`
+ *  as the second parameter means zero edits to those call sites. */
+function backendFromBootUrl(url: string): { apiBase: string; token: string } | null {
+  const hashIndex = url.indexOf("#");
+  if (hashIndex === -1) return null;
+  const params = new URLSearchParams(url.slice(hashIndex + 1));
+  const port = params.get("api");
+  const token = params.get("token");
+  if (!port || !token) return null;
+  return { apiBase: `http://127.0.0.1:${port}`, token };
+}
+
 /** Navigates to a boot URL and waits for real rendered content — the
  *  Settings button in the app bar — rather than a fixed sleep. Callers
  *  assemble the URL themselves (`backend.bootBase` plus any spec-specific
- *  hash params, e.g. font-size.spec's `&fontSize=`). */
-export async function gotoApp(page: Page, url: string): Promise<void> {
+ *  hash params, e.g. font-size.spec's `&fontSize=`). See `GotoAppOptions`
+ *  for the default onboarding-dismissal seeding. */
+export async function gotoApp(page: Page, url: string, options: GotoAppOptions = {}): Promise<void> {
+  const { seedOnboardingDismissed = true } = options;
+  if (seedOnboardingDismissed) {
+    const backend = backendFromBootUrl(url);
+    if (backend) {
+      const res = await page.request.put(`${backend.apiBase}/preferences/${ONBOARDING_DISMISSED_KEY}`, {
+        headers: { authorization: `Bearer ${backend.token}` },
+        data: { value: "true" },
+      });
+      if (!res.ok()) {
+        throw new Error(
+          `gotoApp: failed to seed ${ONBOARDING_DISMISSED_KEY} (${res.status()} ${await res.text()})`,
+        );
+      }
+    }
+  }
   await page.goto(url);
   await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
 }

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,0 +1,246 @@
+import { tmpdir } from "node:os";
+import { test, expect, type APIRequestContext, type E2EBackend, type Page } from "./fixtures";
+import { gotoApp, openSettingsGeneral, getPreferences } from "./helpers";
+
+/**
+ * E2E coverage for first-run onboarding — the welcome dialog + live
+ * "Getting started" checklist (docs/plans/onboarding-first-run.md, §5 TT2).
+ * Runs Chromium against the real webview + real Bun API/orchestrator, same
+ * as theme/font-size/quote — no mocked fetches.
+ *
+ * Unlike those three specs, every test here uses `freshBackend`
+ * (e2e/fixtures.ts) instead of the worker-scoped `backend`: onboarding's
+ * visibility rules (`resolveOnboardingVisibility` in
+ * src/mainview/lib/onboarding.ts) branch on whether the `onboardingDismissed`
+ * preference has *ever* been written (`dismissedPref === undefined`), and
+ * there's no "unset preference" API. Several cases below need that exact
+ * "never evaluated" state independently — a fresh welcome dialog, a Skip
+ * that then persists, an existing-user auto-dismiss on first load — so
+ * sharing one backend/DB across tests (the theme.spec.ts pattern) would let
+ * whichever test runs first permanently consume that state for the rest of
+ * the file. `freshBackend` sidesteps that entirely: a brand-new headless
+ * backend + SQLite DB per test.
+ *
+ * `gotoApp`'s default (`e2e/helpers.ts`) seeds `onboardingDismissed="true"`
+ * before navigating, which is exactly wrong for these tests — they need the
+ * real first-run state — so every navigation here passes
+ * `{ seedOnboardingDismissed: false }` except where a test deliberately wants
+ * the dismissed/replay state (case 4).
+ */
+
+function auth(backend: E2EBackend): { authorization: string } {
+  return { authorization: `Bearer ${backend.apiToken}` };
+}
+
+interface TaskRow {
+  id: string;
+  column: string;
+}
+
+/** Registers a project by absolute path (an authed `POST /projects`, per
+ *  src/bun/server.ts:546-572) — the API equivalent of the native folder
+ *  picker. `os.tmpdir()` always exists, and the fake driver never touches
+ *  the filesystem, so it doesn't need to be a real git repo. */
+async function registerProject(request: APIRequestContext, backend: E2EBackend): Promise<void> {
+  const res = await request.post(`${backend.apiBase}/projects`, {
+    headers: auth(backend),
+    data: { path: tmpdir() },
+  });
+  expect(res.ok(), `POST /projects -> ${res.status()}: ${await res.text()}`).toBeTruthy();
+}
+
+/** Creates a task (isolation "none", a plain temp dir as workdir) via an
+ *  authed `POST /tasks`. Returns the created row. */
+async function createTask(
+  request: APIRequestContext,
+  backend: E2EBackend,
+  title: string,
+): Promise<TaskRow> {
+  const res = await request.post(`${backend.apiBase}/tasks`, {
+    headers: auth(backend),
+    data: { title, prompt: title, isolation: "none", workdir: tmpdir() },
+  });
+  expect(res.ok(), `POST /tasks -> ${res.status()}: ${await res.text()}`).toBeTruthy();
+  return (await res.json()) as TaskRow;
+}
+
+/** Starts a task via an authed `POST /tasks/:id/start`. The backend's fake
+ *  claude driver (`AGETOR_CLAUDE_DRIVER=fake`, set by fixtures.ts) means this
+ *  never shells out to tmux — `startTask` still flips the task's column to
+ *  "running" synchronously before returning, which is already enough for
+ *  onboarding's "run" step (`RUN_DONE_COLUMNS` includes "running"). */
+async function startTask(request: APIRequestContext, backend: E2EBackend, id: string): Promise<void> {
+  const res = await request.post(`${backend.apiBase}/tasks/${id}/start`, { headers: auth(backend) });
+  expect(res.ok(), `POST /tasks/${id}/start -> ${res.status()}: ${await res.text()}`).toBeTruthy();
+}
+
+function welcome(page: Page) {
+  return page.getByTestId("onboarding-welcome");
+}
+
+function checklist(page: Page) {
+  return page.getByTestId("onboarding-checklist");
+}
+
+function step(page: Page, id: "harness" | "project" | "task" | "run") {
+  return page.getByTestId(`onboarding-step-${id}`);
+}
+
+test.describe("onboarding: fresh backend", () => {
+  test("shows the welcome dialog and checklist, with the harness step already done", async ({
+    page,
+    freshBackend,
+  }) => {
+    await gotoApp(page, freshBackend.bootBase, { seedOnboardingDismissed: false });
+
+    await expect(welcome(page)).toBeVisible();
+    await expect(checklist(page)).toBeVisible();
+
+    // The fake driver's claude-code binary probe points AGETOR_CLAUDE_BIN
+    // and AGETOR_TMUX_BIN at /bin/echo (fixtures.ts) — `checkHarness`
+    // resolves that as an existing absolute path, spawns it with
+    // `--version`, gets exit code 0, and reports `available: true`. Since
+    // claude-code is enabled by default, the harness step is already done on
+    // a totally virgin backend, before any project/task/run exists.
+    await expect(step(page, "harness")).toHaveAttribute("data-done", "true");
+    await expect(step(page, "project")).toHaveAttribute("data-done", "false");
+    await expect(step(page, "task")).toHaveAttribute("data-done", "false");
+    await expect(step(page, "run")).toHaveAttribute("data-done", "false");
+  });
+});
+
+test.describe("onboarding: skip", () => {
+  test("Skip hides onboarding immediately and the dismissal persists across reload", async ({
+    page,
+    request,
+    freshBackend,
+  }) => {
+    await gotoApp(page, freshBackend.bootBase, { seedOnboardingDismissed: false });
+    await expect(welcome(page)).toBeVisible();
+
+    await page.getByRole("button", { name: "Skip — I know my way around" }).click();
+    await expect(welcome(page)).toHaveCount(0);
+    await expect(checklist(page)).toHaveCount(0);
+
+    // Reload without re-seeding (still opting out of gotoApp's default
+    // seeding) so this proves the *persisted* pref is what's keeping
+    // onboarding hidden, not a redundant seed from this navigation.
+    await gotoApp(page, freshBackend.bootBase, { seedOnboardingDismissed: false });
+    await expect(welcome(page)).toHaveCount(0);
+    await expect(checklist(page)).toHaveCount(0);
+
+    const prefs = await getPreferences(request, freshBackend);
+    expect(prefs.onboardingDismissed).toBe("true");
+  });
+});
+
+test.describe("onboarding: progressive check-off", () => {
+  test("each step checks off live as harness/project/task/run land, then the checklist auto-dismisses", async ({
+    page,
+    request,
+    freshBackend,
+  }) => {
+    await gotoApp(page, freshBackend.bootBase, { seedOnboardingDismissed: false });
+    await expect(welcome(page)).toBeVisible();
+
+    await page.getByRole("button", { name: "Get started" }).click();
+    await expect(welcome(page)).toHaveCount(0);
+    await expect(checklist(page)).toBeVisible();
+    await expect(step(page, "project")).toHaveAttribute("data-done", "false");
+
+    await registerProject(request, freshBackend);
+    await expect(step(page, "project")).toHaveAttribute("data-done", "true", { timeout: 10_000 });
+
+    const task = await createTask(request, freshBackend, `onboarding-e2e-${Date.now()}`);
+    await expect(step(page, "task")).toHaveAttribute("data-done", "true", { timeout: 10_000 });
+
+    // Starting the task flips its column to "running" synchronously
+    // server-side (before startTask even returns) — that alone satisfies
+    // the "run" step (`RUN_DONE_COLUMNS` includes "running"), which makes
+    // all 4 steps done in the same render pass. `resolveOnboardingVisibility`
+    // hides the checklist the instant `allDone` is true (not just once the
+    // async auto-dismiss pref write lands) — so there's no window where the
+    // "run" step is visibly checked off with the checklist still on screen;
+    // the checklist disappearing IS the observable proof the run step (and
+    // therefore every step) went done. The existing-user upgrade path
+    // (`autoDismiss`) then persists the pref without any dismiss click.
+    await startTask(request, freshBackend, task.id);
+    await expect(checklist(page)).toHaveCount(0, { timeout: 10_000 });
+    await expect
+      .poll(() => getPreferences(request, freshBackend).then((p) => p.onboardingDismissed), {
+        message: "expected auto-dismiss to persist onboardingDismissed=true",
+        timeout: 10_000,
+      })
+      .toBe("true");
+  });
+});
+
+test.describe("onboarding: replay from Settings", () => {
+  test("Settings -> General -> 'Show getting started guide' brings the checklist back; dismiss hides it again", async ({
+    page,
+    request,
+    freshBackend,
+  }) => {
+    // Seed a completed setup (project + task + run) on a virgin backend, then
+    // let gotoApp's default seeding mark it dismissed — this is exactly
+    // "a seeded-dismissed backend with a completed setup" per the plan.
+    await registerProject(request, freshBackend);
+    const task = await createTask(request, freshBackend, `onboarding-replay-e2e-${Date.now()}`);
+    await startTask(request, freshBackend, task.id);
+
+    await gotoApp(page, freshBackend.bootBase);
+    await expect(welcome(page)).toHaveCount(0);
+    await expect(checklist(page)).toHaveCount(0);
+
+    const dialog = await openSettingsGeneral(page);
+    await dialog.getByTestId("settings-replay-onboarding").click();
+
+    // The button's onClick awaits the preference write, then closes the
+    // dialog — App re-reads the pref on close.
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(checklist(page)).toBeVisible();
+    await expect(welcome(page)).toHaveCount(0);
+
+    // Everything was already set up before the first load, so replay shows
+    // every step already done.
+    await expect(step(page, "harness")).toHaveAttribute("data-done", "true");
+    await expect(step(page, "project")).toHaveAttribute("data-done", "true");
+    await expect(step(page, "task")).toHaveAttribute("data-done", "true");
+    await expect(step(page, "run")).toHaveAttribute("data-done", "true");
+
+    await page.getByRole("button", { name: "Dismiss — I know my way around" }).click();
+    await expect(checklist(page)).toHaveCount(0);
+
+    const prefs = await getPreferences(request, freshBackend);
+    expect(prefs.onboardingDismissed).toBe("true");
+  });
+});
+
+test.describe("onboarding: existing-user guard", () => {
+  test("a backend that already has a completed setup before first load never shows onboarding, and auto-marks it dismissed", async ({
+    page,
+    request,
+    freshBackend,
+  }) => {
+    // Seed harness(already available)/project/task/run BEFORE the page ever
+    // loads, with the dismissal pref left untouched (absent) — the scenario
+    // an upgrading user's existing data represents.
+    await registerProject(request, freshBackend);
+    const task = await createTask(request, freshBackend, `onboarding-existing-e2e-${Date.now()}`);
+    await startTask(request, freshBackend, task.id);
+
+    await gotoApp(page, freshBackend.bootBase, { seedOnboardingDismissed: false });
+
+    // Never appears, not even for a beat — all 4 steps already derive as
+    // done on the very first render pass that has real data loaded.
+    await expect(welcome(page)).toHaveCount(0);
+    await expect(checklist(page)).toHaveCount(0);
+
+    await expect
+      .poll(() => getPreferences(request, freshBackend).then((p) => p.onboardingDismissed), {
+        message: "expected the existing-user upgrade path to auto-set onboardingDismissed=true",
+        timeout: 10_000,
+      })
+      .toBe("true");
+  });
+});

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -18,6 +18,8 @@ import { TmuxInstallDialog } from "@/components/tmux/TmuxInstallDialog";
 import { TmuxMissingBanner, errorIsTmuxMissing, isTmuxMissing } from "@/components/tmux/TmuxMissingBanner";
 import { UpdateBanner } from "@/components/updater/UpdateBanner";
 import { WorktreesDialog } from "@/components/worktrees/WorktreesDialog";
+import { WelcomeDialog } from "@/components/onboarding/WelcomeDialog";
+import { OnboardingChecklist } from "@/components/onboarding/OnboardingChecklist";
 import type { UpdateSnapshot } from "@/lib/api";
 import { useConfirm } from "@/components/ui/confirm";
 import { toast } from "sonner";
@@ -28,6 +30,8 @@ import { findTaskById } from "@/lib/notification-open";
 import { parseThemePreference } from "@/lib/theme";
 import { parsePullNumber } from "@/lib/pr-url";
 import { cn } from "@/lib/utils";
+import { ONBOARDING_DISMISSED_PREF, deriveOnboardingSteps, resolveOnboardingVisibility } from "@/lib/onboarding";
+import type { SettingsSectionId } from "@/lib/settings-dialog-view";
 import iconUrl from "../assets/agetor.iconset/icon_32x32@2x.png";
 
 /**
@@ -138,6 +142,16 @@ function reconcileById<T>(
   return merged;
 }
 
+/** Muted one-line hints shown in empty columns while onboarding's checklist
+ *  is visible (see `Column`'s `emptyHint` prop). Review/done intentionally
+ *  have no entry — an empty Review/Done column needs no explanation. */
+const EMPTY_COLUMN_HINT: Partial<Record<ColumnId, string>> = {
+  backlog: "Ideas you haven't queued yet",
+  ready: "Waiting for you to press Run",
+  running: "Agents working right now",
+  blocked: "Needs your attention",
+};
+
 /**
  * The actual app tree. Split out from the default-exported `App` so it can
  * live *inside* `<ThemeProvider>` and call `useTheme()` — the provider must
@@ -149,6 +163,10 @@ function AppInner() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [agents, setAgents] = useState<AgentStatus[]>([]);
   const [harnesses, setHarnesses] = useState<Harness[]>([]);
+  // True once `/harnesses` has resolved at least once — lets onboarding's
+  // harness step tell "not loaded yet" (skip the disabled/enabled
+  // distinction) apart from "loaded, and it happens to be empty".
+  const [harnessesLoaded, setHarnessesLoaded] = useState(false);
   const [agentModels, setAgentModels] = useState<AgentModelMap>({ "claude-code": [], codex: [], cursor: [], gemini: [] });
   const [selected, setSelected] = useState<Task | null>(null);
   const [diffTask, setDiffTask] = useState<Task | null>(null);
@@ -161,6 +179,28 @@ function AppInner() {
   const [harnessFilter, setHarnessFilter] = useState<string[]>([]);
   const [typeFilter, setTypeFilter] = useState<TaskType[]>([]);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  // Section the Settings dialog should land on when it next opens — set by
+  // onboarding's "Enable in Settings…" deep link, cleared on close so the
+  // plain gear-icon open still lands on General.
+  const [settingsInitialSection, setSettingsInitialSection] = useState<SettingsSectionId | undefined>(undefined);
+  // --- Onboarding (docs/plans/onboarding-first-run.md) ---------------------
+  // Server preference mirror. `undefined` = never fetched OR never set;
+  // `resolveOnboardingVisibility` treats those the same (both gate on
+  // `prefsLoaded` below), so no separate "not yet fetched" sentinel is
+  // needed here.
+  const [onboardingDismissedPref, setOnboardingDismissedPref] = useState<string | undefined>(undefined);
+  const [prefsLoaded, setPrefsLoaded] = useState(false);
+  // First successful /tasks fetch — `resolveOnboardingVisibility`'s `loaded`
+  // must not fire before this, or a genuinely-empty fresh board could flash
+  // the welcome dialog for a beat before the first real fetch lands (same
+  // class of bug the boot-splash minimum-dwell guards against elsewhere).
+  const [tasksLoaded, setTasksLoaded] = useState(false);
+  // "Get started" in WelcomeDialog is session-only (doesn't write the
+  // server pref) — only "Skip" and the checklist's own dismiss persist.
+  const [welcomeAcknowledged, setWelcomeAcknowledged] = useState(false);
+  // Nonce bumped by onboarding's "Choose a project…" / "Create your first
+  // task" actions — NewTaskForm reacts to increments (expand + focus Title).
+  const [newTaskFocusNonce, setNewTaskFocusNonce] = useState(0);
   const [githubOpen, setGithubOpen] = useState(false);
   // Set by RunPanel's "Open PR" chip to open GitHubDialog pre-seeded for a
   // specific task; cleared when the dialog closes so a later plain "GitHub"
@@ -223,10 +263,26 @@ function AppInner() {
         const dbFontSize = clampFontSizePercent(prefs.fontSize);
         if (dbFontSize !== fontSizePercentRef.current) setFontSizePercent(dbFontSize);
       }
-    }).catch(() => { /* keep the boot-seeded preferences */ });
+      // Onboarding's dismissal flag piggybacks on this same fetch — no
+      // paint-blocking concern (unlike theme/font-size), so a single async
+      // read at boot is enough. `refetchOnboardingPref` (used after Settings
+      // closes) re-reads just this key via the same route.
+      setOnboardingDismissedPref(prefs[ONBOARDING_DISMISSED_PREF]);
+      setPrefsLoaded(true);
+    }).catch(() => { /* keep the boot-seeded preferences; onboarding stays hidden (prefsLoaded=false) rather than guess */ });
     // Run once at boot only — intentionally not re-run when either local
     // preference changes (that would fight the user's own picker/shortcut).
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /** Re-reads just the onboarding dismissal pref. Called after SettingsDialog
+   *  closes so a "Show getting started guide" replay (which writes the pref
+   *  server-side, then closes the dialog) is reflected without a full
+   *  preferences round-trip through the boot-only effect above. */
+  const refetchOnboardingPref = useCallback(() => {
+    api.listPreferences()
+      .then((prefs) => setOnboardingDismissedPref(prefs[ONBOARDING_DISMISSED_PREF]))
+      .catch(() => { /* keep last known value */ });
   }, []);
 
   // Per-task serialized-form cache for `reconcileById` below — see that
@@ -244,6 +300,10 @@ function AppInner() {
       // (e.g. re-checking a just-created task's branch); the reconciled,
       // identity-preserving version is what actually lands in state.
       setTasks((prev) => reconcileById(prev, list, (t) => t.id, taskReconcileCacheRef.current));
+      // Gates onboarding visibility (see `resolveOnboardingVisibility`'s
+      // `loaded` input) — set unconditionally on every success, cheap no-op
+      // once already true.
+      setTasksLoaded(true);
       return list;
     } catch { return null; /* keep last good snapshot; retry next tick */ }
   }, []);
@@ -252,6 +312,13 @@ function AppInner() {
       const payload = await api.listHarnesses();
       setHarnesses((prev) => reconcileById(prev, payload.harnesses, (h) => h.id));
       setAgents((prev) => reconcileById(prev, payload.statuses, (a) => a.harnessId));
+      // Harness rows (carries `enabled`) are already fetched here for the
+      // header's status dots — onboarding's harness step reuses this same
+      // state instead of a second fetch, but needs to distinguish "not
+      // loaded yet" from "loaded, zero harnesses" (the latter can't
+      // actually happen — built-ins are always seeded — but the checklist
+      // degrades gracefully either way per its contract).
+      setHarnessesLoaded(true);
     } catch { /* leave previous state */ }
   }, []);
   const refreshAgentModels = useCallback(async () => {
@@ -566,6 +633,64 @@ function AppInner() {
     [tasks],
   );
 
+  // --- Onboarding derivation (pure lib/onboarding.ts, thin wiring here) ---
+  const enabledHarnessIds = useMemo(
+    () => (harnessesLoaded ? new Set(harnesses.filter((h) => h.enabled).map((h) => h.id)) : null),
+    [harnessesLoaded, harnesses],
+  );
+  const onboardingSteps = useMemo(
+    () => deriveOnboardingSteps({ statuses: agents, enabledHarnessIds, projectCount: projects.length, tasks }),
+    [agents, enabledHarnessIds, projects.length, tasks],
+  );
+  const onboardingVisibility = useMemo(
+    () => resolveOnboardingVisibility({
+      dismissedPref: onboardingDismissedPref,
+      loaded: prefsLoaded && tasksLoaded,
+      steps: onboardingSteps,
+      taskCount: tasks.length,
+      welcomeAcknowledged,
+    }),
+    [onboardingDismissedPref, prefsLoaded, tasksLoaded, onboardingSteps, tasks.length, welcomeAcknowledged],
+  );
+  // Existing-user upgrade path: write the dismissal pref once, the instant
+  // `resolveOnboardingVisibility` signals every step already derives as
+  // done and the pref was never set — a ref guard (not just relying on the
+  // pref write to flip `autoDismiss` back false) because the write is
+  // async and several renders can land before it resolves.
+  const autoDismissWrittenRef = useRef(false);
+  useEffect(() => {
+    if (!onboardingVisibility.autoDismiss || autoDismissWrittenRef.current) return;
+    autoDismissWrittenRef.current = true;
+    setOnboardingDismissedPref("true");
+    void api.setPreference(ONBOARDING_DISMISSED_PREF, "true").catch(() => {
+      // Best-effort — worst case onboarding re-evaluates (and re-attempts
+      // this write) on the next state change; it never blocks the UI.
+      autoDismissWrittenRef.current = false;
+    });
+  }, [onboardingVisibility.autoDismiss]);
+
+  // Shared by WelcomeDialog's "Skip" and OnboardingChecklist's "Dismiss" —
+  // both permanently hide onboarding.
+  const dismissOnboarding = useCallback(() => {
+    setOnboardingDismissedPref("true");
+    void api.setPreference(ONBOARDING_DISMISSED_PREF, "true").catch(() => {
+      /* best-effort, matching the theme/defaultHarness write idiom elsewhere */
+    });
+  }, []);
+  const openSettingsHarnesses = useCallback(() => {
+    setSettingsInitialSection("harnesses");
+    setSettingsOpen(true);
+  }, []);
+  const onFocusNewTask = useCallback(() => {
+    setNewTaskFocusNonce((n) => n + 1);
+  }, []);
+  const onOpenOnboardingTerminal = useCallback((harnessId: string) => {
+    void api.openHarnessTerminal(harnessId).catch((e: unknown) => {
+      const message = e instanceof Error ? e.message : String(e);
+      toast.error("Couldn't open terminal", { description: message });
+    });
+  }, []);
+
   // Every handler below is wrapped in `useCallback` so it keeps a stable
   // identity across App re-renders (poll ticks, unrelated state changes,
   // etc.) — they're passed straight down to `Column`/`TaskCard`, both
@@ -816,6 +941,7 @@ function AppInner() {
           agents={agents}
           harnesses={harnesses}
           agentModels={agentModels}
+          focusNonce={newTaskFocusNonce}
           onSubmit={async (input, { start }) => {
             try {
               setError(null);
@@ -853,6 +979,20 @@ function AppInner() {
             show={isTmuxMissing(agents)}
             onResolve={() => setTmuxDialogOpen(true)}
           />
+          {onboardingVisibility.showChecklist && tasks.length > 0 && (
+            <div className="px-4 pt-3">
+              <OnboardingChecklist
+                steps={onboardingSteps}
+                statuses={agents}
+                harnessRows={harnessesLoaded ? harnesses : null}
+                compact
+                onOpenSettingsHarnesses={openSettingsHarnesses}
+                onFocusNewTask={onFocusNewTask}
+                onOpenTerminal={onOpenOnboardingTerminal}
+                onDismiss={dismissOnboarding}
+              />
+            </div>
+          )}
           <KanbanFilters
             textQuery={textQuery}
             onTextQueryChange={setTextQuery}
@@ -875,7 +1015,26 @@ function AppInner() {
           {/* Kanban gets all remaining vertical space and scrolls horizontally
               on its own — the bottom bar stays anchored regardless of column
               count. */}
-          <div className="kanban-scroll flex-1 overflow-x-scroll">
+          <div className="kanban-scroll relative flex-1 overflow-x-scroll">
+            {/* Zero-task state: the full onboarding card sits above the
+                (still-visible, still-empty) column grid rather than
+                replacing it — dnd-kit's drop zones stay mounted underneath. */}
+            {onboardingVisibility.showChecklist && tasks.length === 0 && (
+              <div className="pointer-events-none absolute inset-x-0 top-6 z-10 flex justify-center px-4">
+                <div className="pointer-events-auto">
+                  <OnboardingChecklist
+                    steps={onboardingSteps}
+                    statuses={agents}
+                    harnessRows={harnessesLoaded ? harnesses : null}
+                    compact={false}
+                    onOpenSettingsHarnesses={openSettingsHarnesses}
+                    onFocusNewTask={onFocusNewTask}
+                    onOpenTerminal={onOpenOnboardingTerminal}
+                    onDismiss={dismissOnboarding}
+                  />
+                </div>
+              </div>
+            )}
             <DndContext sensors={sensors} onDragEnd={onDragEnd}>
               <div className="flex gap-3 p-4">
                 {visibleColumns.map((c) => (
@@ -893,6 +1052,7 @@ function AppInner() {
                     onMarkDone={markDone}
                     onArchive={archive}
                     onUnarchive={unarchive}
+                    emptyHint={onboardingVisibility.showChecklist ? EMPTY_COLUMN_HINT[c.id] : undefined}
                   />
                 ))}
               </div>
@@ -961,15 +1121,31 @@ function AppInner() {
       />
       <SettingsDialog
         open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
+        onClose={() => {
+          setSettingsOpen(false);
+          // Clear the deep-link so a later plain gear-icon open lands back
+          // on General instead of wherever onboarding last sent it.
+          setSettingsInitialSection(undefined);
+          // Reflects a "Show getting started guide" replay (General section
+          // writes the pref server-side, then calls this same onClose) —
+          // simplest correct option without threading a dedicated callback
+          // through SettingsDialog.
+          refetchOnboardingPref();
+        }}
         onChange={refreshAgents}
         homeDir={homeDir}
         dataDir={dataDir}
+        initialSection={settingsInitialSection}
       />
       <TmuxInstallDialog
         open={tmuxDialogOpen}
         onClose={() => setTmuxDialogOpen(false)}
         onResolved={refreshAgents}
+      />
+      <WelcomeDialog
+        open={onboardingVisibility.showWelcome}
+        onAcknowledge={() => setWelcomeAcknowledged(true)}
+        onSkip={dismissOnboarding}
       />
     </div>
   );

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -147,7 +147,7 @@ function reconcileById<T>(
  *  have no entry — an empty Review/Done column needs no explanation. */
 const EMPTY_COLUMN_HINT: Partial<Record<ColumnId, string>> = {
   backlog: "Ideas you haven't queued yet",
-  ready: "Waiting for you to press Run",
+  ready: "Tasks return here when a run needs another go",
   running: "Agents working right now",
   blocked: "Needs your attention",
 };
@@ -195,6 +195,13 @@ function AppInner() {
   // the welcome dialog for a beat before the first real fetch lands (same
   // class of bug the boot-splash minimum-dwell guards against elsewhere).
   const [tasksLoaded, setTasksLoaded] = useState(false);
+  // First successful `/projects` fetch — mirrors `tasksLoaded`/
+  // `harnessesLoaded`. Onboarding's "project" step needs a live projects
+  // list (added mid-session via NewTaskForm) to ever be able to check off,
+  // and gating on this (rather than assuming the boot-time fetch is enough)
+  // keeps the compact-strip flash guard consistent: a transient poll
+  // failure just delays onboarding rather than flashing it early.
+  const [projectsLoaded, setProjectsLoaded] = useState(false);
   // "Get started" in WelcomeDialog is session-only (doesn't write the
   // server pref) — only "Skip" and the checklist's own dismiss persist.
   const [welcomeAcknowledged, setWelcomeAcknowledged] = useState(false);
@@ -324,14 +331,30 @@ function AppInner() {
   const refreshAgentModels = useCallback(async () => {
     try { setAgentModels(await api.listAgentModels()); } catch { /* leave previous state */ }
   }, []);
+  // Per-project serialized-form cache for `reconcileById` below, mirroring
+  // `taskReconcileCacheRef` — keeps `projects` referentially stable across
+  // polls where nothing actually changed.
+  const projectReconcileCacheRef = useRef(new Map<string, { obj: Project; json: string }>());
+  /** Re-list projects. GET /projects is a cheap DB read, so this rides the
+   *  same 2s poll as `refresh()` — projects added mid-session via
+   *  NewTaskForm now show up without a reload, which onboarding's "project"
+   *  step depends on to ever be able to check off. */
+  const refreshProjects = useCallback(async () => {
+    try {
+      const list = await api.listProjects();
+      setProjects((prev) => reconcileById(prev, list, (p) => p.path, projectReconcileCacheRef.current));
+      // Gates onboarding visibility (see `resolveOnboardingVisibility`'s
+      // `loaded` input) — set unconditionally on every success, cheap no-op
+      // once already true. A transient failure just delays onboarding
+      // (the poll retries), which is the safe direction.
+      setProjectsLoaded(true);
+    } catch { /* leave previous state; poll retries */ }
+  }, []);
   useEffect(() => {
     void refresh();
     void refreshAgents();
     void refreshAgentModels();
-    // Load projects once for the repo filter picker. New projects added
-    // mid-session via NewTaskForm won't show up until reload — matches the
-    // session-only filter persistence model.
-    api.listProjects().then(setProjects).catch(() => { /* leave empty */ });
+    void refreshProjects();
     // Resolve the user's home dir once so SettingsDialog can expand `~/…`
     // template paths into concrete absolute paths before validation.
     // `/defaults` is small + local, but a hiccup at boot would now leave
@@ -364,11 +387,17 @@ function AppInner() {
     // gate the poll" change without an immediate on-return refresh would
     // reintroduce the same class of "frozen until you nudge the window"
     // bug previously fixed there.
-    const t = setInterval(() => { if (!document.hidden) void refresh(); }, 2000);
+    const t = setInterval(() => {
+      if (!document.hidden) {
+        void refresh();
+        void refreshProjects();
+      }
+    }, 2000);
     const a = setInterval(() => { if (!document.hidden) void refreshAgents(); }, 15_000);
     const onVisible = () => {
       if (document.hidden) return;
       void refresh();
+      void refreshProjects();
       void refreshAgents();
     };
     document.addEventListener("visibilitychange", onVisible);
@@ -380,7 +409,7 @@ function AppInner() {
       window.removeEventListener("focus", onVisible);
       if (defaultsTimer) clearTimeout(defaultsTimer);
     };
-  }, [refresh, refreshAgents, refreshAgentModels]);
+  }, [refresh, refreshAgents, refreshAgentModels, refreshProjects]);
 
   // Keep the selected task in sync as the list refreshes.
   useEffect(() => {
@@ -645,12 +674,25 @@ function AppInner() {
   const onboardingVisibility = useMemo(
     () => resolveOnboardingVisibility({
       dismissedPref: onboardingDismissedPref,
-      loaded: prefsLoaded && tasksLoaded,
+      // All four sources the derivation reads from (prefs, tasks, harnesses,
+      // projects) must have resolved at least once — otherwise the checklist
+      // can flash the compact "some steps missing" strip for an existing
+      // user whose harnesses/projects just haven't loaded yet on a slow boot.
+      loaded: prefsLoaded && tasksLoaded && harnessesLoaded && projectsLoaded,
       steps: onboardingSteps,
       taskCount: tasks.length,
       welcomeAcknowledged,
     }),
-    [onboardingDismissedPref, prefsLoaded, tasksLoaded, onboardingSteps, tasks.length, welcomeAcknowledged],
+    [
+      onboardingDismissedPref,
+      prefsLoaded,
+      tasksLoaded,
+      harnessesLoaded,
+      projectsLoaded,
+      onboardingSteps,
+      tasks.length,
+      welcomeAcknowledged,
+    ],
   );
   // Existing-user upgrade path: write the dismissal pref once, the instant
   // `resolveOnboardingVisibility` signals every step already derives as
@@ -1015,10 +1057,44 @@ function AppInner() {
           {/* Kanban gets all remaining vertical space and scrolls horizontally
               on its own — the bottom bar stays anchored regardless of column
               count. */}
-          <div className="kanban-scroll relative flex-1 overflow-x-scroll">
+          {/* Outer positioning context lives OUTSIDE the horizontal
+              scroller: the zero-task overlay below is absolutely positioned
+              against this div, not `.kanban-scroll`, so scrolling the board
+              horizontally can't carry the card off-screen with it (an
+              abs-positioned descendant of a scrolling containing block
+              scrolls along with it — the previous bug). */}
+          <div className="relative flex-1">
+            <div className="kanban-scroll absolute inset-0 overflow-x-scroll">
+              <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+                <div className="flex gap-3 p-4">
+                  {visibleColumns.map((c) => (
+                    <Column
+                      key={c.id}
+                      id={c.id}
+                      label={c.label}
+                      tasks={visibleTasks.filter((t) => t.column === c.id)}
+                      homeDir={homeDir}
+                      onStart={start}
+                      onCancel={cancel}
+                      onDelete={del}
+                      onOpen={setSelected}
+                      onDiff={setDiffTask}
+                      onMarkDone={markDone}
+                      onArchive={archive}
+                      onUnarchive={unarchive}
+                      emptyHint={onboardingVisibility.showChecklist ? EMPTY_COLUMN_HINT[c.id] : undefined}
+                    />
+                  ))}
+                </div>
+              </DndContext>
+            </div>
             {/* Zero-task state: the full onboarding card sits above the
                 (still-visible, still-empty) column grid rather than
-                replacing it — dnd-kit's drop zones stay mounted underneath. */}
+                replacing it — dnd-kit's drop zones stay mounted underneath.
+                Positioned against the outer `relative flex-1` div (a sibling
+                of `.kanban-scroll`, not a descendant of it), so it stays
+                visually centered over the viewport regardless of how far
+                the board is scrolled horizontally. */}
             {onboardingVisibility.showChecklist && tasks.length === 0 && (
               <div className="pointer-events-none absolute inset-x-0 top-6 z-10 flex justify-center px-4">
                 <div className="pointer-events-auto">
@@ -1035,28 +1111,6 @@ function AppInner() {
                 </div>
               </div>
             )}
-            <DndContext sensors={sensors} onDragEnd={onDragEnd}>
-              <div className="flex gap-3 p-4">
-                {visibleColumns.map((c) => (
-                  <Column
-                    key={c.id}
-                    id={c.id}
-                    label={c.label}
-                    tasks={visibleTasks.filter((t) => t.column === c.id)}
-                    homeDir={homeDir}
-                    onStart={start}
-                    onCancel={cancel}
-                    onDelete={del}
-                    onOpen={setSelected}
-                    onDiff={setDiffTask}
-                    onMarkDone={markDone}
-                    onArchive={archive}
-                    onUnarchive={unarchive}
-                    emptyHint={onboardingVisibility.showChecklist ? EMPTY_COLUMN_HINT[c.id] : undefined}
-                  />
-                ))}
-              </div>
-            </DndContext>
           </div>
         </main>
       </div>

--- a/src/mainview/components/kanban/Column.tsx
+++ b/src/mainview/components/kanban/Column.tsx
@@ -18,6 +18,12 @@ interface Props {
   onMarkDone: (t: Task) => void;
   onArchive: (t: Task) => void;
   onUnarchive: (t: Task) => void;
+  /** Muted one-line hint shown in place of the (empty) task list, while
+   *  onboarding's checklist is visible. Only rendered when `tasks.length ===
+   *  0` — never overlays real cards. Non-interactive (`pointer-events-none`)
+   *  and stays inside the existing droppable container so dnd-kit's drop
+   *  zone is unaffected. */
+  emptyHint?: string;
 }
 
 /** Array is considered unchanged when same length and every element is the
@@ -32,7 +38,7 @@ function sameTasks(a: Task[], b: Task[]): boolean {
   return a.every((t, i) => t === b[i]);
 }
 
-function ColumnImpl({ id, label, tasks, homeDir, onStart, onCancel, onDelete, onOpen, onDiff, onMarkDone, onArchive, onUnarchive }: Props) {
+function ColumnImpl({ id, label, tasks, homeDir, onStart, onCancel, onDelete, onOpen, onDiff, onMarkDone, onArchive, onUnarchive, emptyHint }: Props) {
   const { setNodeRef, isOver } = useDroppable({ id });
   return (
     <div
@@ -49,6 +55,9 @@ function ColumnImpl({ id, label, tasks, homeDir, onStart, onCancel, onDelete, on
         <Badge variant="outline">{tasks.length}</Badge>
       </div>
       <div className="flex flex-col gap-2">
+        {tasks.length === 0 && emptyHint && (
+          <p className="pointer-events-none px-1 text-xs text-muted-foreground">{emptyHint}</p>
+        )}
         {tasks.map((t) => (
           <TaskCard
             key={t.id}
@@ -90,5 +99,6 @@ export const Column = memo(ColumnImpl, (prev, next) => (
   prev.onMarkDone === next.onMarkDone &&
   prev.onArchive === next.onArchive &&
   prev.onUnarchive === next.onUnarchive &&
+  prev.emptyHint === next.emptyHint &&
   sameTasks(prev.tasks, next.tasks)
 ));

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -123,11 +123,9 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels, focusNon
     prevFocusNonceRef.current = focusNonce;
     if (focusNonce === undefined || focusNonce === prev) return;
     // Expand exactly like the collapse toggle button does, so the persisted
-    // preference and the in-memory state agree.
-    setCollapsed((c) => {
-      if (c) writeCollapsed(NEW_TASK_PANEL_COLLAPSED_KEY, false);
-      return false;
-    });
+    // preference and the in-memory state agree — the effect above persists
+    // on `[collapsed]` change, so no separate write is needed here.
+    setCollapsed(false);
     // Expansion may need a paint before the Title input exists/lays out —
     // defer the focus by a frame (same idiom as RunPanel's post-open focus).
     requestAnimationFrame(() => {

--- a/src/mainview/components/kanban/NewTaskForm.tsx
+++ b/src/mainview/components/kanban/NewTaskForm.tsx
@@ -91,9 +91,15 @@ interface Props {
   /** Models discovered from each agent's CLI at boot. Merged with the static
    *  AGENT_OPTIONS list. */
   agentModels: AgentModelMap;
+  /** Bumped by the onboarding checklist when it wants to draw attention to
+   *  this panel (e.g. the "create your first task" step). On increment
+   *  (never on mount, never while `undefined`) the panel expands if
+   *  collapsed, the Title field gets focus, and the panel root flashes a
+   *  brief highlight ring. */
+  focusNonce?: number;
 }
 
-export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props) {
+export function NewTaskForm({ onSubmit, agents, harnesses, agentModels, focusNonce }: Props) {
   // Collapsed = thin icon rail; the board's `flex-1` <main> takes the freed
   // width on its own. Seeded synchronously from localStorage (lazy initial
   // state) so a restart repaints in the state the user left it in — an async
@@ -104,6 +110,39 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
   useEffect(() => {
     writeCollapsed(NEW_TASK_PANEL_COLLAPSED_KEY, collapsed);
   }, [collapsed]);
+  const titleRef = useRef<HTMLInputElement>(null);
+  // Transient "look here" ring around the panel root, driven by `focusNonce`.
+  const [spotlight, setSpotlight] = useState(false);
+  const spotlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Guards against firing on mount (initial ref value equals the first prop
+  // value, so the first render never counts as an "increment") and against
+  // `focusNonce` being permanently `undefined` for callers that don't pass it.
+  const prevFocusNonceRef = useRef(focusNonce);
+  useEffect(() => {
+    const prev = prevFocusNonceRef.current;
+    prevFocusNonceRef.current = focusNonce;
+    if (focusNonce === undefined || focusNonce === prev) return;
+    // Expand exactly like the collapse toggle button does, so the persisted
+    // preference and the in-memory state agree.
+    setCollapsed((c) => {
+      if (c) writeCollapsed(NEW_TASK_PANEL_COLLAPSED_KEY, false);
+      return false;
+    });
+    // Expansion may need a paint before the Title input exists/lays out —
+    // defer the focus by a frame (same idiom as RunPanel's post-open focus).
+    requestAnimationFrame(() => {
+      titleRef.current?.focus();
+    });
+    if (spotlightTimeoutRef.current) clearTimeout(spotlightTimeoutRef.current);
+    setSpotlight(true);
+    spotlightTimeoutRef.current = setTimeout(() => setSpotlight(false), 1600);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusNonce]);
+  useEffect(() => {
+    return () => {
+      if (spotlightTimeoutRef.current) clearTimeout(spotlightTimeoutRef.current);
+    };
+  }, []);
   const [title, setTitle] = useState("");
   const [prompt, setPrompt] = useState("");
   const [taskType, setTaskType] = useState<TaskType>(DEFAULT_TASK_TYPE);
@@ -566,6 +605,10 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
         // arm `dragging` on the rail, this also drops a stale ring if the
         // panel is collapsed while one is showing.
         dragging && !collapsed && "ring-2 ring-inset ring-primary",
+        // Onboarding "look here" highlight — independent of the drag ring
+        // above; the two conditions aren't expected to overlap in practice
+        // (drag requires the panel already focused/visible by the user).
+        spotlight && "ring-2 ring-info",
       )}
     >
       {/* VS Code-style collapse control: straddles the border between the
@@ -611,7 +654,13 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
         ) : (
           <div className="flex h-full w-80 flex-col">
             <div className="flex shrink-0 items-center justify-between border-b border-border/60 px-4 py-3">
-              <span className="text-sm font-semibold">New task</span>
+              <div className="flex items-center gap-1.5">
+                <span className="text-sm font-semibold">New task</span>
+                <InfoTip
+                  label="How these fields fit together"
+                  text="A task is a unit of agent work. Type, Title and Prompt say what to do. Project, Branch and Isolate say where — with Isolate on, work happens on a fresh branch in a separate worktree, so your checkout stays clean. Harness, Mode, Model and Effort pick which agent runs it and how much autonomy it gets. Defaults are sensible — a title, a prompt and a project are enough to start."
+                />
+              </div>
               {selectedStatus?.available && selectedStatus.version && (
                 <span className="text-[11px] text-muted-foreground">
                   {selectedStatus.version}
@@ -646,6 +695,7 @@ export function NewTaskForm({ onSubmit, agents, harnesses, agentModels }: Props)
               <div className="space-y-1">
                 <label className="text-muted-foreground">Title</label>
                 <Input
+                  ref={titleRef}
                   placeholder="Short description"
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}

--- a/src/mainview/components/onboarding/OnboardingChecklist.tsx
+++ b/src/mainview/components/onboarding/OnboardingChecklist.tsx
@@ -34,12 +34,13 @@ const STEP_LABEL: Record<OnboardingStepId, string> = {
 /** Exact login command per harness kind — shown in the harness step's login
  *  guidance block. Kept local (not imported from SettingsDialog) since that
  *  file's `HARNESS_HOME_COPY` documents the *env var* a home override sets,
- *  not the literal login invocation. */
-const LOGIN_COMMAND: Record<AgentKind, string> = {
+ *  not the literal login invocation. Gemini is deliberately absent: `gemini`
+ *  on its own isn't a login command, it's the CLI itself — see the prose
+ *  fallback below. */
+const LOGIN_COMMAND: Partial<Record<AgentKind, string>> = {
   "claude-code": "claude /login",
   codex: "codex login",
   cursor: "cursor-agent login",
-  gemini: "gemini",
 };
 
 function StepIcon({ done, index }: { done: boolean; index: number }) {
@@ -70,6 +71,9 @@ function HarnessStepDetail({
 }) {
   const rowById = new Map((harnessRows ?? []).map((h) => [h.id, h] as const));
   const harnessesWithHome = (harnessRows ?? []).filter((h) => h.home);
+  // Only show login guidance for kinds actually present (deduped) — no point
+  // walking a user with only claude-code through codex/cursor/gemini copy.
+  const presentKinds = Array.from(new Set(statuses.map((s) => s.kind)));
 
   return (
     <div className="space-y-3 pt-2">
@@ -78,7 +82,7 @@ function HarnessStepDetail({
           const row = rowById.get(s.harnessId);
           const label = row?.label ?? s.harnessId;
           const disabled = harnessRows !== null && row ? !row.enabled : false;
-          if (disabled) {
+          if (s.available && disabled) {
             return (
               <div key={s.harnessId} className="flex items-center gap-2 text-xs">
                 <span className="inline-block size-1.5 shrink-0 rounded-full bg-muted-foreground" />
@@ -110,7 +114,7 @@ function HarnessStepDetail({
                 <span className="inline-block size-1.5 shrink-0 rounded-full bg-danger-solid" />
                 <AgentIcon kind={s.kind} className="size-3.5 shrink-0" />
                 <span className="min-w-0 flex-1 truncate text-muted-foreground">
-                  {label} — not found
+                  {label} — not found{disabled ? " — disabled" : ""}
                 </span>
               </div>
               {s.installHint && (
@@ -126,11 +130,19 @@ function HarnessStepDetail({
       <div className="space-y-1 border-t border-border/60 pt-2">
         <p className="text-[11px] text-muted-foreground">Just installed one? Log it in first:</p>
         <div className="space-y-1">
-          {(Object.keys(LOGIN_COMMAND) as AgentKind[]).map((kind) => (
-            <code key={kind} className="block rounded bg-muted px-2 py-1 font-mono text-[11px]">
-              {LOGIN_COMMAND[kind]}
-            </code>
-          ))}
+          {presentKinds.map((kind) =>
+            kind === "gemini" ? (
+              <p key={kind} className="text-[11px] text-muted-foreground">
+                Gemini: run{" "}
+                <code className="rounded bg-muted px-1 py-0.5 font-mono">gemini</code> once and
+                follow the browser sign-in.
+              </p>
+            ) : LOGIN_COMMAND[kind] ? (
+              <code key={kind} className="block rounded bg-muted px-2 py-1 font-mono text-[11px]">
+                {LOGIN_COMMAND[kind]}
+              </code>
+            ) : null,
+          )}
         </div>
       </div>
 

--- a/src/mainview/components/onboarding/OnboardingChecklist.tsx
+++ b/src/mainview/components/onboarding/OnboardingChecklist.tsx
@@ -1,0 +1,310 @@
+import { Check, Terminal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { AgentIcon } from "@/components/kanban/AgentIcon";
+import { cn } from "@/lib/utils";
+import type { OnboardingStep, OnboardingStepId } from "@/lib/onboarding";
+import type { AgentKind, Harness, HarnessStatus } from "../../../shared/types.ts";
+
+interface Props {
+  steps: OnboardingStep[];
+  statuses: HarnessStatus[];
+  /** Harness rows (carries `enabled`), or `null` while that fetch hasn't
+   *  landed yet — in which case the disabled/enabled distinction is skipped
+   *  rather than guessed. */
+  harnessRows: Harness[] | null;
+  /** `false` renders the full centered card (zero-task state); `true`
+   *  renders the slim strip that sits above the columns once tasks exist. */
+  compact: boolean;
+  onOpenSettingsHarnesses: () => void;
+  onFocusNewTask: () => void;
+  /** Best-effort — failures (e.g. the 501 a headless build returns) are the
+   *  caller's responsibility to surface (toast), not this component's. */
+  onOpenTerminal: (harnessId: string) => void;
+  onDismiss: () => void;
+}
+
+const STEP_LABEL: Record<OnboardingStepId, string> = {
+  harness: "Get an agent ready",
+  project: "Add a project",
+  task: "Create your first task",
+  run: "Run it",
+};
+
+/** Exact login command per harness kind — shown in the harness step's login
+ *  guidance block. Kept local (not imported from SettingsDialog) since that
+ *  file's `HARNESS_HOME_COPY` documents the *env var* a home override sets,
+ *  not the literal login invocation. */
+const LOGIN_COMMAND: Record<AgentKind, string> = {
+  "claude-code": "claude /login",
+  codex: "codex login",
+  cursor: "cursor-agent login",
+  gemini: "gemini",
+};
+
+function StepIcon({ done, index }: { done: boolean; index: number }) {
+  if (done) {
+    return (
+      <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-success/15 text-success">
+        <Check className="size-3.5" />
+      </span>
+    );
+  }
+  return (
+    <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-border text-[10px] font-medium text-muted-foreground">
+      {index + 1}
+    </span>
+  );
+}
+
+function HarnessStepDetail({
+  statuses,
+  harnessRows,
+  onOpenSettingsHarnesses,
+  onOpenTerminal,
+}: {
+  statuses: HarnessStatus[];
+  harnessRows: Harness[] | null;
+  onOpenSettingsHarnesses: () => void;
+  onOpenTerminal: (harnessId: string) => void;
+}) {
+  const rowById = new Map((harnessRows ?? []).map((h) => [h.id, h] as const));
+  const harnessesWithHome = (harnessRows ?? []).filter((h) => h.home);
+
+  return (
+    <div className="space-y-3 pt-2">
+      <div className="space-y-1.5">
+        {statuses.map((s) => {
+          const row = rowById.get(s.harnessId);
+          const label = row?.label ?? s.harnessId;
+          const disabled = harnessRows !== null && row ? !row.enabled : false;
+          if (disabled) {
+            return (
+              <div key={s.harnessId} className="flex items-center gap-2 text-xs">
+                <span className="inline-block size-1.5 shrink-0 rounded-full bg-muted-foreground" />
+                <AgentIcon kind={s.kind} className="size-3.5 shrink-0" />
+                <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                  {label} — installed but disabled
+                </span>
+                <Button variant="outline" size="sm" onClick={onOpenSettingsHarnesses}>
+                  Enable in Settings…
+                </Button>
+              </div>
+            );
+          }
+          if (s.available) {
+            return (
+              <div key={s.harnessId} className="flex items-center gap-2 text-xs">
+                <span className="inline-block size-1.5 shrink-0 rounded-full bg-success-solid" />
+                <AgentIcon kind={s.kind} className="size-3.5 shrink-0" />
+                <span className="min-w-0 flex-1 truncate">
+                  {label}
+                  {s.version && <span className="text-muted-foreground"> · {s.version}</span>}
+                </span>
+              </div>
+            );
+          }
+          return (
+            <div key={s.harnessId} className="space-y-1 text-xs">
+              <div className="flex items-center gap-2">
+                <span className="inline-block size-1.5 shrink-0 rounded-full bg-danger-solid" />
+                <AgentIcon kind={s.kind} className="size-3.5 shrink-0" />
+                <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                  {label} — not found
+                </span>
+              </div>
+              {s.installHint && (
+                <code className="ml-5 block truncate rounded bg-muted px-2 py-1 font-mono text-[11px]">
+                  {s.installHint}
+                </code>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="space-y-1 border-t border-border/60 pt-2">
+        <p className="text-[11px] text-muted-foreground">Just installed one? Log it in first:</p>
+        <div className="space-y-1">
+          {(Object.keys(LOGIN_COMMAND) as AgentKind[]).map((kind) => (
+            <code key={kind} className="block rounded bg-muted px-2 py-1 font-mono text-[11px]">
+              {LOGIN_COMMAND[kind]}
+            </code>
+          ))}
+        </div>
+      </div>
+
+      {harnessRows !== null && harnessRows.length > 0 && harnessesWithHome.length > 0 && (
+        <div className="space-y-1 border-t border-border/60 pt-2">
+          <p className="text-[11px] text-muted-foreground">
+            Additional accounts have their own login — open a terminal with that harness's env loaded:
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {harnessesWithHome.map((h) => (
+              <Button
+                key={h.id}
+                variant="outline"
+                size="sm"
+                onClick={() => onOpenTerminal(h.id)}
+              >
+                <Terminal className="mr-1.5 size-3.5" />
+                Open {h.label} in Terminal
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <p className="text-[11px] text-muted-foreground">
+        Running multiple accounts? Add more harnesses in Settings → Harnesses.
+      </p>
+    </div>
+  );
+}
+
+function StepDetail({
+  id,
+  statuses,
+  harnessRows,
+  onOpenSettingsHarnesses,
+  onFocusNewTask,
+  onOpenTerminal,
+}: {
+  id: OnboardingStepId;
+  statuses: HarnessStatus[];
+  harnessRows: Harness[] | null;
+  onOpenSettingsHarnesses: () => void;
+  onFocusNewTask: () => void;
+  onOpenTerminal: (harnessId: string) => void;
+}) {
+  switch (id) {
+    case "harness":
+      return (
+        <HarnessStepDetail
+          statuses={statuses}
+          harnessRows={harnessRows}
+          onOpenSettingsHarnesses={onOpenSettingsHarnesses}
+          onOpenTerminal={onOpenTerminal}
+        />
+      );
+    case "project":
+      return (
+        <div className="space-y-2 pt-2">
+          <p className="text-xs text-muted-foreground">
+            Register the folder of a repo you want agents to work in.
+          </p>
+          <Button variant="outline" size="sm" onClick={onFocusNewTask}>
+            Choose a project…
+          </Button>
+        </div>
+      );
+    case "task":
+      return (
+        <div className="space-y-2 pt-2">
+          <p className="text-xs text-muted-foreground">
+            Give it a title and a prompt — the panel on the left has everything else prefilled.
+          </p>
+          <Button variant="outline" size="sm" onClick={onFocusNewTask}>
+            Create your first task
+          </Button>
+        </div>
+      );
+    case "run":
+      return (
+        <p className="pt-2 text-xs text-muted-foreground">
+          Press Run on your task's card, then watch the agent stream its work live.
+        </p>
+      );
+    default: {
+      const _exhaustive: never = id;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Live "Getting started" checklist. Steps are derived elsewhere
+ * (`deriveOnboardingSteps`) — this component is purely presentational plus
+ * event wiring. Two layouts: a centered full card (zero tasks) and a slim
+ * strip (once tasks exist) — see `compact`.
+ */
+export function OnboardingChecklist({
+  steps,
+  statuses,
+  harnessRows,
+  compact,
+  onOpenSettingsHarnesses,
+  onFocusNewTask,
+  onOpenTerminal,
+  onDismiss,
+}: Props) {
+  const firstNotDoneId = steps.find((s) => !s.done)?.id;
+
+  if (compact) {
+    return (
+      <Card data-testid="onboarding-checklist" className="py-2">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 px-4">
+          <span className="text-xs font-medium text-muted-foreground">Getting started</span>
+          {steps.map((step, i) => (
+            <div
+              key={step.id}
+              data-testid={`onboarding-step-${step.id}`}
+              data-done={step.done ? "true" : "false"}
+              className="flex items-center gap-1.5"
+            >
+              <StepIcon done={step.done} index={i} />
+              <span className={cn("text-xs", step.done ? "text-muted-foreground line-through" : "text-foreground")}>
+                {STEP_LABEL[step.id]}
+              </span>
+            </div>
+          ))}
+          <Button variant="ghost" size="sm" className="ml-auto text-muted-foreground" onClick={onDismiss}>
+            Dismiss — I know my way around
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card data-testid="onboarding-checklist" className="mx-auto w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Welcome to Agetor</CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Create your first task to run an agent on a project.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {steps.map((step, i) => (
+          <div key={step.id} data-testid={`onboarding-step-${step.id}`} data-done={step.done ? "true" : "false"}>
+            <div className="flex items-center gap-2">
+              <StepIcon done={step.done} index={i} />
+              <span className={cn("text-sm", step.done ? "text-muted-foreground line-through" : "font-medium text-foreground")}>
+                {STEP_LABEL[step.id]}
+              </span>
+            </div>
+            {!step.done && step.id === firstNotDoneId && (
+              <StepDetail
+                id={step.id}
+                statuses={statuses}
+                harnessRows={harnessRows}
+                onOpenSettingsHarnesses={onOpenSettingsHarnesses}
+                onFocusNewTask={onFocusNewTask}
+                onOpenTerminal={onOpenTerminal}
+              />
+            )}
+          </div>
+        ))}
+        <div className="border-t border-border/60 pt-3 text-center">
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="text-xs text-muted-foreground underline-offset-2 hover:underline"
+          >
+            Dismiss — I know my way around
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/mainview/components/onboarding/WelcomeDialog.tsx
+++ b/src/mainview/components/onboarding/WelcomeDialog.tsx
@@ -44,13 +44,12 @@ export function WelcomeDialog({ open, onAcknowledge, onSkip }: Props) {
             and a coding agent — Claude Code, Codex, Cursor, or Gemini.
           </p>
           <p>
-            Run a task and its card moves itself across the board — from{" "}
-            <span className="text-foreground">Backlog</span> to{" "}
-            <span className="text-foreground">Ready</span> to{" "}
-            <span className="text-foreground">Running</span> to{" "}
-            <span className="text-foreground">Review</span> or{" "}
-            <span className="text-foreground">Done</span> — while the agent's output streams
-            live in the run panel.
+            Run it and the card moves to <span className="text-foreground">Running</span> while
+            the agent's output streams live; it lands in{" "}
+            <span className="text-foreground">Review</span> when the agent finishes (or{" "}
+            <span className="text-foreground">Blocked</span> / back to{" "}
+            <span className="text-foreground">Ready</span> if something goes wrong), and you
+            mark it <span className="text-foreground">Done</span>.
           </p>
           <p>
             The checklist that's about to appear walks through the handful of things a fresh

--- a/src/mainview/components/onboarding/WelcomeDialog.tsx
+++ b/src/mainview/components/onboarding/WelcomeDialog.tsx
@@ -1,0 +1,72 @@
+import { Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+
+interface Props {
+  open: boolean;
+  /** "Get started" — dismisses the dialog for this session only, leaving the
+   *  checklist card visible underneath. */
+  onAcknowledge: () => void;
+  /** "Skip — I know my way around" — persists the dismissal server-side so
+   *  neither the welcome dialog nor the checklist appear again. */
+  onSkip: () => void;
+}
+
+/**
+ * First-run welcome dialog. Shown once for a brand-new user (see
+ * `resolveOnboardingVisibility` in `lib/onboarding.ts`), explaining the core
+ * workflow before the "Getting started" checklist takes over. Copy is seeded
+ * from README.md's "Getting started" section.
+ */
+export function WelcomeDialog({ open, onAcknowledge, onSkip }: Props) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onAcknowledge}
+      className="max-w-lg"
+      labelledBy="onboarding-welcome-title"
+      describedBy="onboarding-welcome-desc"
+    >
+      <div data-testid="onboarding-welcome">
+        <div className="flex items-center gap-2 border-b border-border/60 pb-3">
+          <div className="rounded-md bg-primary/10 p-1.5 text-primary">
+            <Sparkles className="size-4" />
+          </div>
+          <h2 id="onboarding-welcome-title" className="text-base font-semibold">
+            Welcome to Agetor
+          </h2>
+        </div>
+
+        <div id="onboarding-welcome-desc" className="space-y-3 pt-4 text-sm text-muted-foreground">
+          <p>
+            Agetor turns a kanban board into a control plane for AI coding agents. A{" "}
+            <span className="text-foreground">task</span> is just a prompt, a project folder,
+            and a coding agent — Claude Code, Codex, Cursor, or Gemini.
+          </p>
+          <p>
+            Run a task and its card moves itself across the board — from{" "}
+            <span className="text-foreground">Backlog</span> to{" "}
+            <span className="text-foreground">Ready</span> to{" "}
+            <span className="text-foreground">Running</span> to{" "}
+            <span className="text-foreground">Review</span> or{" "}
+            <span className="text-foreground">Done</span> — while the agent's output streams
+            live in the run panel.
+          </p>
+          <p>
+            The checklist that's about to appear walks through the handful of things a fresh
+            install needs: a ready agent, a registered project, and your first task.
+          </p>
+        </div>
+
+        <div className="flex items-center justify-between gap-2 border-t border-border/60 pt-3">
+          <Button variant="ghost" size="sm" onClick={onSkip}>
+            Skip — I know my way around
+          </Button>
+          <Button size="sm" onClick={onAcknowledge}>
+            Get started
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -25,6 +25,7 @@ import {
   openSection,
   openTemplates,
   resolveEscape,
+  type SettingsSectionId,
   type SettingsView,
 } from "@/lib/settings-dialog-view";
 import {
@@ -67,6 +68,10 @@ interface Props {
    *  template `home` paths so new harnesses default under the running dir
    *  (~/.agetor for the .app, ~/.agetor-dev for `bun run dev`). */
   dataDir: string;
+  /** Section to land on when the dialog opens. Applied on every open
+   *  transition (not just the first) — absent/undefined preserves today's
+   *  behavior of always resetting to General. */
+  initialSection?: SettingsSectionId;
 }
 
 /**
@@ -190,7 +195,7 @@ async function describeHarnessInUse(err: unknown): Promise<string | null> {
   return `In use by ${titles.length} ${noun}: ${titles.join(", ")}`;
 }
 
-export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Props) {
+export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir, initialSection }: Props) {
   const [version, setVersion] = useState<string>("");
   const [payload, setPayload] = useState<HarnessesPayload>({ harnesses: [], statuses: [] });
   const [defaultHarness, setDefaultHarness] = useState<string>("claude-code");
@@ -257,11 +262,12 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
   useEffect(() => {
     if (!open) return;
     void refresh();
-    // Reset to the General section on every open so a half-filled editor
-    // doesn't greet the user next time.
-    setView(initialView());
+    // Reset to the General section (or `initialSection`, when the caller
+    // wants a deep link) on every open so a half-filled editor doesn't
+    // greet the user next time.
+    setView(initialSection ? openSection(initialSection) : initialView());
     setFormError(null);
-  }, [open]);
+  }, [open, initialSection]);
 
   const statusByHarness = useMemo(() => {
     const map = new Map(payload.statuses.map((s) => [s.harnessId, s]));
@@ -452,6 +458,7 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir }: Pr
                       tmuxSource={tmuxSource}
                       bundledTmuxAvailable={bundledTmuxAvailable}
                       onPickTmuxSource={onPickTmuxSource}
+                      onClose={onClose}
                     />
                   );
                 case "harnesses":
@@ -589,6 +596,7 @@ function GeneralSection({
   tmuxSource,
   bundledTmuxAvailable,
   onPickTmuxSource,
+  onClose,
 }: {
   payload: HarnessesPayload;
   defaultHarness: string;
@@ -596,6 +604,9 @@ function GeneralSection({
   tmuxSource: "system" | "bundled";
   bundledTmuxAvailable: boolean;
   onPickTmuxSource: (source: "system" | "bundled") => void;
+  /** Closes the Settings dialog — used by "Show getting started guide" so the
+   *  onboarding checklist underneath is visible after replaying it. */
+  onClose: () => void;
 }) {
   // Disabled harnesses are excluded from the default-harness picker so a
   // soft-deleted harness can't silently become the default for new tasks.
@@ -709,6 +720,34 @@ function GeneralSection({
           </Button>
         </div>
         <p className="text-[11px] text-muted-foreground">{FONT_SIZE_HINT}</p>
+      </section>
+
+      <section className="space-y-1">
+        <label className="text-xs text-muted-foreground">Getting started</label>
+        <div>
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="settings-replay-onboarding"
+            onClick={() => {
+              // "onboardingDismissed" mirrors ONBOARDING_DISMISSED_PREF in
+              // lib/onboarding.ts (kept inline since that module may not
+              // exist yet when this file is authored — do not import it).
+              void api.setPreference("onboardingDismissed", "false").catch(() => {
+                // Best-effort, matching the theme/defaultHarness write idiom
+                // above — the checklist will simply not reappear if this
+                // silently fails, which is a minor papercut, not a hard
+                // error worth surfacing.
+              });
+              onClose();
+            }}
+          >
+            Show getting started guide
+          </Button>
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          Bring back the welcome tour and the onboarding checklist.
+        </p>
       </section>
     </div>
   );

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -15,6 +15,7 @@ import { SavedPromptsSection } from "@/components/settings/SavedPromptsSection";
 import { useFontSize } from "@/components/font-size-provider";
 import { useTheme } from "@/components/theme-provider";
 import { isMacPlatform } from "@/lib/font-size";
+import { ONBOARDING_DISMISSED_PREF } from "@/lib/onboarding";
 import { abbreviateHome, cn } from "@/lib/utils";
 import {
   SETTINGS_SECTIONS,
@@ -616,6 +617,7 @@ function GeneralSection({
   const canDecreaseFontSize = fontSizePercent > FONT_SIZE_MIN;
   const canIncreaseFontSize = fontSizePercent < FONT_SIZE_MAX;
   const canResetFontSize = fontSizePercent !== FONT_SIZE_DEFAULT;
+  const [replayingOnboarding, setReplayingOnboarding] = useState(false);
   return (
     <div className="space-y-4 pt-3 text-sm">
       <section className="space-y-1">
@@ -729,16 +731,20 @@ function GeneralSection({
             variant="outline"
             size="sm"
             data-testid="settings-replay-onboarding"
-            onClick={() => {
-              // "onboardingDismissed" mirrors ONBOARDING_DISMISSED_PREF in
-              // lib/onboarding.ts (kept inline since that module may not
-              // exist yet when this file is authored — do not import it).
-              void api.setPreference("onboardingDismissed", "false").catch(() => {
+            disabled={replayingOnboarding}
+            onClick={async () => {
+              if (replayingOnboarding) return;
+              setReplayingOnboarding(true);
+              // Await the write before closing — App re-reads preferences on
+              // close, so a fire-and-forget PUT can lose the race against
+              // that GET and silently discard the replay.
+              await api.setPreference(ONBOARDING_DISMISSED_PREF, "false").catch(() => {
                 // Best-effort, matching the theme/defaultHarness write idiom
                 // above — the checklist will simply not reappear if this
                 // silently fails, which is a minor papercut, not a hard
                 // error worth surfacing.
               });
+              setReplayingOnboarding(false);
               onClose();
             }}
           >
@@ -746,7 +752,7 @@ function GeneralSection({
           </Button>
         </div>
         <p className="text-[11px] text-muted-foreground">
-          Bring back the welcome tour and the onboarding checklist.
+          Bring back the onboarding checklist.
         </p>
       </section>
     </div>

--- a/src/mainview/lib/onboarding.test.ts
+++ b/src/mainview/lib/onboarding.test.ts
@@ -1,0 +1,396 @@
+import { expect, test } from "bun:test";
+import {
+  deriveOnboardingSteps,
+  ONBOARDING_DISMISSED_PREF,
+  type OnboardingStep,
+  resolveOnboardingVisibility,
+} from "./onboarding.ts";
+import type { ColumnId, HarnessStatus } from "../../shared/types.ts";
+
+function status(overrides: Partial<HarnessStatus> = {}): HarnessStatus {
+  return {
+    harnessId: "claude-code",
+    kind: "claude-code",
+    bin: "claude",
+    available: false,
+    path: null,
+    version: null,
+    reason: null,
+    installHint: null,
+    ...overrides,
+  } as HarnessStatus;
+}
+
+// --- ONBOARDING_DISMISSED_PREF ---------------------------------------------
+
+test("ONBOARDING_DISMISSED_PREF is the pinned preference key", () => {
+  expect(ONBOARDING_DISMISSED_PREF).toBe("onboardingDismissed");
+});
+
+// --- deriveOnboardingSteps: ordering ----------------------------------------
+
+test("deriveOnboardingSteps always returns all 4 steps in fixed order", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [],
+    enabledHarnessIds: null,
+    projectCount: 0,
+    tasks: [],
+  });
+  expect(steps.map((s) => s.id)).toEqual(["harness", "project", "task", "run"]);
+});
+
+test("deriveOnboardingSteps preserves fixed order even when everything is done", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [status({ harnessId: "claude-code", available: true })],
+    enabledHarnessIds: null,
+    projectCount: 3,
+    tasks: [{ column: "running" }],
+  });
+  expect(steps.map((s) => s.id)).toEqual(["harness", "project", "task", "run"]);
+  expect(steps.every((s) => s.done)).toBe(true);
+});
+
+// --- deriveOnboardingSteps: harness rule ------------------------------------
+
+test("harness step is not done when no status is available", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [status({ available: false })],
+    enabledHarnessIds: null,
+    projectCount: 0,
+    tasks: [],
+  });
+  expect(steps.find((s) => s.id === "harness")!.done).toBe(false);
+});
+
+test("harness step is done when an available status has enabledHarnessIds === null (no filtering)", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [status({ harnessId: "claude-code", available: true })],
+    enabledHarnessIds: null,
+    projectCount: 0,
+    tasks: [],
+  });
+  expect(steps.find((s) => s.id === "harness")!.done).toBe(true);
+});
+
+test("harness step is done when an available status's harnessId is in the enabled set", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [status({ harnessId: "codex", available: true })],
+    enabledHarnessIds: new Set(["codex", "gemini"]),
+    projectCount: 0,
+    tasks: [],
+  });
+  expect(steps.find((s) => s.id === "harness")!.done).toBe(true);
+});
+
+test("harness step is NOT done when the only available status is disabled (available but not in enabled set)", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [status({ harnessId: "cursor", available: true })],
+    enabledHarnessIds: new Set(["claude-code"]),
+    projectCount: 0,
+    tasks: [],
+  });
+  expect(steps.find((s) => s.id === "harness")!.done).toBe(false);
+});
+
+test("harness step is not done when a status is enabled but not available", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [status({ harnessId: "claude-code", available: false })],
+    enabledHarnessIds: new Set(["claude-code"]),
+    projectCount: 0,
+    tasks: [],
+  });
+  expect(steps.find((s) => s.id === "harness")!.done).toBe(false);
+});
+
+test("harness step is done if ANY status among several satisfies available+enabled", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [
+      status({ harnessId: "claude-code", available: false }),
+      status({ harnessId: "codex", available: true }),
+    ],
+    enabledHarnessIds: new Set(["codex"]),
+    projectCount: 0,
+    tasks: [],
+  });
+  expect(steps.find((s) => s.id === "harness")!.done).toBe(true);
+});
+
+// --- deriveOnboardingSteps: project rule ------------------------------------
+
+test("project step is not done when projectCount is 0", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [],
+    enabledHarnessIds: null,
+    projectCount: 0,
+    tasks: [],
+  });
+  expect(steps.find((s) => s.id === "project")!.done).toBe(false);
+});
+
+test("project step is done when projectCount > 0", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [],
+    enabledHarnessIds: null,
+    projectCount: 1,
+    tasks: [],
+  });
+  expect(steps.find((s) => s.id === "project")!.done).toBe(true);
+});
+
+// --- deriveOnboardingSteps: task rule ---------------------------------------
+
+test("task step is not done when tasks is empty", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [],
+    enabledHarnessIds: null,
+    projectCount: 0,
+    tasks: [],
+  });
+  expect(steps.find((s) => s.id === "task")!.done).toBe(false);
+});
+
+test("task step is done when at least one task exists, regardless of column", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [],
+    enabledHarnessIds: null,
+    projectCount: 0,
+    tasks: [{ column: "backlog" }],
+  });
+  expect(steps.find((s) => s.id === "task")!.done).toBe(true);
+});
+
+// --- deriveOnboardingSteps: run rule -----------------------------------------
+
+test("run step is not done when tasks is empty", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [],
+    enabledHarnessIds: null,
+    projectCount: 0,
+    tasks: [],
+  });
+  expect(steps.find((s) => s.id === "run")!.done).toBe(false);
+});
+
+test("run step is not done when every task is still backlog/ready", () => {
+  const steps = deriveOnboardingSteps({
+    statuses: [],
+    enabledHarnessIds: null,
+    projectCount: 0,
+    tasks: [{ column: "backlog" }, { column: "ready" }],
+  });
+  expect(steps.find((s) => s.id === "run")!.done).toBe(false);
+});
+
+test.each(["running", "review", "done", "blocked"] as ColumnId[])(
+  "run step is done when a task's column is %s",
+  (column) => {
+    const steps = deriveOnboardingSteps({
+      statuses: [],
+      enabledHarnessIds: null,
+      projectCount: 0,
+      tasks: [{ column: "backlog" }, { column }],
+    });
+    expect(steps.find((s) => s.id === "run")!.done).toBe(true);
+  },
+);
+
+// --- resolveOnboardingVisibility: not loaded --------------------------------
+
+test("resolveOnboardingVisibility: everything false while not loaded, regardless of other inputs", () => {
+  const allDoneSteps: OnboardingStep[] = [
+    { id: "harness", done: true },
+    { id: "project", done: true },
+    { id: "task", done: true },
+    { id: "run", done: true },
+  ];
+  const result = resolveOnboardingVisibility({
+    dismissedPref: undefined,
+    loaded: false,
+    steps: allDoneSteps,
+    taskCount: 0,
+    welcomeAcknowledged: false,
+  });
+  expect(result).toEqual({ showWelcome: false, showChecklist: false, autoDismiss: false });
+});
+
+// --- resolveOnboardingVisibility: dismissed "true" --------------------------
+
+test("resolveOnboardingVisibility: dismissedPref 'true' hides everything and never auto-dismisses", () => {
+  const notDoneSteps: OnboardingStep[] = [
+    { id: "harness", done: false },
+    { id: "project", done: false },
+    { id: "task", done: false },
+    { id: "run", done: false },
+  ];
+  const result = resolveOnboardingVisibility({
+    dismissedPref: "true",
+    loaded: true,
+    steps: notDoneSteps,
+    taskCount: 0,
+    welcomeAcknowledged: false,
+  });
+  expect(result).toEqual({ showWelcome: false, showChecklist: false, autoDismiss: false });
+});
+
+// --- resolveOnboardingVisibility: replay "false" ----------------------------
+
+test("resolveOnboardingVisibility: replay ('false') shows checklist but never the welcome dialog", () => {
+  const notDoneSteps: OnboardingStep[] = [
+    { id: "harness", done: false },
+    { id: "project", done: false },
+    { id: "task", done: false },
+    { id: "run", done: false },
+  ];
+  const result = resolveOnboardingVisibility({
+    dismissedPref: "false",
+    loaded: true,
+    steps: notDoneSteps,
+    taskCount: 0,
+    welcomeAcknowledged: false,
+  });
+  expect(result.showChecklist).toBe(true);
+  expect(result.showWelcome).toBe(false);
+  expect(result.autoDismiss).toBe(false);
+});
+
+test("resolveOnboardingVisibility: replay stays non-autoDismiss even if all steps happen to be done", () => {
+  const allDoneSteps: OnboardingStep[] = [
+    { id: "harness", done: true },
+    { id: "project", done: true },
+    { id: "task", done: true },
+    { id: "run", done: true },
+  ];
+  const result = resolveOnboardingVisibility({
+    dismissedPref: "false",
+    loaded: true,
+    steps: allDoneSteps,
+    taskCount: 5,
+    welcomeAcknowledged: false,
+  });
+  expect(result.autoDismiss).toBe(false);
+  // allDone means the checklist has nothing left to show either.
+  expect(result.showChecklist).toBe(false);
+  expect(result.showWelcome).toBe(false);
+});
+
+// --- resolveOnboardingVisibility: fresh user (pref undefined) --------------
+
+test("resolveOnboardingVisibility: fresh user (pref undefined, no tasks, steps incomplete) shows welcome + checklist", () => {
+  const notDoneSteps: OnboardingStep[] = [
+    { id: "harness", done: false },
+    { id: "project", done: false },
+    { id: "task", done: false },
+    { id: "run", done: false },
+  ];
+  const result = resolveOnboardingVisibility({
+    dismissedPref: undefined,
+    loaded: true,
+    steps: notDoneSteps,
+    taskCount: 0,
+    welcomeAcknowledged: false,
+  });
+  expect(result).toEqual({ showWelcome: true, showChecklist: true, autoDismiss: false });
+});
+
+// --- resolveOnboardingVisibility: welcome acknowledged ----------------------
+
+test("resolveOnboardingVisibility: welcomeAcknowledged suppresses only the welcome dialog", () => {
+  const notDoneSteps: OnboardingStep[] = [
+    { id: "harness", done: false },
+    { id: "project", done: false },
+    { id: "task", done: false },
+    { id: "run", done: false },
+  ];
+  const result = resolveOnboardingVisibility({
+    dismissedPref: undefined,
+    loaded: true,
+    steps: notDoneSteps,
+    taskCount: 0,
+    welcomeAcknowledged: true,
+  });
+  expect(result.showWelcome).toBe(false);
+  expect(result.showChecklist).toBe(true);
+  expect(result.autoDismiss).toBe(false);
+});
+
+// --- resolveOnboardingVisibility: taskCount > 0 suppresses welcome ----------
+
+test("resolveOnboardingVisibility: taskCount > 0 suppresses welcome but not the checklist", () => {
+  const notDoneSteps: OnboardingStep[] = [
+    { id: "harness", done: true },
+    { id: "project", done: true },
+    { id: "task", done: true },
+    { id: "run", done: false },
+  ];
+  const result = resolveOnboardingVisibility({
+    dismissedPref: undefined,
+    loaded: true,
+    steps: notDoneSteps,
+    taskCount: 1,
+    welcomeAcknowledged: false,
+  });
+  expect(result.showWelcome).toBe(false);
+  expect(result.showChecklist).toBe(true);
+  expect(result.autoDismiss).toBe(false);
+});
+
+// --- resolveOnboardingVisibility: all done -> autoDismiss -------------------
+
+test("resolveOnboardingVisibility: all steps done + pref undefined -> autoDismiss true, checklist/welcome hidden", () => {
+  const allDoneSteps: OnboardingStep[] = [
+    { id: "harness", done: true },
+    { id: "project", done: true },
+    { id: "task", done: true },
+    { id: "run", done: true },
+  ];
+  const result = resolveOnboardingVisibility({
+    dismissedPref: undefined,
+    loaded: true,
+    steps: allDoneSteps,
+    taskCount: 3,
+    welcomeAcknowledged: false,
+  });
+  expect(result).toEqual({ showWelcome: false, showChecklist: false, autoDismiss: true });
+});
+
+test("resolveOnboardingVisibility: autoDismiss requires pref to be undefined, not merely falsy/'false'", () => {
+  const allDoneSteps: OnboardingStep[] = [
+    { id: "harness", done: true },
+    { id: "project", done: true },
+    { id: "task", done: true },
+    { id: "run", done: true },
+  ];
+  const withFalsePref = resolveOnboardingVisibility({
+    dismissedPref: "false",
+    loaded: true,
+    steps: allDoneSteps,
+    taskCount: 3,
+    welcomeAcknowledged: false,
+  });
+  const withUndefinedPref = resolveOnboardingVisibility({
+    dismissedPref: undefined,
+    loaded: true,
+    steps: allDoneSteps,
+    taskCount: 3,
+    welcomeAcknowledged: false,
+  });
+  expect(withFalsePref.autoDismiss).toBe(false);
+  expect(withUndefinedPref.autoDismiss).toBe(true);
+});
+
+test("resolveOnboardingVisibility: all done + already dismissed ('true') -> autoDismiss stays false (no redundant write)", () => {
+  const allDoneSteps: OnboardingStep[] = [
+    { id: "harness", done: true },
+    { id: "project", done: true },
+    { id: "task", done: true },
+    { id: "run", done: true },
+  ];
+  const result = resolveOnboardingVisibility({
+    dismissedPref: "true",
+    loaded: true,
+    steps: allDoneSteps,
+    taskCount: 3,
+    welcomeAcknowledged: false,
+  });
+  expect(result.autoDismiss).toBe(false);
+});

--- a/src/mainview/lib/onboarding.test.ts
+++ b/src/mainview/lib/onboarding.test.ts
@@ -253,7 +253,7 @@ test("resolveOnboardingVisibility: replay ('false') shows checklist but never th
   expect(result.autoDismiss).toBe(false);
 });
 
-test("resolveOnboardingVisibility: replay stays non-autoDismiss even if all steps happen to be done", () => {
+test("resolveOnboardingVisibility: replay stays visible (not a no-op) even when all steps happen to be done", () => {
   const allDoneSteps: OnboardingStep[] = [
     { id: "harness", done: true },
     { id: "project", done: true },
@@ -268,9 +268,27 @@ test("resolveOnboardingVisibility: replay stays non-autoDismiss even if all step
     welcomeAcknowledged: false,
   });
   expect(result.autoDismiss).toBe(false);
-  // allDone means the checklist has nothing left to show either.
-  expect(result.showChecklist).toBe(false);
+  // Replay must force the checklist visible even though allDone — otherwise
+  // replaying onboarding for a fully set-up board would be a silent no-op.
+  expect(result.showChecklist).toBe(true);
   expect(result.showWelcome).toBe(false);
+});
+
+test("resolveOnboardingVisibility: dismissing again after a replay ('true') hides the checklist even if all steps are done", () => {
+  const allDoneSteps: OnboardingStep[] = [
+    { id: "harness", done: true },
+    { id: "project", done: true },
+    { id: "task", done: true },
+    { id: "run", done: true },
+  ];
+  const result = resolveOnboardingVisibility({
+    dismissedPref: "true",
+    loaded: true,
+    steps: allDoneSteps,
+    taskCount: 5,
+    welcomeAcknowledged: false,
+  });
+  expect(result).toEqual({ showWelcome: false, showChecklist: false, autoDismiss: false });
 });
 
 // --- resolveOnboardingVisibility: fresh user (pref undefined) --------------

--- a/src/mainview/lib/onboarding.ts
+++ b/src/mainview/lib/onboarding.ts
@@ -71,6 +71,11 @@ export interface OnboardingVisibility {
  * this session, and the pref has never been set at all. A replay (pref
  * explicitly `"false"`) shows the checklist but skips the welcome dialog —
  * the user has already seen the intro once.
+ *
+ * Replay forces the checklist visible even when every step already derives
+ * as done — the whole point of replaying is to look at it again, so "all
+ * done" must not make it a no-op. Dismissing again (pref back to `"true"`)
+ * hides it as usual.
  */
 export function resolveOnboardingVisibility(input: {
   dismissedPref: string | undefined;
@@ -86,11 +91,12 @@ export function resolveOnboardingVisibility(input: {
   }
 
   const dismissed = dismissedPref === "true";
+  const replaying = dismissedPref === "false";
   const allDone = steps.every((step) => step.done);
   const prefUnset = dismissedPref === undefined;
 
   const autoDismiss = prefUnset && allDone;
-  const showChecklist = !dismissed && !allDone;
+  const showChecklist = loaded && (replaying || (!dismissed && !allDone));
   const showWelcome = showChecklist && taskCount === 0 && !welcomeAcknowledged && prefUnset;
 
   return { showWelcome, showChecklist, autoDismiss };

--- a/src/mainview/lib/onboarding.ts
+++ b/src/mainview/lib/onboarding.ts
@@ -1,0 +1,97 @@
+import type { ColumnId, HarnessStatus, Task } from "../../shared/types.ts";
+
+/**
+ * Preference key (see `preferences` table / `GET|PUT /preferences/:key`)
+ * that persists whether the user has dismissed first-run onboarding.
+ * `"true"` = dismissed, `"false"` = explicitly replayed, absent = never
+ * evaluated. Server-side, cross-session, no migration needed (string KV).
+ */
+export const ONBOARDING_DISMISSED_PREF = "onboardingDismissed";
+
+export type OnboardingStepId = "harness" | "project" | "task" | "run";
+
+export interface OnboardingStep {
+  id: OnboardingStepId;
+  done: boolean;
+}
+
+/** Task columns that count as "the run step is done" — anything that has left backlog/ready. */
+const RUN_DONE_COLUMNS: ReadonlySet<ColumnId> = new Set(["running", "review", "done", "blocked"]);
+
+/**
+ * Pure derivation of the 4 onboarding steps from live app state. Always
+ * returns all 4 steps in the fixed order harness, project, task, run —
+ * callers render them positionally, so the order is load-bearing.
+ */
+export function deriveOnboardingSteps(input: {
+  statuses: HarnessStatus[];
+  enabledHarnessIds: Set<string> | null;
+  projectCount: number;
+  tasks: Pick<Task, "column">[];
+}): OnboardingStep[] {
+  const { statuses, enabledHarnessIds, projectCount, tasks } = input;
+
+  const harnessDone = statuses.some(
+    (status) =>
+      status.available === true &&
+      (enabledHarnessIds === null || enabledHarnessIds.has(status.harnessId)),
+  );
+  const projectDone = projectCount > 0;
+  const taskDone = tasks.length > 0;
+  const runDone = tasks.some((task) => RUN_DONE_COLUMNS.has(task.column));
+
+  return [
+    { id: "harness", done: harnessDone },
+    { id: "project", done: projectDone },
+    { id: "task", done: taskDone },
+    { id: "run", done: runDone },
+  ];
+}
+
+export interface OnboardingVisibility {
+  showWelcome: boolean;
+  showChecklist: boolean;
+  autoDismiss: boolean;
+}
+
+/**
+ * Pure derivation of what onboarding UI (if any) should be visible.
+ *
+ * Everything is false until `loaded` is true (prefs haven't been fetched
+ * yet — don't flash onboarding before we know the real dismissal state).
+ *
+ * `autoDismiss` is the existing-user upgrade path: when the pref has never
+ * been set AND every step already derives as done, the caller should write
+ * the pref once (so onboarding never appears for users who already have a
+ * fully set-up board) — this function only signals that it should happen,
+ * it doesn't perform the write itself (pure module, no side effects).
+ *
+ * `showWelcome` only ever appears for a truly fresh user: the checklist is
+ * visible, there are zero tasks, the welcome dialog hasn't been acknowledged
+ * this session, and the pref has never been set at all. A replay (pref
+ * explicitly `"false"`) shows the checklist but skips the welcome dialog —
+ * the user has already seen the intro once.
+ */
+export function resolveOnboardingVisibility(input: {
+  dismissedPref: string | undefined;
+  loaded: boolean;
+  steps: OnboardingStep[];
+  taskCount: number;
+  welcomeAcknowledged: boolean;
+}): OnboardingVisibility {
+  const { dismissedPref, loaded, steps, taskCount, welcomeAcknowledged } = input;
+
+  if (!loaded) {
+    return { showWelcome: false, showChecklist: false, autoDismiss: false };
+  }
+
+  const dismissed = dismissedPref === "true";
+  const allDone = steps.every((step) => step.done);
+  const prefUnset = dismissedPref === undefined;
+
+  const autoDismiss = prefUnset && allDone;
+  const showChecklist = !dismissed && !allDone;
+  const showWelcome = showChecklist && taskCount === 0 && !welcomeAcknowledged && prefUnset;
+
+  return { showWelcome, showChecklist, autoDismiss };
+}


### PR DESCRIPTION
## Why

New users open agetor to an empty board and a 12-field New Task panel with no guidance on what to do first (GitHub issue: "New users don't know what to do first"). There was no empty state at all — zero tasks rendered blank columns — and nothing explained the workflow, how to get a harness working, or how the form's fields fit together.

## What changed

**First-run experience** (plan: `docs/plans/onboarding-first-run.md`)
- **Welcome dialog** on true first run (fresh data, never dismissed): a short intro to the workflow, with *Get started* and *Skip — I know my way around*.
- **Live "Getting started" checklist** fills the empty board (compact strip once tasks exist) with four steps auto-checked from real state:
  1. **Harness ready** — per-harness install status (dot + version), install hints for missing binaries, "installed but disabled → Enable in Settings" deep link, login guidance with each CLI's login command plus the env-preloaded *Open in Terminal* affordance, and a multi-account pointer.
  2. **Add a project** / 3. **Create your first task** — both expand and spotlight the New Task panel and focus the Title field.
  4. **Run it** — checks off when a task first leaves the backlog.
- Checklist auto-completes when all steps are done; **existing users never see it** (an all-done state on first evaluation silently writes the dismissal).
- **Replay** from Settings → General → *Show getting started guide*; `SettingsDialog` gained an `initialSection` deep-link prop.
- **New Task panel**: workflow InfoTip in the header explaining how the fields fit together (what / where / which agent); onboarding actions trigger expand + focus + a transient spotlight ring.
- **Column hints**: one-line muted meaning per empty column while onboarding is visible.

**Persistence**: a single `onboardingDismissed` key in the existing `preferences` KV store — no migration, no server/DB changes.

## Implementation notes

- All decision logic is pure and unit-tested in `src/mainview/lib/onboarding.ts` (`deriveOnboardingSteps` / `resolveOnboardingVisibility`, 30 tests); components stay thin.
- Login-state probing is deliberately out of scope: the harness probe only detects installed binaries, so login remains guidance + terminal, not a checkmark.
- Codex/Cursor stay disabled-by-default; onboarding deep-links to Settings instead of auto-enabling.
- Copy reflects the real column flow (cards go straight to Running; Ready is where failed runs return; Done is manual).

## Testing

- `e2e/onboarding.spec.ts` — 5 cases: fresh-run welcome + harness auto-check, skip persistence across reload, progressive step check-off through project → task → run with auto-complete, replay from Settings, and the existing-user guard.
- New test-scoped `freshBackend` fixture (virgin DB per test, needed because "preference never written" is unrepresentable on a shared backend); `gotoApp` now default-seeds the dismissed flag so the three pre-existing specs needed zero edits (opt-out used only by the onboarding spec).
- Full verification: `tsc --noEmit` clean · `bun test` 2620 pass / 0 fail / 3 skip · `bunx playwright test` 22/22.