### PR TITLE
fix: stop the unparsable-prompt fallback card flickering Answer↔Run on Claude Code 2.1.239

### DIFF
--- a/docs/plans/unknown-tui-detection-flicker.md
+++ b/docs/plans/unknown-tui-detection-flicker.md
@@ -1,0 +1,260 @@
+# Plan — Fix false-positive "unknown Claude Code TUI" fallback card flicker
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-22 |
+| Source | User request: "fix the unknown Claude Code TUI warning that is wrongly detecting normal messaging for a fraction of time which is making the card flickering between the `answer` status and the `run` status" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Flags | none |
+| Gates | grill dismissed by owner (no answer) → self-resolved autonomously; decisions recorded in §8 |
+| Branch | fix/fix-unknown-tui-detection (already checked out) |
+| Base SHA | 1e5f65491e9f059a29da52bedee0604df98e5139 (tree clean) |
+
+## 1. Objective & success criteria
+
+The #185 fallback card (`matchUnparsableModal`, "Claude is asking something Agetor can't
+read") must stop registering during **normal** Claude Code 2.1.239 activity, which today
+makes the board card flip between the **Answer** state (amber ring / `pendingInteractionCount`)
+and **Run**, and fires a spurious native "waiting on you" notification each flip.
+
+Success:
+- No fallback card (and no notification) registers while a turn is working normally:
+  streaming, thinking, running a tool (incl. long shells), or waiting on background agents —
+  even across the long JSONL-quiet windows those produce.
+- A genuinely unknown/unparsable **prompt** (the 2.1.234+ auto-mode wizard, a footer-bearing
+  modal no matcher parses) still surfaces the card, at boot and mid-session.
+- Usage-limit **auto-continue** notices (`Usage limit reached · continuing automatically …
+  · esc to cancel`) do not surface a card — nothing for the user to answer; claude resumes
+  itself.
+- `bun run typecheck` green; `bun test` green (modulo the known pre-existing flake noted in
+  the fleet's claude-tmux-queue timing note); new 2.1.239 fixtures assert both the
+  non-firing (normal work) and firing (real wizard) cases.
+
+## 2. Context & constraints (Phase 1 findings — all with evidence)
+
+Live evidence: 4 running agetor sessions watched read-only for ~9 min (555 ticks), plus 6
+throwaway claude **2.1.239** tmux sessions (~190 deduped frames) covering idle, argv turn,
+pasted follow-up, queued-while-busy follow-up, long `sleep` shell, background-Agent wait,
+AskUserQuestion mid-turn, auto + manual modes. Installed claude is **2.1.239**; the running
+release build is Agetor 0.1.1 with the #185 code bundled (verified the shipped
+`MODAL_FOOTER_RE`/`SPINNER_RE`/`STUCK_TURN_FALLBACK_MS` in `bun/index.js`).
+
+- **The registration→resolution path** (`src/bun/claude-tmux.ts:3921-4118`): `scrapeOnce`
+  runs each `SCRAPE_INTERVAL_MS` (1s). `claudeIsWriting` = JSONL appended < `JSONL_RECENT_WRITE_MS`
+  (500ms) ago (`:3982`). The match chain is
+  `matchNumberedModal ?? matchYesNoModal ?? matchUnparsableModal(tail, stuckTurnFallbackArmed(...))`
+  (`:4041-4049`), forced null while `claudeIsWriting` or an ask "question" modal is on-pane.
+  The **`__external__` auto-cancel sweep** (`:4051-4060`) runs **every tick** — including
+  `claudeIsWriting` ticks where match is null — and resolves any registered prompt whose
+  fingerprint isn't the current match. So register (2 lucky consecutive-tick matches) →
+  next JSONL write / pane change → sweep resolves ≈ 1s later → **flicker**. The two-tick
+  gate (`clearedStabilityGate`, `:3513`) needs the **same fingerprint on two consecutive
+  ticks**; `scrapeLastFingerprint` resets to null on any null-match tick (`:4072`).
+- **Board effect** (why it reads as answer↔run): registering a `tmux_prompt` never changes
+  `task.column`; it bumps `pendingInteractionCount` (`db.ts:286` ← `interactions.ts` counts,
+  incl. `unparsable`). `TaskCard.tsx:53-67` renders `awaiting` (amber ring + "Answer") when
+  `pendingCount>0`. `App.tsx:609-635` optimistically increments on the `interaction` SSE
+  `pending` event **and** fires `notifyWaitingInput` on the first pending interaction — so
+  each spurious registration is also a native notification.
+- **Stale TUI signals (the core drift).** `SPINNER_RE=/esc to interrupt/i` (`:3889`) and
+  `VOLATILE_PANE_LINE_RE=esc to interrupt|^\s*Tip:` (`:3896`) no longer describe 2.1.239:
+  - Working indicator is now a **ticking spinner line**: `✽ Frosting… (2m 52s · ↓ 12.1k
+    tokens)`, `✻ Cooked for 2m 18s`, `✻ Brewed for 9s · 1 shell still running`,
+    `✻ Waiting for 1 background agent to finish` (glyph cycles `✻ ✽ ✶ ✳ ✢ ·`).
+  - `esc to interrupt` moved into the **status bar** (`⏵⏵ auto mode on (shift+tab to cycle)
+    · esc to interrupt · ← 1 agent`) and **blinks on/off at ~1 Hz** (watcher logged it
+    toggling `true→false→true` every tick). During background-agent waits and long tool
+    calls it is **absent for the whole window** while JSONL is silent.
+  - Consequence A — **watchdog false-fires**: `stuckTurnFallbackArmed` (`:3572`) = turnInFlight
+    && jsonlQuiet>60s && `!tailHasSpinner` && !askCardLive. Normal long-quiet turns satisfy
+    all four (my Fable/auto session: **9 JSONL gaps >60s in 25 min**; bg-agent wait shows no
+    `esc to interrupt` at all). → a working turn is flagged "stuck" → card.
+  - Consequence B — **fingerprint/activity jitter**: the animated glyph + `(… · ↓ N tokens)`
+    counter line is not in `VOLATILE_PANE_LINE_RE`, so it changes the fallback fingerprint
+    and the activity diff tick-to-tick.
+- **Footer arm is clean for real prompts, but catches notices.** Across all normal-work
+  frames, **no** frame carried a `MODAL_FOOTER_RE` phrase in its last 3 non-blank lines; a
+  real modal (AskUserQuestion, permission) or wizard **replaces** the status bar. The only
+  normal-session strings matching `MODAL_FOOTER_RE` are usage-limit notices — from the
+  2.1.239 binary: `Usage limit reached · continuing automatically at <t> · esc to cancel`,
+  `… continuing shortly · esc to cancel`, `… continuing automatically when it resets · esc
+  to cancel`, and `Usage limit has reset · press enter to continue`. The first three are
+  **auto-continue** (nothing to answer).
+- **AskUserQuestion is NOT the flicker source.** `detectAskModal` (needs `Chat about this`
+  + `Esc to cancel`) drives the structured-card path and suppresses the generic matchers
+  while a question modal is on-pane; the `WOULD-FIRE footer=true` hits the watcher logged
+  were exactly such a modal (this session's own grill), which the real scraper suppresses.
+- **Runnability**: `bun run typecheck`, `bun test`, per-file
+  `bun test src/bun/claude-tmux-scraper.test.ts` (54 pass standalone; auto-mkdtemps its own
+  `AGETOR_DATA_DIR`). No e2e harness; convention is pane-string fixtures + pure-function
+  gates. `bun` is at `~/.bun/bin/bun`; tmux/claude at `/opt/homebrew/bin/tmux`,
+  `~/.local/bin/claude`. Manual smoke only against `~/.agetor-dev` (never prod `~/.agetor`).
+- **Existing tests**: `claude-tmux-scraper.test.ts` (~lines 524-788) exercise
+  `matchUnparsableModal`/`stuckTurnFallbackArmed`/`MODAL_FOOTER_RE` with inline pane strings;
+  none drive `scrapeOnce` across a working↔quiet transition (the actual flicker path is
+  uncovered). `interactions.test.ts` covers the `unparsable` flag + `__external__` resolve.
+
+## 3. Approach & key decisions
+
+The fix is entirely inside the scraper's detection logic in `src/bun/claude-tmux.ts` +
+its test file. No UI, interactions, orchestrator, or contract change (the card renders fine;
+the defect is that it should never have registered). Four coordinated changes:
+
+1. **Sync a `WORKING_LINE_RE` to 2.1.239** (evidence-backed, extensible like `MODAL_FOOTER_RE`)
+   recognizing claude is busy on the pane: the ticking-spinner line (a leading spinner glyph
+   from `✻✽✶✳✢·` followed by a word and `…`, OR `<Word> for <n>s`/`(…s · … tokens)` elapsed
+   forms), `Waiting for N background agent`, `N shell[s] still running`/`· N shell`, and the
+   legacy `esc to interrupt`. Fold it into `VOLATILE_PANE_LINE_RE` (so the animated
+   spinner/counter never jitters fingerprints or the activity diff) and expose a pure
+   `paneShowsClaudeWorking(tail: string): boolean`. Decision: keep `SPINNER_RE` as one input,
+   but stop treating `esc to interrupt` as the *sole* busy signal — its 1 Hz blink is exactly
+   what makes the current guard unreliable.
+2. **Gate both fallback arms on `!paneShowsClaudeWorking(tail)`.** The footer arm and the
+   watchdog arm only fire when the pane shows claude is *not* visibly working. This kills the
+   watchdog false-positive on background-agent waits and long tool calls (they now read as
+   working) and hardens the footer arm against a stray phrase during a working frame. Rests
+   on the measured fact that a real prompt/wizard replaces the working chrome (§2), so the
+   gate can't hide a genuine prompt.
+3. **Raise unparsable stability to ≥3 consecutive ticks** (from 2). Add a small
+   `scrapeUnparsableStreak` counter in `SessionState`: increment when this tick's unparsable
+   fingerprint equals last tick's, reset on any change/non-match; register only at
+   `UNPARSABLE_STABILITY_TICKS` (3). Real prompts sit on screen for many seconds, so this is
+   free for true positives but defeats a 1–2 tick blip. (Parseable numbered/yes-no/ask paths
+   are untouched — they keep their existing gates and high-confidence fast path.)
+4. **Exclude usage-limit auto-continue notices.** A `MODAL_NOTICE_RE`
+   (`/continuing automatically|continuing shortly|continuing now/i`) that, when present in the
+   footer window, vetoes the footer arm — claude resumes itself, nothing to answer. Decision
+   (§8): keep `Usage limit has reset · press enter to continue` eligible (it is genuinely
+   actionable), suppress only the auto-continue variants.
+
+The watchdog arm is **kept, not removed**: with gate (2) applied it still catches a genuinely
+wedged, footerless TUI (no working chrome, no JSONL, quiet past threshold) — its original
+purpose — without firing on the normal long-quiet turns that were the false-positive source.
+Threshold left at 60s (gate (2) already removes the false positives; raising it would only
+delay a true catch).
+
+Boot poller (`:4894`) already passes `watchdogArmed=false`; add the same
+`!paneShowsClaudeWorking` guard + notice veto to its footer-arm call so boot behaves
+identically (a real startup wizard has no working chrome, so it still surfaces).
+
+## 4. Work breakdown — implementation tasks
+
+**Wave 1 — single task (localized, one file; no parallel fan-out warranted).**
+- **T1 — Detection sync + arm gating.** Owns `src/bun/claude-tmux.ts` only.
+  - Add `WORKING_LINE_RE` + `MODAL_NOTICE_RE` (evidence comments citing the 2.1.239 forms in
+    §2); refactor `VOLATILE_PANE_LINE_RE` to include `WORKING_LINE_RE`; add pure
+    `paneShowsClaudeWorking(tail)`.
+  - Gate the runtime match chain (`:4041-4049`) footer+watchdog behind `!paneShowsClaudeWorking`
+    and the notice veto; thread the same into the boot poller (`:4894`).
+  - Replace `matchUnparsableModal`'s implicit 2-tick reliance with the `scrapeUnparsableStreak`
+    ≥3 gate: add `scrapeUnparsableStreak: number` to `SessionState` (init 0 where the other
+    scrape fields init), increment/reset in `scrapeOnce`, register only at the threshold; keep
+    the `unparsable` match itself never `highConfidence`.
+  - Keep `stuckTurnFallbackArmed`'s signature stable but change its `tailHasSpinner` input to
+    the broader `paneShowsClaudeWorking` at the call site (or add a `paneWorking` param) — do
+    not silently drift the two.
+  - Export new pieces (`WORKING_LINE_RE`, `MODAL_NOTICE_RE`, `paneShowsClaudeWorking`,
+    `UNPARSABLE_STABILITY_TICKS`) in `__forTest`.
+  - Acceptance: typecheck green; auto-mode wizard still registers; a bg-agent-wait / long-shell
+    / ticking-spinner pane never registers; numbered/yes-no/ask precedence unchanged.
+
+## 5. Work breakdown — test tasks
+
+**Wave 2 — single task (after T1 lands `__forTest` exports).**
+- **T2 — Scraper tests + 2.1.239 fixtures.** Owns `src/bun/claude-tmux-scraper.test.ts`
+  (+ any new fixture strings inline, matching the file's convention).
+  - `paneShowsClaudeWorking` truth table over real 2.1.239 forms: ticking spinner
+    (`✽ Frosting… (2m52s · ↓12.1k tokens)`), `✻ Cooked for 2m18s`, `✻ Waiting for 1
+    background agent to finish`, `✻ Brewed for 9s · 1 shell still running`, status-bar
+    `esc to interrupt`; false on an idle input-box pane and on the auto-mode wizard.
+  - Footer arm: does **not** fire on any working pane above; does **not** fire on
+    `Usage limit reached · continuing automatically at 8am · esc to cancel`; **does** fire on
+    the auto-mode wizard and on a footer-bearing unknown modal with no working chrome.
+  - Watchdog arm: `stuckTurnFallbackArmed`/`paneShowsClaudeWorking` combination — a
+    bg-agent-wait pane (turn in flight, jsonl quiet >60s) does **not** arm because the pane
+    shows working; a truly blank/wedged pane still arms.
+  - Stability: an unparsable match needs 3 consecutive equal-fingerprint sightings; a 1–2
+    tick blip never registers. (Drive via the exported streak helper or a minimal
+    `scrapeOnce` seam if one exists; otherwise assert the pure gate.)
+  - Regression: fingerprint stable across the animated glyph + token-counter changing between
+    ticks (now stripped by the widened `VOLATILE_PANE_LINE_RE`).
+  - Keep the existing 15 fallback tests passing (adjust only where behavior deliberately
+    changed, with a comment explaining why).
+
+**E2e: not applicable.** No e2e harness; the scraper's contract is pane-string fixtures +
+pure gates. Manual smoke (owner, later): run a claude task in `~/.agetor-dev`, drive a long
+tool call / background-agent wave, confirm no flicker; trigger the auto-mode wizard, confirm
+the card still appears.
+
+## 6. Execution waves
+
+1. Wave 1: T1 (implementation runner = sonnet).
+2. Review (opus): diff vs base `1e5f654`; rubric incl. "does the working-gate ever hide a
+   real prompt?" and precedence of parseable matchers.
+3. Wave 2: T2 (tests runner = sonnet).
+4. Run (haiku / direct): `bun run typecheck` + `bun test src/bun/claude-tmux-scraper.test.ts`
+   + `bun test src/bun/interactions.test.ts`, then full `bun test`. Fix loop as needed (≤3
+   rounds).
+
+## 7. Blast radius & risks
+
+- **Under-firing (new risk we accept small)**: gate (2) could suppress a real prompt if a
+  genuine prompt ever co-rendered with working chrome. Measured false: a real prompt replaces
+  the status bar. Mitigation: the watchdog (still present) catches a footerless wedge; the
+  footer arm still fires the instant working chrome clears.
+- **`WORKING_LINE_RE` breadth**: too broad and it could mask a real modal that happens to
+  contain a matched word. Mitigation: anchor the spinner form on the leading glyph + `…`/
+  elapsed pattern, and keep it evidence-backed (comment each phrase to a captured 2.1.239
+  frame), exactly like `MODAL_FOOTER_RE`.
+- **Fingerprint change**: widening `VOLATILE_PANE_LINE_RE` changes `normalizePaneForActivity`
+  and the fallback fingerprint — intended (kills jitter), but re-confirm the reaper's activity
+  diff still bumps on real transcript changes (a working line stripped, real content not).
+- **Version-proofing**: 2.1.240+ may rename spinners again; the watchdog arm + the evidence
+  comment (add-a-phrase-with-a-captured-pane rule) are the maintenance contract.
+- Files churned since #185 (`1e5f654`/#189 RunPanel, `2f2316b`/#188, `c141b73`/#187) do not
+  touch the scraper matchers — no conflict.
+
+## 8. Open questions / assumptions — self-resolved (owner dismissed the grill)
+
+| Question | Answer | Source | Confidence |
+| --- | --- | --- | --- |
+| What is claude doing when the card flickers? | Normal work: mid-turn streaming/tool, and especially background-agent waits / long tool calls (long JSONL-quiet windows). | Live watcher + JSONL gap stats (9 gaps >60s/25min); watchdog-arm analysis | High |
+| Is AskUserQuestion the trigger? | No — `detectAskModal` suppresses it; the observed `WOULD-FIRE` was a real ask modal the production scraper suppresses. | Source + watcher | High |
+| Suppress usage-limit auto-continue notice? | Yes — no user action; keep `press enter to continue` eligible. | 2.1.239 binary strings; recommended option | Med-High |
+| Remove the watchdog arm entirely? | No — keep it, but gate on `paneShowsClaudeWorking` so it only catches a true footerless wedge. Removing it would drop the only net for footerless unknown prompts. | Design judgment | Medium |
+| Raise the 60s watchdog threshold? | No — gate (2) removes the false positives; a higher threshold would only slow a real catch. | Design judgment | Medium |
+| Change the card copy/UX? | No — complaint is false-firing, not copy. Out of scope. | Request scope | High |
+
+**No one-way doors**: no data migration, no public API/contract change, no auth/tenancy
+change — all changes are reversible detection-logic edits behind tests.
+
+## 10. Post-review addendum (2026-08-22)
+
+Two review passes ran on the implementation (opus sub-agent, then `/code-review`); every
+valid finding was applied and re-verified. Net changes on top of §3:
+
+- **Notice veto window** — `MODAL_NOTICE_RE` is checked over the card's own 12-line
+  stripped window (`paneLines`), not the last 3 lines: claude draws notice-class lines in
+  the hint slot *above* the input box (5 non-blank rows from the bottom for the observed
+  weekly-limit hint), outside the footer window but inside the card's. The veto is an early
+  return before **both** arms (a footer-only veto let the 60 s watchdog still card a
+  mid-turn limit pause). `press enter to continue` in that slot reaches the user via the
+  watchdog arm, not instantly — documented on `MODAL_NOTICE_RE`.
+- **Bounded working-chrome window** — `paneShowsClaudeWorking` inspects only the last
+  `WORKING_CHROME_WINDOW_LINES` (16) non-blank lines (the widget area; deepest live capture
+  was 13 with 4 background agents), so transcript text that merely resembles chrome (a tool
+  result echoing a pane, prose like `· 3 shell scripts`, `Waiting for 2 background agents`)
+  can't hide a real prompt rendered below it. Every arm is also anchored to its chrome
+  shape (leading `SPINNER_GLYPH`; spinner `…` must be followed by `(` or EOL; status-bar
+  shell item must be `·`-delimited).
+- **Elapsed spinner form** added (`✻ Cooked for 2m 18s`), `SPINNER_RE` deleted, shared
+  fragments (`ESC_TO_INTERRUPT`, `SPINNER_GLYPH`, `SPINNER_ACTIVE_LINE`,
+  `SPINNER_ELAPSED_LINE`, `TOKEN_COUNTER_LINE`) are the single source of truth for both
+  `WORKING_LINE_RE` and `VOLATILE_PANE_LINE_RE`.
+- **Streak logic extracted** into pure `nextUnparsableStreak` / `unparsableStreakCleared`
+  (exported via `__forTest`) and driven by sequence tests (A,A,A registers on the 3rd;
+  A,B,A and A,A,∅,A,A never; 1–2-tick blips never).
+
+Verification after the addendum: `bun run typecheck` clean; scraper file 84 pass / 0 fail;
+interactions 22 pass; full suite green (see final report). Manual smoke in `~/.agetor-dev`
+remains the owner's step.

--- a/src/bun/claude-tmux-scraper.test.ts
+++ b/src/bun/claude-tmux-scraper.test.ts
@@ -19,6 +19,13 @@ const {
   stuckTurnFallbackArmed,
   MODAL_FOOTER_RE,
   STUCK_TURN_FALLBACK_MS,
+  WORKING_LINE_RE,
+  MODAL_NOTICE_RE,
+  paneShowsClaudeWorking,
+  WORKING_CHROME_WINDOW_LINES,
+  UNPARSABLE_STABILITY_TICKS,
+  nextUnparsableStreak,
+  unparsableStreakCleared,
 } = __forTest;
 
 /** Real tmux pane captures of claude-code 2.1.161's AskUserQuestion modal —
@@ -720,7 +727,7 @@ const ALL_ARMED = {
   turnInFlight: true,
   lastJsonlAppendAt: WATCHDOG_NOW - STUCK_TURN_FALLBACK_MS - 1,
   now: WATCHDOG_NOW,
-  tailHasSpinner: false,
+  paneWorking: false,
   askCardLive: false,
 };
 
@@ -750,8 +757,12 @@ test("stuckTurnFallbackArmed — quiet one ms past the threshold → armed", () 
   })).toBe(true);
 });
 
-test("stuckTurnFallbackArmed — working spinner present → not armed (busy, not stuck)", () => {
-  expect(stuckTurnFallbackArmed({ ...ALL_ARMED, tailHasSpinner: true })).toBe(false);
+test("stuckTurnFallbackArmed — pane shows claude working → not armed (busy, not stuck)", () => {
+  // No longer spinner-specific: `paneWorking` is `paneShowsClaudeWorking(tail)`,
+  // which stays true across a working turn's quiet-JSONL windows (background
+  // agent waits, long tool calls, elapsed-summary spinners) — not just while
+  // the 1 Hz-blinking "esc to interrupt" text happens to be on-screen.
+  expect(stuckTurnFallbackArmed({ ...ALL_ARMED, paneWorking: true })).toBe(false);
 });
 
 test("stuckTurnFallbackArmed — an ask card/collection is already live → not armed (owns its own give-up ladder)", () => {
@@ -785,4 +796,328 @@ test("clearedStabilityGate — an unparsable match never has highConfidence, so 
   expect(clearedStabilityGate(m, "some-other-fingerprint")).toBe(false);
   // Same fingerprint on the second consecutive tick → clears.
   expect(clearedStabilityGate(m, m.fingerprint)).toBe(true);
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 2.1.239 hardening — docs/plans/unknown-tui-detection-flicker.md §5.
+//
+// The #185 fallback card was flickering during NORMAL claude-code 2.1.239
+// activity (streaming, tool calls, background-agent waits): the working
+// indicators the old `SPINNER_RE=/esc to interrupt/i` guard relied on moved
+// (status-bar `esc to interrupt` now blinks at ~1 Hz and is absent for whole
+// quiet-JSONL windows during a bg-agent wait or long tool call) or changed
+// shape (a ticking spinner glyph + elapsed/token-counter line). This section
+// covers: (A) `paneShowsClaudeWorking`'s truth table against real captured
+// 2.1.239 panes, (B) `MODAL_NOTICE_RE`'s usage-limit auto-continue veto on
+// BOTH matchUnparsableModal arms, (C) that the veto/gate doesn't over-
+// suppress genuinely actionable notices or the existing wizard fixture, (D)
+// that the working-gate — not the matcher itself — is what suppresses a
+// footer-bearing pane that also shows working chrome (mirrors scrapeOnce's
+// real `paneShowsClaudeWorking(tail) ? null : matchUnparsableModal(...)`
+// dispatch), (E) fingerprint stability across the new volatile forms, and
+// (F) the raised 3-tick stability constant.
+
+// ── A. paneShowsClaudeWorking truth table ──────────────────────────────────
+
+const WORKING_PANE_LINES = [
+  // Present-participle spinner (glyph + word + ellipsis).
+  "✽ Frosting… (2m 52s · ↓ 12.1k tokens)",
+  // Dot-glyph spinner — `·` doubles as the spinner glyph here, not just a
+  // mid-line separator; the leading-anchor is what makes this safe (see the
+  // prose-bullet false case below).
+  "· Prestidigitating… (1h 21m 31s · ↓ 259.0k tokens)",
+  // Elapsed summary — no ellipsis, just "<Word> for <n><unit>".
+  "✻ Cooked for 2m 18s",
+  // Elapsed + a live shell.
+  "✻ Brewed for 9s · 1 shell still running",
+  // Background-agent wait — the only normal-work window with NO ticking
+  // spinner line at all; this phrase is what covers it.
+  "✻ Waiting for 1 background agent to finish",
+  // Status-bar interrupt (auto mode) — the legacy signal, now 1 Hz-blinking,
+  // kept as one input among several rather than the sole gate.
+  "  ⏵⏵ auto mode on (shift+tab to cycle) · esc to interrupt · ← 1 agent",
+  // Background-agent roster row — ticking token counter, no spinner glyph.
+  "  ◯ general-purpose  W2-A launch-path persistence  10s · ↓ 46.2k tokens",
+  // Status-bar shell count (no "esc to interrupt" on this particular frame).
+  "  ⏵⏵ auto mode on · 1 shell · ← 1 agent · ↓ to manage",
+];
+
+for (const line of WORKING_PANE_LINES) {
+  test(`paneShowsClaudeWorking — true for 2.1.239 working chrome: ${JSON.stringify(line)}`, () => {
+    expect(paneShowsClaudeWorking(line)).toBe(true);
+    // Also true when the line sits inside a fuller pane tail.
+    expect(paneShowsClaudeWorking(`some prior line\n${line}\nsome later line`)).toBe(true);
+  });
+}
+
+const IDLE_INPUT_BOX_PANE = `╭────╮
+│ >  │
+╰────╯
+  ? for shortcuts · ← for agents`;
+
+test("paneShowsClaudeWorking — false for the idle input-box pane", () => {
+  expect(paneShowsClaudeWorking(IDLE_INPUT_BOX_PANE)).toBe(false);
+});
+
+test("paneShowsClaudeWorking — false for the auto-mode wizard fixture (fallback must still fire for it)", () => {
+  // This is the safety property the whole gate rests on: a real prompt/wizard
+  // REPLACES the working chrome rather than co-rendering with it, so gating
+  // the fallback on `!paneShowsClaudeWorking` can never hide this fixture.
+  expect(paneShowsClaudeWorking(AUTO_MODE_WIZARD_PANE)).toBe(false);
+});
+
+test("paneShowsClaudeWorking — false for a prose bullet that merely starts with the '·' glyph", () => {
+  // Regression for the over-match the review caught: the dot-glyph spinner
+  // form requires an ellipsis (`…`) right after the leading word, and the
+  // elapsed form requires `\d+` immediately followed by `s`/`m`/`h` (no
+  // space). "for 3 reasons" has neither — the digit is followed by a space,
+  // not a unit letter — so ordinary prose starting with "· " must not read
+  // as a spinner.
+  expect(paneShowsClaudeWorking("  · Something worth noting for 3 reasons below")).toBe(false);
+});
+
+test("paneShowsClaudeWorking — false for prose that merely mentions tokens", () => {
+  // Regression for the over-match the review caught: TOKEN_COUNTER_LINE is
+  // anchored to a `·`/arrow separator immediately before the count, so plain
+  // prose mentioning "tokens" (no `·↓`/`·↑` glyph) must not match.
+  expect(paneShowsClaudeWorking("The response used about 5 tokens total, roughly.")).toBe(false);
+});
+
+test("paneShowsClaudeWorking — false for the idle manual-mode status bar", () => {
+  expect(paneShowsClaudeWorking("  ⏸ manual mode on · ? for shortcuts · ← 1 agent")).toBe(false);
+});
+
+test("WORKING_LINE_RE — sanity: still matches the legacy 'esc to interrupt' status-bar phrase directly", () => {
+  expect(WORKING_LINE_RE.test("esc to interrupt")).toBe(true);
+  expect(WORKING_LINE_RE.test("nothing to see here")).toBe(false);
+});
+
+test("paneShowsClaudeWorking — transcript prose that merely RESEMBLES working chrome stays false", () => {
+  // Regression for the review finding: every arm is anchored to the chrome
+  // shape it came from, so look-alike prose in the transcript can't read as
+  // working (and thereby hide a genuine prompt rendered below it).
+  expect(paneShowsClaudeWorking("  · 3 shell scripts were updated")).toBe(false); // status-bar arm needs `· N shell ·`/EOL
+  expect(paneShowsClaudeWorking("Waiting for 2 background agents to report back.")).toBe(false); // needs the leading spinner glyph
+  expect(paneShowsClaudeWorking("· Loading… more text follows")).toBe(false); // spinner arm needs `(` or EOL after `…`
+  // …while the real chrome shapes those guards protect still read as working.
+  expect(paneShowsClaudeWorking("✻ Waiting for 1 background agent to finish")).toBe(true);
+  expect(paneShowsClaudeWorking("  ⏵⏵ auto mode on · 1 shell · ← 1 agent · ↓ to manage")).toBe(true);
+  expect(paneShowsClaudeWorking("✻ Determining…")).toBe(true); // bare spinner, no parenthetical yet
+  expect(paneShowsClaudeWorking("✳ Compacting… (esc to interrupt)")).toBe(true);
+});
+
+test("paneShowsClaudeWorking — only inspects the bottom widget area (last WORKING_CHROME_WINDOW_LINES non-blank lines), not the scrollback transcript", () => {
+  expect(WORKING_CHROME_WINDOW_LINES).toBe(16);
+  // A tool result that echoes claude chrome (an agent inspecting tmux panes —
+  // agetor dogfooding) sits in the TRANSCRIPT, well above a real wizard that
+  // then renders below it. Before the window was bounded, that echo gated the
+  // fallback off for as long as it stayed inside the 40-line scrape tail.
+  const echoedChromeAboveWizard =
+    "  ⎿  status: ⏵⏵ auto mode on · esc to interrupt · ← 1 agent\n"
+    + Array.from({ length: 20 }, (_, i) => `transcript line ${i + 1}`).join("\n")
+    + "\n" + AUTO_MODE_WIZARD_PANE;
+  expect(paneShowsClaudeWorking(echoedChromeAboveWizard)).toBe(false);
+  // …and the real scrapeOnce dispatch therefore still cards the wizard.
+  const dispatched = paneShowsClaudeWorking(echoedChromeAboveWizard)
+    ? null
+    : matchUnparsableModal(echoedChromeAboveWizard, false);
+  expect(dispatched).not.toBeNull();
+  expect(dispatched!.unparsable).toBe(true);
+  // Boundary: a working line exactly WORKING_CHROME_WINDOW_LINES non-blank
+  // lines from the bottom is still seen; one line further up is not. The
+  // deepest live widget area captured (4 background agents) was 13 rows, so
+  // 16 keeps every real form inside the window.
+  const filler = (n: number) => Array.from({ length: n }, (_, i) => `row ${i + 1}`).join("\n");
+  const working = "  ⏵⏵ auto mode on (shift+tab to cycle) · esc to interrupt · ← 1 agent";
+  expect(paneShowsClaudeWorking(`${working}\n${filler(WORKING_CHROME_WINDOW_LINES - 1)}`)).toBe(true);
+  expect(paneShowsClaudeWorking(`${working}\n${filler(WORKING_CHROME_WINDOW_LINES)}`)).toBe(false);
+  // Blank rows don't count toward the window (tmux pads the capture).
+  expect(paneShowsClaudeWorking(`${working}\n\n\n\n${filler(WORKING_CHROME_WINDOW_LINES - 1)}`)).toBe(true);
+});
+
+// ── B. MODAL_NOTICE_RE veto — both matchUnparsableModal arms ───────────────
+
+test("matchUnparsableModal — usage-limit auto-continue notice is vetoed on the footer arm", () => {
+  const m = matchUnparsableModal(
+    "Usage limit reached · continuing automatically at 8am · esc to cancel",
+    false,
+  );
+  expect(m).toBeNull();
+});
+
+test("matchUnparsableModal — usage-limit auto-continue notice is ALSO vetoed on the watchdog arm (the must-fix from review)", () => {
+  // A mid-turn limit pause keeps the turn in flight and the pane quiet, which
+  // would otherwise arm the stuck-turn watchdog — so the notice veto has to
+  // apply regardless of which arm would have fired.
+  const m = matchUnparsableModal(
+    "Usage limit reached · continuing automatically at 8am · esc to cancel",
+    true,
+  );
+  expect(m).toBeNull();
+});
+
+test("matchUnparsableModal — 'continuing shortly' variant is also vetoed on the watchdog arm", () => {
+  const m = matchUnparsableModal(
+    "Usage limit reached · continuing shortly · esc to cancel",
+    true,
+  );
+  expect(m).toBeNull();
+});
+
+test("MODAL_NOTICE_RE — matches both auto-continue phrasings, not the actionable reset notice", () => {
+  expect(MODAL_NOTICE_RE.test("continuing automatically")).toBe(true);
+  expect(MODAL_NOTICE_RE.test("continuing shortly")).toBe(true);
+  expect(MODAL_NOTICE_RE.test("press enter to continue")).toBe(false);
+});
+
+// ── C. Still-cards cases (veto/gate must not over-suppress) ────────────────
+
+test("matchUnparsableModal — 'Usage limit has reset · press enter to continue' is never vetoed (genuinely actionable)", () => {
+  // Carries a MODAL_FOOTER_RE phrase ("enter to continue") and no
+  // MODAL_NOTICE_RE phrase ("has reset" is not an auto-continue notice) — the
+  // veto must not sweep this one up along with the auto-continue variants.
+  // Drawn as the bottom line it fires the footer arm outright …
+  const bottom = matchUnparsableModal("Usage limit has reset · press enter to continue", false);
+  expect(bottom).not.toBeNull();
+  expect(bottom!.unparsable).toBe(true);
+  // … but claude draws notice-class lines in the HINT SLOT above the input
+  // box (observed 5 non-blank lines from the bottom for the weekly-limit
+  // hint), which is outside the footer arm's last-3 window. There it reaches
+  // the user via the watchdog arm instead — the turn is still in flight, the
+  // pane is quiet, nothing shows working — so assert exactly that split, not
+  // an instant footer-arm card the real rendering can't deliver.
+  const hintSlot = `⏺ Working on it.
+
+          Usage limit has reset · press enter to continue
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  ⏵⏵ auto mode on (shift+tab to cycle) · ← 1 agent`;
+  expect(paneShowsClaudeWorking(hintSlot)).toBe(false);
+  expect(matchUnparsableModal(hintSlot, false)).toBeNull(); // footer arm can't see it
+  const viaWatchdog = matchUnparsableModal(hintSlot, true);
+  expect(viaWatchdog).not.toBeNull(); // watchdog arm: NOT vetoed
+  expect(viaWatchdog!.unparsable).toBe(true);
+});
+
+test("matchUnparsableModal — the auto-continue veto covers the card's 12-line window, not just the last 3 lines (hint-slot notice + watchdog → null)", () => {
+  // Regression for the review finding: with the veto scoped to the last 3
+  // non-blank lines, a notice drawn in the hint slot (5th from the bottom)
+  // was invisible to the veto while the watchdog arm — turn in flight, JSONL
+  // quiet for hours during the limit pause, no working chrome — still built
+  // the card. The veto must scan the same window the card is built from.
+  const hintSlot = `⏺ Working on it.
+
+          Usage limit reached · continuing automatically at 8am · esc to cancel
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  ⏵⏵ auto mode on (shift+tab to cycle) · ← 1 agent`;
+  expect(paneShowsClaudeWorking(hintSlot)).toBe(false); // so the watchdog WOULD arm
+  expect(matchUnparsableModal(hintSlot, true)).toBeNull();
+  expect(matchUnparsableModal(hintSlot, false)).toBeNull();
+});
+
+test("matchUnparsableModal — the auto-mode wizard fixture still cards (unchanged; see the existing footer-arm test above)", () => {
+  const m = matchUnparsableModal(AUTO_MODE_WIZARD_PANE, false);
+  expect(m).not.toBeNull();
+  expect(m!.unparsable).toBe(true);
+});
+
+// ── D. Working-gate composition (mirrors scrapeOnce's real dispatch) ───────
+
+test("matchUnparsableModal + paneShowsClaudeWorking — a footer-bearing pane that ALSO shows working chrome is only suppressed by the gate, not the matcher", () => {
+  const pane = `Some prompt?
+
+✻ Waiting for 1 background agent to finish
+
+Enter to continue · Esc to cancel`;
+
+  // The matcher alone doesn't know about working chrome — it still matches.
+  const alone = matchUnparsableModal(pane, false);
+  expect(alone).not.toBeNull();
+  expect(alone!.unparsable).toBe(true);
+
+  // scrapeOnce's real call site gates on `!paneShowsClaudeWorking` first —
+  // this is what actually suppresses it. Documents the gate is load-bearing:
+  // if it were ever dropped at the call site, this exact pane would flicker
+  // a card during a normal background-agent wait.
+  const gated = paneShowsClaudeWorking(pane) ? null : matchUnparsableModal(pane, false);
+  expect(gated).toBeNull();
+});
+
+// ── E. Fingerprint stability across the new volatile forms ─────────────────
+
+test("matchUnparsableModal — fingerprint is stable across an inserted elapsed-spinner/shell line (widened VOLATILE_PANE_LINE_RE)", () => {
+  // Analogous to the existing "inserted volatile line" test above, but for
+  // the new 2.1.239 forms specifically: a `✻ Brewed for 9s · 1 shell still
+  // running` line landing between ticks must not jitter the fingerprint, or
+  // the __external__ auto-cancel sweep would resolve a card that never
+  // stopped being the same real modal.
+  const clean = matchUnparsableModal(SHORT_UNPARSABLE_PANE, false)!;
+  const withElapsedSpinner = matchUnparsableModal(
+    SHORT_UNPARSABLE_PANE.replace(
+      "Do a thing?",
+      "Do a thing?\n✻ Brewed for 9s · 1 shell still running",
+    ),
+    false,
+  )!;
+  expect(clean).not.toBeNull();
+  expect(withElapsedSpinner).not.toBeNull();
+  expect(withElapsedSpinner.fingerprint).toBe(clean.fingerprint);
+
+  const withTokenCounterRoster = matchUnparsableModal(
+    SHORT_UNPARSABLE_PANE.replace(
+      "Do a thing?",
+      "Do a thing?\n  ◯ general-purpose  some task  10s · ↓ 46.2k tokens",
+    ),
+    false,
+  )!;
+  expect(withTokenCounterRoster.fingerprint).toBe(clean.fingerprint);
+});
+
+// ── F. Constant sanity ──────────────────────────────────────────────────────
+
+test("UNPARSABLE_STABILITY_TICKS is 3 (raised from the generic 2-tick gate)", () => {
+  expect(UNPARSABLE_STABILITY_TICKS).toBe(3);
+});
+
+// Drive the pure streak step exactly the way scrapeOnce does: per tick,
+// `streak = nextUnparsableStreak(streak, sameFingerprintAsLastTick)` when the
+// tick produced an unparsable match, `streak = 0` on any tick that didn't
+// (null match, parseable match, answered prompt). Registration happens on the
+// first tick where `unparsableStreakCleared(streak)`.
+function driveStreak(ticks: Array<string | null>): number | null {
+  let streak = 0;
+  let last: string | null = null;
+  for (const [i, fp] of ticks.entries()) {
+    if (fp === null) { streak = 0; last = null; continue; }
+    streak = nextUnparsableStreak(streak, last === fp);
+    last = fp;
+    if (unparsableStreakCleared(streak)) return i; // 0-based tick index of registration
+  }
+  return null;
+}
+
+test("unparsable streak — the same fingerprint on 3 consecutive ticks registers on the 3rd, never earlier", () => {
+  expect(driveStreak(["A", "A"])).toBeNull();
+  expect(driveStreak(["A", "A", "A"])).toBe(2);
+});
+
+test("unparsable streak — a different fingerprint in between restarts the count (A,B,A never registers)", () => {
+  expect(driveStreak(["A", "B", "A"])).toBeNull();
+  expect(driveStreak(["A", "B", "A", "A"])).toBeNull();
+  expect(driveStreak(["A", "B", "B", "B"])).toBe(3);
+});
+
+test("unparsable streak — a null-match tick (claude wrote JSONL / working chrome appeared) resets it (A,A,∅,A,A never registers)", () => {
+  expect(driveStreak(["A", "A", null, "A", "A"])).toBeNull();
+  expect(driveStreak(["A", "A", null, "A", "A", "A"])).toBe(5);
+});
+
+test("unparsable streak — a 1–2 tick blip (the old flicker) never registers", () => {
+  // The exact shape the fix exists for: a transient match that survives one
+  // or two ticks before the pane moves on must never become a card.
+  expect(driveStreak(["A", null, "A", null, "A", null])).toBeNull();
+  expect(driveStreak(["A", "A", null, "A", "A", null])).toBeNull();
 });

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -1842,6 +1842,12 @@ interface SessionState {
    *  flickers past during normal output. Reset whenever the pane no
    *  longer matches any signature. */
   scrapeLastFingerprint: string | null;
+  /** Consecutive scrape ticks the CURRENT unparsable-fallback fingerprint has
+   *  held. `matchUnparsableModal` registers only at `UNPARSABLE_STABILITY_TICKS`
+   *  — a stricter gate than the generic two-tick one, because a footer/watchdog
+   *  sighting IS the whole trigger (no parsed choice set behind it), so a 1–2
+   *  tick blip from an animating modal or a spinner blink must never card. */
+  scrapeUnparsableStreak: number;
   /** `Date.now()` stamp of the most recent successful JSONL append the
    *  flusher dispatched. The scraper consults it to (a) suppress
    *  matches that happened while claude was actively writing (the
@@ -2075,6 +2081,7 @@ function makeSessionState(o: MakeSessionStateOpts): SessionState {
     lastActivityAt: Date.now(),
     scrapeLastPaneText: null,
     scrapeLastFingerprint: null,
+    scrapeUnparsableStreak: 0,
     lastJsonlAppendAt: 0,
     lastIdleScrapeAt: 0,
     recentlyAnsweredFingerprints: new Map(),
@@ -3559,27 +3566,27 @@ const MODAL_FOOTER_RE = /esc to cancel|enter to confirm|enter to continue/i;
 const STUCK_TURN_FALLBACK_MS = 60_000;
 
 /** Pure decision for the watchdog arm of `matchUnparsableModal` — exposed via
- *  `__forTest` so the in-flight/quiet/spinner/ask truth table is unit-
+ *  `__forTest` so the in-flight/quiet/working/ask truth table is unit-
  *  testable without a live tmux pane. True only when ALL of: a turn is
  *  actually in flight (there's a "running" run to protect), the session has
  *  written JSONL before (a `0` timestamp means we've never seen a turn
  *  start — nothing to be stuck on), it's been quiet past the threshold, the
- *  raw pane tail does NOT show claude's `esc to interrupt` working spinner
- *  (a long-running tool call is busy, not stuck — the spinner repaints even
- *  when no JSONL line has landed yet), and no AskUserQuestion card/collection
- *  is already live (that path owns the pane and has its own give-up ladder,
- *  see `askFallbackAllowed`). */
+ *  pane shows claude working (see `paneShowsClaudeWorking`) is FALSE (a
+ *  long-running tool call, a background-agent wait, or a live shell is busy,
+ *  not stuck — that chrome repaints even when no JSONL line has landed yet),
+ *  and no AskUserQuestion card/collection is already live (that path owns the
+ *  pane and has its own give-up ladder, see `askFallbackAllowed`). */
 function stuckTurnFallbackArmed(p: {
   turnInFlight: boolean;
   lastJsonlAppendAt: number;
   now: number;
-  tailHasSpinner: boolean;
+  paneWorking: boolean;
   askCardLive: boolean;
 }): boolean {
   return p.turnInFlight
     && p.lastJsonlAppendAt !== 0
     && p.now - p.lastJsonlAppendAt > STUCK_TURN_FALLBACK_MS
-    && !p.tailHasSpinner
+    && !p.paneWorking
     && !p.askCardLive;
 }
 
@@ -3591,11 +3598,15 @@ function stuckTurnFallbackArmed(p: {
  * keystroke this scraper can plan, so the UI's job is just "tell the user to
  * go answer it in the attached terminal", not drive an answer back.
  *
- * Fires under either of two independent arms:
+ * Fires under either of two independent arms, both gated at the call site on
+ * `!paneShowsClaudeWorking(tail)` (a real prompt/wizard replaces the working
+ * chrome, so this can't hide a genuine one — see `paneShowsClaudeWorking`):
  *   (1) Footer arm — the last 3 NON-BLANK tail lines contain a recognised
- *       modal footer (`MODAL_FOOTER_RE`). Non-blank, not a fixed raw-line
- *       slice, because `tmux capture-pane` pads trailing blank rows (same
- *       reasoning as `matchNumberedModal`'s high-confidence check).
+ *       modal footer (`MODAL_FOOTER_RE`) AND none of those same lines is a
+ *       usage-limit auto-continue notice (`MODAL_NOTICE_RE`) — claude resumes
+ *       those on its own, nothing for the user to answer. Non-blank, not a
+ *       fixed raw-line slice, because `tmux capture-pane` pads trailing blank
+ *       rows (same reasoning as `matchNumberedModal`'s high-confidence check).
  *   (2) Watchdog arm — `watchdogArmed` (the caller pre-computes this via
  *       `stuckTurnFallbackArmed`, since it needs session state this pure
  *       matcher doesn't have).
@@ -3603,10 +3614,12 @@ function stuckTurnFallbackArmed(p: {
  * Deliberately never `highConfidence` (see `ScrapeMatch.unparsable`): unlike
  * `matchNumberedModal`'s footer fast-path, footer presence here IS the
  * trigger itself, not extra confidence layered on top of an already-parsed
- * choice set — so a single-tick sighting must not register a card. Skipping
- * the two-tick gate would let a mid-repaint transient (a real modal's frame
- * still animating in, a paste in flight) flash a fallback card the user
- * never needed.
+ * choice set — so a single-tick sighting must not register a card. The caller
+ * (`scrapeOnce`) holds this to `UNPARSABLE_STABILITY_TICKS` (3) consecutive
+ * equal-fingerprint sightings, stricter than the generic two-tick gate —
+ * skipping it would let a mid-repaint transient (a real modal's frame still
+ * animating in, a paste in flight) flash a fallback card the user never
+ * needed.
  *
  * The fingerprint is sha1 of the SAME trailing lines used for `paneText`
  * (not the full scrape tail), with blank lines and volatile chrome
@@ -3624,13 +3637,28 @@ function stuckTurnFallbackArmed(p: {
 function matchUnparsableModal(tail: string, watchdogArmed: boolean): ScrapeMatch | null {
   const lines = tail.split("\n");
   const nonBlank = lines.filter((l) => l.trim().length > 0);
-  const footerFires = nonBlank.slice(-3).some((l) => MODAL_FOOTER_RE.test(l));
-  if (!footerFires && !watchdogArmed) return null;
-
+  const last3 = nonBlank.slice(-3);
+  // The card's own window: the last 12 meaningful lines (blank + volatile
+  // chrome stripped FIRST — see the fingerprint note above). Computed before
+  // the arm logic because the notice veto below scans this same window.
   const paneLines = lines
     .map((l) => l.trimEnd())
     .filter((l) => l.length > 0 && !VOLATILE_PANE_LINE_RE.test(l))
     .slice(-12);
+  // Usage-limit auto-continue notice (`continuing automatically/shortly · esc
+  // to cancel`): claude resumes on its own, so there's nothing to card — veto
+  // BOTH arms here, before the footer/watchdog split. A mid-turn limit pause
+  // keeps the turn in flight and the pane quiet, so a footer-only veto would
+  // still let the stuck-turn watchdog arm surface the notice as a card. The
+  // veto scans the SAME 12-line window the card is built from, not just the
+  // last 3 lines: claude draws notice-class lines in the hint slot ABOVE the
+  // input box (observed 5 non-blank lines from the bottom for the weekly-limit
+  // hint), which is outside the footer window but squarely inside the card's.
+  // A genuinely wedged TUI never carries a `continuing …` line.
+  if (paneLines.some((l) => MODAL_NOTICE_RE.test(l))) return null;
+  const footerFires = last3.some((l) => MODAL_FOOTER_RE.test(l));
+  if (!footerFires && !watchdogArmed) return null;
+
   const paneText = paneLines.join("\n");
   const fingerprint = sha1(`unparsable:${paneText}`);
   return { paneText, choices: [], cursorIndex: 0, fingerprint, unparsable: true };
@@ -3797,6 +3825,27 @@ const STARTUP_DIALOG_POLL_MS = 350;
  *  generous on a busy machine but cheap to wait through.  */
 const RECENTLY_ANSWERED_TTL_MS = 3_000;
 
+/** Consecutive equal-fingerprint scrape ticks an unparsable fallback match
+ *  must hold before it registers a card (vs. the 2-tick gate parseable modals
+ *  use). See `SessionState.scrapeUnparsableStreak`. */
+const UNPARSABLE_STABILITY_TICKS = 3;
+
+/** Pure streak step for the unparsable fallback's stability gate: the streak
+ *  grows only while this tick's fingerprint equals the previous tick's;
+ *  any change restarts it at 1 (this sighting counts). The caller resets it
+ *  to 0 on every tick with no unparsable match (a null match, a parseable
+ *  match, an answered prompt, session teardown). Exposed via `__forTest` so
+ *  the A,A,A / A,B,A / A,A,∅,A,A sequences are unit-testable without a tmux
+ *  pane. */
+function nextUnparsableStreak(prevStreak: number, sameFingerprintAsLastTick: boolean): number {
+  return sameFingerprintAsLastTick ? prevStreak + 1 : 1;
+}
+
+/** Whether an unparsable streak has held long enough to register a card. */
+function unparsableStreakCleared(streak: number): boolean {
+  return streak >= UNPARSABLE_STABILITY_TICKS;
+}
+
 /** A scrape tick is skipped when the JSONL has been written to this
  *  recently — claude is mid-stream, so whatever's on the pane is
  *  likely transient output (a numbered list being printed) and not a
@@ -3881,19 +3930,119 @@ function decideScrapeTick(p: {
   return { run: true, stampIdle: true };
 }
 
-/** Claude's working-spinner line ("esc to interrupt"). Single source of truth
- *  for the phrase — it feeds both `VOLATILE_PANE_LINE_RE` below and the
- *  stuck-turn watchdog's `tailHasSpinner` input in `scrapeOnce`, which must
- *  never drift apart (a spinner the watchdog can't see would false-trip the
- *  fallback card mid-turn). */
-const SPINNER_RE = /esc to interrupt/i;
+/** Shared line-shape fragments for claude's 2.1.239 pane chrome, kept in one
+ *  place so `WORKING_LINE_RE` and `VOLATILE_PANE_LINE_RE` can't drift on the
+ *  literals they share (this supersedes the old standalone `SPINNER_RE`, whose
+ *  sole `esc to interrupt` phrase now lives in `ESC_TO_INTERRUPT`). Spinner
+ *  glyphs are matched only at line start — the `·` glyph doubles as a mid-line
+ *  separator/bullet in claude's prose, so anchoring is what stops a stray
+ *  `foo · bar…` from reading as a spinner. */
+const ESC_TO_INTERRUPT = "esc to interrupt";
+/** The rotating spinner glyph set claude draws at the start of its working /
+ *  elapsed / background-agent lines (`✻→✽→✶→✳→✢→·`, with two rarer starbursts
+ *  seen in older captures). */
+const SPINNER_GLYPH = "[✻✽✶✳✢·⚹✴]";
+/** Present-participle spinner, e.g. `✽ Frosting… (2m 52s · ↓ 12.1k tokens)` /
+ *  `· Prestidigitating… (1h 21m…)` / `✻ Determining…` — a leading glyph, ONE
+ *  word, a trailing `…`, then either the `(elapsed · tokens)` parenthetical or
+ *  end of line. The tail anchor keeps a prose bullet that merely starts with
+ *  `· Loading… more text` out. Animated (the glyph cycles), so it's volatile
+ *  as well as busy. */
+const SPINNER_ACTIVE_LINE = `^\\s*${SPINNER_GLYPH}\\s+\\S+…(?:\\s*\\(|\\s*$)`;
+/** Elapsed spinner summary, e.g. `✻ Cooked for 2m 18s`, `✻ Brewed for 9s`,
+ *  `✻ Cogitated for 5s` — no ellipsis. Still "busy" while a turn is in flight
+ *  (a long non-shell tool call whose only pane signal is the elapsed timer).
+ *  The `\d+[smh]` unit anchor keeps prose like `· foo for 3 reasons` out. */
+const SPINNER_ELAPSED_LINE = `^\\s*${SPINNER_GLYPH}\\s+\\S+\\s+for\\s+\\d+[smh]`;
+/** Ticking token counter that rides the spinner line and the background-agent
+ *  roster, e.g. `… · ↓ 12.1k tokens`, `general-purpose  10s · ↓ 46.2k tokens`.
+ *  Anchored to the `·`-separator + arrow so a bare `↓ 5 tokens` in prose can't
+ *  match. */
+const TOKEN_COUNTER_LINE = "·\\s*(?:↓|↑)\\s*[0-9.]+k?\\s*tokens";
+
+/** Lines that prove claude is actively working on the pane in Claude Code
+ *  2.1.239. Evidence (captured live): the present-participle spinner
+ *  (`SPINNER_ACTIVE_LINE`) and its elapsed summary (`SPINNER_ELAPSED_LINE`);
+ *  the ticking token counter (`TOKEN_COUNTER_LINE`); the status-bar
+ *  `esc to interrupt`; a background-agent wait `✻ Waiting for 1 background
+ *  agent to finish`; and a live shell `✻ Brewed for 9s · 1 shell still
+ *  running` / status-bar `· 1 shell ·`. Unlike 1 Hz-blinking `esc to
+ *  interrupt` alone, this union stays true across a working turn's quiet-JSONL
+ *  windows (background agents, long tool calls) — exactly when the old
+ *  watchdog false-fired. Every arm is anchored to the chrome shape it came
+ *  from (leading glyph, `·`-separated status-bar item, `still running`) so
+ *  look-alike transcript prose — `· 3 shell scripts were updated`, `Waiting
+ *  for 2 background agents to report back.` — can't read as working. Add a
+ *  form only with a captured pane to back it. */
+const WORKING_LINE_RE = new RegExp(
+  [
+    ESC_TO_INTERRUPT,
+    SPINNER_ACTIVE_LINE,
+    SPINNER_ELAPSED_LINE,
+    TOKEN_COUNTER_LINE,
+    `^\\s*${SPINNER_GLYPH}\\s+Waiting for \\d+ background agent`,
+    "\\d+\\s+shells?\\s+still\\s+running",
+    "·\\s*\\d+\\s+shells?\\s*(?:·|$)",
+  ].join("|"),
+  "i",
+);
+
+/** How many trailing NON-BLANK pane lines `paneShowsClaudeWorking` inspects.
+ *  Working chrome lives in the bottom widget area — spinner/elapsed line, the
+ *  hint line, the `Tip:` banner, the input box (3 rows), the status bar, the
+ *  `✔ Update installed` notice and the background-agent roster (`⏺ main` +
+ *  one `◯` row per agent) — which in the deepest live capture ran 13 non-blank
+ *  rows (4 agents). 16 covers that with slack while keeping the scrollback
+ *  transcript above it out of the decision: a tool result that echoes claude
+ *  chrome (an agent inspecting tmux panes — agetor dogfooding), or prose that
+ *  resembles a spinner line, must not be able to hide a genuine prompt that
+ *  renders below it. */
+const WORKING_CHROME_WINDOW_LINES = 16;
+
+/** Usage-limit AUTO-CONTINUE notices, which carry a `MODAL_FOOTER_RE` phrase
+ *  (`… · esc to cancel`) but need no user action — claude resumes on its own.
+ *  Evidence (2.1.239 binary): `Usage limit reached · continuing automatically
+ *  at 8am · esc to cancel`, `… continuing shortly · esc to cancel`, `…
+ *  continuing automatically when it resets · esc to cancel`.
+ *  `matchUnparsableModal` vetoes on these on BOTH arms, over the card's own
+ *  12-line window, so they never surface a card — a mid-turn limit pause keeps
+ *  the turn in flight and the pane quiet, which would otherwise arm the
+ *  stuck-turn watchdog. `Usage limit has reset · press enter to continue` is
+ *  deliberately NOT here — it is genuinely actionable. Note that when it
+ *  renders in the hint slot above the input box it sits outside the footer
+ *  arm's last-3-line window, so it reaches the user via the watchdog arm
+ *  (turn still in flight, pane quiet, no working chrome) rather than
+ *  instantly — acceptable for a "go press Enter in the terminal" card. */
+const MODAL_NOTICE_RE = /continuing automatically|continuing shortly/i;
 
 /** Pane chrome that repaints on a fixed cadence independent of anything
- *  meaningful happening — claude's "esc to interrupt" spinner/status footer
- *  (its elapsed-time-and-token-count portion ticks every render) and its
- *  rotating "Tip: …" hint banner. Matched against a line AFTER trailing
- *  whitespace has already been trimmed off (see `normalizePaneForActivity`). */
-const VOLATILE_PANE_LINE_RE = new RegExp(`${SPINNER_RE.source}|^\\s*Tip:`, "i");
+ *  meaningful — the animated spinner line and its token counter (shared with
+ *  `WORKING_LINE_RE`) and the rotating `Tip:` banner. Matched AFTER trailing
+ *  whitespace is trimmed (see `normalizePaneForActivity`). Filtering these
+ *  before fingerprinting is what keeps the stability gate and the `__external__`
+ *  sweep from jittering on the animated `✻→✽→✶` glyph and the ticking
+ *  `↓ N tokens` counter. */
+const VOLATILE_PANE_LINE_RE = new RegExp(
+  [ESC_TO_INTERRUPT, SPINNER_ACTIVE_LINE, SPINNER_ELAPSED_LINE, TOKEN_COUNTER_LINE, "^\\s*Tip:"].join("|"),
+  "i",
+);
+
+/** True when the live pane shows claude actively working (see
+ *  `WORKING_LINE_RE`), checked over the last `WORKING_CHROME_WINDOW_LINES`
+ *  non-blank lines of the scrape tail — the bottom widget area, NOT the
+ *  scrollback transcript above it. Gates BOTH arms of `matchUnparsableModal`:
+ *  a real prompt/wizard REPLACES the working chrome (verified against live
+ *  2.1.239 panes), so suppressing the fallback whenever working chrome is
+ *  present cannot hide a genuine prompt, but it does kill the false card on
+ *  normal long-quiet-JSONL turns. Bounding the window is what keeps that
+ *  safety claim honest: the transcript can legitimately contain chrome-shaped
+ *  text (a tool result echoing a pane, prose resembling a spinner line) above
+ *  a real modal. Pure/exported so the truth table is unit-testable without a
+ *  live tmux pane. */
+function paneShowsClaudeWorking(tail: string): boolean {
+  const nonBlank = tail.split("\n").filter((l) => l.trim().length > 0);
+  return nonBlank.slice(-WORKING_CHROME_WINDOW_LINES).some((l) => WORKING_LINE_RE.test(l));
+}
 
 /**
  * Normalize a captured pane tail into the form used for the "did the pane
@@ -4038,15 +4187,20 @@ function scrapeOnce(state: SessionState): void {
   // wrong-index risk, just a less structured card.
   const askUnrecoverable = askOnPane && askFallbackAllowed(state.askGrowAttempts, state.askCardId !== null);
 
+  // Computed once and passed through even into the branch that skips the
+  // unparsable matcher entirely (see below) — `stuckTurnFallbackArmed`'s
+  // signature stays honest about what it was actually gated on, rather than
+  // silently hardcoding `false` at the call site.
+  const paneWorking = paneShowsClaudeWorking(tail);
   const match = (claudeIsWriting || (askOnPane && !askUnrecoverable))
     ? null
-    : (matchNumberedModal(tail) ?? matchYesNoModal(tail) ?? matchUnparsableModal(tail, stuckTurnFallbackArmed({
+    : (matchNumberedModal(tail) ?? matchYesNoModal(tail) ?? (paneWorking ? null : matchUnparsableModal(tail, stuckTurnFallbackArmed({
         turnInFlight: turnInFlight(state),
         lastJsonlAppendAt: state.lastJsonlAppendAt,
         now,
-        tailHasSpinner: SPINNER_RE.test(tail),
+        paneWorking,
         askCardLive: state.askCardId !== null,
-      })));
+      }))));
 
   // Auto-cancel: any registered prompt for this task whose fingerprint
   // is NOT what we see now has been dismissed (either externally via
@@ -4070,6 +4224,7 @@ function scrapeOnce(state: SessionState): void {
 
   if (!match) {
     state.scrapeLastFingerprint = null;
+    state.scrapeUnparsableStreak = 0;
     return;
   }
 
@@ -4091,9 +4246,23 @@ function scrapeOnce(state: SessionState): void {
   // the turn resolved to `review` registers in ~two idle ticks rather than ~2s;
   // the AskUserQuestion path above and any high-confidence match skip the gate
   // and surface on the first idle capture.
-  const cleared = clearedStabilityGate(match, state.scrapeLastFingerprint);
-  state.scrapeLastFingerprint = match.fingerprint;
-  if (!cleared) return;
+  //
+  // The unparsable fallback (`match.unparsable`) uses its OWN stricter gate —
+  // `UNPARSABLE_STABILITY_TICKS` (3) consecutive equal-fingerprint sightings,
+  // tracked in `scrapeUnparsableStreak` — instead of the generic two-tick one:
+  // for that matcher, footer/watchdog presence IS the whole trigger (there's
+  // no already-parsed choice set behind it), so a 1–2 tick blip must not card.
+  const sameAsLast = state.scrapeLastFingerprint === match.fingerprint;
+  if (match.unparsable) {
+    state.scrapeUnparsableStreak = nextUnparsableStreak(state.scrapeUnparsableStreak, sameAsLast);
+    state.scrapeLastFingerprint = match.fingerprint;
+    if (!unparsableStreakCleared(state.scrapeUnparsableStreak)) return;
+  } else {
+    state.scrapeUnparsableStreak = 0;
+    const cleared = clearedStabilityGate(match, state.scrapeLastFingerprint);
+    state.scrapeLastFingerprint = match.fingerprint;
+    if (!cleared) return;
+  }
 
   // Already registered? Nothing to do — the previous tick's broadcast
   // is what the UI is showing.
@@ -4136,6 +4305,7 @@ export function markTmuxPromptAnswered(taskId: string, fingerprint: string): voi
   // claude immediately printed an identical-looking dialog), without
   // racing the registration.
   state.scrapeLastFingerprint = null;
+  state.scrapeUnparsableStreak = 0;
 }
 
 /** Install or refresh the scraper interval for a session. Called from
@@ -4890,8 +5060,13 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
           // Footer arm only — no turn is in flight during boot, so the
           // stuck-turn watchdog arm doesn't apply here (see
           // `matchUnparsableModal`). This is the fix for the screenshotted
-          // 2.1.234 auto-mode wizard, which appears pre-JSONL.
-          const generic = matchNumberedModal(tail) ?? matchYesNoModal(tail) ?? matchUnparsableModal(tail, false);
+          // 2.1.234 auto-mode wizard, which appears pre-JSONL. Same working-
+          // chrome gate as the runtime scraper (`paneShowsClaudeWorking`) — a
+          // real startup wizard has no working chrome, so it still surfaces;
+          // the `MODAL_NOTICE_RE` auto-continue veto lives inside
+          // `matchUnparsableModal` itself, so it already applies here too.
+          const generic = matchNumberedModal(tail) ?? matchYesNoModal(tail)
+            ?? (paneShowsClaudeWorking(tail) ? null : matchUnparsableModal(tail, false));
           if (!generic) { lastGenericFingerprint = null; continue; }
           // External dismissal: a previously surfaced startup prompt whose
           // content no longer matches the pane (user answered it from a real
@@ -5593,6 +5768,7 @@ function disposeSessionState(state: SessionState | undefined, orphanSubagents = 
   state.deathTimer = null;
   clearContinuationWatchdog(state);
   state.scrapeLastFingerprint = null;
+  state.scrapeUnparsableStreak = 0;
   // Release the subagent watcher's fs.watch + poll timer. Read-only teardown:
   // this stops us TAILING the subagent files, never the agent itself.
   state.subagentWatcher?.detach();
@@ -5695,6 +5871,16 @@ export const __forTest = {
   stuckTurnFallbackArmed,
   MODAL_FOOTER_RE,
   STUCK_TURN_FALLBACK_MS,
+  /** Working-chrome detection (2.1.239) that gates both fallback arms, the
+   *  auto-continue notice veto, and the unparsable stability streak length —
+   *  exposed so the truth table is unit-testable without a live tmux pane. */
+  WORKING_LINE_RE,
+  MODAL_NOTICE_RE,
+  paneShowsClaudeWorking,
+  WORKING_CHROME_WINDOW_LINES,
+  UNPARSABLE_STABILITY_TICKS,
+  nextUnparsableStreak,
+  unparsableStreakCleared,
   /** Pure idle-throttle decision used by `scrapeOnce` — exposed so the
    *  regression test can assert a JSONL-idle session keeps scraping (at the
    *  throttled cadence) instead of stopping forever, which would strand a


### PR DESCRIPTION
## What

The #185 fallback card ("Claude is asking something Agetor can't read") was registering during **normal** Claude Code 2.1.239 activity — streaming, long tool calls, background-agent waits — and the every-tick `__external__` sweep resolved it ~1 s later. That register→resolve oscillation flipped the board card between the **Answer** state and **Run** and fired a spurious native "waiting on you" notification each time.

This PR makes the fallback detection understand 2.1.239's TUI, gates it on "claude isn't visibly working", and tightens its stability requirement — while keeping the card for genuinely unknown prompts (the auto-mode wizard still surfaces it).

## Why (root cause)

The detection was written against 2.1.234 and its signals went stale:

- The working indicator is now a ticking glyph line — `✽ Frosting… (2m 52s · ↓ 12.1k tokens)`, `✻ Cooked for 2m 18s`, `✻ Waiting for 1 background agent to finish`, `✻ Brewed for 9s · 1 shell still running`.
- `esc to interrupt` moved into the status bar, **blinks at ~1 Hz**, and is absent for whole quiet-JSONL windows (background-agent waits, long tool calls).
- The stuck-turn watchdog's only busy guard was `esc to interrupt`, so a normal long-quiet turn (one session showed nine >60 s JSONL gaps in 25 min) read as "stuck" → card → next pane change → sweep resolves → flicker.

Evidence: ~9 min of read-only watching over live agetor sessions plus six throwaway 2.1.239 tmux sessions (~190 captured frames) covering idle, argv turn, pasted/queued follow-ups, Bash calls, background-agent wait, AskUserQuestion mid-turn, auto + manual modes. Full write-up in `docs/plans/unknown-tui-detection-flicker.md`.

## How (`src/bun/claude-tmux.ts`)

- **`WORKING_LINE_RE` synced to 2.1.239**, built from shared, anchored chrome fragments (`SPINNER_GLYPH`, `SPINNER_ACTIVE_LINE`, `SPINNER_ELAPSED_LINE`, `TOKEN_COUNTER_LINE`, `ESC_TO_INTERRUPT`) that also feed `VOLATILE_PANE_LINE_RE`, so the animated glyph and token counter no longer jitter fingerprints or the activity diff.
- **New pure `paneShowsClaudeWorking(tail)` gates both fallback arms** (runtime `scrapeOnce` and the boot poller). It reads only the bottom widget area (last `WORKING_CHROME_WINDOW_LINES = 16` non-blank rows), never the scrollback transcript, so chrome-shaped transcript text (a tool result echoing a pane, prose like `· 3 shell scripts`) can't hide a genuine prompt rendered below it. A real modal/wizard replaces the widget area, so the gate can't suppress one.
- **Unparsable stability raised from 2 to 3 consecutive equal-fingerprint ticks** via `SessionState.scrapeUnparsableStreak` and pure `nextUnparsableStreak` / `unparsableStreakCleared`.
- **`MODAL_NOTICE_RE` vetoes usage-limit auto-continue notices** (`continuing automatically/shortly · esc to cancel`) before both arms, over the card's own 12-line window — claude draws notices in the hint slot above the input box, outside the footer arm's last-3 lines. `Usage limit has reset · press enter to continue` stays eligible (surfaced via the watchdog arm).
- `stuckTurnFallbackArmed`'s `tailHasSpinner` input becomes `paneWorking`; dead `SPINNER_RE` removed.

## Tests (`src/bun/claude-tmux-scraper.test.ts`, 54 → 84)

2.1.239 working-chrome truth table against real captured panes; both-arm and hint-slot notice veto; the press-enter-to-continue split; bounded-window/echoed-chrome regression with the exact 16-line boundary; prose look-alike guards; streak sequences (A,A,A registers on the 3rd; A,B,A and A,A,∅,A,A never; 1–2-tick blips never); fingerprint stability across the new volatile forms.

## Verification

- `bun run typecheck` clean
- `bun test src/bun/claude-tmux-scraper.test.ts` 84 pass / 0 fail; `interactions.test.ts` 22 / 0
- Full `bun test`: 3039 pass / 3 skip / 1 fail — the failure is `terminals.test.ts` › "a shell that exits is auto-removed from the manager", a 2 s PTY timing test that imports only `db.ts` (never `claude-tmux.ts`), passed in an earlier clean run, and fails in isolation under a load average of 48–85 from parallel agent sessions. Environmental, unrelated to this change.

## Not in this PR

- Manual smoke in `~/.agetor-dev`: drive a long tool call / background-agent wave → no flicker; trigger the auto-mode wizard → card still appears. (The running release build predates this fix.)
- A distinct "paused on usage limit" status instead of the generic fallback card — out of scope; the auto-continue notice is simply suppressed here.