### PR TITLE
feature: move the Git Diff section to the end of the PR detail modal

### DIFF
--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -6710,10 +6710,6 @@ function GitHubItemDetail({
             <CommitStatus status={commitStatus} loading={commitStatusLoading} error={commitStatusError} onRetry={onRetryCommitStatus} onRefresh={onRefreshCommitStatus} />
           )}
           <PullCommits commits={commits} loading={commitsLoading} error={commitsError} onRetry={onRetryCommits} />
-          <PullDiff diff={diff} loading={diffLoading} error={diffError} onRetry={onRetryDiff} onRefresh={onRefreshDiff} onLineComment={onLineComment} onAddToReview={onAddToReview} pending={pendingReview} allowBatchReview={provider === "github"} blobCtx={blobCtx} />
-          {provider === "github" && (
-            <PendingReview comments={pendingReview} stale={pendingStale} onRemove={onRemovePendingReview} />
-          )}
           <ReviewComments
             path={itemPath}
             caps={caps}
@@ -6786,6 +6782,19 @@ function GitHubItemDetail({
         onSubmit={onSubmitComment}
         onRetry={onRetryComments}
       />
+      {/* The diff renders LAST, after the conversation. It's by far the tallest
+       *  section, and sitting it mid-detail buried the review/conversation
+       *  comment threads behind a long scroll. `PendingReview` stays glued to
+       *  it — that queue is built by clicking diff lines, and its "stale"
+       *  banner refers to the diff directly above it. */}
+      {item.kind === "pulls" && (
+        <>
+          <PullDiff diff={diff} loading={diffLoading} error={diffError} onRetry={onRetryDiff} onRefresh={onRefreshDiff} onLineComment={onLineComment} onAddToReview={onAddToReview} pending={pendingReview} allowBatchReview={provider === "github"} blobCtx={blobCtx} />
+          {provider === "github" && (
+            <PendingReview comments={pendingReview} stale={pendingStale} onRemove={onRemovePendingReview} />
+          )}
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Why

In the Git Integration modal's pull-request detail view, the diff rendered between the commits list and the review comments. At up to `55vh` tall it pushed the review-comment threads and the conversation composer behind a long scroll, so reaching the comments section meant scrolling past the entire diff every time.

## What changed

`src/mainview/components/kanban/GitHubDialog.tsx` (`ItemDetail`):

- Removed `<PullDiff>` and the GitHub-only `<PendingReview>` from their old slot between `PullCommits` and `ReviewComments`.
- Re-rendered them **after** `<Conversation>`, in a second `{item.kind === "pulls" && …}` fragment. The extra fragment is required rather than a plain move: `Conversation` is shared with issues and therefore lives *outside* the pulls-only block.

New section order in the PR detail view:

```
description → reactions → actions → triage → checks → commit status →
commits → review comments → conversation → diff → pending review
```

## Notes

- `PendingReview` deliberately stays glued to `PullDiff`: the queue is populated by clicking diff lines (`onAddToReview`), and its "the diff changed since these were queued" banner reads as referring to the diff immediately above it.
- Its footer copy ("Submit these with Approve / Comment / Request in the Actions panel above") remains accurate, since the actions panel is still at the top.
- No positional copy elsewhere referenced the diff's old placement, no `scrollIntoView` logic targets it, and no tests assert section order.

## Verification

`bun run typecheck` is green. This is a pure JSX reorder with no logic or data-fetching changes.