### PR TITLE
fix: surface unknown/unparsable Claude Code prompts as a fallback card with Open in Terminal

### DIFF
--- a/docs/plans/unknown-claude-prompts-fallback.md
+++ b/docs/plans/unknown-claude-prompts-fallback.md
@@ -1,0 +1,198 @@
+# Plan — Fallback card for unknown/unparsable Claude Code prompts
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-18 |
+| Source | User request + screenshot of Claude Code 2.1.234 "Set up auto mode" startup wizard |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Flags | none |
+| Branch | fix/missing-unknown-claude-code-prompts-in-a (cut from main @ 295d91e) |
+| Base SHA | 295d91eb0c6ca10e0a6e4b79103551941f6c7b49 (tree clean except this plan file) |
+
+## 1. Objective & success criteria
+
+When Claude Code sits blocked on an interactive prompt that none of agetor's matchers can
+parse, the RunPanel must show **something**: a fallback interaction card with the raw pane
+text and an **Open in Terminal** button (the existing Attach flow), instead of today's
+silence. Success:
+
+- The screenshotted "Set up auto mode for your environment?" wizard (claude 2.1.234)
+  surfaces a card — at boot *and* mid-session — and the boot timeout no longer kills the
+  run while it's on screen.
+- Any future unknown modal with a recognizable claude footer does the same.
+- A turn that is silently stuck (>60s, no JSONL, no working spinner) surfaces the card too.
+- The card auto-resolves when the prompt is answered in the attached terminal (existing
+  `__external__` sweep) and never fires while claude is working or idle at the input box.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- **The gap**: `scrapeOnce` tries only `matchNumberedModal ?? matchYesNoModal` for
+  non-AskUserQuestion panes (`src/bun/claude-tmux.ts:3931-3933`); on null it silently
+  returns (`:3955-3958`). The boot poller mirrors the same two matchers and silently
+  `continue`s on no-match (`:4767-4810`), so an unmatched startup prompt strands the run
+  until `BOOT_TIMEOUT_MS` (30s) kills it.
+- **Prompt families that fall through**: unnumbered arrow-key widgets (the screenshot),
+  free-text/device-code auth prompts, single-option modals (`numbered.length < 2` rejects),
+  prose confirmations, update notices, new startup dialogs absent from
+  `STARTUP_CONSENT_DIALOGS`.
+- **The screenshot prompt**: header question, prose description, `◂ Mixed ▸` value
+  selector, `[ ]` checkbox rows with `❯` cursor, bold `Continue`, footer
+  `←/→ to change usage · Enter to continue · Esc to cancel`. Cannot be auto-answered
+  (privacy choice — scanning shell history) and is too widget-rich to drive remotely; the
+  fallback card + Attach is the *designed* handler, not a stopgap.
+- **Registration infra**: `registerTmuxPrompt` (`src/bun/interactions.ts:272-306`) creates
+  a `TmuxPromptRequest`, broadcasts on the task SSE stream + a global notification event
+  (`orchestrator.ts:475-522`). The `__external__` sweep (`claude-tmux.ts:3935-3944`, boot
+  analogue `:4775-4782`) resolves any registered prompt whose fingerprint no longer matches
+  the live pane — so a fallback "match" must keep producing a stable fingerprint every tick
+  while the modal is up, or the sweep kills its own card.
+- **Stability gates**: `clearedStabilityGate` (`:3507-3509`) — two-tick fingerprint
+  stability, with an Esc-footer high-confidence fast path. The fallback will use the
+  two-tick path only (repaint/paste transients must never register a card).
+- **Working/idle signals**: `claudeIsWriting` = JSONL grew < 500ms ago (`:3872`);
+  `turnInFlight(state)` (`:4294-4297`); raw tail contains `esc to interrupt` while a turn
+  streams (the spinner line, `VOLATILE_PANE_LINE_RE:3786`); `state.lastJsonlAppendAt`.
+- **AskUserQuestion routing**: when `detectAskModal` fires, generic matchers are suppressed
+  unless `askFallbackAllowed` latches after `MAX_ASK_GROW_ATTEMPTS=3` (`:3744`). Once that
+  latch opens and numbered/yes-no *also* fail, the new fallback becomes the final net — the
+  intended completion of the existing give-up path.
+- **Attach**: `POST /tasks/:id/open-tmux` (`server.ts:3571-3654`) → `healWindowSize` →
+  AppleScript → Terminal.app `tmux attach`; client `api.openTmux(taskId)`
+  (`api.ts:1306-1308`). Reused as-is (owner decision).
+- **UI**: interaction cards render via the `renderInteraction` switch on `kind`
+  (`RunPanel.tsx:3953-3968`); `TmuxPromptCard` (`:5522-5670`) is the visual template;
+  `modalPending = interactions.length > 0` (`:1546`) gates the composer automatically for
+  any pending interaction. `PendingTmuxPrompt` is hand-mirrored in
+  `src/mainview/lib/api.ts:190-223` (not shared/types.ts).
+- **Tests**: `claude-tmux-scraper.test.ts` uses inline pane-string fixtures + the
+  `__forTest` export bag; nothing currently exercises the all-matchers-null fallthrough.
+- **Runnability**: `bun run typecheck` + `bun test` (per file:
+  `bun test src/bun/claude-tmux-scraper.test.ts`). No e2e harness exists; live tmux/claude
+  is not exercised by the suite (fake drivers + pane fixtures are the convention).
+
+## 3. Approach & key decisions
+
+1. **Reuse the `tmux_prompt` interaction kind with an `unparsable: true` flag and
+   `choices: []`**, rather than a new interaction kind. Rationale: the fallback card *is* a
+   tmux prompt — it lives in the same `tmuxPrompts` map, so the `__external__`
+   sweep, `listPendingForTask`, SSE broadcast, global notification, and `modalPending`
+   gating all work unchanged. A new kind would force parallel plumbing through
+   interactions.ts, server.ts, api.ts, and the sweep for zero user-visible gain.
+2. **Footer-gated detection** (`matchUnparsableModal`): fires only when the last 3
+   non-blank tail lines contain a claude modal footer
+   (`/esc to cancel|enter to confirm|enter to continue|esc to go back/i` — checked over
+   non-blank lines because tmux capture emits trailing blank rows, same as
+   `clearedStabilityGate`). Runs strictly after `matchNumberedModal` and `matchYesNoModal`
+   return null, so parseable modals always win. Fingerprint = sha1 of the cleaned tail
+   block, stable across ticks while the modal is up. Two-tick stability gate, **no**
+   high-confidence fast path (footer presence is the trigger itself, not extra confidence;
+   transient paste/repaint frames must age out).
+3. **Stuck-turn watchdog** as a second trigger for the *same* match: when
+   `turnInFlight && now - lastJsonlAppendAt > STUCK_TURN_FALLBACK_MS (60s)` and the raw
+   tail has no `esc to interrupt` working spinner and no ask card/collection is live,
+   `matchUnparsableModal` fires even without a footer (footerless unknown prompt or a
+   wedged TUI). Decision extracted as a pure function for unit tests. The condition stays
+   true while stuck, so the fingerprint persists and the sweep doesn't kill the card; when
+   JSONL resumes or the pane moves on, the match disappears and the sweep resolves the card
+   `__external__`.
+4. **Boot-window coverage**: the boot poller, after `matchNumberedModal ?? matchYesNoModal`
+   returns null, tries footer-gated `matchUnparsableModal` (watchdog arm excluded — no turn
+   in flight at boot) and registers the fallback card through the existing generic-card
+   path, setting `sawStartupPromptThisWindow` so the boot window re-arms instead of dying
+   at 30s. This is the exact fix for the screenshotted wizard, which appears pre-JSONL.
+5. **Card UX** (owner decisions): explanation line ("Claude is asking something agetor
+   can't read — answer it in the terminal"), cleaned pane preview (`cleanPromptPane`,
+   `whitespace-pre-wrap break-words`), one primary **Open in Terminal** button →
+   `api.openTmux(task.id)` with the route's error taxonomy surfaced via toast
+   (`tmux-missing` / `session-missing`). No Esc button (declined). No in-app terminal
+   (declined — Terminal.app reuse). Auto-resolve note in muted text.
+6. **No dedicated matcher for the auto-mode wizard**: it can't be auto-answered and can't
+   be safely driven remotely; the fallback card is the correct terminal state. Its pane
+   text becomes the canonical test fixture instead.
+7. **Task stays `running`** with a pending interaction (matches every other prompt card;
+   `blocked` remains reserved for dead sessions).
+
+## 4. Work breakdown — implementation tasks
+
+Wave 1 (parallel, file-disjoint):
+
+- **T1 — Bun-side detection + registration.** Owns `src/bun/claude-tmux.ts`,
+  `src/bun/interactions.ts`.
+  - `interactions.ts`: add optional `unparsable?: boolean` to `TmuxPromptRequest`;
+    `registerTmuxPrompt` passes it through (empty `choices` already legal).
+  - `claude-tmux.ts`: add `MODAL_FOOTER_RE`, `STUCK_TURN_FALLBACK_MS = 60_000`;
+    `matchUnparsableModal(tail, opts)` returning a `ScrapeMatch`-shaped
+    `{fingerprint, paneText, choices: [], cursorIndex: 0, unparsable: true}` under (a) the
+    footer signal or (b) the watchdog signal (pure decision helper
+    `stuckTurnFallbackArmed({turnInFlight, lastJsonlAppendAt, now, tailHasSpinner,
+    askCardLive})`); wire it as the final `??` arm at `:3931-3933` (runtime) and into the
+    boot poller's generic branch (`:4767-4810`) footer-arm-only + set
+    `sawStartupPromptThisWindow`; thread `unparsable` into `registerTmuxPrompt`; ensure the
+    two-tick gate applies (no high-confidence for unparsable matches); export new pieces in
+    `__forTest`.
+  - Acceptance: typecheck green; auto-mode pane registers via footer arm; sweep resolves it
+    when the pane moves on; numbered/yes-no/ask matches always take precedence.
+- **T2 — Webview card.** Owns `src/mainview/lib/api.ts`, `src/mainview/components/kanban/RunPanel.tsx`.
+  - `api.ts`: mirror `unparsable?: boolean` on `PendingTmuxPrompt`.
+  - `RunPanel.tsx`: in `TmuxPromptCard`, branch on `req.unparsable` (or empty `choices`):
+    warning-tinted card, `Terminal` icon, explanation line, cleaned pane `<pre>`
+    (existing `cleanPromptPane`), primary "Open in Terminal" button → `api.openTmux` with
+    `toast.error` on failure (same copy pattern as the TaskDetails Attach button), muted
+    "resolves automatically once answered" hint. Semantic tokens only (`bg-warning/10`
+    etc.), no literal palette classes.
+  - Acceptance: typecheck green; card renders from a synthetic interaction; composer is
+    gated while pending (comes free via `modalPending`).
+
+No shared files between T1 and T2 (`api.ts` mirror is hand-maintained by design). The type
+contract between them is fixed by this plan (§3.1), so they can run concurrently.
+
+## 5. Work breakdown — test tasks
+
+- **T3 — Scraper tests.** Owns `src/bun/claude-tmux-scraper.test.ts` (+ optional fixture
+  file under `src/bun/fixtures/`): the auto-mode wizard pane as fixture (from the
+  screenshot); assert `matchNumberedModal`/`matchYesNoModal` both null on it and
+  `matchUnparsableModal` fires with a stable fingerprint; footer detection tolerates
+  trailing blank rows; null on a normal idle pane, on a working/spinner pane, and on a
+  numbered-modal pane; `stuckTurnFallbackArmed` truth-table (in-flight/quiet/spinner/ask
+  combinations); two-tick gate applies to unparsable matches.
+- **T4 — Interactions test.** Owns `src/bun/interactions.test.ts`: register a
+  `tmux_prompt` with `choices: []` + `unparsable: true`, assert broadcast shape and
+  `__external__` resolution path.
+
+**E2e: not applicable.** The repo has no e2e harness; the scraper's convention is pane-text
+fixtures + pure-function gates (live tmux/claude is explicitly out of test scope). Manual
+smoke: run a claude task in `~/.agetor-dev` (never prod `~/.agetor`) and observe the card.
+
+## 6. Execution waves
+
+1. **Wave 1**: T1 + T2 in parallel (Phase 4).
+2. **Review** (Phase 5): diff vs base, opus.
+3. **Wave 2**: T3 + T4 in parallel (Phase 6) — after T1 lands `__forTest` exports.
+4. **Run** (Phase 7): `bun run typecheck` + `bun test`; fix loop (Phase 8) as needed.
+
+## 7. Blast radius & risks
+
+- **False positives** are the main risk: a fallback card gates the composer. Mitigations:
+  footer allow-list (not a "looks boxy" heuristic), strict post-precedence ordering,
+  `claudeIsWriting` gate, two-tick stability, 60s watchdog threshold + spinner exclusion.
+  A transient card self-heals via the `__external__` sweep, but we bias to precision.
+- **Sweep interaction**: the fallback match must re-fire with the same fingerprint every
+  tick while the modal is up, or the sweep resolves its own card — covered by
+  fingerprinting the cleaned tail and by the watchdog condition being persistent.
+- **Boot re-arm**: reuses the existing `sawStartupPromptThisWindow` machinery (proven by
+  the Chrome-extension-prompt fix); a genuinely hung boot with no prompt still dies at 30s.
+- **AskUserQuestion give-up path**: after `askFallbackAllowed` latches, an unparsable ask
+  modal now lands on the fallback card instead of nothing — intended, but T3 should pin
+  precedence so a *parseable* ask modal never reaches it.
+- Recent churn in the same files (#183/#184 touched `claude-tmux.ts`/`RunPanel.tsx`) — the
+  branch is cut from `295d91e` (post-both), so no conflict expected.
+
+## 8. Open questions / assumptions
+
+- Footer regex seeded with the four phrasings we have evidence for; future claude versions
+  may add new footer texts (extending the regex is a one-line change, and the watchdog arm
+  is the version-proof net for in-turn prompts).
+- The watchdog threshold (60s) is a judgment call approved by the owner; not empirically
+  tuned.
+- Boot-window watchdog arm is deliberately excluded (no turn in flight; boot has its own
+  timeout semantics).

--- a/src/bun/claude-tmux-scraper.test.ts
+++ b/src/bun/claude-tmux-scraper.test.ts
@@ -8,8 +8,18 @@ import path from "node:path";
 process.env.AGETOR_DATA_DIR = mkdtempSync(path.join(tmpdir(), "agetor-scraper-"));
 
 import { __forTest } from "./claude-tmux.ts";
+import { detectAskModal } from "./claude-questions.ts";
 
-const { matchNumberedModal, matchYesNoModal, matchStartupConsentDialog, clearedStabilityGate } = __forTest;
+const {
+  matchNumberedModal,
+  matchYesNoModal,
+  matchStartupConsentDialog,
+  clearedStabilityGate,
+  matchUnparsableModal,
+  stuckTurnFallbackArmed,
+  MODAL_FOOTER_RE,
+  STUCK_TURN_FALLBACK_MS,
+} = __forTest;
 
 /** Real tmux pane captures of claude-code 2.1.161's AskUserQuestion modal —
  *  same fixture directory claude-questions.test.ts reads from. */
@@ -509,4 +519,270 @@ test("decideScrapeTick — a session that never appended (lastJsonlAppendAt === 
     now: NOW,
   });
   expect(d).toEqual({ run: true, stampIdle: false });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// matchUnparsableModal / stuckTurnFallbackArmed — the unknown/unparsable
+// Claude Code prompt fallback (docs/plans/unknown-claude-prompts-fallback.md
+// §5). Last-resort matcher for a pane no real matcher parsed: fires on a
+// recognised modal footer (`MODAL_FOOTER_RE`) over the last 3 non-blank tail
+// lines, or on the stuck-turn watchdog. Always `unparsable: true`, empty
+// `choices`, never `highConfidence` — so it always needs the two-tick
+// stability gate.
+
+// The claude 2.1.234 "Set up auto mode for your environment?" startup wizard
+// — a real tmux pane capture (from a screenshot). Unnumbered arrow-key
+// widget (`◂ Mixed ▸` value selector, `[ ]` checkbox rows) that
+// matchNumberedModal/matchYesNoModal/detectAskModal all reject, bounded by a
+// real Ink footer. This is the canonical fixture the fallback exists for.
+const AUTO_MODE_WIZARD_PANE = `Set up auto mode for your environment?
+
+Claude Code reads this project, your recent Claude sessions, and optionally your shell history and other
+repositories. Claude analyzes this data and customizes auto mode to make better decisions.
+
+  How you use Claude here    ◂ Mixed ▸
+❯ Also scan shell history    [ ]
+  Also scan your other repos [ ]
+
+  Continue
+
+←/→ to change usage · Enter to continue · Esc to cancel`;
+
+test("matchUnparsableModal — auto-mode wizard: no real matcher parses it, fallback fires via the footer arm", () => {
+  expect(matchNumberedModal(AUTO_MODE_WIZARD_PANE)).toBeNull();
+  expect(matchYesNoModal(AUTO_MODE_WIZARD_PANE)).toBeNull();
+  expect(detectAskModal(AUTO_MODE_WIZARD_PANE)).toBeNull();
+
+  const m = matchUnparsableModal(AUTO_MODE_WIZARD_PANE, false);
+  expect(m).not.toBeNull();
+  expect(m!.unparsable).toBe(true);
+  expect(m!.choices).toEqual([]);
+  expect(m!.cursorIndex).toBe(0);
+  // Deliberately never high-confidence — footer presence IS the trigger, not
+  // extra confidence on top of an already-parsed choice set, so a single-tick
+  // sighting must still clear the two-tick stability gate.
+  expect(m!.highConfidence).toBeFalsy();
+});
+
+test("MODAL_FOOTER_RE — matches the three evidence-backed footer phrasings, case-insensitively", () => {
+  expect(MODAL_FOOTER_RE.test("Esc to cancel · Tab to amend")).toBe(true);
+  expect(MODAL_FOOTER_RE.test("Enter to confirm · Esc to cancel")).toBe(true);
+  expect(MODAL_FOOTER_RE.test("←/→ to change usage · Enter to continue · Esc to cancel")).toBe(true);
+  expect(MODAL_FOOTER_RE.test("ENTER TO CONTINUE")).toBe(true);
+  expect(MODAL_FOOTER_RE.test("? for shortcuts")).toBe(false);
+});
+
+// ── Fingerprint stability ────────────────────────────────────────────────
+//
+// `matchUnparsableModal`'s fingerprint is sha1 of the same last-12-raw-line
+// window used for `paneText`, with blank + volatile lines stripped before
+// hashing. That's only tick-to-tick stable when the meaningful content has
+// slack inside the 12-line window — i.e. fewer than 12 raw lines total, so a
+// trailing blank row or a transient volatile line (the spinner, the "Tip:"
+// banner) lands in the slack instead of evicting real content from the
+// FRONT of the window (`lines.slice(-12)` is a raw positional slice, not a
+// last-N-non-blank slice the way the footer-arm check and paneText's own
+// "12 lines" comment imply).
+//
+// The canonical wizard fixture above is exactly 12 raw lines (8 meaningful +
+// 4 blank) with the footer as its true last line — zero slack — so it is
+// the worst case, not the representative one. Use a shorter footer-bearing
+// pane (well under 12 lines, as a fuller real capture with scrollback above
+// the modal would leave slack in this window) to pin the intended
+// tolerance; see the fixture below for the canonical pane's actual
+// (fragile) behavior at zero slack, which is a discovered gap, not
+// something this suite asserts as "working".
+const SHORT_UNPARSABLE_PANE = `Do a thing?
+
+Enter to continue · Esc to cancel`;
+
+test("matchUnparsableModal — fingerprint is stable across trailing blank-row padding (with window slack)", () => {
+  const clean = matchUnparsableModal(SHORT_UNPARSABLE_PANE, false)!;
+  const withTrailingBlanks = matchUnparsableModal(`${SHORT_UNPARSABLE_PANE}\n\n\n`, false)!;
+  expect(clean).not.toBeNull();
+  expect(withTrailingBlanks.fingerprint).toBe(clean.fingerprint);
+});
+
+test("matchUnparsableModal — fingerprint is stable across an inserted volatile line (with window slack)", () => {
+  // A spinner/"Tip:" line appearing between ticks (VOLATILE_PANE_LINE_RE)
+  // must not change the fingerprint — it's stripped before hashing.
+  const clean = matchUnparsableModal(SHORT_UNPARSABLE_PANE, false)!;
+  const withVolatile = matchUnparsableModal(
+    SHORT_UNPARSABLE_PANE.replace("Do a thing?", "Do a thing?\n✳ Compacting… (esc to interrupt)"),
+    false,
+  )!;
+  expect(withVolatile.fingerprint).toBe(clean.fingerprint);
+
+  const withTip = matchUnparsableModal(
+    SHORT_UNPARSABLE_PANE.replace("Do a thing?", "Do a thing?\nTip: press Shift+Tab to cycle modes"),
+    false,
+  )!;
+  expect(withTip.fingerprint).toBe(clean.fingerprint);
+});
+
+test("matchUnparsableModal — a genuinely different modal gets a different fingerprint", () => {
+  const a = matchUnparsableModal(SHORT_UNPARSABLE_PANE, false)!;
+  const b = matchUnparsableModal(`Do a DIFFERENT thing?\n\nEnter to continue · Esc to cancel`, false)!;
+  expect(a.fingerprint).not.toBe(b.fingerprint);
+});
+
+test("matchUnparsableModal — the canonical (zero-slack) wizard fixture's fingerprint IS stable across trailing padding", () => {
+  // Regression guard for a window-saturation bug: an earlier implementation
+  // took a raw `lines.slice(-12)` BEFORE filtering blank/volatile lines, so
+  // when the meaningful content already filled all 12 lines (as the real
+  // wizard pane does — 8 meaningful + 4 blank, footer as the true last
+  // line), a fluctuating trailing blank row or a transient spinner line
+  // evicted real content from the FRONT of the window and jittered the
+  // hash — the two-tick stability gate could never converge on exactly the
+  // tall modal this feature was built for. The filter must run first.
+  const clean = matchUnparsableModal(AUTO_MODE_WIZARD_PANE, false)!;
+  const withTrailingBlanks = matchUnparsableModal(`${AUTO_MODE_WIZARD_PANE}\n\n`, false)!;
+  const withTrailingSpinner = matchUnparsableModal(
+    `${AUTO_MODE_WIZARD_PANE}\n✳ Compacting… (esc to interrupt)`,
+    false,
+  )!;
+  expect(clean).not.toBeNull();
+  expect(withTrailingBlanks).not.toBeNull();
+  expect(withTrailingBlanks.fingerprint).toBe(clean.fingerprint);
+  expect(withTrailingSpinner.fingerprint).toBe(clean.fingerprint);
+});
+
+// ── Negative panes (footer arm must stay silent) ─────────────────────────
+
+test("matchUnparsableModal — normal idle input-box pane does not fire", () => {
+  const pane = `╭──────────────────────────────────────────────────────────────────────────╮
+│ >                                                                            │
+╰──────────────────────────────────────────────────────────────────────────╯
+  ? for shortcuts · ← for agents`;
+  expect(matchUnparsableModal(pane, false)).toBeNull();
+});
+
+test("matchUnparsableModal — working pane with the 'esc to interrupt' spinner but no footer does not fire", () => {
+  const pane = `● Running Bash(npm test)…
+
+✳ Working… (esc to interrupt · 12s · 1.2k tokens)`;
+  expect(matchUnparsableModal(pane, false)).toBeNull();
+});
+
+test("matchUnparsableModal — plain transcript pane does not fire", () => {
+  const pane = `● I've updated the file to fix the bug.
+
+Let me run the tests now to confirm the fix works as expected.`;
+  expect(matchUnparsableModal(pane, false)).toBeNull();
+});
+
+test("matchUnparsableModal — a footer phrase quoted in transcript prose ABOVE the last 3 non-blank lines does not fire", () => {
+  const pane = `The dialog said "Esc to cancel · Tab to amend" when I saw it earlier.
+
+Here's what I found after digging further:
+Line A
+Line B
+Line C
+Line D`;
+  expect(matchUnparsableModal(pane, false)).toBeNull();
+});
+
+// ── Precedence sanity ─────────────────────────────────────────────────────
+
+test("matchUnparsableModal — precedence: a numbered tool-permission modal is caught by matchNumberedModal first, but WOULD also match the fallback alone", () => {
+  // scrapeOnce's real dispatch is `matchNumberedModal(tail) ?? matchYesNoModal(tail)
+  // ?? matchUnparsableModal(...)` — the fallback is the final `??` arm, so a
+  // parseable numbered modal never reaches it in practice. This test documents
+  // that ordering is load-bearing: in isolation, matchUnparsableModal WOULD
+  // also fire on the same pane (it carries a recognised footer), so if the
+  // `??` chain were ever reordered, a real numbered modal would silently
+  // downgrade to the "read it in the terminal" fallback card instead of
+  // rendering real clickable choices.
+  const pane = `Do you want to proceed?
+❯ 1. Yes
+  2. No
+
+Esc to cancel · Tab to amend`;
+
+  const numbered = matchNumberedModal(pane);
+  expect(numbered).not.toBeNull();
+  expect(numbered!.choices.map((c) => c.key)).toEqual(["1", "2"]);
+  expect(numbered!.highConfidence).toBe(true);
+
+  const fallbackAlone = matchUnparsableModal(pane, false);
+  expect(fallbackAlone).not.toBeNull();
+  expect(fallbackAlone!.unparsable).toBe(true);
+
+  // scrapeOnce's actual `??` chain: numbered wins.
+  const dispatched = matchNumberedModal(pane) ?? matchYesNoModal(pane) ?? matchUnparsableModal(pane, false);
+  expect(dispatched).toEqual(numbered);
+});
+
+// ── stuckTurnFallbackArmed truth table ────────────────────────────────────
+
+const WATCHDOG_NOW = 2_000_000;
+const ALL_ARMED = {
+  turnInFlight: true,
+  lastJsonlAppendAt: WATCHDOG_NOW - STUCK_TURN_FALLBACK_MS - 1,
+  now: WATCHDOG_NOW,
+  tailHasSpinner: false,
+  askCardLive: false,
+};
+
+test("stuckTurnFallbackArmed — all conditions true → armed", () => {
+  expect(stuckTurnFallbackArmed(ALL_ARMED)).toBe(true);
+});
+
+test("stuckTurnFallbackArmed — no turn in flight → not armed", () => {
+  expect(stuckTurnFallbackArmed({ ...ALL_ARMED, turnInFlight: false })).toBe(false);
+});
+
+test("stuckTurnFallbackArmed — lastJsonlAppendAt === 0 (never appended) → not armed", () => {
+  expect(stuckTurnFallbackArmed({ ...ALL_ARMED, lastJsonlAppendAt: 0 })).toBe(false);
+});
+
+test("stuckTurnFallbackArmed — quiet exactly AT the threshold (not strictly over) → not armed", () => {
+  expect(stuckTurnFallbackArmed({
+    ...ALL_ARMED,
+    lastJsonlAppendAt: WATCHDOG_NOW - STUCK_TURN_FALLBACK_MS, // quiet === threshold, not >
+  })).toBe(false);
+});
+
+test("stuckTurnFallbackArmed — quiet one ms past the threshold → armed", () => {
+  expect(stuckTurnFallbackArmed({
+    ...ALL_ARMED,
+    lastJsonlAppendAt: WATCHDOG_NOW - STUCK_TURN_FALLBACK_MS - 1,
+  })).toBe(true);
+});
+
+test("stuckTurnFallbackArmed — working spinner present → not armed (busy, not stuck)", () => {
+  expect(stuckTurnFallbackArmed({ ...ALL_ARMED, tailHasSpinner: true })).toBe(false);
+});
+
+test("stuckTurnFallbackArmed — an ask card/collection is already live → not armed (owns its own give-up ladder)", () => {
+  expect(stuckTurnFallbackArmed({ ...ALL_ARMED, askCardLive: true })).toBe(false);
+});
+
+// ── Watchdog arm on matchUnparsableModal ──────────────────────────────────
+
+test("matchUnparsableModal — watchdog arm fires on a footerless stuck pane when watchdogArmed is true, stays silent when false", () => {
+  const stuckPane = `● Running Bash(a very long build)…
+
+Still going, no visible progress, nothing that looks like a modal or a
+footer — just a wedged TUI.`;
+  expect(matchUnparsableModal(stuckPane, false)).toBeNull();
+  const armed = matchUnparsableModal(stuckPane, true);
+  expect(armed).not.toBeNull();
+  expect(armed!.unparsable).toBe(true);
+  expect(armed!.choices).toEqual([]);
+});
+
+// ── Two-tick stability gate applies to unparsable matches ─────────────────
+
+test("clearedStabilityGate — an unparsable match never has highConfidence, so it needs two ticks like any other low-confidence match", () => {
+  const m = matchUnparsableModal(AUTO_MODE_WIZARD_PANE, false)!;
+  expect(m.unparsable).toBe(true);
+  expect(m.highConfidence).toBeFalsy();
+  // First sighting: no previous fingerprint recorded yet → does not clear.
+  expect(clearedStabilityGate(m, null)).toBe(false);
+  // A different prior fingerprint (a different modal was on screen last
+  // tick) → still does not clear.
+  expect(clearedStabilityGate(m, "some-other-fingerprint")).toBe(false);
+  // Same fingerprint on the second consecutive tick → clears.
+  expect(clearedStabilityGate(m, m.fingerprint)).toBe(true);
 });

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -3378,6 +3378,12 @@ interface ScrapeMatch {
    *  first sighting and skip the two-tick stability gate, so tool-use permission
    *  prompts appear promptly. */
   highConfidence?: boolean;
+  /** True when this is the last-resort fallback match (`matchUnparsableModal`) —
+   *  a modal-shaped or stuck-turn pane no real matcher parsed. `choices` is
+   *  always empty; the UI renders a "read it in the terminal" card instead of
+   *  choice buttons. Deliberately never paired with `highConfidence` — see
+   *  `matchUnparsableModal`. */
+  unparsable?: boolean;
 }
 
 /** Recognise claude's standard numbered-choice modal:
@@ -3531,6 +3537,101 @@ function matchYesNoModal(tail: string): ScrapeMatch | null {
 
 function sha1(s: string): string {
   return createHash("sha1").update(s).digest("hex").slice(0, 16);
+}
+
+/**
+ * Footer phrasings claude's Ink modals draw, seeded from every modal this
+ * scraper already knows how to parse (`Esc to cancel`, the trust-folder
+ * dialog's `Enter to confirm`, ExitPlanMode's `Enter to continue`) plus the
+ * 2.1.234 auto-mode wizard's `Esc to cancel` / arrow-key variant. A pane
+ * ending in one of these is unambiguously a drawn-and-waiting modal, not
+ * streamed prose — printed numbered lists and normal assistant text never
+ * carry this exact phrasing. Extending this list is a one-line change if a
+ * future claude version introduces a new footer we haven't seen yet (see
+ * plan §8); the stuck-turn watchdog below is the version-proof net for
+ * whatever this allow-list misses.
+ */
+const MODAL_FOOTER_RE = /esc to cancel|enter to confirm|enter to continue|esc to go back/i;
+
+/** How long a turn can sit silent (no JSONL growth, no working spinner) before
+ *  `matchUnparsableModal`'s watchdog arm treats it as stuck rather than just
+ *  slow. A judgment call (plan §8), not empirically tuned — long enough that
+ *  a genuinely slow tool call (a big `Bash` run, a large read) doesn't false-
+ *  trip, short enough that a silently wedged TUI doesn't strand the task. */
+const STUCK_TURN_FALLBACK_MS = 60_000;
+
+/** Pure decision for the watchdog arm of `matchUnparsableModal` — exposed via
+ *  `__forTest` so the in-flight/quiet/spinner/ask truth table is unit-
+ *  testable without a live tmux pane. True only when ALL of: a turn is
+ *  actually in flight (there's a "running" run to protect), the session has
+ *  written JSONL before (a `0` timestamp means we've never seen a turn
+ *  start — nothing to be stuck on), it's been quiet past the threshold, the
+ *  raw pane tail does NOT show claude's `esc to interrupt` working spinner
+ *  (a long-running tool call is busy, not stuck — the spinner repaints even
+ *  when no JSONL line has landed yet), and no AskUserQuestion card/collection
+ *  is already live (that path owns the pane and has its own give-up ladder,
+ *  see `askFallbackAllowed`). */
+function stuckTurnFallbackArmed(p: {
+  turnInFlight: boolean;
+  lastJsonlAppendAt: number;
+  now: number;
+  tailHasSpinner: boolean;
+  askCardLive: boolean;
+}): boolean {
+  return p.turnInFlight
+    && p.lastJsonlAppendAt !== 0
+    && p.now - p.lastJsonlAppendAt > STUCK_TURN_FALLBACK_MS
+    && !p.tailHasSpinner
+    && !p.askCardLive;
+}
+
+/**
+ * Last-resort fallback for a pane no other matcher parsed: an unnumbered
+ * arrow-key widget, a free-text/device-code prompt, a single-option modal
+ * (`matchNumberedModal` requires ≥2), a prose confirmation, or a genuinely
+ * wedged turn. Registers a `tmux_prompt` with empty `choices` — there's no
+ * keystroke this scraper can plan, so the UI's job is just "tell the user to
+ * go answer it in the attached terminal", not drive an answer back.
+ *
+ * Fires under either of two independent arms:
+ *   (1) Footer arm — the last 3 NON-BLANK tail lines contain a recognised
+ *       modal footer (`MODAL_FOOTER_RE`). Non-blank, not a fixed raw-line
+ *       slice, because `tmux capture-pane` pads trailing blank rows (same
+ *       reasoning as `matchNumberedModal`'s high-confidence check).
+ *   (2) Watchdog arm — `watchdogArmed` (the caller pre-computes this via
+ *       `stuckTurnFallbackArmed`, since it needs session state this pure
+ *       matcher doesn't have).
+ *
+ * Deliberately never `highConfidence` (see `ScrapeMatch.unparsable`): unlike
+ * `matchNumberedModal`'s footer fast-path, footer presence here IS the
+ * trigger itself, not extra confidence layered on top of an already-parsed
+ * choice set — so a single-tick sighting must not register a card. Skipping
+ * the two-tick gate would let a mid-repaint transient (a real modal's frame
+ * still animating in, a paste in flight) flash a fallback card the user
+ * never needed.
+ *
+ * The fingerprint is sha1 of the SAME trailing lines used for `paneText`
+ * (not the full scrape tail), with blank lines and volatile chrome
+ * (`VOLATILE_PANE_LINE_RE` — the spinner/token-count line, the rotating
+ * "Tip:" banner) stripped first. This has to be stable tick-to-tick while
+ * the same modal sits on screen, or the `__external__` auto-cancel sweep
+ * (which resolves any registered prompt whose fingerprint no longer matches
+ * the live pane) would kill its own card on every tick.
+ */
+function matchUnparsableModal(tail: string, watchdogArmed: boolean): ScrapeMatch | null {
+  const lines = tail.split("\n");
+  const nonBlank = lines.filter((l) => l.trim().length > 0);
+  const footerFires = nonBlank.slice(-3).some((l) => MODAL_FOOTER_RE.test(l));
+  if (!footerFires && !watchdogArmed) return null;
+
+  const paneLines = lines.slice(-12);
+  const paneText = paneLines.join("\n").trimEnd();
+  const cleaned = paneLines
+    .map((l) => l.trimEnd())
+    .filter((l) => l.length > 0 && !VOLATILE_PANE_LINE_RE.test(l))
+    .join("\n");
+  const fingerprint = sha1(`unparsable:${cleaned}`);
+  return { paneText, choices: [], cursorIndex: 0, fingerprint, unparsable: true };
 }
 
 /**
@@ -3930,7 +4031,13 @@ function scrapeOnce(state: SessionState): void {
 
   const match = (claudeIsWriting || (askOnPane && !askUnrecoverable))
     ? null
-    : (matchNumberedModal(tail) ?? matchYesNoModal(tail));
+    : (matchNumberedModal(tail) ?? matchYesNoModal(tail) ?? matchUnparsableModal(tail, stuckTurnFallbackArmed({
+        turnInFlight: turnInFlight(state),
+        lastJsonlAppendAt: state.lastJsonlAppendAt,
+        now,
+        tailHasSpinner: /esc to interrupt/i.test(tail),
+        askCardLive: state.askCardId !== null,
+      })));
 
   // Auto-cancel: any registered prompt for this task whose fingerprint
   // is NOT what we see now has been dismissed (either externally via
@@ -3997,6 +4104,7 @@ function scrapeOnce(state: SessionState): void {
     choices: match.choices,
     cursorIndex: match.cursorIndex,
     fingerprint: match.fingerprint,
+    unparsable: match.unparsable,
   });
 }
 
@@ -4770,7 +4878,11 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
           // slice, two-tick stability gate, and external-dismissal sweep.
           const paneLines = pane.split("\n");
           const tail = paneLines.slice(Math.max(0, paneLines.length - SCRAPE_TAIL_LINES)).join("\n");
-          const generic = matchNumberedModal(tail) ?? matchYesNoModal(tail);
+          // Footer arm only — no turn is in flight during boot, so the
+          // stuck-turn watchdog arm doesn't apply here (see
+          // `matchUnparsableModal`). This is the fix for the screenshotted
+          // 2.1.234 auto-mode wizard, which appears pre-JSONL.
+          const generic = matchNumberedModal(tail) ?? matchYesNoModal(tail) ?? matchUnparsableModal(tail, false);
           if (!generic) { lastGenericFingerprint = null; continue; }
           // External dismissal: a previously surfaced startup prompt whose
           // content no longer matches the pane (user answered it from a real
@@ -4805,6 +4917,7 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
             choices: generic.choices,
             cursorIndex: generic.cursorIndex,
             fingerprint: generic.fingerprint,
+            unparsable: generic.unparsable,
           });
           sawStartupPromptThisWindow = true;
           opts.onChunk("status", "claude is asking a question on startup — answer it to continue");
@@ -5565,6 +5678,14 @@ export const __forTest = {
   matchYesNoModal,
   matchStartupConsentDialog,
   clearedStabilityGate,
+  /** Fallback matcher for prompts no real matcher parsed, plus its pure
+   *  watchdog-arm decision and tuning constants — exposed so the scraper
+   *  test suite can assert footer/watchdog firing and non-firing without a
+   *  live tmux pane. */
+  matchUnparsableModal,
+  stuckTurnFallbackArmed,
+  MODAL_FOOTER_RE,
+  STUCK_TURN_FALLBACK_MS,
   /** Pure idle-throttle decision used by `scrapeOnce` — exposed so the
    *  regression test can assert a JSONL-idle session keeps scraping (at the
    *  throttled cadence) instead of stopping forever, which would strand a

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -3614,7 +3614,12 @@ function stuckTurnFallbackArmed(p: {
  * "Tip:" banner) stripped first. This has to be stable tick-to-tick while
  * the same modal sits on screen, or the `__external__` auto-cancel sweep
  * (which resolves any registered prompt whose fingerprint no longer matches
- * the live pane) would kill its own card on every tick.
+ * the live pane) would kill its own card on every tick. The blank/volatile
+ * filter runs BEFORE the trailing-window slice — a raw `slice(-12)` window
+ * saturated by the modal would let a fluctuating trailing blank row or a
+ * transient spinner line evict real content from the front and jitter the
+ * hash, so the two-tick gate could never converge on exactly the tall
+ * modals this matcher exists for.
  */
 function matchUnparsableModal(tail: string, watchdogArmed: boolean): ScrapeMatch | null {
   const lines = tail.split("\n");
@@ -3622,13 +3627,12 @@ function matchUnparsableModal(tail: string, watchdogArmed: boolean): ScrapeMatch
   const footerFires = nonBlank.slice(-3).some((l) => MODAL_FOOTER_RE.test(l));
   if (!footerFires && !watchdogArmed) return null;
 
-  const paneLines = lines.slice(-12);
-  const paneText = paneLines.join("\n").trimEnd();
-  const cleaned = paneLines
+  const paneLines = lines
     .map((l) => l.trimEnd())
     .filter((l) => l.length > 0 && !VOLATILE_PANE_LINE_RE.test(l))
-    .join("\n");
-  const fingerprint = sha1(`unparsable:${cleaned}`);
+    .slice(-12);
+  const paneText = paneLines.join("\n");
+  const fingerprint = sha1(`unparsable:${paneText}`);
   return { paneText, choices: [], cursorIndex: 0, fingerprint, unparsable: true };
 }
 

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -3540,18 +3540,16 @@ function sha1(s: string): string {
 }
 
 /**
- * Footer phrasings claude's Ink modals draw, seeded from every modal this
- * scraper already knows how to parse (`Esc to cancel`, the trust-folder
- * dialog's `Enter to confirm`, ExitPlanMode's `Enter to continue`) plus the
- * 2.1.234 auto-mode wizard's `Esc to cancel` / arrow-key variant. A pane
- * ending in one of these is unambiguously a drawn-and-waiting modal, not
- * streamed prose — printed numbered lists and normal assistant text never
- * carry this exact phrasing. Extending this list is a one-line change if a
- * future claude version introduces a new footer we haven't seen yet (see
- * plan §8); the stuck-turn watchdog below is the version-proof net for
- * whatever this allow-list misses.
+ * Footer phrasings claude's Ink modals draw. Every entry is evidence-backed —
+ * a false hit here gates the user's composer, so this allow-list only carries
+ * footers observed on a real pane: `esc to cancel` / `enter to confirm` from
+ * the tool-permission and trust-folder fixtures in claude-tmux-scraper.test.ts,
+ * `enter to continue` from the 2.1.234 auto-mode wizard footer
+ * (`←/→ to change usage · Enter to continue · Esc to cancel`). Do not add a
+ * phrasing without a captured pane to back it (plan §8); the stuck-turn
+ * watchdog below is the version-proof net for whatever this list misses.
  */
-const MODAL_FOOTER_RE = /esc to cancel|enter to confirm|enter to continue|esc to go back/i;
+const MODAL_FOOTER_RE = /esc to cancel|enter to confirm|enter to continue/i;
 
 /** How long a turn can sit silent (no JSONL growth, no working spinner) before
  *  `matchUnparsableModal`'s watchdog arm treats it as stuck rather than just
@@ -3879,12 +3877,19 @@ function decideScrapeTick(p: {
   return { run: true, stampIdle: true };
 }
 
+/** Claude's working-spinner line ("esc to interrupt"). Single source of truth
+ *  for the phrase — it feeds both `VOLATILE_PANE_LINE_RE` below and the
+ *  stuck-turn watchdog's `tailHasSpinner` input in `scrapeOnce`, which must
+ *  never drift apart (a spinner the watchdog can't see would false-trip the
+ *  fallback card mid-turn). */
+const SPINNER_RE = /esc to interrupt/i;
+
 /** Pane chrome that repaints on a fixed cadence independent of anything
  *  meaningful happening — claude's "esc to interrupt" spinner/status footer
  *  (its elapsed-time-and-token-count portion ticks every render) and its
  *  rotating "Tip: …" hint banner. Matched against a line AFTER trailing
  *  whitespace has already been trimmed off (see `normalizePaneForActivity`). */
-const VOLATILE_PANE_LINE_RE = /esc to interrupt|^\s*Tip:/i;
+const VOLATILE_PANE_LINE_RE = new RegExp(`${SPINNER_RE.source}|^\\s*Tip:`, "i");
 
 /**
  * Normalize a captured pane tail into the form used for the "did the pane
@@ -4035,7 +4040,7 @@ function scrapeOnce(state: SessionState): void {
         turnInFlight: turnInFlight(state),
         lastJsonlAppendAt: state.lastJsonlAppendAt,
         now,
-        tailHasSpinner: /esc to interrupt/i.test(tail),
+        tailHasSpinner: SPINNER_RE.test(tail),
         askCardLive: state.askCardId !== null,
       })));
 

--- a/src/bun/interactions.test.ts
+++ b/src/bun/interactions.test.ts
@@ -310,6 +310,96 @@ test("registerTmuxPrompt rejects reserved sentinel keys", async () => {
   })).toThrow(/reserved/);
 });
 
+/* ── Unparsable fallback tmux_prompt (unparsable:true, choices:[]) ────── */
+
+test("registerTmuxPrompt with unparsable:true + choices:[] creates a request carrying both, broadcast + listPendingForTask included, and it survives JSON serialization", async () => {
+  const { registerTmuxPrompt, listPendingForTask, setBroadcaster } = await import("./interactions.ts");
+  const broadcasted: unknown[] = [];
+  setBroadcaster((req) => broadcasted.push(req));
+
+  const { req } = registerTmuxPrompt({
+    taskId: "tUnparsable", runId: "rU",
+    paneText: "Set up auto mode for your environment?\n...\nEsc to cancel",
+    choices: [],
+    fingerprint: "fp-unparsable",
+    unparsable: true,
+  });
+
+  expect(req.unparsable).toBe(true);
+  expect(req.choices).toEqual([]);
+
+  // Broadcast payload carries the flag.
+  expect(broadcasted).toHaveLength(1);
+  expect((broadcasted[0] as { unparsable?: boolean }).unparsable).toBe(true);
+
+  // listPendingForTask (the SSE-replay / snapshot path) carries it too.
+  const pending = listPendingForTask("tUnparsable");
+  expect(pending).toHaveLength(1);
+  expect((pending[0] as { unparsable?: boolean }).unparsable).toBe(true);
+  expect((pending[0] as { choices: unknown[] }).choices).toEqual([]);
+
+  // Must survive JSON round-tripping the way the SSE path serializes events.
+  const roundTripped = JSON.parse(JSON.stringify(pending[0]));
+  expect(roundTripped.unparsable).toBe(true);
+  expect(roundTripped.choices).toEqual([]);
+});
+
+test("registerTmuxPrompt without the unparsable flag leaves it undefined (back-compat)", async () => {
+  const { registerTmuxPrompt, listPendingForTask } = await import("./interactions.ts");
+  const { req } = registerTmuxPrompt({
+    taskId: "tNormal", runId: "rN",
+    paneText: "Do you want to proceed?",
+    choices: [{ key: "1", label: "Yes" }, { key: "2", label: "No" }],
+    fingerprint: "fp-normal",
+  });
+
+  expect(req.unparsable).toBeUndefined();
+
+  const pending = listPendingForTask("tNormal");
+  expect(pending).toHaveLength(1);
+  expect((pending[0] as { unparsable?: boolean }).unparsable).toBeUndefined();
+
+  // Round-tripping through JSON must not invent the key (JSON.stringify
+  // drops `undefined` properties, matching how the SSE payload would look).
+  const roundTripped = JSON.parse(JSON.stringify(pending[0]));
+  expect("unparsable" in roundTripped).toBe(false);
+});
+
+test("an unparsable prompt resolves via the __external__ sentinel (scrapeOnce sweep path), leaves the pending list, and fans out a resolved event", async () => {
+  const { registerTmuxPrompt, answerTmuxPrompt, listPendingForTask, setResolvedBroadcaster } =
+    await import("./interactions.ts");
+  const resolved: Array<{ id: string; kind: string }> = [];
+  setResolvedBroadcaster((r) => resolved.push({ id: r.id, kind: r.kind }));
+
+  const { id, req, answer } = registerTmuxPrompt({
+    taskId: "tExternal", runId: "rE",
+    paneText: "Set up auto mode for your environment?",
+    choices: [],
+    fingerprint: "fp-external",
+    unparsable: true,
+  });
+  expect(listPendingForTask("tExternal")).toHaveLength(1);
+
+  // The scraper sweep resolves a fallback card the same way it resolves any
+  // other tmux_prompt whose fingerprint no longer matches the live pane.
+  expect(answerTmuxPrompt(id, { key: "__external__" })).toBe(true);
+  await expect(answer).resolves.toEqual({ key: "__external__" });
+
+  expect(listPendingForTask("tExternal")).toHaveLength(0);
+  expect(resolved).toEqual([{ id: req.id, kind: "tmux_prompt" }]);
+});
+
+test("empty choices array passes the reserved-key validation (no choices to reject)", async () => {
+  const { registerTmuxPrompt } = await import("./interactions.ts");
+  expect(() => registerTmuxPrompt({
+    taskId: "t-empty-choices", runId: "r1",
+    paneText: "?",
+    choices: [],
+    fingerprint: "fp-empty-choices",
+    unparsable: true,
+  })).not.toThrow();
+});
+
 test("answer* paths emit on the resolved broadcaster", async () => {
   const {
     setResolvedBroadcaster,

--- a/src/bun/interactions.ts
+++ b/src/bun/interactions.ts
@@ -120,6 +120,13 @@ export interface TmuxPromptRequest {
    *  dismissal (the prompt disappeared from the pane). */
   fingerprint: string;
   createdAt: number;
+  /** True when this card is the fallback for a prompt no real matcher
+   *  parsed — `choices` is empty and there's no keystroke path back into
+   *  the pane. The UI renders a distinct "answer it in the terminal" card
+   *  instead of choice buttons; the answer route still accepts only
+   *  `__external__` / `__cancelled__` since there are no real choices to
+   *  validate against. */
+  unparsable?: boolean;
 }
 
 export interface TmuxPromptAnswer {
@@ -276,6 +283,7 @@ export function registerTmuxPrompt(args: {
   choices: TmuxPromptChoice[];
   cursorIndex?: number;
   fingerprint: string;
+  unparsable?: boolean;
 }): { id: string; req: TmuxPromptRequest; answer: Promise<TmuxPromptAnswer> } {
   // Defend the reserved-key namespace — `__external__` / `__cancelled__`
   // must be unambiguously sentinels, not legitimate user keystrokes.
@@ -297,6 +305,7 @@ export function registerTmuxPrompt(args: {
     cursorIndex: args.cursorIndex,
     fingerprint: args.fingerprint,
     createdAt: Date.now(),
+    unparsable: args.unparsable,
   };
   const answer = new Promise<TmuxPromptAnswer>((resolve) => {
     tmuxPrompts.set(id, { req, resolve });

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -5641,7 +5641,7 @@ function TmuxPromptCard({
   // click — the only correct action is handing the user off to the real
   // terminal, where the existing `__external__` sweep notices the prompt
   // was answered and clears this card on its own.
-  if (req.unparsable === true || req.choices.length === 0) {
+  if (req.unparsable === true) {
     const openInTerminal = async () => {
       if (opening) return;
       setOpening(true);
@@ -5651,7 +5651,6 @@ function TmuxPromptCard({
       } catch (e) {
         const msg = e instanceof Error ? e.message : "Could not attach to tmux session";
         setOpenError(msg);
-        toast.error(msg);
       } finally {
         setOpening(false);
       }

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -5538,6 +5538,11 @@ function TmuxPromptCard({
 }) {
   const [submitting, setSubmitting] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Only used by the unparsable-fallback branch below, but declared here
+  // (unconditionally) to satisfy the rules of hooks — this component has
+  // early returns above where these would otherwise live.
+  const [openError, setOpenError] = useState<string | null>(null);
+  const [opening, setOpening] = useState(false);
   const send = async (key: string) => {
     if (submitting) return;
     setSubmitting(key);
@@ -5627,6 +5632,57 @@ function TmuxPromptCard({
           Rejecting dismisses the plan; then describe your changes in the message box below.
         </p>
         {error && <p className="mt-2 text-[11px] text-destructive">{error}</p>}
+      </div>
+    );
+  }
+
+  // Footer-gated / stuck-turn fallback: the scraper saw *something* claude
+  // is blocked on but couldn't parse it into choices. There's nothing to
+  // click — the only correct action is handing the user off to the real
+  // terminal, where the existing `__external__` sweep notices the prompt
+  // was answered and clears this card on its own.
+  if (req.unparsable === true || req.choices.length === 0) {
+    const openInTerminal = async () => {
+      if (opening) return;
+      setOpening(true);
+      setOpenError(null);
+      try {
+        await api.openTmux(req.taskId);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "Could not attach to tmux session";
+        setOpenError(msg);
+        toast.error(msg);
+      } finally {
+        setOpening(false);
+      }
+    };
+    return (
+      <div className="rounded-md border border-warning/60 bg-card p-3 ring-1 ring-warning/40">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-warning">
+            <Terminal className="size-3.5" aria-hidden /> Claude is asking something Agetor can’t read
+          </span>
+        </div>
+        <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/40 bg-muted/40 p-2 font-mono text-[11px] leading-snug">
+          {cleanPromptPane(req.paneText)}
+        </pre>
+        <div className="mt-3 flex items-center justify-end gap-2">
+          <Button
+            onClick={() => void openInTerminal()}
+            size="sm"
+            variant="secondary"
+            disabled={opening}
+          >
+            <Terminal className="mr-1 size-3.5" aria-hidden />
+            {opening ? "Opening…" : "Open in Terminal"}
+          </Button>
+        </div>
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          Answering the prompt in the terminal resolves this card automatically.
+        </p>
+        {openError && (
+          <p className="mt-2 text-right text-[11px] text-destructive">{openError}</p>
+        )}
       </div>
     );
   }

--- a/src/mainview/lib/api.ts
+++ b/src/mainview/lib/api.ts
@@ -216,6 +216,11 @@ export interface PendingTmuxPrompt {
   choices: Array<{ key: string; label: string }>;
   fingerprint: string;
   createdAt: number;
+  /** True when the scraper couldn't parse this modal into choices (footer-
+   *  gated fallback or stuck-turn watchdog) — `choices` is always `[]` in
+   *  that case. The RunPanel renders an "Open in Terminal" fallback card
+   *  instead of choice buttons. */
+  unparsable?: boolean;
 }
 
 export type PendingInteraction =


### PR DESCRIPTION
## Problem

Claude Code prompts that fail all four pane matchers (`matchNumberedModal`, `matchYesNoModal`, `matchStartupConsentDialog`, `detectAskModal`) surfaced **nothing** in the RunPanel — the scrape tick exited silently while claude sat blocked. At boot it was worse: an unmatched startup prompt stranded the run until the 30s JSONL timeout killed it.

Concrete trigger: claude 2.1.234's new **"Set up auto mode for your environment?"** startup wizard — an unnumbered arrow-key widget (`◂ Mixed ▸` selector, `[ ]` checkboxes, footer `←/→ to change usage · Enter to continue · Esc to cancel`). No numbered lines, no `(y/n)` tail, not an AskUserQuestion, and not a consent dialog agetor may auto-answer (scanning shell history is the user's privacy call).

## What changed

**Detection (`src/bun/claude-tmux.ts`)** — new `matchUnparsableModal`, tried as the *final* `??` arm after the existing matchers (parseable modals always win; AskUserQuestion suppression and the `askFallbackAllowed` give-up latch are respected). Two arms:

- **Footer arm**: one of the last 3 non-blank tail lines matches `MODAL_FOOTER_RE` (`esc to cancel` / `enter to confirm` / `enter to continue` — evidence-backed phrasings only).
- **Stuck-turn watchdog**: pure `stuckTurnFallbackArmed()` — turn in flight, JSONL quiet >60s, no `esc to interrupt` spinner (shared `SPINNER_RE`), no ask card live. The version-proof net for footerless future prompts.

Matches are never `highConfidence` — a fallback card always needs two-tick fingerprint stability, so repaint/paste transients can't flash one. The fingerprint strips blank + volatile lines **before** taking the trailing window; a raw slice let a fluctuating trailing blank row jitter the hash on window-saturating modals (exactly the auto-mode wizard), which would have kept the two-tick gate from ever converging.

**Boot coverage** — the boot poller now registers the same fallback card for unmatched prompt panes and sets `sawStartupPromptThisWindow`, so the 30s boot window **re-arms** while the prompt is up instead of killing the run.

**Card (`RunPanel.tsx`, `interactions.ts`, `api.ts`)** — the fallback rides the existing `tmux_prompt` interaction with `unparsable: true` + `choices: []`, inheriting SSE broadcast, notifications, composer gating (`modalPending`), and `__external__` auto-resolution for free. The card shows the cleaned pane text and one action — **Open in Terminal** — reusing the existing `POST /tasks/:id/open-tmux` Terminal.app attach. Answering in the terminal resolves the card automatically.

## Tests

17 new tests (`claude-tmux-scraper.test.ts`, `interactions.test.ts`): the real 2.1.234 wizard pane as canonical fixture (all existing matchers null, fallback fires), fingerprint stability across trailing blanks/spinner lines (regression guard for the window-saturation bug), negative panes (idle input box, working spinner, transcript prose quoting a footer phrase), matcher-precedence pinning, the watchdog truth table, two-tick gate behavior, and registry round-trip/`__external__` resolution for the new flag.

Full suite: 2946 pass / 1 fail — the failure is a pre-existing wall-clock flake on `main` (`claude-tmux-queue` "non-image bracketed paste" 500ms budget), reproduced failing at the base commit `295d91e` in a clean worktree; unrelated to this branch.

## Notes for reviewers

- The auto-mode wizard deliberately gets **no** dedicated matcher/auto-answer: it's a user privacy choice and too widget-rich to drive remotely — the fallback card *is* its designed handler.
- `MODAL_FOOTER_RE` is an evidence-only allow-list (a false positive gates the composer); don't extend it without a captured pane. The watchdog arm covers what the list misses.
- Manual smoke (live tmux isn't exercised by the suite): run a claude task via `bun run dev` (`~/.agetor-dev`) in a fresh worktree where the wizard appears; the card should show at boot and Attach should open Terminal.app.