### PR TITLE
feature: guidance popover for topbar chips without usage data

### DIFF
--- a/src/bun/usage/poller.ts
+++ b/src/bun/usage/poller.ts
@@ -1,5 +1,5 @@
 import type { AgentKind, Harness, HarnessQuota } from "../../shared/types.ts";
-import { USAGE_MIN_REFRESH_MS } from "../../shared/types.ts";
+import { USAGE_MIN_REFRESH_MS, USAGE_SUPPORTED_KINDS } from "../../shared/types.ts";
 import { harnessUsage, harnesses } from "../db.ts";
 import { broadcastAppEvent } from "../quit-guard.ts";
 import { fetchClaudeQuota } from "./claude-usage.ts";
@@ -25,9 +25,12 @@ import { fetchCursorQuota } from "./cursor-usage.ts";
  * live gemini/grok data), so harnesses of those kinds are skipped by both
  * `refreshOne` (returns null, no snapshot stored) and `pollAllUsage` (filtered
  * out of the sweep). Adding a new provider later is one new module + one
- * line here.
+ * line here + the kind added to `USAGE_SUPPORTED_KINDS` (shared/types.ts) —
+ * the key type below is derived from that list so the webview's
+ * supported-kind messaging can't drift from this registry.
  */
-export const USAGE_PROVIDERS: Partial<Record<AgentKind, (h: Harness) => Promise<HarnessQuota>>> = {
+export const USAGE_PROVIDERS: Partial<Record<AgentKind, (h: Harness) => Promise<HarnessQuota>>> &
+  Record<(typeof USAGE_SUPPORTED_KINDS)[number], (h: Harness) => Promise<HarnessQuota>> = {
   "claude-code": fetchClaudeQuota,
   codex: fetchCodexQuota,
   cursor: fetchCursorQuota,

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -3,7 +3,7 @@ import { DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors } f
 import { AlertTriangle, FolderGit2, GitPullRequest, Settings, X } from "lucide-react";
 import { api, type AgentModelMap } from "@/lib/api";
 import { Button } from "@/components/ui/button";
-import { clampFontSizePercent, COLUMNS, type AgentStatus, type ColumnId, type GlobalEvent, type Harness, type HarnessQuota, type Project, type Task, type TaskType } from "../shared/types.ts";
+import { clampFontSizePercent, COLUMNS, USAGE_SUPPORTED_KINDS, type AgentStatus, type ColumnId, type GlobalEvent, type Harness, type HarnessQuota, type Project, type Task, type TaskType } from "../shared/types.ts";
 import { AgentIcon } from "@/components/kanban/AgentIcon";
 import { Column } from "@/components/kanban/Column";
 import { DiffDialog } from "@/components/kanban/DiffDialog";
@@ -952,19 +952,21 @@ function AppInner() {
                   }
                 />
               );
-              if (!q) {
-                return (
-                  <span
-                    key={a.harnessId}
-                    className="flex items-center gap-1"
-                    title={a.reason ?? a.path ?? ""}
-                  >
-                    <AgentIcon kind={a.kind} className="size-3" />
-                    {displayName}
-                    {dot}
-                  </span>
-                );
-              }
+              // Every chip is clickable: with a snapshot the popover shows
+              // meters; without one it explains WHY there's no data (harness
+              // disabled / kind unsupported / first poll pending) instead of
+              // silently rendering a bare chip — "no bar and no explanation"
+              // reads as broken.
+              const kindSupported = (USAGE_SUPPORTED_KINDS as readonly string[]).includes(a.kind);
+              const enabled = harness?.enabled ?? false;
+              const placeholder = !kindSupported
+                ? { message: "Usage tracking isn't supported for this harness yet.", canRefresh: false }
+                : !enabled
+                  ? {
+                      message: "Usage tracking is off because this harness is disabled — enable it in Settings → Harnesses to see its meters.",
+                      canRefresh: false,
+                    }
+                  : { message: "No usage data yet — the first poll runs shortly, or refresh now.", canRefresh: true };
               const chip = (
                 <span
                   className="flex items-center gap-1"
@@ -972,15 +974,16 @@ function AppInner() {
                 >
                   <AgentIcon kind={a.kind} className="size-3" />
                   {displayName}
-                  <UsageMeter quota={q} />
+                  {q && <UsageMeter quota={q} />}
                   {dot}
                 </span>
               );
               return (
                 <UsagePopover
                   key={a.harnessId}
-                  quota={q}
+                  quota={q ?? null}
                   harnessLabel={displayName}
+                  placeholder={placeholder}
                   onRefresh={async () => {
                     const fresh = await api.refreshHarnessUsage(a.harnessId);
                     setUsage((prev) => ({ ...prev, [fresh.harnessId]: fresh }));

--- a/src/mainview/components/usage/UsagePopover.tsx
+++ b/src/mainview/components/usage/UsagePopover.tsx
@@ -6,10 +6,16 @@ import { clampPercent, formatResetsIn, formatUpdatedAgo, tierColorVar, warnTier 
 import type { HarnessQuota } from "../../../shared/types.ts";
 
 interface Props {
-  quota: HarnessQuota;
+  /** The harness's latest usage snapshot, or `null` when none exists yet
+   *  (disabled harness, unsupported kind, or first poll still pending) —
+   *  the popover then renders `placeholder` guidance instead of meters. */
+  quota: HarnessQuota | null;
   harnessLabel: string;
   children: ReactNode;
   onRefresh: () => Promise<void>;
+  /** Guidance shown when `quota` is null: why there's no data and whether a
+   *  manual Refresh could produce some (`canRefresh` gates the button). */
+  placeholder?: { message: string; canRefresh: boolean };
 }
 
 // Same explicit map as UsageMeter — dynamic `bg-${token}` strings don't
@@ -30,7 +36,7 @@ const FILL_CLASS: Record<"success" | "warning" | "danger", string> = {
  * `index.css` or `tailwind.config.js` (checked at implementation time) — this
  * uses `bg-card`/`text-card-foreground` instead, which are.
  */
-export function UsagePopover({ quota, harnessLabel, children, onRefresh }: Props) {
+export function UsagePopover({ quota, harnessLabel, children, onRefresh, placeholder }: Props) {
   const [open, setOpen] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -91,10 +97,14 @@ export function UsagePopover({ quota, harnessLabel, children, onRefresh }: Props
         >
           <div className="flex items-center justify-between gap-2">
             <span className="font-medium">{harnessLabel}</span>
-            {quota.planType && <span className="text-muted-foreground">{quota.planType}</span>}
+            {quota?.planType && <span className="text-muted-foreground">{quota.planType}</span>}
           </div>
 
-          {quota.meters.length === 0 ? (
+          {quota === null ? (
+            <div className="mt-2 text-muted-foreground">
+              {placeholder?.message ?? "No usage data"}
+            </div>
+          ) : quota.meters.length === 0 ? (
             <div className="mt-2 text-muted-foreground">{quota.reason ?? "No usage data"}</div>
           ) : (
             <div className="mt-2 space-y-2.5">
@@ -124,24 +134,30 @@ export function UsagePopover({ quota, harnessLabel, children, onRefresh }: Props
             </div>
           )}
 
-          <div className="mt-3 flex items-center justify-between gap-2 border-t border-border pt-2">
-            <span className="text-muted-foreground">{formatUpdatedAgo(quota.fetchedAtMs, Date.now())}</span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="size-6"
-              disabled={refreshing}
-              aria-label="Refresh usage"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                void handleRefresh();
-              }}
-            >
-              <RefreshCw className={cn("size-3", refreshing && "animate-spin")} />
-            </Button>
-          </div>
+          {(quota !== null || placeholder?.canRefresh) && (
+            <div className="mt-3 flex items-center justify-between gap-2 border-t border-border pt-2">
+              <span className="text-muted-foreground">
+                {quota !== null ? formatUpdatedAgo(quota.fetchedAtMs, Date.now()) : ""}
+              </span>
+              {(quota !== null || placeholder?.canRefresh) && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-6"
+                  disabled={refreshing}
+                  aria-label="Refresh usage"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    void handleRefresh();
+                  }}
+                >
+                  <RefreshCw className={cn("size-3", refreshing && "animate-spin")} />
+                </Button>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -849,6 +849,13 @@ export const USAGE_WARN_PERCENT = 70;
 /** `QuotaMeter.usedPercent` at/above which the UI renders red ("crit"). */
 export const USAGE_CRIT_PERCENT = 90;
 
+/** Agent kinds with a usage provider registered bun-side (the
+ *  `USAGE_PROVIDERS` registry in `src/bun/usage/poller.ts` is typed against
+ *  this list, so the two can't drift). The webview uses it to decide whether
+ *  a chip without a snapshot should say "enable the harness / refresh" vs
+ *  "usage tracking isn't supported for this kind yet" (gemini/grok). */
+export const USAGE_SUPPORTED_KINDS = ["claude-code", "codex", "cursor"] as const satisfies readonly AgentKind[];
+
 /**
  * A git worktree materialized on disk under `dataDir/worktrees/`, as surfaced
  * by `GET /worktrees`. One row per directory found on disk — computed live by


### PR DESCRIPTION
## What

Follow-up to #177. A harness chip with no usage snapshot previously rendered as a bare icon + dot with no explanation — which reads as "the usage tracker is broken" when the real cause is mundane (the harness is disabled, its kind has no provider yet, or the first poll simply hasn't run).

Every topbar chip is now clickable, and when there's no snapshot the popover says exactly why:

- **Disabled harness** → "Usage tracking is off because this harness is disabled — enable it in Settings → Harnesses to see its meters." (Codex and Cursor ship disabled by default, so this is the case most users will actually hit.)
- **Unsupported kind** (gemini/grok) → "Usage tracking isn't supported for this harness yet."
- **Enabled + supported, not yet polled** → "No usage data yet — the first poll runs shortly, or refresh now." with a working Refresh button (force-refreshes via `POST /harnesses/:id/usage/refresh`).

Chips with a snapshot behave exactly as before (mini-bar + full meter popover).

## How

- `UsagePopover` accepts `quota: HarnessQuota | null` plus a `placeholder` (`{ message, canRefresh }`); the footer's Refresh button only renders when a refresh could actually produce data.
- New shared constant `USAGE_SUPPORTED_KINDS` in `src/shared/types.ts`; the bun-side `USAGE_PROVIDERS` registry is **typed against it**, so the webview's "supported vs not" messaging cannot drift from the actual provider registry — adding a future provider without updating the shared list is a compile error.
- `App.tsx` chip strip derives the placeholder from `harness.enabled` + kind support; chips without snapshots previously returned early with a plain span.

## Verification

- `bun run typecheck` green; Vite build clean.
- Unit suites pass (usage lib + poller, 44 tests on this branch's tree; full usage suites green pre-cherry-pick).
- `e2e/usage-tracker.spec.ts` passes — the with-snapshot popover behavior is unchanged.