### PR TITLE
feature: refresh PR merge status on detail open and show a merged-state card in the Git dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ All persistent state lives in `~/.agetor/` (override with `AGETOR_DATA_DIR`):
 | `AGETOR_CODEX_ARGS` | Extra args appended to every Codex spawn. | *(none)* |
 | `AGETOR_TMUX_BIN` | Override the `tmux` binary path. | `tmux` on `PATH` |
 | `AGETOR_CLAUDE_DRIVER` | Set to `fake` to skip tmux + the real CLI (test-only). | unset |
+| `AGETOR_GITHUB_API_BASE` | GitHub API origin override (dev/e2e only; default `https://api.github.com`). | `https://api.github.com` |
 | `AGETOR_DAEMON_IDLE_MS` | CLI daemon: idle-shutdown after this long with no run and no attached client. `0` disables. | `300000` (5 min) |
 
 Per-harness `bin`, `home`, and `env` overrides are configured through the Settings dialog and stored in SQLite — they take precedence over the corresponding env vars.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ All persistent state lives in `~/.agetor/` (override with `AGETOR_DATA_DIR`):
 | `AGETOR_CODEX_ARGS` | Extra args appended to every Codex spawn. | *(none)* |
 | `AGETOR_TMUX_BIN` | Override the `tmux` binary path. | `tmux` on `PATH` |
 | `AGETOR_CLAUDE_DRIVER` | Set to `fake` to skip tmux + the real CLI (test-only). | unset |
-| `AGETOR_GITHUB_API_BASE` | GitHub API origin override (dev/e2e only; default `https://api.github.com`). | `https://api.github.com` |
+| `AGETOR_GITHUB_API_BASE` | GitHub REST/GraphQL API origin. Dev/e2e only — see `e2e/github-stub.ts`; never point it at a non-loopback host (the GitHub token is sent there). | `https://api.github.com` |
 | `AGETOR_DAEMON_IDLE_MS` | CLI daemon: idle-shutdown after this long with no run and no attached client. `0` disables. | `300000` (5 min) |
 
 Per-harness `bin`, `home`, and `env` overrides are configured through the Settings dialog and stored in SQLite — they take precedence over the corresponding env vars.

--- a/docs/plans/pr-modal-refresh-merge-status-and-merged-banner.md
+++ b/docs/plans/pr-modal-refresh-merge-status-and-merged-banner.md
@@ -1,0 +1,79 @@
+# Plan — PR modal: refresh merge status on open + merged-state purple banner
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-21 |
+| Source | /implement conversation + screenshot (merged PR still showing full Review/Merge/Close grid and stale mergeability banner) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Flags | none |
+| Gates | grilled + approved by owner |
+| Branch | feature/pr-modal-merge-status-and-message |
+| Base SHA | 1e5f65491e9f059a29da52bedee0604df98e5139 |
+
+## 1. Objective & success criteria
+
+1. Every time the PR detail view opens inside the GitHub dialog (dialog open via "View PR", row click from the list, re-navigation within the dialog, dialog reopen onto a surviving detail view), the PR's state **and** mergeability are re-fetched — no stale "Mergeability hasn't been verified" banner, and a PR merged outside agetor is detected.
+2. When a PR is merged (`mergedAt` set), the Review/Merge/Close 3-column action grid **and** the mergeability banner are replaced by a single positive purple card: GitMerge icon + "Pull request successfully merged" + merged date, using the existing `--merged` token (GitHub's merge purple).
+3. Merging from inside agetor shows the purple card immediately (local `mergedAt` stamp on merge success), corrected by the next real fetch.
+
+Success: `bun run typecheck` green, `bun test` green, review clean, and the merged PR from the screenshot renders the purple card instead of the disabled grid.
+
+## 2. Context & constraints (Phase 1 findings, verified against source)
+
+- **Component:** `src/mainview/components/kanban/GitHubDialog.tsx` (monolith). Detail view state is the `GitHubDialogView` union (`src/mainview/lib/github-dialog-view.ts:29-38`, `openDetail(item)`).
+- **`expandedItem`** (`GitHubDialog.tsx:1252-1259`) re-resolves the navigated item against `result.items` by `itemKey` (kind+number+sourcePath), falling back to the navigation snapshot. Per-item fetch path: `expandedItemPath = expandedItem?.sourcePath ?? projectPath` (`:1265`).
+- **Mergeability staleness (root cause 1):** fetch effect `GitHubDialog.tsx:2250-2284` only fires when the cached item's `state === "open"` (`:2253`) and is cache-guarded at `:2256` (`mergeability[key] || mergeabilityLoading[key] || mergeabilityErrors[key]`) — opening the detail view never invalidates it. Manual refresh handler clears the caches + retry budget (`:3651-3656`).
+- **Item staleness (root cause 2):** nothing re-fetches the item on detail entry, and detail views deliberately survive dialog close/reopen (`:1217-1220`) — a PR merged elsewhere keeps its cached `state: "open"`.
+- **Fresh-detail machinery exists:** `api.getGitHubPullDetail(path, number)` → `GET /github/pull-detail` (`src/bun/server.ts:982-997` → `git-host.ts:460-469` → `github.ts:1948-1963`, plain REST `GET /pulls/{number}`) returns a full fresh `GitHubListItem` incl. `state`/`mergedAt`. Currently only used by the "View PR" prefill effect (`GitHubDialog.tsx:1180-1206`), which has the navigation-clobber (`viewRef`) + wrong-repo guards.
+- **Cache patch helper exists:** `upsertListItem(next, false, true)` (keepIfPresent) — used by `markPullClosed` (`:2562-2565`) so a closed/merged row stays in `result.items` even when the filter no longer matches.
+- **Merge success gap:** `runPullMerge` (`:2627-2644`) calls `markPullClosed(item)` at `:2637`, which stamps `state/closedAt` but **not** `mergedAt` (merge API response is just `{merged, sha, message}` — `github.ts:2392-2397`).
+- **`PullActions`** (`GitHubDialog.tsx:7440-7773`): header row `7536-7572` (Convert-to-draft gated `state==="open"`, purple "Merged" tag gated `mergedAt` at `7548-7553`, ephemeral `actionMessages` line `7560-7571`); mergeability banner `7574-7625` (gated `state==="open"`); **Review/Merge/Close grid `7628-7754` renders unconditionally** — buttons merely `disabled` when not open (`:7503`).
+- **Purple token exists:** `--merged` in `:root` and `.dark` (`src/mainview/index.css:46-49`, `:99-100`) mapped in `tailwind.config.js:60-63`; usable as `text-merged`, `bg-merged/10`, `border-merged/30`. Repo rule: semantic tokens only.
+- **Test idiom:** dialog is not component-tested; logic is extracted into pure lib modules with `bun:test` unit tests (`mergeability.test.ts`, `github-dialog-view.test.ts`). Test command `bun test`; typecheck `bun run typecheck`.
+- **Peer knowledge honored:** GitHubDialog prefill flow guards (wrong-repo, navigation-clobber via `viewRef`) must be mirrored by any new async fetch that lands in view state (fleet entry `f45b5cb6`).
+
+## 3. Approach & key decisions
+
+- **Refresh = fresh pull detail + mergeability invalidation, on every detail-view entry** (owner-confirmed). A new effect watches `view` transitions into `{kind:"detail"}` for a `pulls` item and fires once per entry:
+  1. Clear `mergeability[key]`, `mergeabilityErrors[key]`, reset `mergeabilityRetries.current[key]` (mirrors the manual refresh handler) — the existing effect at `2250-2284` then refetches by itself for open PRs, and correctly skips merged/closed ones.
+  2. `api.getGitHubPullDetail(itemPath, number)`; on success `upsertListItem(fresh, false, true)` **and** patch the view snapshot (`setView` to `openDetail(fresh)` only if still on the same item key via `viewRef`) so the fallback path (item absent from `result.items`) is also fresh.
+  3. Failure is **silent** (keep showing cached data; the mergeability banner has its own error surface for open PRs; a toast on every open would be noisy offline). No wrong-repo guard needed here — the fetch is keyed off the already-trusted cached item, not a URL.
+- **"Once per entry" bookkeeping:** a `lastDetailRefreshKeyRef` cleared whenever `view.kind !== "detail"` or `open === false`, so detail(A) → list → detail(A) refreshes again, and dialog reopen onto a surviving detail view refreshes. The "View PR" prefill effect (`1180-1206`) already fetches fresh detail; it may double-fetch once — acceptable, but the implementer may set the ref from the prefill path to dedupe (optional, low-risk only).
+- **Merged banner replaces both the mergeability banner and the action grid** when `Boolean(item.mergedAt)`. Header row stays (Merged tag, ephemeral messages). Card: `GitMerge` icon (lucide, already imported for the Merged tag area), "Pull request successfully merged", "Merged on <formatted date>", `rounded-md border border-merged/30 bg-merged/10 text-merged` — reuse the file's existing date formatting helper. Closed-but-unmerged PRs keep today's behavior (out of scope).
+- **Immediate post-merge purple** (owner-confirmed): extract a pure helper `mergedPullReplacement(item, mergedAtIso)` into a new lib module and use it in `runPullMerge`'s success path in place of the bare `markPullClosed(item)` (stamps `state:"closed"`, `closedAt`, `mergedAt`). Timestamps are client-approximate; the on-open refresh corrects them.
+- Alternatives considered: mergeability-only refresh (rejected — cannot detect externally-merged PRs, fails objective 2); refreshing only on dialog open (rejected — user intuition of "opened" includes in-dialog navigation); new purple token (unnecessary — `--merged` exists).
+
+## 4. Work breakdown — implementation tasks
+
+- **T1 — lib helper + dialog changes** (single task; the helper and its consumer are too entangled to split without a fake wave barrier)
+  - Files owned: `src/mainview/components/kanban/GitHubDialog.tsx`, `src/mainview/lib/pull-merged.ts` (new)
+  - Goal: (a) new `pull-merged.ts` exporting `isMergedPull(item)` and `mergedPullReplacement(item, mergedAtIso?)`; (b) refresh-on-detail-entry effect per §3; (c) `runPullMerge` success path uses `mergedPullReplacement`; (d) `PullActions` renders the purple merged card in place of mergeability banner + grid when `isMergedPull(item)`.
+  - Acceptance: typecheck green; no changes outside owned files; guards per §3 present.
+
+## 5. Work breakdown — test tasks
+
+- **T2 — unit tests** (after T1)
+  - Files owned: `src/mainview/lib/pull-merged.test.ts` (new)
+  - Goal: cover `isMergedPull` (mergedAt set / null / undefined-ish) and `mergedPullReplacement` (state flip, closedAt/mergedAt stamped, other fields preserved, explicit timestamp honored). Follow `mergeability.test.ts` fixture idiom.
+- **e2e: not applicable** — desktop Electrobun app with no e2e harness in the repo; logic is covered by the extracted-pure-helper idiom the codebase standardizes on. Recorded decision, not an omission.
+
+## 6. Execution waves
+
+- Wave 1: T1 (one implementation agent, sonnet)
+- Review (opus) on the diff vs base SHA
+- Wave 2: T2 (one test agent, sonnet)
+- Test run (haiku): `bun run typecheck` + `bun test`
+- Fixes as needed (sonnet), re-run to green
+
+## 7. Blast radius & risks
+
+- `GitHubDialog.tsx` detail flow: the new effect must not clobber navigation (guards via `viewRef` + item-key check) and must not loop (ref bookkeeping; effect must not depend on state it sets, or must be entry-keyed).
+- `upsertListItem(fresh, false, true)` with a merged item interacts with the open-filter list — the keepIfPresent path is exactly the one `markPullClosed` already exercises.
+- Extra API call per detail entry (one `GET /pulls/{number}`) — negligible, matches the prefill flow's cost.
+- Mergeability effect remains gated on `state === "open"` — after a refresh flips state to merged, the effect correctly stops polling; no wasted server-side poll.
+- Rollback: revert the branch; no schema/API changes, UI-only.
+
+## 8. Open questions / assumptions
+
+- Silent failure on the detail-refresh fetch (no toast) — chosen for calm UX; flip to a toast if the owner prefers loud failures.
+- Merged-date formatting reuses the file's existing date helper; exact wording "Pull request successfully merged" + "Merged on <date>" per approved preview.

--- a/docs/plans/pr-modal-refresh-merge-status-and-merged-banner.md
+++ b/docs/plans/pr-modal-refresh-merge-status-and-merged-banner.md
@@ -55,7 +55,7 @@ Success: `bun run typecheck` green, `bun test` green, review clean, and the merg
 - **T2 — unit tests** (after T1)
   - Files owned: `src/mainview/lib/pull-merged.test.ts` (new)
   - Goal: cover `isMergedPull` (mergedAt set / null / undefined-ish) and `mergedPullReplacement` (state flip, closedAt/mergedAt stamped, other fields preserved, explicit timestamp honored). Follow `mergeability.test.ts` fixture idiom.
-- **e2e: not applicable** — desktop Electrobun app with no e2e harness in the repo; logic is covered by the extracted-pure-helper idiom the codebase standardizes on. Recorded decision, not an omission.
+- ~~**e2e: not applicable**~~ **Superseded by §10** — the repo *does* have a Playwright harness (`e2e/`, per-worker headless backends); the original investigation missed it. `e2e/pr-merged-state.spec.ts` now covers the feature end-to-end against a stubbed GitHub API (see §10.3 T7).
 
 ## 6. Execution waves
 

--- a/docs/plans/pr-modal-refresh-merge-status-and-merged-banner.md
+++ b/docs/plans/pr-modal-refresh-merge-status-and-merged-banner.md
@@ -77,3 +77,48 @@ Success: `bun run typecheck` green, `bun test` green, review clean, and the merg
 
 - Silent failure on the detail-refresh fetch (no toast) — chosen for calm UX; flip to a toast if the owner prefers loud failures.
 - Merged-date formatting reuses the file's existing date helper; exact wording "Pull request successfully merged" + "Merged on <date>" per approved preview.
+
+---
+
+## 10. Hardening pass (2026-08-21) — "make sure everything is right and is the best we can do"
+
+| Field | Value |
+| --- | --- |
+| Source | owner follow-up after delivery; 3 fresh investigators (opus correctness re-review, opus UX/design review, sonnet runtime-verification feasibility) |
+| Gates | grilled (card design + e2e decision) + owner approval of this section |
+| Base SHA (this pass) | 46a70fa |
+| Correction to §5 | the repo **does** have a Playwright e2e harness (`e2e/` + `playwright.config.ts`, per-worker headless backends via `e2e/fixtures.ts`). "e2e not applicable" was wrong; e2e **applies** and is added here. Run Playwright as `bun node_modules/@playwright/test/cli.js test …` (the `bunx` shim runs under Node and breaks on `bun:sqlite`). |
+
+### 10.1 Owner decisions (grill)
+- **Card design:** keep the positive headline "Pull request successfully merged" (GitHub's own persistent phrasing) but move to the app's status-card idiom: purple carried by icon + `border-merged/40` + `bg-merged/10`; headline `text-sm font-medium text-foreground`; secondary `text-xs text-muted-foreground` using `fmtRelativeDate` ("Merged today" / "Merged 3d ago" / falls back to full date); `px-3 py-6 min-h-[7.5rem]`; panel label reads "Merge status" when merged. Fixes the dark-mode AA failure of `text-merged/80` (~4.1:1).
+- **E2E:** yes — add a real Playwright spec backed by a stub GitHub API, via a small product seam (`GITHUB_API_BASE` constant + `AGETOR_GITHUB_API_BASE` env override in `src/bun/github.ts`, mirroring Bitbucket's `BITBUCKET_API_BASE` idiom).
+
+### 10.2 Fix list (both reviewers; all accepted unless noted)
+Correctness (GitHubDialog.tsx):
+- C1 **Duplicate mergeability fetch on first entry** — the refresh effect is declared after the mergeability fetch effect, so entry fires GET #1, bumps seq, re-fires GET #2 (3–7 identical `GET /pulls/{n}` incl. server polling). Fix: declare the refresh effect **above** the mergeability effect.
+- C2 **In-app merge of a non-listed PR never shows the card** — `markPullClosed` only patches `result.items`; when the PR isn't in the loaded list `upsertListItem` drops it and `expandedItem` falls back to the frozen snapshot. Fix: `markPullClosed` also patches the view snapshot (`setView(cur => detail && sameItem(cur.item,next) ? openDetail(next) : cur)`) — single choke point for merge/close/reopen.
+- C3 **No refresh affordance for closed/merged PRs; silent failure dead-end** — extract `refreshPullDetail(item)` (entry-refresh body) + `invalidateMergeability(key)` helpers; header button becomes a full "Refresh" (item + mergeability), rendered for every PR state, not just open; effect, manual button, and prefill share the helpers.
+- C4 **Latent item-key shift** — pin identity: `fresh = { ...detail.item, sourcePath: item.sourcePath }`, bail if `itemKey(fresh) !== key`; guard `itemPath === AGGREGATE_PROJECT_PATH`; fix the stale "sourcePath is null in single-repo mode" doc comment (~:230).
+- C5 **Structural update-only** — add an `updateOnly` option to `upsertListItem` evaluated inside the `setResult` updater (fresh state) so the effect no longer reads a stale `result` closure; document the deliberately-narrow deps with the file's `eslint-disable-next-line react-hooks/exhaustive-deps` + why idiom.
+- C6 **itemMutationSeq invariant** — hoist the bump into a `mutateItems()` wrapper used by `upsertListItem` AND the direct `setResult` writers (`editLabel`, `removeLabel`, `editMilestone`, `removeMilestone`, `runTransferIssue`); fix the "every local item write goes through here" comment.
+- C7 **"View PR" double fetch** — prefill part 2 already has the fresh item: set `lastDetailRefreshKeyRef` + call `invalidateMergeability(key)` before `setView(openDetail(result.item))` (dedupe without losing the mergeability refresh).
+- C8 Unify `!detail.ok` and thrown-error paths (both reset the ref for retry). C9 `mergedPullReplacement` gets the `pulls` guard; test for `mergedAt: ""`; drop the unnecessary label cast in the test. C10 one-line comment on the sibling refresh handlers (`onRefreshDiff/Checks/CommitStatus`) noting they're shielded by `disabled={…Loading}`. C11 readability: extract the action grid into a sibling `PullActionGrid` component (or re-indent) so the merged branch reads `{merged ? <MergedPullCard/> : <PullActionGrid/>}`.
+UX (PullActions):
+- U1 card per §10.1; `role="status"`, `aria-hidden` icon; `tabIndex={-1}` + focus the card when it mounts and `document.activeElement === document.body` (focus was dropped by the grid unmounting after an in-app merge).
+- U2 suppress the green `actionMessages` success line when merged (keep the header "Merged" tag + card; error line stays unconditional).
+- U3 "Mergeability unavailable." one-frame flicker: render "Checking mergeability…" whenever `!mergeability && !mergeabilityError`.
+- U4 entry-refresh affordance: `detailRefreshing` state (set around the entry fetch, per key) → `Loader2` spinner in the panel header row + Merge disabled with title "Checking latest state…" while refreshing (only Merge; Approve/Comment/Close stay live). Grid is **not** held (both reviewers agree).
+- U5 queued-review hint copy branches on `merged` (no longer points at Approve/Comment/Request; says the PR is merged so they can no longer be posted; discard under "Pending review" below).
+- U6 `runPullMerge` success clears `reviewDrafts[key]` (mirrors `runClosePull` clearing `closeDrafts`).
+Declined: dropping the header "Merged" tag (kept — compact scan marker, matches list rows); "merged by / into base" (no `mergedBy`/`baseRef` on `GitHubListItem`; server change — different ticket); closed-unmerged state polish (different ticket).
+
+### 10.3 Work breakdown
+- **T5 — dialog polish + correctness** (wave 1). Files: `src/mainview/components/kanban/GitHubDialog.tsx`, `src/mainview/lib/pull-merged.ts`, `src/mainview/lib/pull-merged.test.ts`. Everything in §10.2. Acceptance: typecheck green, `bun test src/mainview/lib` green.
+- **T6 — GitHub API seam + e2e plumbing** (wave 1, disjoint). Files: `src/bun/github.ts` (all 90 `https://api.github.com` literals → `${GITHUB_API_BASE}`; `const GITHUB_API_BASE = process.env.AGETOR_GITHUB_API_BASE ?? "https://api.github.com"`; any origin/Link-header checks derive from it; GraphQL too), `README.md` (env table row), `e2e/fixtures.ts` (per-worker `githubStubPort = 4800 + parallelIndex` exposed on `E2EBackend`; backend env gains `AGETOR_GITHUB_API_BASE=http://127.0.0.1:<port>` and `GITHUB_TOKEN=e2e-github-token` so token resolution never shells out to `gh`), `e2e/github-stub.ts` (new: tiny Node `http` stub — route table keyed by method+path regex, JSON responses, mutable state, per-route call log, 404 JSON + stderr log for unmatched paths). Acceptance: typecheck green; `bun test src/bun/github*.test.ts src/bun/pull-detail.test.ts src/bun/git-host*.test.ts` green; default behavior byte-identical.
+- **T7 — Playwright spec** (wave 2, after T5+T6). File: `e2e/pr-merged-state.spec.ts` (new). Arrange: temp git repo with `origin = https://github.com/e2e-org/e2e-repo.git`, registered as a project via the API; stub routes for `/user`, `/repos/e2e-org/e2e-repo` (permissions.push true), pulls list, labels, `/pulls/42` (detail+mergeability), `PUT /pulls/42/merge`, plus whatever per-item fetches the dialog issues (discover by running with the unmatched-path log). Scenarios: (a) list says open, detail says merged → entering detail shows the `role="status"` card with "Pull request successfully merged", no Merge button; (b) detail open on first entry → grid; back to list; flip stub to merged; re-enter → card; assert `/pulls/42` detail hit count increased (refresh on every entry); (c) open + mergeable → click Merge → stub returns `{merged:true}` → card appears immediately, green success line absent. Run: `bun node_modules/@playwright/test/cli.js test e2e/pr-merged-state.spec.ts`.
+- Then: opus review of `1e5f654..HEAD`, fixes, full `bun test` + full Playwright suite (fixture env change touches every worker).
+
+### 10.4 Risks
+- T6 touches 90 URL sites — mechanical, default unchanged, covered by `github.test.ts`/`github-network.test.ts` (89 literal URL assertions) which must stay green.
+- Refresh effect reordering (C1) changes effect declaration order only; behavior verified by the reviewer's trace.
+- Stub completeness for the dialog's many per-item fetches — unmatched routes 404; sections show their own errors but the Actions card/grid still renders; the spec asserts only on the Actions section.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -25,6 +25,12 @@ export interface E2EBackend {
   apiBase: string;
   bootBase: string;
   dataDir: string;
+  /** Port the per-worker/per-test stub GitHub API server should (or does)
+   *  listen on — see `e2e/github-stub.ts`. The backend is launched with
+   *  `AGETOR_GITHUB_API_BASE` pointed at this port, so a spec that starts
+   *  `startGitHubStub(backend.githubStubPort, routes)` transparently becomes
+   *  the app's GitHub API for the lifetime of that backend. */
+  githubStubPort: number;
 }
 
 const REPO_ROOT = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
@@ -156,6 +162,7 @@ async function killGracefully(child: ChildProcess): Promise<void> {
 async function provisionBackend(
   apiPort: number,
   apiToken: string,
+  githubStubPort: number,
   logLabel: string,
   use: (backend: E2EBackend) => Promise<void>,
 ): Promise<void> {
@@ -203,6 +210,16 @@ async function provisionBackend(
       AGETOR_CLAUDE_BIN: "/bin/echo",
       AGETOR_TMUX_BIN: "/bin/echo",
       AGETOR_CLAUDE_ARGS: "",
+      // Points every GitHub REST/GraphQL call this backend makes at a local
+      // stub server instead of the real api.github.com (see
+      // src/bun/github.ts's `GITHUB_API_BASE` seam and e2e/github-stub.ts).
+      // Specs that never open the Git dialog never hit this — it's inert
+      // until something calls startGitHubStub(backend.githubStubPort, ...).
+      AGETOR_GITHUB_API_BASE: `http://127.0.0.1:${githubStubPort}`,
+      // So `githubToken()` resolves this literal token from env and never
+      // shells out to `gh auth token` on the dev machine (which could hang,
+      // fail, or leak a real token into a test run).
+      GITHUB_TOKEN: "e2e-github-token",
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -270,6 +287,7 @@ async function provisionBackend(
     apiBase,
     bootBase: `${E2E_BASE_URL}/#api=${apiPort}&token=${apiToken}`,
     dataDir,
+    githubStubPort,
   };
 
   await use(backend);
@@ -299,6 +317,13 @@ async function provisionBackend(
 // these run concurrently even on a many-worker machine.
 const FRESH_BASE_API_PORT = 4700;
 
+// Disjoint from BASE_API_PORT (4600+) and FRESH_BASE_API_PORT (4700+) above —
+// each worker's (and each freshBackend test's) stub GitHub API server gets
+// its own port so parallel workers/tests never collide on it, mirroring how
+// the two API-port ranges stay disjoint from each other.
+const GITHUB_STUB_BASE_PORT = 4800;
+const FRESH_GITHUB_STUB_BASE_PORT = 4900;
+
 export const test = base.extend<{ freshBackend: E2EBackend }, { backend: E2EBackend }>({
   backend: [
     async ({}, use, workerInfo) => {
@@ -315,7 +340,8 @@ export const test = base.extend<{ freshBackend: E2EBackend }, { backend: E2EBack
       // raced it. A random token makes any such impostor fail auth loudly
       // instead.
       const apiToken = `e2e-w${workerInfo.parallelIndex}-${randomUUID()}`;
-      await provisionBackend(apiPort, apiToken, `worker ${workerInfo.parallelIndex}`, use);
+      const githubStubPort = GITHUB_STUB_BASE_PORT + workerInfo.parallelIndex;
+      await provisionBackend(apiPort, apiToken, githubStubPort, `worker ${workerInfo.parallelIndex}`, use);
     },
     { scope: "worker" },
   ],
@@ -337,6 +363,7 @@ export const test = base.extend<{ freshBackend: E2EBackend }, { backend: E2EBack
   freshBackend: async ({}, use, testInfo) => {
     const apiPort = FRESH_BASE_API_PORT + testInfo.parallelIndex;
     const apiToken = `e2e-fresh-w${testInfo.parallelIndex}-${randomUUID()}`;
-    await provisionBackend(apiPort, apiToken, `test "${testInfo.title}"`, use);
+    const githubStubPort = FRESH_GITHUB_STUB_BASE_PORT + testInfo.parallelIndex;
+    await provisionBackend(apiPort, apiToken, githubStubPort, `test "${testInfo.title}"`, use);
   },
 });

--- a/e2e/github-stub.ts
+++ b/e2e/github-stub.ts
@@ -17,10 +17,20 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
  * Routes are matched in declaration order by method (default: any) + path
  * (exact string match, or a `RegExp` tested against the URL's pathname —
  * query strings are stripped before matching and handed to route bodies
- * separately via `query`). `routes` is a live, mutable array — a spec can
- * either call `setRoutes()` to swap the whole table (e.g. flipping a PR from
- * open to merged mid-test) or mutate `stub.routes` in place; both are seen by
- * the very next request since the server always reads the current array.
+ * separately via `query`) + `accept` header (optional — a route that declares
+ * one only matches a request whose `accept` header matches it; a route with
+ * no `accept` matches regardless of the request's header, same as before).
+ * `routes` is a live, mutable array — a spec can either call `setRoutes()` to
+ * swap the whole table (e.g. flipping a PR from open to merged mid-test) or
+ * mutate `stub.routes` in place; both are seen by the very next request since
+ * the server always reads the current array.
+ *
+ * A route body function normally returns a plain JSON-serializable value or a
+ * `{status, body}` envelope; it can additionally set `contentType` alongside
+ * a string `body` to send that string raw (no `JSON.stringify`) — e.g. for
+ * `.diff`/`.patch` media-type responses. There's no `stubResponse()` helper
+ * for building that envelope — the shape is small enough to write inline, and
+ * skipping the helper keeps the stub's own API surface small.
  *
  * Every request (matched or not) is appended to `calls` so a spec can assert
  * on hit counts (`callsMatching`) — e.g. "the detail endpoint was refetched
@@ -45,6 +55,12 @@ export interface StubRoute {
   method?: string;
   /** Exact match against the URL pathname, or a RegExp tested against it. */
   path: RegExp | string;
+  /** When set, this route only matches a request whose `accept` header
+   *  matches (substring test for a string, `.test()` for a RegExp) — e.g. to
+   *  give a `.diff`-media-type request on the same path a different response
+   *  than the default JSON one. A route with no `accept` matches any request,
+   *  same as before this field existed. */
+  accept?: string | RegExp;
   /** Status to send when `body` is a plain value (ignored when `body` is a
    *  function that returns a `{ status, body }` envelope — that overrides). */
   status?: number;
@@ -52,10 +68,14 @@ export interface StubRoute {
    * Either a plain JSON-serializable value to send back verbatim, or a
    * function receiving the parsed request (JSON body if any, else the raw
    * text, else `null`) and returning either a plain value (sent with
-   * `status`/200) or a `{ status, body }` envelope to override the status
-   * for that particular call.
+   * `status`/200) or a `{ status, body[, contentType] }` envelope to override
+   * the status for that particular call. Setting `contentType` together with
+   * a string `body` sends that string raw (no `JSON.stringify`) — for a
+   * non-JSON response such as a `.diff`/`.patch` media-type fetch.
    */
-  body: unknown | ((req: StubRequest) => unknown | { status: number; body: unknown });
+  body:
+    | unknown
+    | ((req: StubRequest) => unknown | { status: number; body: unknown; contentType?: string });
 }
 
 export interface GitHubStub {
@@ -68,19 +88,49 @@ export interface GitHubStub {
   close(): Promise<void>;
 }
 
-function isStatusBodyEnvelope(value: unknown): value is { status: number; body: unknown } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "status" in value &&
-    typeof (value as { status: unknown }).status === "number" &&
-    "body" in value
-  );
+const ENVELOPE_KEYS = new Set(["status", "body", "contentType"]);
+
+/** Distinguishes a route body function's `{status, body[, contentType]}`
+ *  control envelope from an ordinary payload value that happens to be a
+ *  plain object with `status`/`body` keys of its own. Matched structurally,
+ *  not just by key presence: every own key of `value` must be one of
+ *  `status`/`body`/`contentType`, `status` must be a number, and `body` must
+ *  be present — so a route that genuinely wants to send back
+ *  `{status: "ok", body: "…"}` (a real API payload shape, `status` as a
+ *  string) is never misread as the envelope. A route that needs to send an
+ *  object shaped exactly like the envelope (numeric `status` key et al.) for
+ *  some other reason should wrap it: return `{status: 200, body: thatObject}`
+ *  explicitly. */
+function isStatusBodyEnvelope(
+  value: unknown,
+): value is { status: number; body: unknown; contentType?: string } {
+  if (typeof value !== "object" || value === null) return false;
+  const keys = Object.keys(value);
+  if (keys.length === 0 || !keys.every((k) => ENVELOPE_KEYS.has(k))) return false;
+  if (typeof (value as { status: unknown }).status !== "number") return false;
+  return "body" in value;
 }
 
-function matchesRoute(route: StubRoute, method: string, pathname: string): boolean {
+/** Strips a `g` flag before using a RegExp for a stateless `.test()` — a
+ *  route or `callsMatching` filter reused across multiple requests/assertions
+ *  with a `g`-flagged RegExp would otherwise silently start failing every
+ *  other call because `.test()` advances `lastIndex` and never resets it. */
+function stateless(re: RegExp): RegExp {
+  return re.flags.includes("g") ? new RegExp(re.source, re.flags.replace("g", "")) : re;
+}
+
+function matchesAccept(want: string | RegExp | undefined, header: string | undefined): boolean {
+  if (!want) return true;
+  const value = header ?? "";
+  return typeof want === "string" ? value.includes(want) : stateless(want).test(value);
+}
+
+function matchesRoute(route: StubRoute, method: string, pathname: string, acceptHeader: string | undefined): boolean {
   if (route.method && route.method.toUpperCase() !== method) return false;
-  return typeof route.path === "string" ? route.path === pathname : route.path.test(pathname);
+  const pathMatches =
+    typeof route.path === "string" ? route.path === pathname : stateless(route.path).test(pathname);
+  if (!pathMatches) return false;
+  return matchesAccept(route.accept, acceptHeader);
 }
 
 /** Buffers the request body and JSON-parses it when possible. Empty bodies
@@ -133,11 +183,14 @@ export async function startGitHubStub(port: number, initialRoutes: StubRoute[] =
     const body = method === "GET" || isHead ? null : await readBody(req);
     calls.push({ method, path: pathname, body });
 
+    const acceptHeader = req.headers.accept;
+    const accept = Array.isArray(acceptHeader) ? acceptHeader.join(", ") : acceptHeader;
+
     // HEAD falls back to matching as if it were GET when no route explicitly
     // declares `method: "HEAD"` — mirrors ordinary HTTP server behavior.
     const route =
-      routes.find((r) => matchesRoute(r, method, pathname)) ??
-      (isHead ? routes.find((r) => matchesRoute(r, "GET", pathname)) : undefined);
+      routes.find((r) => matchesRoute(r, method, pathname, accept)) ??
+      (isHead ? routes.find((r) => matchesRoute(r, "GET", pathname, accept)) : undefined);
 
     if (!route) {
       const message = `stub: no route for ${method} ${pathname}`;
@@ -150,6 +203,8 @@ export async function startGitHubStub(port: number, initialRoutes: StubRoute[] =
     }
 
     let status = route.status ?? 200;
+    let contentType = "application/json";
+    let rawBody: string | undefined;
     let payload: unknown;
     if (typeof route.body === "function") {
       const result = await (route.body as (req: StubRequest) => unknown)({
@@ -160,7 +215,12 @@ export async function startGitHubStub(port: number, initialRoutes: StubRoute[] =
       });
       if (isStatusBodyEnvelope(result)) {
         status = result.status;
-        payload = result.body;
+        if (result.contentType && typeof result.body === "string") {
+          contentType = result.contentType;
+          rawBody = result.body;
+        } else {
+          payload = result.body;
+        }
       } else {
         payload = result;
       }
@@ -168,8 +228,8 @@ export async function startGitHubStub(port: number, initialRoutes: StubRoute[] =
       payload = route.body;
     }
 
-    res.writeHead(status, { "content-type": "application/json" });
-    res.end(isHead ? undefined : JSON.stringify(payload ?? null));
+    res.writeHead(status, { "content-type": contentType });
+    res.end(isHead ? undefined : rawBody !== undefined ? rawBody : JSON.stringify(payload ?? null));
   }
 
   const server: Server = createServer((req, res) => {
@@ -182,10 +242,28 @@ export async function startGitHubStub(port: number, initialRoutes: StubRoute[] =
     });
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(port, "127.0.0.1", () => resolve());
-  });
+  // Keep-alive sockets left open by a client (Bun's fetch, in practice) can
+  // otherwise hold `server.close()` pending indefinitely — a stub that never
+  // closes is exactly the "stale process squatting the port" failure mode
+  // `startGitHubStub`'s EADDRINUSE message below warns about for the *next*
+  // run. Disabling keep-alive timeout server-side plus force-closing
+  // connections in `close()` (below) makes shutdown prompt and deterministic.
+  server.keepAliveTimeout = 0;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(port, "127.0.0.1", () => resolve());
+    });
+  } catch (err) {
+    if (err && typeof err === "object" && (err as { code?: string }).code === "EADDRINUSE") {
+      throw new Error(
+        `[github-stub] port ${port} is already in use — a previous run's stub may still be alive: ` +
+          `\`lsof -ti :${port} | xargs kill\``,
+      );
+    }
+    throw err;
+  }
 
   const stub: GitHubStub = {
     port,
@@ -202,11 +280,21 @@ export async function startGitHubStub(port: number, initialRoutes: StubRoute[] =
     },
     callsMatching(re: RegExp, method?: string): number {
       const wantMethod = method?.toUpperCase();
-      return calls.filter((c) => (!wantMethod || c.method === wantMethod) && re.test(c.path)).length;
+      const stableRe = stateless(re);
+      return calls.filter((c) => (!wantMethod || c.method === wantMethod) && stableRe.test(c.path)).length;
     },
     close(): Promise<void> {
       return new Promise((resolve, reject) => {
+        // `close()` first (stops accepting new connections, waits for
+        // existing ones to end before firing its callback), THEN
+        // `closeAllConnections()` to force-terminate any lingering
+        // keep-alive sockets so that callback actually fires promptly
+        // instead of hanging until a client-side idle timeout. Reversing
+        // this order breaks under Bun's `node:http` shim, where
+        // `closeAllConnections()` appears to tear down the listener itself
+        // — a subsequent `close()` then throws "Server is not running".
         server.close((err) => (err ? reject(err) : resolve()));
+        server.closeAllConnections?.();
       });
     },
   } as GitHubStub;

--- a/e2e/github-stub.ts
+++ b/e2e/github-stub.ts
@@ -1,0 +1,215 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+/**
+ * Tiny reusable stub GitHub API server for Playwright specs.
+ *
+ * Pairs with `src/bun/github.ts`'s `GITHUB_API_BASE` seam (overridable via
+ * `AGETOR_GITHUB_API_BASE`) and `e2e/fixtures.ts`'s per-worker/per-test
+ * `githubStubPort`: a spec starts a stub on `backend.githubStubPort` and the
+ * app's GitHub REST/GraphQL calls transparently land here instead of the
+ * real `api.github.com`, with no product-code branching on "am I in a test".
+ *
+ * Uses Node's `node:http` rather than `Bun.serve` purely for portability —
+ * Playwright specs run under Bun (`bun node_modules/@playwright/test/cli.js
+ * test`), and `node:http` works fine there while staying the more portable
+ * choice if the harness ever changes.
+ *
+ * Routes are matched in declaration order by method (default: any) + path
+ * (exact string match, or a `RegExp` tested against the URL's pathname —
+ * query strings are stripped before matching and handed to route bodies
+ * separately via `query`). `routes` is a live, mutable array — a spec can
+ * either call `setRoutes()` to swap the whole table (e.g. flipping a PR from
+ * open to merged mid-test) or mutate `stub.routes` in place; both are seen by
+ * the very next request since the server always reads the current array.
+ *
+ * Every request (matched or not) is appended to `calls` so a spec can assert
+ * on hit counts (`callsMatching`) — e.g. "the detail endpoint was refetched
+ * on re-entry". An unmatched request gets a 404 JSON body AND a
+ * `console.error` naming the method+path, so a spec author can discover what
+ * the app actually fetches by just running it once and reading stderr.
+ *
+ * NOT emulated: GitHub's pagination `Link` response header. Every stub
+ * response here is a single page — a spec that needs multi-page behavior
+ * must fake it itself (e.g. a route body that inspects `query.get("page")`).
+ */
+
+export interface StubRequest {
+  method: string;
+  path: string;
+  query: URLSearchParams;
+  body: unknown;
+}
+
+export interface StubRoute {
+  /** Defaults to matching any method. */
+  method?: string;
+  /** Exact match against the URL pathname, or a RegExp tested against it. */
+  path: RegExp | string;
+  /** Status to send when `body` is a plain value (ignored when `body` is a
+   *  function that returns a `{ status, body }` envelope — that overrides). */
+  status?: number;
+  /**
+   * Either a plain JSON-serializable value to send back verbatim, or a
+   * function receiving the parsed request (JSON body if any, else the raw
+   * text, else `null`) and returning either a plain value (sent with
+   * `status`/200) or a `{ status, body }` envelope to override the status
+   * for that particular call.
+   */
+  body: unknown | ((req: StubRequest) => unknown | { status: number; body: unknown });
+}
+
+export interface GitHubStub {
+  port: number;
+  baseUrl: string;
+  routes: StubRoute[];
+  calls: Array<{ method: string; path: string; body: unknown }>;
+  setRoutes(routes: StubRoute[]): void;
+  callsMatching(re: RegExp, method?: string): number;
+  close(): Promise<void>;
+}
+
+function isStatusBodyEnvelope(value: unknown): value is { status: number; body: unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "status" in value &&
+    typeof (value as { status: unknown }).status === "number" &&
+    "body" in value
+  );
+}
+
+function matchesRoute(route: StubRoute, method: string, pathname: string): boolean {
+  if (route.method && route.method.toUpperCase() !== method) return false;
+  return typeof route.path === "string" ? route.path === pathname : route.path.test(pathname);
+}
+
+/** Buffers the request body and JSON-parses it when possible. Empty bodies
+ *  (GET/HEAD, or a request with no payload) resolve to `null`; a non-JSON
+ *  body resolves to the raw text rather than throwing, so a route body
+ *  function can still inspect it. */
+function readBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      if (chunks.length === 0) {
+        resolve(null);
+        return;
+      }
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (!raw) {
+        resolve(null);
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        resolve(raw);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+export async function startGitHubStub(port: number, initialRoutes: StubRoute[] = []): Promise<GitHubStub> {
+  let routes: StubRoute[] = initialRoutes;
+  const calls: Array<{ method: string; path: string; body: unknown }> = [];
+
+  async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const method = (req.method ?? "GET").toUpperCase();
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const pathname = url.pathname;
+
+    // Minimal handling: no route table lookup needed for a bare CORS-style
+    // preflight — the app never actually sends one (server-side fetch, not a
+    // browser), but respond harmlessly if anything ever does.
+    if (method === "OPTIONS") {
+      calls.push({ method, path: pathname, body: null });
+      res.writeHead(204).end();
+      return;
+    }
+
+    const isHead = method === "HEAD";
+    const body = method === "GET" || isHead ? null : await readBody(req);
+    calls.push({ method, path: pathname, body });
+
+    // HEAD falls back to matching as if it were GET when no route explicitly
+    // declares `method: "HEAD"` — mirrors ordinary HTTP server behavior.
+    const route =
+      routes.find((r) => matchesRoute(r, method, pathname)) ??
+      (isHead ? routes.find((r) => matchesRoute(r, "GET", pathname)) : undefined);
+
+    if (!route) {
+      const message = `stub: no route for ${method} ${pathname}`;
+      // eslint-disable-next-line no-console -- deliberate: lets a spec author
+      // discover unhandled fetches by reading stderr from one run.
+      console.error(`[github-stub] unmatched ${method} ${pathname}`);
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(isHead ? undefined : JSON.stringify({ message }));
+      return;
+    }
+
+    let status = route.status ?? 200;
+    let payload: unknown;
+    if (typeof route.body === "function") {
+      const result = await (route.body as (req: StubRequest) => unknown)({
+        method,
+        path: pathname,
+        query: url.searchParams,
+        body,
+      });
+      if (isStatusBodyEnvelope(result)) {
+        status = result.status;
+        payload = result.body;
+      } else {
+        payload = result;
+      }
+    } else {
+      payload = route.body;
+    }
+
+    res.writeHead(status, { "content-type": "application/json" });
+    res.end(isHead ? undefined : JSON.stringify(payload ?? null));
+  }
+
+  const server: Server = createServer((req, res) => {
+    handle(req, res).catch((err: unknown) => {
+      // eslint-disable-next-line no-console -- surfaces a stub bug loudly
+      // rather than hanging the request or crashing the process.
+      console.error("[github-stub] handler error", err);
+      if (!res.headersSent) res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ message: "stub: internal error" }));
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => resolve());
+  });
+
+  const stub: GitHubStub = {
+    port,
+    baseUrl: `http://127.0.0.1:${port}`,
+    get routes() {
+      return routes;
+    },
+    set routes(next: StubRoute[]) {
+      routes = next;
+    },
+    calls,
+    setRoutes(next: StubRoute[]) {
+      routes = next;
+    },
+    callsMatching(re: RegExp, method?: string): number {
+      const wantMethod = method?.toUpperCase();
+      return calls.filter((c) => (!wantMethod || c.method === wantMethod) && re.test(c.path)).length;
+    },
+    close(): Promise<void> {
+      return new Promise((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  } as GitHubStub;
+
+  return stub;
+}

--- a/e2e/pr-merged-state.spec.ts
+++ b/e2e/pr-merged-state.spec.ts
@@ -1,0 +1,365 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test, expect, type Page } from "./fixtures";
+import { gotoApp } from "./helpers";
+import { startGitHubStub, type GitHubStub, type StubRoute } from "./github-stub";
+
+/**
+ * E2E coverage for the PR modal's merge-status refresh + merged-state banner
+ * (docs/plans/pr-modal-refresh-merge-status-and-merged-banner.md §10, esp.
+ * T7) — the "Actions" section of the Git dialog's PR detail view
+ * (`PullActions`/`PullActionGrid`/`MergedPullCard` in
+ * `src/mainview/components/kanban/GitHubDialog.tsx`):
+ *
+ *   1. a PR that was merged *outside* agetor (GitHub web UI, another agetor
+ *      window, ...) is caught by the refresh-on-detail-entry effect
+ *      (`refreshPullDetail`) even when the cached list still says "open",
+ *      and the purple merged card replaces the mergeability banner + action
+ *      grid;
+ *   2. that refresh fires on *every* entry into the detail view (list ->
+ *      detail(A) -> list -> detail(A) refetches, not just the first visit);
+ *   3. merging from inside agetor flips the card in place, with no need to
+ *      leave the detail view or re-navigate.
+ *
+ * Arrange: one throwaway git repo (`git init` + `commit.gpgsign false`, one
+ * commit, `origin` pointed at `https://github.com/e2e-org/e2e-repo.git` so
+ * the backend's remote-parsing resolves it to owner `e2e-org` / repo
+ * `e2e-repo` — see `repoForDir` in src/bun/github.ts) registered as a
+ * project through the real `POST /projects` API. Shared across all three
+ * tests below (`beforeAll`/`afterAll`, serial mode) rather than one repo per
+ * test: the three scenarios are really three views of the *same* PR #42
+ * over time (open -> merged), so a single registered project avoids the
+ * "multiple projects registered, which one does the dialog auto-select"
+ * question entirely — there is always exactly one.
+ *
+ * The stub GitHub API (`e2e/github-stub.ts`) is started once on
+ * `backend.githubStubPort` (the backend was launched with
+ * `AGETOR_GITHUB_API_BASE` already pointed there — see e2e/fixtures.ts) and
+ * each test installs its own route table via `setRoutes` so the previous
+ * test's PR state can't leak into the next. Route bodies are closures over a
+ * test-local `merged` flag (mutated either directly, to simulate an
+ * out-of-band merge, or by the stubbed `PUT .../merge` handler, to simulate
+ * an in-app one) rather than static payloads, so "the PR just changed
+ * state" needs no second `setRoutes` call — the next matching request just
+ * reads the current flag.
+ *
+ * Deliberately NOT stubbed with any care: pull commits/comments/review
+ * comments/check-runs/commit-status/labels/milestones/assignees/releases/
+ * reactions and the GraphQL linked-issues/review-threads queries the detail
+ * view also fires on entry — all answered with cheap empty payloads (see
+ * `auxiliaryRoutes`) purely to keep the stub's unmatched-route stderr log
+ * quiet; none of them affect the Actions section these tests assert on.
+ */
+
+test.describe.configure({ mode: "serial" });
+
+const REPO_PATH = "/repos/e2e-org/e2e-repo";
+const PR_TITLE = "e2e test pull request";
+
+// The refresh-on-entry effect chains a project-select render, an item-list
+// fetch, and (for the merged assertions) the entry-refresh + mergeability
+// fetches settling and re-rendering — generous but bounded, rather than a
+// fixed sleep, so a loaded CI/dev machine doesn't flake on the default 5s
+// expect timeout while a normal machine still fails fast on a real bug.
+const CONVERGE_TIMEOUT = 15_000;
+
+let stub: GitHubStub;
+let projectDir: string;
+
+function git(cwd: string, args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+}
+
+async function initRepo(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "agetor-e2e-pr-merged-"));
+  git(dir, ["init", "-q", "-b", "main"]);
+  git(dir, ["config", "user.email", "e2e@example.com"]);
+  git(dir, ["config", "user.name", "e2e"]);
+  git(dir, ["config", "commit.gpgsign", "false"]);
+  git(dir, ["remote", "add", "origin", "https://github.com/e2e-org/e2e-repo.git"]);
+  await writeFile(path.join(dir, "README.md"), "e2e fixture repo\n");
+  git(dir, ["add", "-A"]);
+  git(dir, ["commit", "-q", "-m", "initial commit"]);
+  return dir;
+}
+
+/** Registers `dir` as a project directly against the worker backend's API,
+ *  using the plain global `fetch` (not Playwright's `request` fixture) so
+ *  this can run from `test.beforeAll`, which only has worker-scoped fixtures
+ *  (`backend`) available — `request` is test-scoped. */
+async function registerProject(apiBase: string, apiToken: string, dir: string): Promise<void> {
+  const res = await fetch(`${apiBase}/projects`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${apiToken}`, "content-type": "application/json" },
+    body: JSON.stringify({ path: dir }),
+  });
+  if (!res.ok) {
+    throw new Error(`POST /projects -> ${res.status}: ${await res.text()}`);
+  }
+}
+
+interface PrOverrides {
+  state?: "open" | "closed";
+  merged?: boolean;
+  mergedAt?: string | null;
+  closedAt?: string | null;
+  mergeable?: boolean | null;
+  mergeableState?: string;
+}
+
+/** A minimally-shaped GitHub pull request JSON object — enough for
+ *  `normalizeItem` (number/title/state/html_url/user/assignees/milestone/
+ *  body/labels/comments/created_at/updated_at/closed_at/merged_at/draft/
+ *  locked) AND `normalizeMergeability` (head/base/mergeable/mergeable_state/
+ *  rebaseable/merged/auto_merge) to both accept it — the same `GET
+ *  .../pulls/42` stub route serves the detail fetch, the mergeability poll,
+ *  and (harmlessly, since it degrades to "no diff") the `.diff`-media-type
+ *  fetch. */
+function prPayload(overrides: PrOverrides = {}) {
+  return {
+    number: 42,
+    title: PR_TITLE,
+    state: overrides.state ?? "open",
+    html_url: "https://github.com/e2e-org/e2e-repo/pull/42",
+    user: { login: "e2e-author", avatar_url: null, html_url: null },
+    assignees: [] as unknown[],
+    milestone: null,
+    body: "",
+    labels: [] as unknown[],
+    comments: 0,
+    created_at: "2026-08-18T09:00:00Z",
+    updated_at: "2026-08-19T09:00:00Z",
+    closed_at: overrides.closedAt ?? null,
+    merged_at: overrides.mergedAt ?? null,
+    locked: false,
+    draft: false,
+    head: {
+      ref: "feature-branch",
+      sha: "abc123deadbeef0000000000000000000000000",
+      repo: { full_name: "e2e-org/e2e-repo" },
+    },
+    base: { ref: "main", repo: { full_name: "e2e-org/e2e-repo" } },
+    mergeable: overrides.mergeable ?? true,
+    mergeable_state: overrides.mergeableState ?? "clean",
+    rebaseable: true,
+    merged: overrides.merged ?? false,
+    auto_merge: null,
+  };
+}
+
+/** Routes every scenario needs regardless of PR state, so the detail view's
+ *  many per-item sections (commits, conversation + review comments, check
+ *  runs, combined commit status, repo labels/milestones/assignees, and the
+ *  linked-issues/review-threads GraphQL queries) resolve cleanly instead of
+ *  404ing into the stub's unmatched-route log. None of these are asserted on
+ *  — only the Actions section is. */
+function auxiliaryRoutes(): StubRoute[] {
+  return [
+    { method: "GET", path: "/user", body: { login: "e2e-user", id: 1 } },
+    {
+      method: "GET",
+      path: new RegExp(`^${REPO_PATH}$`),
+      body: { permissions: { push: true, admin: true, maintain: true }, default_branch: "main" },
+    },
+    { method: "GET", path: new RegExp(`^${REPO_PATH}/pulls/42/commits$`), body: [] },
+    { method: "GET", path: new RegExp(`^${REPO_PATH}/pulls/42/comments$`), body: [] },
+    { method: "GET", path: new RegExp(`^${REPO_PATH}/issues/42/comments$`), body: [] },
+    { method: "GET", path: new RegExp(`^${REPO_PATH}/commits/[^/]+/check-runs$`), body: { check_runs: [] } },
+    { method: "GET", path: new RegExp(`^${REPO_PATH}/commits/[^/]+/status$`), body: { state: "success", statuses: [] } },
+    { method: "GET", path: new RegExp(`^${REPO_PATH}/labels$`), body: [] },
+    { method: "GET", path: new RegExp(`^${REPO_PATH}/milestones$`), body: [] },
+    { method: "GET", path: new RegExp(`^${REPO_PATH}/assignees$`), body: [] },
+    { method: "GET", path: new RegExp(`^${REPO_PATH}/releases$`), body: [] },
+    { method: "GET", path: new RegExp(`^${REPO_PATH}/issues/42/reactions$`), body: [] },
+    {
+      method: "POST",
+      path: "/graphql",
+      // Same shape answers both the linked-issues and review-threads
+      // queries — each parser only reads the one field it cares about and
+      // ignores the rest.
+      body: {
+        data: {
+          repository: {
+            pullRequest: {
+              closingIssuesReferences: { nodes: [] },
+              reviewThreads: { pageInfo: { hasNextPage: false }, nodes: [] },
+            },
+          },
+        },
+      },
+    },
+  ];
+}
+
+/** Opens the Git dialog (board toolbar button, aria-label "Git") and returns
+ *  its `role="dialog"` locator once rendered. */
+async function openGitDialog(page: Page) {
+  await page.getByRole("button", { name: "Git" }).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+test.beforeAll(async ({ backend }) => {
+  projectDir = await initRepo();
+  await registerProject(backend.apiBase, backend.apiToken, projectDir);
+  stub = await startGitHubStub(backend.githubStubPort);
+});
+
+test.afterAll(async () => {
+  await stub.close();
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+test.beforeEach(() => {
+  // Each test calls `stub.setRoutes(...)` with its own full table before
+  // navigating (below) — deliberately NOT reset to `[]` here first: the
+  // previous test's page can still have a trailing background fetch in
+  // flight (comments/checks/commit-status, fired automatically on detail
+  // entry but never awaited by any assertion) when this hook runs, and an
+  // empty-routes window would turn that harmless straggler into a logged
+  // "unmatched" 404. Leaving the previous table live until the new test
+  // overwrites it means a straggler either lands on the outgoing test's
+  // routes or the incoming one — both well-formed either way. Only the call
+  // log needs a clean slate per test (for the hit-count assertions above).
+  stub.calls.length = 0;
+});
+
+test.describe("PR detail: merge status refresh + merged banner", () => {
+  test("a PR merged outside agetor is caught on detail entry: merged card, no Merge button, Merged tag", async ({
+    page,
+    backend,
+  }) => {
+    test.setTimeout(60_000);
+    // The list still says "open" (as if agetor's cached view predates the
+    // merge); the per-PR detail/mergeability fetch says merged. Entering the
+    // detail view must resolve to the merged truth, not the stale list.
+    stub.setRoutes([
+      { method: "GET", path: new RegExp(`^${REPO_PATH}/pulls$`), body: [prPayload({ state: "open" })] },
+      {
+        method: "GET",
+        path: new RegExp(`^${REPO_PATH}/pulls/42$`),
+        body: prPayload({
+          state: "closed",
+          merged: true,
+          mergedAt: "2026-08-20T12:00:00Z",
+          closedAt: "2026-08-20T12:00:00Z",
+        }),
+      },
+      ...auxiliaryRoutes(),
+    ]);
+
+    await gotoApp(page, backend.bootBase);
+    const dialog = await openGitDialog(page);
+
+    const row = dialog.getByRole("button", { name: `#42 ${PR_TITLE}` });
+    await expect(row).toBeVisible();
+    await row.click();
+
+    const mergedCard = dialog.getByRole("status");
+    await expect(mergedCard).toContainText("Pull request successfully merged", { timeout: CONVERGE_TIMEOUT });
+    await expect(dialog.getByText("Merge status")).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Merge", exact: true })).toHaveCount(0);
+    await expect(dialog.getByText("Merged", { exact: true })).toBeVisible();
+  });
+
+  test("refreshes on every detail entry: open+mergeable grid, then a merge that happened while back on the list is picked up on re-entry", async ({
+    page,
+    backend,
+  }) => {
+    test.setTimeout(60_000);
+    let merged = false;
+    const pr = () =>
+      merged
+        ? prPayload({ state: "closed", merged: true, mergedAt: "2026-08-21T10:00:00Z", closedAt: "2026-08-21T10:00:00Z" })
+        : prPayload({ state: "open" });
+
+    stub.setRoutes([
+      { method: "GET", path: new RegExp(`^${REPO_PATH}/pulls$`), body: () => [pr()] },
+      { method: "GET", path: new RegExp(`^${REPO_PATH}/pulls/42$`), body: () => pr() },
+      ...auxiliaryRoutes(),
+    ]);
+
+    await gotoApp(page, backend.bootBase);
+    const dialog = await openGitDialog(page);
+
+    const row = dialog.getByRole("button", { name: `#42 ${PR_TITLE}` });
+    await expect(row).toBeVisible();
+    await row.click();
+
+    // First entry: open + mergeable -> the ordinary action grid renders.
+    await expect(dialog.getByRole("button", { name: "Merge", exact: true })).toBeVisible({ timeout: CONVERGE_TIMEOUT });
+    await expect(dialog.getByText("Ready to merge")).toBeVisible({ timeout: CONVERGE_TIMEOUT });
+
+    const hitsBeforeReentry = stub.callsMatching(/\/pulls\/42$/, "GET");
+
+    // Back to the list, flip the PR to merged (simulating it happening
+    // elsewhere while the user was looking at the list), then re-enter the
+    // same detail view.
+    await dialog.getByRole("button", { name: "Back" }).click();
+    merged = true;
+    await row.click();
+
+    const mergedCard = dialog.getByRole("status");
+    await expect(mergedCard).toContainText("Pull request successfully merged", { timeout: CONVERGE_TIMEOUT });
+
+    const hitsAfterReentry = stub.callsMatching(/\/pulls\/42$/, "GET");
+    expect(hitsAfterReentry).toBeGreaterThan(hitsBeforeReentry);
+  });
+
+  test("merging in-app flips the card in place, with no navigation and no green success line", async ({
+    page,
+    backend,
+  }) => {
+    test.setTimeout(60_000);
+    let merged = false;
+    const pr = () =>
+      merged
+        ? prPayload({ state: "closed", merged: true, mergedAt: "2026-08-22T08:00:00Z", closedAt: "2026-08-22T08:00:00Z" })
+        : prPayload({ state: "open" });
+
+    stub.setRoutes([
+      { method: "GET", path: new RegExp(`^${REPO_PATH}/pulls$`), body: () => [pr()] },
+      { method: "GET", path: new RegExp(`^${REPO_PATH}/pulls/42$`), body: () => pr() },
+      {
+        method: "PUT",
+        path: new RegExp(`^${REPO_PATH}/pulls/42/merge$`),
+        body: () => {
+          merged = true;
+          return { merged: true, sha: "abc123", message: "Pull Request successfully merged" };
+        },
+      },
+      ...auxiliaryRoutes(),
+    ]);
+
+    await gotoApp(page, backend.bootBase);
+    const dialog = await openGitDialog(page);
+
+    const row = dialog.getByRole("button", { name: `#42 ${PR_TITLE}` });
+    await expect(row).toBeVisible();
+    await row.click();
+
+    const mergeButton = dialog.getByRole("button", { name: "Merge", exact: true });
+    await expect(mergeButton).toBeEnabled({ timeout: CONVERGE_TIMEOUT });
+    await mergeButton.click();
+
+    const mergedCard = dialog.getByRole("status");
+    await expect(mergedCard).toContainText("Pull request successfully merged", { timeout: CONVERGE_TIMEOUT });
+    // Still on the detail subpage — merging didn't navigate away.
+    await expect(dialog.getByRole("button", { name: "Back" })).toBeVisible();
+    await expect(dialog.getByText("Merged", { exact: true })).toBeVisible();
+    // The green success line is suppressed once merged — the card + "Merged"
+    // tag already say it (U2).
+    await expect(dialog.getByText(/Pull Request successfully merged/)).toHaveCount(0);
+
+    // Optional (T7 "4"): the header's Refresh button still works on a merged
+    // PR and re-hits the detail endpoint.
+    const hitsBeforeRefresh = stub.callsMatching(/\/pulls\/42$/, "GET");
+    await dialog.getByRole("button", { name: "Refresh", exact: true }).click();
+    await expect
+      .poll(() => stub.callsMatching(/\/pulls\/42$/, "GET"), { timeout: CONVERGE_TIMEOUT })
+      .toBeGreaterThan(hitsBeforeRefresh);
+  });
+});

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -70,8 +70,13 @@ import { tokenForHost } from "./github-tokens.ts";
 /** GitHub REST/GraphQL API origin. `AGETOR_GITHUB_API_BASE` is a dev/test-only
  *  override (the Playwright e2e harness points it at a local stub server); unset in
  *  normal use. Mirrors `BITBUCKET_API_BASE` in bitbucket.ts. GitHub Enterprise
- *  (per-host bases) is a separate follow-up — see docs/plans/per-host-git-api-bases.md. */
-const GITHUB_API_BASE = (process.env.AGETOR_GITHUB_API_BASE ?? "https://api.github.com").replace(/\/+$/, "");
+ *  (per-host bases) is a separate follow-up — see docs/plans/per-host-git-api-bases.md.
+ *  `||` (not `??`) so an exported-but-empty env var falls back to the default instead
+ *  of pinning every request to the empty-string origin. Never point this at a
+ *  non-loopback host: `fetchGitHub` sends the user's GitHub token
+ *  (`authorization: Bearer …`) to whatever origin it names, so anything other than
+ *  `https://api.github.com` or a local test stub would leak the token off-machine. */
+const GITHUB_API_BASE = (process.env.AGETOR_GITHUB_API_BASE || "https://api.github.com").replace(/\/+$/, "");
 
 export interface CommandResult {
   ok: boolean;
@@ -4601,11 +4606,21 @@ export async function deleteGitHubRelease(input: DeleteGitHubReleaseInput): Prom
  *  null when the shape isn't a recognizable repo subject URL. */
 function notificationHtmlUrl(subjectUrl: string | null): string | null {
   if (!subjectUrl) return null;
-  const m = /^https:\/\/api\.github\.com\/repos\/([^/]+)\/([^/]+)\/(.+)$/.exec(subjectUrl);
-  if (!m) return null;
-  const [, owner, name, rest] = m;
+  // Derived from the same `GITHUB_API_BASE` seam every other request uses,
+  // rather than a hardcoded `api.github.com` regex — so this keeps working
+  // (and keeps rejecting non-matching origins) when the base is overridden
+  // for dev/test via `AGETOR_GITHUB_API_BASE`. Output host stays
+  // `https://github.com` regardless — that's the real notification web UI.
+  const prefix = `${GITHUB_API_BASE}/repos/`;
+  if (!subjectUrl.startsWith(prefix)) return null;
+  const rest = subjectUrl.slice(prefix.length);
+  const [owner, name, ...pathParts] = rest.split("/");
+  if (!owner || !name || pathParts.length === 0) return null;
   // pulls → pull, commits → commit; issues/releases map straight through.
-  const path = rest!.replace(/^pulls\//, "pull/").replace(/^commits\//, "commit/");
+  const path = pathParts
+    .join("/")
+    .replace(/^pulls\//, "pull/")
+    .replace(/^commits\//, "commit/");
   return `https://github.com/${owner}/${name}/${path}`;
 }
 

--- a/src/bun/github.ts
+++ b/src/bun/github.ts
@@ -67,6 +67,12 @@ import { contentTypeForPreviewPath, MAX_BLOB_PREVIEW_BYTES } from "../shared/att
 import { MAX_DIFF_FILES, parseGitDiff } from "./git-diff.ts";
 import { tokenForHost } from "./github-tokens.ts";
 
+/** GitHub REST/GraphQL API origin. `AGETOR_GITHUB_API_BASE` is a dev/test-only
+ *  override (the Playwright e2e harness points it at a local stub server); unset in
+ *  normal use. Mirrors `BITBUCKET_API_BASE` in bitbucket.ts. GitHub Enterprise
+ *  (per-host bases) is a separate follow-up — see docs/plans/per-host-git-api-bases.md. */
+const GITHUB_API_BASE = (process.env.AGETOR_GITHUB_API_BASE ?? "https://api.github.com").replace(/\/+$/, "");
+
 export interface CommandResult {
   ok: boolean;
   stdout: string;
@@ -718,7 +724,7 @@ function spliceSuggestionLines(content: string, startLine: number, endLine: numb
  *  separators are preserved (the Contents API treats them as directories). */
 function contentsUrl(repo: GitHubRepo, filePath: string): string {
   const encoded = filePath.split("/").map(encodeURIComponent).join("/");
-  return `https://api.github.com/repos/${repo.owner}/${repo.name}/contents/${encoded}`;
+  return `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/contents/${encoded}`;
 }
 
 type IssueUpdatePatch = {
@@ -1286,7 +1292,7 @@ function privateRepoHint(status: number, message: string, repo: GitHubRepo, hadT
 }
 
 async function pullHeadSha(repo: GitHubRepo, token: string | null, number: number): Promise<string | GitHubListError> {
-  const prUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${number}`;
+  const prUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${number}`;
   const prRes = await fetchGitHub(prUrl, token, "application/vnd.github+json");
   if (!("status" in prRes)) return prRes;
   const pr = await prRes.json().catch(() => null);
@@ -1374,7 +1380,7 @@ export async function listGitHubItems(input: ListGitHubItemsInput): Promise<GitH
   const buildPageUrl = (sourcePage: number): string => {
     let url: URL;
     if (useSearch) {
-      url = new URL("https://api.github.com/search/issues");
+      url = new URL(`${GITHUB_API_BASE}/search/issues`);
       url.searchParams.set("q", buildSearchQuery(slug, input));
       url.searchParams.set("per_page", String(perPage));
       url.searchParams.set("page", String(sourcePage));
@@ -1387,7 +1393,7 @@ export async function listGitHubItems(input: ListGitHubItemsInput): Promise<GitH
       }
     } else {
       const endpoint = input.kind === "pulls" ? "pulls" : "issues";
-      url = new URL(`https://api.github.com/repos/${repo.owner}/${repo.name}/${endpoint}`);
+      url = new URL(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/${endpoint}`);
       url.searchParams.set("state", input.state);
       url.searchParams.set("per_page", String(perPage));
       url.searchParams.set("page", String(sourcePage));
@@ -1605,7 +1611,7 @@ export async function createGitHubPull(input: CreateGitHubPullInput): Promise<Gi
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to create a pull request" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls`;
   const res = await fetchGitHub(
     url,
     token,
@@ -1632,7 +1638,7 @@ export async function createGitHubPull(input: CreateGitHubPullInput): Promise<Gi
     return { ok: true, item, message: "Pull request created." };
   }
 
-  const reviewerUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${item.number}/requested_reviewers`;
+  const reviewerUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${item.number}/requested_reviewers`;
   const reviewerRes = await fetchGitHub(
     reviewerUrl,
     token,
@@ -1661,7 +1667,7 @@ export async function getGitHubPullDiff(input: GetGitHubPullDiffInput): Promise<
   }
 
   const token = await githubToken(repo.remoteHost ?? null);
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   const res = await fetchGitHub(url, token, "application/vnd.github.v3.diff");
   if (!("status" in res)) return res;
   const contentLength = Number(res.headers.get("content-length") ?? 0);
@@ -1834,7 +1840,7 @@ export async function getGitHubPullBlob(input: GetGitHubPullBlobInput): Promise<
   if (cachedDetail && Date.now() - cachedDetail.fetchedAt < PULL_DETAIL_CACHE_TTL_MS) {
     ({ headSha, baseSha, headRepoFullName, baseRepoFullName } = cachedDetail);
   } else {
-    const prUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+    const prUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
     const prRes = await fetchGitHub(prUrl, token, "application/vnd.github+json");
     if (!("status" in prRes)) return { ok: false, error: prRes.error, status: 502 };
     const prJson = await prRes.json().catch(() => null);
@@ -1884,7 +1890,7 @@ export async function getGitHubPullBlob(input: GetGitHubPullBlobInput): Promise<
     if (cached) {
       ref = cached;
     } else {
-      const compareUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/compare/`
+      const compareUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/compare/`
         + `${encodeURIComponent(baseSha)}...${encodeURIComponent(headSha)}`;
       const compareRes = await fetchGitHub(compareUrl, token, "application/vnd.github+json");
       if (!("status" in compareRes)) return { ok: false, error: compareRes.error, status: 502 };
@@ -1953,7 +1959,7 @@ export async function getGitHubPullDetail(input: GitHubItemNumberInput): Promise
   }
 
   const token = await githubToken(repo.remoteHost ?? null);
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
@@ -1971,7 +1977,7 @@ export async function listGitHubComments(input: GitHubItemNumberInput): Promise<
   }
 
   const token = await githubToken(repo.remoteHost ?? null);
-  const url = new URL(`https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}/comments`);
+  const url = new URL(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${input.number}/comments`);
   url.searchParams.set("per_page", "100");
   const res = await fetchGitHub(url.toString(), token, "application/vnd.github+json");
   if (!("status" in res)) return res;
@@ -2002,7 +2008,7 @@ export async function createGitHubComment(input: CreateGitHubCommentInput): Prom
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to comment" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}/comments`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${input.number}/comments`;
   const res = await fetchGitHub(
     url,
     token,
@@ -2046,7 +2052,7 @@ export async function createGitHubPullLineComment(
   const sha = await pullHeadSha(repo, token, input.number);
   if (typeof sha !== "string") return sha;
 
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/comments`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}/comments`;
   const res = await fetchGitHub(
     url,
     token,
@@ -2080,7 +2086,7 @@ export async function listGitHubPullReviewComments(
   }
 
   const token = await githubToken(repo.remoteHost ?? null);
-  const url = new URL(`https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/comments`);
+  const url = new URL(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}/comments`);
   url.searchParams.set("per_page", "100");
   const res = await fetchGitHub(url.toString(), token, "application/vnd.github+json");
   if (!("status" in res)) return res;
@@ -2111,7 +2117,7 @@ export async function replyGitHubPullLineComment(
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to reply" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/comments/${input.commentId}/replies`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}/comments/${input.commentId}/replies`;
   const res = await fetchGitHub(
     url,
     token,
@@ -2150,7 +2156,7 @@ export async function applyGitHubSuggestion(input: ApplyGitHubSuggestionInput): 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to apply a suggestion" };
 
-  const reviewCommentUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/comments/${input.commentId}`;
+  const reviewCommentUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/comments/${input.commentId}`;
   const commentRes = await fetchGitHub(reviewCommentUrl, token, "application/vnd.github+json");
   if (!("status" in commentRes)) return commentRes;
   const commentJson = await commentRes.json().catch(() => null);
@@ -2170,7 +2176,7 @@ export async function applyGitHubSuggestion(input: ApplyGitHubSuggestionInput): 
   const parsed = parseSuggestion(range.body);
   if (!parsed) return { ok: false, error: "This comment doesn't contain a suggested change." };
 
-  const prUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+  const prUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   const prRes = await fetchGitHub(prUrl, token, "application/vnd.github+json");
   if (!("status" in prRes)) return prRes;
   const prJson = await prRes.json().catch(() => null);
@@ -2246,7 +2252,7 @@ export async function getGitHubPullChecks(input: GitHubItemNumberInput): Promise
   const sha = await pullHeadSha(repo, token, input.number);
   if (typeof sha !== "string") return sha;
 
-  const checksUrl = new URL(`https://api.github.com/repos/${repo.owner}/${repo.name}/commits/${sha}/check-runs`);
+  const checksUrl = new URL(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/commits/${sha}/check-runs`);
   checksUrl.searchParams.set("per_page", "100");
   const checksRes = await fetchGitHub(checksUrl.toString(), token, "application/vnd.github+json");
   if (!("status" in checksRes)) return checksRes;
@@ -2281,7 +2287,7 @@ export async function getGitHubCommitStatus(input: GetGitHubCommitStatusInput): 
   if (!ref) return { ok: false, error: "commit ref required" };
 
   const token = await githubToken(repo.remoteHost ?? null);
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/commits/${encodeURIComponent(ref)}/status`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/commits/${encodeURIComponent(ref)}/status`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
@@ -2302,7 +2308,7 @@ export async function listGitHubPullCommits(input: GitHubItemNumberInput): Promi
 
   const token = await githubToken(repo.remoteHost ?? null);
   const commits: GitHubPullCommit[] = [];
-  let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/commits?per_page=100`;
+  let next: string | null = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}/commits?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
     const res = await fetchGitHub(next, token, "application/vnd.github+json");
     if (!("status" in res)) return res;
@@ -2331,7 +2337,7 @@ export async function reviewGitHubPull(input: ReviewGitHubPullInput): Promise<Gi
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to review" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/reviews`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}/reviews`;
   const res = await fetchGitHub(
     url,
     token,
@@ -2371,7 +2377,7 @@ export async function mergeGitHubPull(input: MergeGitHubPullInput): Promise<GitH
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to merge" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/merge`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}/merge`;
   const res = await fetchGitHub(
     url,
     token,
@@ -2408,7 +2414,7 @@ export async function closeGitHubPull(input: CloseGitHubPullInput): Promise<GitH
   if (!token) return { ok: false, error: "GitHub authentication required to close a pull request" };
   const comment = input.comment?.trim() ?? "";
 
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   const res = await fetchGitHub(
     url,
     token,
@@ -2448,7 +2454,7 @@ export async function createGitHubIssue(input: CreateGitHubIssueInput): Promise<
   if (!token) return { ok: false, error: "GitHub authentication required to create an issue" };
   const labels = input.labels?.map((s) => s.trim()).filter(Boolean) ?? [];
   const assignees = input.assignees?.map((s) => s.trim()).filter(Boolean) ?? [];
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues`;
   const res = await fetchGitHub(
     url,
     token,
@@ -2489,7 +2495,7 @@ export async function updateGitHubIssue(input: UpdateGitHubIssueInput): Promise<
   const built = buildIssueUpdatePatch(input);
   if (!built.ok) return built;
 
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${input.number}`;
   const res = await fetchGitHub(
     url,
     token,
@@ -2520,7 +2526,7 @@ export async function requestGitHubPullReviewers(
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to request reviewers" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/requested_reviewers`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}/requested_reviewers`;
   const res = await fetchGitHub(
     url,
     token,
@@ -2588,7 +2594,7 @@ export async function getGitHubPullMergeability(input: GitHubItemNumberInput): P
   }
 
   const token = await githubToken(repo.remoteHost ?? null);
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   // GitHub computes `mergeable` asynchronously — the first read after a push can
   // return null. Poll a couple of times before giving up so the UI usually gets
   // a real verdict without the user hitting refresh.
@@ -2618,7 +2624,7 @@ export async function updateGitHubPullBranch(input: GitHubItemNumberInput): Prom
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to update the branch" };
   // Merges the base branch into the PR head. 202 Accepted with a message body.
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}/update-branch`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}/update-branch`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json", { method: "PUT", body: "{}" });
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
@@ -2638,7 +2644,7 @@ export async function reopenGitHubPull(input: GitHubItemNumberInput): Promise<Gi
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to reopen a pull request" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   const res = await fetchGitHub(
     url,
     token,
@@ -3053,7 +3059,7 @@ export async function setGitHubPullDraft(input: SetGitHubPullDraftInput): Promis
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to change draft state" };
-  const prUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+  const prUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   const prRes = await fetchGitHub(prUrl, token, "application/vnd.github+json");
   if (!("status" in prRes)) return prRes;
   const pr = await prRes.json().catch(() => null);
@@ -3066,7 +3072,7 @@ export async function setGitHubPullDraft(input: SetGitHubPullDraftInput): Promis
   const field = input.draft ? "convertPullRequestToDraft" : "markPullRequestReadyForReview";
   const query = `mutation($id: ID!) { ${field}(input: { pullRequestId: $id }) { pullRequest { isDraft } } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { id: nodeId } }) },
@@ -3097,7 +3103,7 @@ export async function setGitHubPullAutoMerge(input: SetGitHubPullAutoMergeInput)
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to change auto-merge" };
-  const prUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
+  const prUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${input.number}`;
   const prRes = await fetchGitHub(prUrl, token, "application/vnd.github+json");
   if (!("status" in prRes)) return prRes;
   const pr = await prRes.json().catch(() => null);
@@ -3114,7 +3120,7 @@ export async function setGitHubPullAutoMerge(input: SetGitHubPullAutoMergeInput)
     ? { id: nodeId, method: (input.mergeMethod ?? "merge").toUpperCase() }
     : { id: nodeId };
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables }) },
@@ -3145,7 +3151,7 @@ export async function setGitHubIssueLock(input: SetGitHubIssueLockInput): Promis
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to lock/unlock" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}/lock`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${input.number}/lock`;
 
   if (!input.locked) {
     const res = await fetchGitHub(url, token, "application/vnd.github+json", { method: "DELETE" });
@@ -3182,7 +3188,7 @@ export async function setGitHubIssuePinned(input: SetGitHubIssuePinnedInput): Pr
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to pin/unpin" };
-  const issueUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}`;
+  const issueUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${input.number}`;
   const issueRes = await fetchGitHub(issueUrl, token, "application/vnd.github+json");
   if (!("status" in issueRes)) return issueRes;
   const issue = await issueRes.json().catch(() => null);
@@ -3195,7 +3201,7 @@ export async function setGitHubIssuePinned(input: SetGitHubIssuePinnedInput): Pr
   const field = input.pinned ? "pinIssue" : "unpinIssue";
   const query = `mutation($id: ID!) { ${field}(input: { issueId: $id }) { issue { isPinned } } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { id: nodeId } }) },
@@ -3231,7 +3237,7 @@ export async function getGitHubIssuePinned(input: GitHubItemNumberInput): Promis
   const query = `query($owner:String!,$name:String!,$number:Int!){`
     + `repository(owner:$owner,name:$name){issue(number:$number){isPinned}}}`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { owner: repo.owner, name: repo.name, number: input.number } }) },
@@ -3266,7 +3272,7 @@ export async function listGitHubSubIssues(input: GitHubItemNumberInput): Promise
 
   const token = await githubToken(repo.remoteHost ?? null);
   const subIssues: GitHubSubIssue[] = [];
-  let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}/sub_issues?per_page=100`;
+  let next: string | null = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${input.number}/sub_issues?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
     const res = await fetchGitHub(next, token, "application/vnd.github+json");
     if (!("status" in res)) return res;
@@ -3298,7 +3304,7 @@ export async function addGitHubSubIssue(input: AddGitHubSubIssueInput): Promise<
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to add a sub-issue" };
 
-  const childUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.childNumber}`;
+  const childUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${input.childNumber}`;
   const childRes = await fetchGitHub(childUrl, token, "application/vnd.github+json");
   if (!("status" in childRes)) return childRes;
   const childJson = await childRes.json().catch(() => null);
@@ -3310,7 +3316,7 @@ export async function addGitHubSubIssue(input: AddGitHubSubIssueInput): Promise<
     : null;
   if (childId === null) return { ok: false, error: "GitHub returned a child issue without an id" };
 
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}/sub_issues`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${input.number}/sub_issues`;
   const res = await fetchGitHub(
     url,
     token,
@@ -3339,7 +3345,7 @@ export async function removeGitHubSubIssue(input: RemoveGitHubSubIssueInput): Pr
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to remove a sub-issue" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}/sub_issue`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${input.number}/sub_issue`;
   const res = await fetchGitHub(
     url,
     token,
@@ -3371,7 +3377,7 @@ export async function transferGitHubIssue(input: TransferGitHubIssueInput): Prom
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to transfer an issue" };
 
-  const issueUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${input.number}`;
+  const issueUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${input.number}`;
   const issueRes = await fetchGitHub(issueUrl, token, "application/vnd.github+json");
   if (!("status" in issueRes)) return issueRes;
   const issueJson = await issueRes.json().catch(() => null);
@@ -3383,7 +3389,7 @@ export async function transferGitHubIssue(input: TransferGitHubIssueInput): Prom
 
   const repoIdQuery = `query($owner:String!,$name:String!){repository(owner:$owner,name:$name){id}}`;
   const repoIdRes = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query: repoIdQuery, variables: { owner: target.owner, name: target.name } }) },
@@ -3400,7 +3406,7 @@ export async function transferGitHubIssue(input: TransferGitHubIssueInput): Prom
 
   const transferQuery = `mutation($id:ID!,$repo:ID!){ transferIssue(input:{issueId:$id,repositoryId:$repo}){ issue { number url } } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query: transferQuery, variables: { id: nodeId, repo: targetId } }) },
@@ -3428,7 +3434,7 @@ export async function listGitHubProjectsV2(input: { dir: string }): Promise<GitH
 
   const query = `query($owner:String!,$name:String!){repository(owner:$owner,name:$name){projectsV2(first:20){nodes{id number title url}}}}`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { owner: repo.owner, name: repo.name } }) },
@@ -3460,7 +3466,7 @@ export async function getGitHubProjectItems(input: GetGitHubProjectItemsInput): 
     + `fieldValues(first:20){ nodes{ __typename ... on ProjectV2ItemFieldSingleSelectValue{ optionId name field{ ... on ProjectV2FieldCommon{ id } } } } } } }`
     + `} } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { id: input.projectId } }) },
@@ -3492,7 +3498,7 @@ export async function addGitHubProjectItem(input: AddGitHubProjectItemInput): Pr
   if (!token) return { ok: false, error: "GitHub authentication required to add a project item" };
 
   const segment = input.contentKind === "pr" ? "pulls" : "issues";
-  const contentUrl = `https://api.github.com/repos/${repo.owner}/${repo.name}/${segment}/${input.contentNumber}`;
+  const contentUrl = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/${segment}/${input.contentNumber}`;
   const contentRes = await fetchGitHub(contentUrl, token, "application/vnd.github+json");
   if (!("status" in contentRes)) return contentRes;
   const contentJson = await contentRes.json().catch(() => null);
@@ -3504,7 +3510,7 @@ export async function addGitHubProjectItem(input: AddGitHubProjectItemInput): Pr
 
   const query = `mutation($p:ID!,$c:ID!){ addProjectV2ItemById(input:{ projectId:$p, contentId:$c }){ item{ id } } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { p: input.projectId, c: nodeId } }) },
@@ -3531,7 +3537,7 @@ export async function removeGitHubProjectItem(input: RemoveGitHubProjectItemInpu
 
   const query = `mutation($p:ID!,$i:ID!){ deleteProjectV2Item(input:{ projectId:$p, itemId:$i }){ deletedItemId } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { p: input.projectId, i: input.itemId } }) },
@@ -3561,7 +3567,7 @@ export async function setGitHubProjectItemStatus(input: SetGitHubProjectItemStat
 
   const query = `mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){ updateProjectV2ItemFieldValue(input:{ projectId:$p, itemId:$i, fieldId:$f, value:{ singleSelectOptionId:$o } }){ projectV2Item { id } } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { p: input.projectId, i: input.itemId, f: input.fieldId, o: input.optionId } }) },
@@ -3592,7 +3598,7 @@ export async function listGitHubDiscussions(input: { dir: string }): Promise<Git
     + `discussionCategories(first:25){ nodes{ id name } }`
     + `} }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { owner: repo.owner, name: repo.name } }) },
@@ -3625,7 +3631,7 @@ export async function getGitHubDiscussion(input: GetGitHubDiscussionInput): Prom
     + `discussion(number:$number){ id title body category{ isAnswerable } comments(first:50){ nodes{ id body createdAt isAnswer author{ login } } } }`
     + `} }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { owner: repo.owner, name: repo.name, number: input.number } }) },
@@ -3658,7 +3664,7 @@ export async function createGitHubDiscussion(input: CreateGitHubDiscussionInput)
 
   const repoIdQuery = `query($owner:String!,$name:String!){repository(owner:$owner,name:$name){id}}`;
   const repoIdRes = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query: repoIdQuery, variables: { owner: repo.owner, name: repo.name } }) },
@@ -3673,7 +3679,7 @@ export async function createGitHubDiscussion(input: CreateGitHubDiscussionInput)
 
   const query = `mutation($r:ID!,$c:ID!,$t:String!,$b:String!){ createDiscussion(input:{ repositoryId:$r, categoryId:$c, title:$t, body:$b }){ discussion{ number url } } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { r: repoId, c: input.categoryId, t: title, b: body } }) },
@@ -3701,7 +3707,7 @@ export async function addGitHubDiscussionComment(input: AddGitHubDiscussionComme
 
   const query = `mutation($d:ID!,$b:String!){ addDiscussionComment(input:{ discussionId:$d, body:$b }){ comment{ id } } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { d: input.discussionId, b: body } }) },
@@ -3731,7 +3737,7 @@ export async function setGitHubDiscussionAnswer(input: SetGitHubDiscussionAnswer
   const field = input.answer ? "markDiscussionCommentAsAnswer" : "unmarkDiscussionCommentAsAnswer";
   const query = `mutation($id:ID!){ ${field}(input:{ id:$id }){ clientMutationId } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { id: input.commentId } }) },
@@ -3757,7 +3763,7 @@ export async function deleteGitHubDiscussion(input: DeleteGitHubDiscussionInput)
 
   const query = `mutation($id:ID!){ deleteDiscussion(input:{ id:$id }){ clientMutationId } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { id: input.discussionId } }) },
@@ -3781,7 +3787,7 @@ export async function deleteGitHubDiscussionComment(input: DeleteGitHubDiscussio
 
   const query = `mutation($id:ID!){ deleteDiscussionComment(input:{ id:$id }){ clientMutationId } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { id: input.commentId } }) },
@@ -3802,7 +3808,7 @@ export async function getGitHubViewer(input: { dir: string }): Promise<GitHubVie
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: true, login: "" };
-  const res = await fetchGitHub("https://api.github.com/user", token, "application/vnd.github+json");
+  const res = await fetchGitHub(`${GITHUB_API_BASE}/user`, token, "application/vnd.github+json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
   if (!res.ok) return { ok: false, error: privateRepoHint(res.status, apiError(json, res.status, res.statusText), repo, !!token) };
@@ -3822,7 +3828,7 @@ export async function getGitHubRepoPermissions(input: { dir: string }): Promise<
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: true, push: false, admin: false, maintain: false };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json");
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
@@ -3843,7 +3849,7 @@ export async function getGitHubRepoPermissions(input: { dir: string }): Promise<
  *  an inline review comment. GitHub only permits the author (or a maintainer). */
 function commentUrl(repo: GitHubRepo, kind: GitHubCommentKind, commentId: number): string {
   const seg = kind === "review" ? "pulls" : "issues";
-  return `https://api.github.com/repos/${repo.owner}/${repo.name}/${seg}/comments/${commentId}`;
+  return `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/${seg}/comments/${commentId}`;
 }
 
 export async function updateGitHubComment(input: UpdateGitHubCommentInput): Promise<GitHubCommentResponse> {
@@ -3959,7 +3965,7 @@ export async function getGitHubPullReviewThreads(input: GitHubItemNumberInput): 
     + `repository(owner:$owner,name:$name){pullRequest(number:$number){`
     + `reviewThreads(first:100){pageInfo{hasNextPage} nodes{id isResolved isOutdated comments(first:1){nodes{databaseId}}}}}}}`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { owner: repo.owner, name: repo.name, number: input.number } }) },
@@ -3995,7 +4001,7 @@ export async function getGitHubPullLinkedIssues(input: GitHubItemNumberInput): P
     + `repository(owner:$owner,name:$name){pullRequest(number:$number){`
     + `closingIssuesReferences(first:20){nodes{number title url state}}}}}`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { owner: repo.owner, name: repo.name, number: input.number } }) },
@@ -4020,7 +4026,7 @@ export async function setGitHubReviewThreadResolved(
   const field = input.resolved ? "resolveReviewThread" : "unresolveReviewThread";
   const query = `mutation($id:ID!){ ${field}(input:{threadId:$id}){ thread { isResolved } } }`;
   const res = await fetchGitHub(
-    "https://api.github.com/graphql",
+    `${GITHUB_API_BASE}/graphql`,
     token,
     "application/vnd.github+json",
     { method: "POST", body: JSON.stringify({ query, variables: { id: input.threadId } }) },
@@ -4061,7 +4067,7 @@ function normalizeColor(color: string | undefined): string | undefined {
 /** `/repos/:o/:r/labels/:name` — the label name goes in the path, so it must be
  *  URL-encoded ("help wanted", "good first issue", etc. contain spaces). */
 function labelUrl(repo: GitHubRepo, name: string): string {
-  return `https://api.github.com/repos/${repo.owner}/${repo.name}/labels/${encodeURIComponent(name)}`;
+  return `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/labels/${encodeURIComponent(name)}`;
 }
 
 export async function listGitHubLabels(input: { dir: string }): Promise<GitHubLabelsResponse> {
@@ -4070,7 +4076,7 @@ export async function listGitHubLabels(input: { dir: string }): Promise<GitHubLa
 
   const token = await githubToken(repo.remoteHost ?? null);
   const labels: GitHubRepoLabel[] = [];
-  let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/labels?per_page=100`;
+  let next: string | null = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/labels?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
     const res = await fetchGitHub(next, token, "application/vnd.github+json");
     if (!("status" in res)) return res;
@@ -4093,7 +4099,7 @@ export async function listGitHubAssignees(input: { dir: string }): Promise<GitHu
 
   const token = await githubToken(repo.remoteHost ?? null);
   const assignees: GitHubUser[] = [];
-  let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/assignees?per_page=100`;
+  let next: string | null = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/assignees?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
     const res = await fetchGitHub(next, token, "application/vnd.github+json");
     if (!("status" in res)) return res;
@@ -4119,7 +4125,7 @@ export async function createGitHubLabel(input: CreateGitHubLabelInput): Promise<
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to create a label" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/labels`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/labels`;
   const res = await fetchGitHub(
     url,
     token,
@@ -4228,7 +4234,7 @@ export async function listGitHubMilestones(input: { dir: string }): Promise<GitH
 
   const token = await githubToken(repo.remoteHost ?? null);
   const milestones: GitHubRepoMilestone[] = [];
-  let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/milestones?state=all&per_page=100&sort=due_on&direction=asc`;
+  let next: string | null = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/milestones?state=all&per_page=100&sort=due_on&direction=asc`;
   for (let page = 0; next && page < 3; page++) {
     const res = await fetchGitHub(next, token, "application/vnd.github+json");
     if (!("status" in res)) return res;
@@ -4253,7 +4259,7 @@ export async function createGitHubMilestone(input: CreateGitHubMilestoneInput): 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to create a milestone" };
   const dueOn = normalizeDueOn(input.dueOn);
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/milestones`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/milestones`;
   const res = await fetchGitHub(
     url,
     token,
@@ -4296,7 +4302,7 @@ export async function updateGitHubMilestone(input: UpdateGitHubMilestoneInput): 
     return { ok: false, error: "milestone update requires a title, description, due date, or state" };
   }
 
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/milestones/${input.number}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/milestones/${input.number}`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json", { method: "PATCH", body: JSON.stringify(patch) });
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
@@ -4321,7 +4327,7 @@ const REACTION_CONTENT_ORDER: GitHubReactionContent[] = [
  *  for a conversation comment, `/pulls/comments/:id/reactions` for an inline
  *  review comment. Pure — unit-tested. */
 function reactionSubjectPath(repo: GitHubRepo, subject: GitHubReactionSubject): string {
-  const base = `https://api.github.com/repos/${repo.owner}/${repo.name}`;
+  const base = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}`;
   switch (subject.type) {
     case "issue":
       return `${base}/issues/${subject.id}/reactions`;
@@ -4444,7 +4450,7 @@ export async function deleteGitHubMilestone(input: DeleteGitHubMilestoneInput): 
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to delete a milestone" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/milestones/${input.number}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/milestones/${input.number}`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json", { method: "DELETE" });
   if (!("status" in res)) return res;
   if (!res.ok) {
@@ -4463,7 +4469,7 @@ export async function listGitHubReleases(input: { dir: string }): Promise<GitHub
 
   const token = await githubToken(repo.remoteHost ?? null);
   const releases: GitHubRelease[] = [];
-  let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/releases?per_page=100`;
+  let next: string | null = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/releases?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
     const res = await fetchGitHub(next, token, "application/vnd.github+json");
     if (!("status" in res)) return res;
@@ -4488,7 +4494,7 @@ export async function listGitHubTags(input: { dir: string }): Promise<GitHubTags
 
   const token = await githubToken(repo.remoteHost ?? null);
   const tags: GitHubTag[] = [];
-  let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/tags?per_page=100`;
+  let next: string | null = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/tags?per_page=100`;
   for (let page = 0; next && page < 3; page++) {
     const res = await fetchGitHub(next, token, "application/vnd.github+json");
     if (!("status" in res)) return res;
@@ -4512,7 +4518,7 @@ export async function createGitHubRelease(input: CreateGitHubReleaseInput): Prom
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to create a release" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/releases`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/releases`;
   const res = await fetchGitHub(
     url,
     token,
@@ -4558,7 +4564,7 @@ export async function updateGitHubRelease(input: UpdateGitHubReleaseInput): Prom
     return { ok: false, error: "release update requires a tag, name, body, draft, or prerelease change" };
   }
 
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/releases/${input.id}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/releases/${input.id}`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json", { method: "PATCH", body: JSON.stringify(patch) });
   if (!("status" in res)) return res;
   const json = await res.json().catch(() => null);
@@ -4575,7 +4581,7 @@ export async function deleteGitHubRelease(input: DeleteGitHubReleaseInput): Prom
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to delete a release" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/releases/${input.id}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/releases/${input.id}`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json", { method: "DELETE" });
   if (!("status" in res)) return res;
   if (!res.ok) {
@@ -4639,7 +4645,7 @@ export async function listGitHubNotifications(input: ListGitHubNotificationsInpu
 
   const notifications: GitHubNotification[] = [];
   const all = input.all === true ? "true" : "false";
-  let next: string | null = `https://api.github.com/repos/${repo.owner}/${repo.name}/notifications?all=${all}&per_page=50`;
+  let next: string | null = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/notifications?all=${all}&per_page=50`;
   for (let page = 0; next && page < 3; page++) {
     const res = await fetchGitHub(next, token, "application/vnd.github+json");
     if (!("status" in res)) return res;
@@ -4666,7 +4672,7 @@ export async function markGitHubNotificationRead(input: GitHubThreadInput): Prom
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to mark a notification read" };
   const res = await fetchGitHub(
-    `https://api.github.com/notifications/threads/${encodeURIComponent(threadId)}`,
+    `${GITHUB_API_BASE}/notifications/threads/${encodeURIComponent(threadId)}`,
     token,
     "application/vnd.github+json",
     { method: "PATCH" },
@@ -4689,7 +4695,7 @@ export async function markAllGitHubNotificationsRead(input: { dir: string }): Pr
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to mark notifications read" };
   const res = await fetchGitHub(
-    `https://api.github.com/repos/${repo.owner}/${repo.name}/notifications`,
+    `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/notifications`,
     token,
     "application/vnd.github+json",
     { method: "PUT" },
@@ -4715,7 +4721,7 @@ export async function getGitHubThreadSubscription(input: GitHubThreadInput): Pro
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to view thread subscription" };
   const res = await fetchGitHub(
-    `https://api.github.com/notifications/threads/${encodeURIComponent(threadId)}/subscription`,
+    `${GITHUB_API_BASE}/notifications/threads/${encodeURIComponent(threadId)}/subscription`,
     token,
     "application/vnd.github+json",
   );
@@ -4739,7 +4745,7 @@ export async function setGitHubThreadSubscription(input: SetGitHubThreadSubscrip
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to update thread subscription" };
   const res = await fetchGitHub(
-    `https://api.github.com/notifications/threads/${encodeURIComponent(threadId)}/subscription`,
+    `${GITHUB_API_BASE}/notifications/threads/${encodeURIComponent(threadId)}/subscription`,
     token,
     "application/vnd.github+json",
     { method: "PUT", body: JSON.stringify({ ignored: input.ignored === true }) },
@@ -4763,7 +4769,7 @@ export async function unsubscribeGitHubThread(input: GitHubThreadInput): Promise
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to unsubscribe from a thread" };
   const res = await fetchGitHub(
-    `https://api.github.com/notifications/threads/${encodeURIComponent(threadId)}/subscription`,
+    `${GITHUB_API_BASE}/notifications/threads/${encodeURIComponent(threadId)}/subscription`,
     token,
     "application/vnd.github+json",
     { method: "DELETE" },
@@ -4786,7 +4792,7 @@ export async function listGitHubWorkflowRuns(input: { dir: string }): Promise<Gi
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
   const token = await githubToken(repo.remoteHost ?? null);
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/runs?per_page=30`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/actions/runs?per_page=30`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json");
   if (!("status" in res)) return res;
   const body = await res.json().catch(() => null);
@@ -4807,7 +4813,7 @@ export async function listGitHubWorkflows(input: { dir: string }): Promise<GitHu
   if (!repo) return { ok: false, error: "project does not have a GitHub remote" };
 
   const token = await githubToken(repo.remoteHost ?? null);
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/workflows?per_page=100`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/actions/workflows?per_page=100`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json");
   if (!("status" in res)) return res;
   const body = await res.json().catch(() => null);
@@ -4831,7 +4837,7 @@ export async function rerunGitHubWorkflowRun(input: RerunGitHubWorkflowRunInput)
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to re-run a workflow" };
   const segment = input.failedOnly ? "rerun-failed-jobs" : "rerun";
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/runs/${input.runId}/${segment}`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/actions/runs/${input.runId}/${segment}`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json", { method: "POST" });
   if (!("status" in res)) return res;
   if (!res.ok) {
@@ -4850,7 +4856,7 @@ export async function cancelGitHubWorkflowRun(input: CancelGitHubWorkflowRunInpu
 
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to cancel a workflow run" };
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/runs/${input.runId}/cancel`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/actions/runs/${input.runId}/cancel`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json", { method: "POST" });
   if (!("status" in res)) return res;
   if (!res.ok) {
@@ -4878,7 +4884,7 @@ export async function dispatchGitHubWorkflow(input: DispatchGitHubWorkflowInput)
   const token = await githubToken(repo.remoteHost ?? null);
   if (!token) return { ok: false, error: "GitHub authentication required to dispatch a workflow" };
   const inputs = input.inputs && Object.keys(input.inputs).length > 0 ? input.inputs : undefined;
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/workflows/${input.workflowId}/dispatches`;
+  const url = `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/actions/workflows/${input.workflowId}/dispatches`;
   const res = await fetchGitHub(url, token, "application/vnd.github+json", {
     method: "POST",
     body: JSON.stringify({ ref, ...(inputs ? { inputs } : {}) }),

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -68,6 +68,7 @@ import {
 import { cn } from "@/lib/utils";
 import { toRows, type DiffRow } from "@/lib/diff-rows";
 import { mergeabilityView, type MergeTone } from "@/lib/mergeability";
+import { isMergedPull, mergedPullReplacement } from "@/lib/pull-merged";
 import { isCredentialError } from "@/lib/credential-error";
 import { BinaryFilePreview, binaryFileBasename, binaryPreviewSides } from "./BinaryFilePreview";
 import { binaryPreviewKind } from "../../../shared/attachments.ts";
@@ -666,6 +667,12 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   // Bounds the self-healing re-poll when GitHub returns mergeable=null. Keyed by
   // itemKey (G8) so two same-numbered PRs across repos don't share a retry budget.
   const mergeabilityRetries = useRef<Record<string, number>>({});
+  // Tracks the itemKey of the pulls-detail view the refresh-on-entry effect
+  // (below) last refreshed, so it fires once per *entry* into a detail view
+  // rather than on every render — reset to null whenever the dialog closes
+  // or the view leaves "detail", so detail(A) -> list -> detail(A) and a
+  // dialog reopen onto a surviving detail view both refresh again.
+  const lastDetailRefreshKeyRef = useRef<string | null>(null);
   const [view, setView] = useState<GitHubDialogView>({ kind: "list" });
   // Mirrors `view` for the async prefill effect below, which needs to check
   // "has the user navigated away from the list?" from inside a promise
@@ -2283,6 +2290,65 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
       });
   }, [open, projectPath, expandedItem, mergeability, mergeabilityLoading, mergeabilityErrors]);
 
+  // Refresh-on-detail-entry: detail views deliberately survive dialog
+  // close/reopen (see the close effect above `resetComposers`), and the
+  // mergeability effect above never invalidates its own cache once
+  // populated — it's gated on the cached item's `state === "open"` and
+  // skips entirely once a value/error/loading flag is already set. So
+  // opening back into a detail view for a PR that was merged (or otherwise
+  // changed) somewhere else — another agetor window, the GitHub web UI —
+  // would show a stale mergeability banner and a live action grid forever.
+  // This effect fires once per *entry* into a pulls detail view (tracked via
+  // `lastDetailRefreshKeyRef`, reset whenever the dialog closes or the view
+  // leaves "detail", so detail(A) -> list -> detail(A) and a dialog reopen
+  // onto a surviving detail view both refresh again) and does two things:
+  // (1) invalidates the mergeability cache exactly like the manual refresh
+  // handler (`onRefreshMergeability` below) does — the fetch effect above
+  // then refetches on its own for open PRs, and correctly skips merged/closed
+  // ones; (2) fetches a fresh copy of the item itself via the same
+  // `getGitHubPullDetail` endpoint the "View PR" prefill effect above uses,
+  // since mergeability alone can't detect a PR merged outside agetor.
+  // Failure is silent — no toast, no error state — cached data stays on
+  // screen and the mergeability banner has its own error surface for open
+  // PRs; a toast on every detail-view entry would be noisy offline. Guarded
+  // against navigation clobber via `viewRef` (a plain closure over `view`
+  // would only see the value from the render that started the fetch), same
+  // idiom as the "View PR" prefill effect.
+  useEffect(() => {
+    if (!open || view.kind !== "detail" || view.item.kind !== "pulls") {
+      lastDetailRefreshKeyRef.current = null;
+      return;
+    }
+    const item = view.item;
+    const key = itemKey(item);
+    if (lastDetailRefreshKeyRef.current === key) return;
+    lastDetailRefreshKeyRef.current = key;
+
+    mergeabilityRetries.current[key] = 0;
+    setMergeability((cur) => ({ ...cur, [key]: undefined }));
+    setMergeabilityErrors((cur) => ({ ...cur, [key]: undefined }));
+
+    const itemPath = item.sourcePath ?? projectPath;
+    if (!itemPath) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const result = await api.getGitHubPullDetail(itemPath, item.number);
+        if (cancelled || !result?.ok || !result.item) return;
+        const fresh = result.item;
+        upsertListItem(fresh, false, true);
+        if (viewRef.current.kind === "detail" && itemKey(viewRef.current.item) === key) {
+          setView(openDetail(fresh));
+        }
+      } catch {
+        // Silent — cached data stays, mergeability banner surfaces its own error.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, view, projectPath]);
+
   useEffect(() => {
     if (!open || !projectPath || !expandedItem || expandedItem.kind !== "pulls") return;
     const number = expandedItem.number;
@@ -2634,7 +2700,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     setActionMessages((cur) => ({ ...cur, [itemKey(item)]: undefined }));
     try {
       const result = await api.mergeGitHubPull({ path: itemPath, number: item.number, method });
-      if (result.merged) markPullClosed(item);
+      if (result.merged) markPullClosed(item, mergedPullReplacement(item));
       setActionMessages((cur) => ({ ...cur, [itemKey(item)]: result.message ?? "Pull request merged." }));
     } catch (e) {
       setActionErrors((cur) => ({ ...cur, [itemKey(item)]: e instanceof Error ? e.message : String(e) }));
@@ -7500,6 +7566,11 @@ function PullActions({
   // Merge, auto-merge, update-branch and draft-toggle stay push-only.
   canModifyOwn: boolean;
 }) {
+  // A merged PR replaces the mergeability banner + Review/Merge/Close grid
+  // below with a single positive card — there's nothing actionable left to
+  // show once GitHub has actually merged the branches (as opposed to just
+  // closing the PR unmerged, which keeps today's disabled-grid behavior).
+  const merged = isMergedPull(item);
   const disabled = item.state !== "open" || !!busy;
   const view = item.state === "open" && mergeability ? mergeabilityView(mergeability) : null;
   const mergeDisabled = disabled || !canPush || (view ? !view.canMerge : false);
@@ -7625,6 +7696,13 @@ function PullActions({
         </div>
       )}
 
+      {merged ? (
+        <div className="flex flex-col items-center justify-center gap-2 rounded-md border border-merged/30 bg-merged/10 px-4 py-6 text-center">
+          <GitMerge className="size-6 text-merged" />
+          <span className="text-sm font-medium text-merged">Pull request successfully merged</span>
+          {item.mergedAt && <span className="text-[11px] text-merged/80">Merged on {fmtDate(item.mergedAt)}</span>}
+        </div>
+      ) : (
       <div className="grid gap-3 lg:grid-cols-3">
         <div className="min-w-0">
           <div className="mb-1 flex items-center justify-between gap-2">
@@ -7752,8 +7830,9 @@ function PullActions({
           </Button>
         </div>
       </div>
+      )}
 
-      {pendingCount > 0 && (
+      {!merged && pendingCount > 0 && (
         <div className="mt-3 flex items-start gap-1.5 text-[11px] text-warning">
           <AlertCircle className="mt-px size-3.5 shrink-0" />
           {pendingCount} review comment{pendingCount === 1 ? "" : "s"} queued — submit via Approve / Comment / Request; merging or closing won't post {pendingCount === 1 ? "it" : "them"}.

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -2303,13 +2303,21 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   // failure — cached data stays on screen, and open PRs have their own
   // mergeability error surface; a toast on every entry would be noisy
   // offline.
-  const refreshPullDetail = (item: GitHubListItem): Promise<void> => {
+  const refreshPullDetail = (item: GitHubListItem, retried = false): Promise<void> => {
     const key = itemKey(item);
     const itemPath = item.sourcePath ?? projectPath;
     // `item.sourcePath` should always be set (see itemKey's doc comment) so
     // this is a defensive guard, not the common case: never fetch against the
     // aggregate sentinel.
     if (!itemPath || itemPath === AGGREGATE_PROJECT_PATH) return Promise.resolve();
+    // Dedupe concurrent same-key refreshes: the entry-effect fetch and a
+    // manual header "Refresh" click can both target the same item, and
+    // without this guard two in-flight fetches would race each other with no
+    // ordering guarantee about which response lands (and gets applied) last.
+    // Only guards the *entry* call — never the internal retry below, which
+    // deliberately runs a second, sequential fetch after this same flag was
+    // already set true by the call it's retrying.
+    if (!retried && detailRefreshing[key]) return Promise.resolve();
     // Snapshot before the await so a local mutation that lands mid-flight
     // (e.g. the user clicks Merge while this fetch is in flight) is
     // detectable once the response comes back — see `itemMutationSeq`.
@@ -2336,8 +2344,22 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
         // A local mutation (merge, close, reopen, edit, ...) landed while
         // this fetch was in flight and already reflects the newer truth —
         // applying this now-stale response would revert it (e.g. un-merge a
-        // just-merged card). Drop it.
-        if (itemMutationSeq.current !== epoch) return;
+        // just-merged card). Rather than silently keeping the stale cached
+        // data, retry once — the mutation that just landed is exactly the
+        // post-mutation truth we want, so a fresh fetch right after it should
+        // reconcile cleanly. Bounded to a single retry so a mutation storm
+        // can't loop forever.
+        if (itemMutationSeq.current !== epoch) {
+          if (!retried) {
+            await refreshPullDetail(item, true);
+          } else if (lastDetailRefreshKeyRef.current === key) {
+            // The retry landed stale too (another mutation beat it) — reset
+            // so the next natural entry into this detail view retries from
+            // scratch instead of leaving stale data stuck indefinitely.
+            lastDetailRefreshKeyRef.current = null;
+          }
+          return;
+        }
         upsertListItem(fresh, false, true, true);
         if (viewRef.current.kind === "detail" && itemKey(viewRef.current.item) === key) {
           setView(openDetail(fresh));
@@ -2696,6 +2718,18 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     return true;
   };
 
+  // Patches the view snapshot in place when it's currently showing `next`
+  // (matched via `sameItem`) — a no-op otherwise. `upsertListItem` only
+  // updates `result.items`, but a deep-linked PR/issue may not be in that
+  // list at all (the current filters would never have returned it), and the
+  // open detail subpage renders from its own frozen navigation snapshot, not
+  // from `result.items` — so every mutation site that replaces an item which
+  // might be the one currently open in detail must patch both. Shared by
+  // close/merge (`markPullClosed`), reopen, draft toggle, and lock below.
+  const patchDetailView = (next: GitHubListItem) => {
+    setView((cur) => (cur.kind === "detail" && sameItem(cur.item, next) ? openDetail(next) : cur));
+  };
+
   // Identity is the closed PR itself (kind+number+sourcePath), not just the
   // number — in aggregate mode (G8) two repos can each have a PR #5, and only
   // the one that was actually closed should flip/drop.
@@ -2711,7 +2745,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     // falls back to the frozen navigation snapshot — without this, the
     // merged/closed card would never appear after an in-app merge/close of a
     // PR outside the current filter.
-    setView((cur) => (cur.kind === "detail" && sameItem(cur.item, next) ? openDetail(next) : cur));
+    patchDetailView(next);
   };
 
   const runPullReview = async (item: GitHubListItem, event: GitHubPullReviewEvent) => {
@@ -2784,11 +2818,22 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     setActionMessages((cur) => ({ ...cur, [itemKey(item)]: undefined }));
     try {
       const result = await api.mergeGitHubPull({ path: itemPath, number: item.number, method });
-      if (result.merged) markPullClosed(item, mergedPullReplacement(item));
-      setActionMessages((cur) => ({ ...cur, [itemKey(item)]: result.message ?? "Pull request merged." }));
-      // Any queued (unsubmitted) review note is now moot — mirrors
-      // `runPullClose` clearing `closeDrafts` on success.
-      setReviewDrafts((cur) => ({ ...cur, [itemKey(item)]: "" }));
+      if (result.merged) {
+        markPullClosed(item, mergedPullReplacement(item));
+        setActionMessages((cur) => ({ ...cur, [itemKey(item)]: result.message ?? "Pull request merged." }));
+        // Any queued (unsubmitted) review note is now moot — mirrors
+        // `runPullClose` clearing `closeDrafts` on success.
+        setReviewDrafts((cur) => ({ ...cur, [itemKey(item)]: "" }));
+      } else {
+        // GitHub's merge endpoint can respond 2xx with `merged: false` (e.g. a
+        // required check landed red between the mergeability read and this
+        // call) — that's not success, so surface it as an error instead of
+        // claiming "Pull request merged." and clearing the review draft.
+        setActionErrors((cur) => ({
+          ...cur,
+          [itemKey(item)]: result.message ?? "GitHub did not merge the pull request.",
+        }));
+      }
     } catch (e) {
       setActionErrors((cur) => ({ ...cur, [itemKey(item)]: e instanceof Error ? e.message : String(e) }));
     } finally {
@@ -2868,6 +2913,10 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
       // Keep the row visible even under a "closed" filter so the reopen is
       // legible; it drops out on the next refresh.
       upsertListItem(result.item, false, true);
+      // C2: also patch the detail-view snapshot (see `patchDetailView`'s doc
+      // comment) — a deep-linked PR reopened from detail may not be in the
+      // loaded list.
+      patchDetailView(result.item);
       setActionMessages((cur) => ({ ...cur, [itemKey(item)]: result.message ?? "Pull request reopened." }));
       // Now open again — let the mergeability effect fetch a fresh verdict.
       mergeabilityRetries.current[itemKey(item)] = 0;
@@ -2888,7 +2937,12 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     setActionMessages((cur) => ({ ...cur, [itemKey(item)]: undefined }));
     try {
       const result = await api.setGitHubPullDraft({ path: itemPath, number: item.number, draft: nextDraft });
-      upsertListItem({ ...item, draft: result.draft });
+      const next = { ...item, draft: result.draft };
+      upsertListItem(next);
+      // C2: also patch the detail-view snapshot (see `patchDetailView`'s doc
+      // comment) — a deep-linked PR toggled from detail may not be in the
+      // loaded list.
+      patchDetailView(next);
       setActionMessages((cur) => ({ ...cur, [itemKey(item)]: result.message ?? "Draft state updated." }));
       // Draft ↔ ready flips mergeable_state (draft PRs report "draft"), so refresh.
       mergeabilityRetries.current[itemKey(item)] = 0;
@@ -2942,7 +2996,12 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
         locked: nextLocked,
         lockReason: nextLocked ? (lockReasonDrafts[itemKey(item)] || undefined) : undefined,
       });
-      upsertListItem({ ...item, locked: result.locked }, false, true);
+      const next = { ...item, locked: result.locked };
+      upsertListItem(next, false, true);
+      // C2: also patch the detail-view snapshot (see `patchDetailView`'s doc
+      // comment) — a deep-linked PR/issue locked from detail may not be in
+      // the loaded list.
+      patchDetailView(next);
       setActionMessages((cur) => ({ ...cur, [itemKey(item)]: result.message ?? "Lock state updated." }));
     } catch (e) {
       setActionErrors((cur) => ({ ...cur, [itemKey(item)]: e instanceof Error ? e.message : String(e) }));
@@ -7696,6 +7755,25 @@ function PullActions({
   // show once GitHub has actually merged the branches (as opposed to just
   // closing the PR unmerged, which keeps today's disabled-grid behavior).
   const merged = isMergedPull(item);
+  // Tracks the false -> true flip of `merged` *while this component stays
+  // mounted*, so `MergedPullCard`'s focus-reclaim effect can distinguish "the
+  // PR just got merged in front of the user" from "the user navigated into
+  // an already-merged PR's detail view" (the list row is a `<button>` that
+  // unmounts on click, so `document.activeElement === document.body` is true
+  // on the latter too — without this gate the card would steal focus on
+  // every ordinary list -> detail entry into a merged PR, not just the live
+  // transition). Initialized to `merged` itself (not `false`) so a fresh
+  // mount that's already merged never reports a transition. Synced via
+  // `useEffect` rather than an inline mutation (contrast `viewRef` elsewhere
+  // in this file) because this needs the *previous* render's value preserved
+  // across React 18 Strict Mode's dev-only double-render — an inline write
+  // would get consumed by the throwaway first pass and silently suppress
+  // `justMerged` on the render that actually commits.
+  const prevMergedRef = useRef(merged);
+  const justMerged = merged && !prevMergedRef.current;
+  useEffect(() => {
+    prevMergedRef.current = merged;
+  }, [merged]);
   const disabled = item.state !== "open" || !!busy;
   const view = item.state === "open" && mergeability ? mergeabilityView(mergeability) : null;
   // Held while an entry/manual refresh is in flight — merging against a
@@ -7741,55 +7819,64 @@ function PullActions({
           <GitPullRequest className="size-3.5" />
           {merged ? "Merge status" : "Actions"}
         </div>
-        {item.state === "open" && provider === "github" && (
-          <Button size="sm" variant="ghost" className="h-7" disabled={!!busy || !canPush} title={pushTitle} onClick={onToggleDraft}>
-            {busy === "draft" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <FilePen className="mr-2 size-3.5" />}
-            {item.draft ? "Mark ready for review" : "Convert to draft"}
+        {/* Everything after the label is one flex cluster (rather than
+            individual siblings of the label under `justify-between`) so the
+            label stays pinned left and the controls stay pinned right no
+            matter how many of these conditionally render — with more than
+            two direct children, `justify-between` spreads space evenly
+            across all of them instead of keeping "label" and "controls" as
+            two groups. */}
+        <div className="flex items-center gap-2">
+          {item.state === "open" && provider === "github" && (
+            <Button size="sm" variant="ghost" className="h-7" disabled={!!busy || !canPush} title={pushTitle} onClick={onToggleDraft}>
+              {busy === "draft" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <FilePen className="mr-2 size-3.5" />}
+              {item.draft ? "Mark ready for review" : "Convert to draft"}
+            </Button>
+          )}
+          {item.state !== "open" && item.mergedAt && (
+            <span className="inline-flex items-center gap-1 text-[11px] text-merged">
+              <GitMerge className="size-3.5" />
+              Merged
+            </span>
+          )}
+          {item.state !== "open" && !item.mergedAt && (
+            <Button size="sm" variant="outline" className="h-7" disabled={reopenDisabled} title={ownTitle} onClick={onReopenPull}>
+              {busy === "reopen" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <GitPullRequest className="mr-2 size-3.5" />}
+              Reopen
+            </Button>
+          )}
+          {/* Full item + mergeability refresh (C3) — rendered for every PR
+              state, not just open, so a closed/merged PR that was reopened or
+              re-merged elsewhere has a way to catch up without leaving the
+              detail view. */}
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-6"
+            title="Refresh"
+            aria-label="Refresh"
+            disabled={refreshing}
+            onClick={onRefresh}
+          >
+            {refreshing ? <Loader2 className="size-3.5 animate-spin text-muted-foreground" aria-hidden /> : <RefreshCw className="size-3.5" />}
           </Button>
-        )}
-        {item.state !== "open" && item.mergedAt && (
-          <span className="inline-flex items-center gap-1 text-[11px] text-merged">
-            <GitMerge className="size-3.5" />
-            Merged
-          </span>
-        )}
-        {item.state !== "open" && !item.mergedAt && (
-          <Button size="sm" variant="outline" className="h-7" disabled={reopenDisabled} title={ownTitle} onClick={onReopenPull}>
-            {busy === "reopen" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <GitPullRequest className="mr-2 size-3.5" />}
-            Reopen
-          </Button>
-        )}
-        {/* Full item + mergeability refresh (C3) — rendered for every PR
-            state, not just open, so a closed/merged PR that was reopened or
-            re-merged elsewhere has a way to catch up without leaving the
-            detail view. */}
-        <Button
-          size="icon"
-          variant="ghost"
-          className="size-6"
-          title="Refresh"
-          aria-label="Refresh"
-          disabled={refreshing}
-          onClick={onRefresh}
-        >
-          {refreshing ? <Loader2 className="size-3.5 animate-spin text-muted-foreground" aria-hidden /> : <RefreshCw className="size-3.5" />}
-        </Button>
-        {/* Suppressed once merged — the purple "Merged" tag above and the
-            card below already say everything a success line would; the
-            error line stays unconditional since a failed action still needs
-            surfacing regardless of merge state. */}
-        {message && !merged && (
-          <span className="inline-flex items-center gap-1 text-[11px] text-success">
-            <CheckCircle2 className="size-3.5" />
-            {message}
-          </span>
-        )}
-        {error && (
-          <span className="inline-flex items-center gap-1 text-[11px] text-danger">
-            <AlertCircle className="size-3.5" />
-            {error}
-          </span>
-        )}
+          {/* Suppressed once merged — the purple "Merged" tag above and the
+              card below already say everything a success line would; the
+              error line stays unconditional since a failed action still needs
+              surfacing regardless of merge state. */}
+          {message && !merged && (
+            <span className="inline-flex items-center gap-1 text-[11px] text-success">
+              <CheckCircle2 className="size-3.5" />
+              {message}
+            </span>
+          )}
+          {error && (
+            <span className="inline-flex items-center gap-1 text-[11px] text-danger">
+              <AlertCircle className="size-3.5" />
+              {error}
+            </span>
+          )}
+        </div>
       </div>
 
       {item.state === "open" && (
@@ -7807,27 +7894,40 @@ function PullActions({
             <span className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
               <Loader2 className="size-3.5 animate-spin" /> Checking mergeability…
             </span>
-          ) : view ? (
-            <>
-              <span className={cn("inline-flex items-center gap-1.5 text-[11px]", MERGE_TONE_CLASS[view.tone])}>
-                <span className={cn("size-2 shrink-0 rounded-full bg-current")} />
-                {view.label}
-              </span>
-              {canResolveConflicts && (
-                <Button size="sm" variant="outline" onClick={() => setResolveOpen(true)}>
-                  <GitMerge className="mr-2 size-3.5" />
-                  Resolve with Agetor
-                </Button>
-              )}
-              {resolveConfirmed && (
-                <span className="inline-flex items-center gap-1 text-[11px] text-success">
-                  <CheckCircle2 className="size-3.5" />
-                  Task created and started — check the board
-                </span>
-              )}
-            </>
           ) : (
-            <span className="text-[11px] text-muted-foreground">Mergeability unavailable.</span>
+            // No third "Mergeability unavailable." fallback here (dead code
+            // after U3): this branch only renders when `mergeabilityError` is
+            // unset AND `mergeability` is truthy, and the banner itself only
+            // renders for `item.state === "open"` (see the wrapping block
+            // above) — so `mergeabilityView(mergeability)` is unconditionally
+            // defined at this point. Recomputed locally (rather than reusing
+            // the `view` computed above, which is typed nullable because it
+            // also covers non-open states for `mergeDisabled`/`mergeTitle`)
+            // purely to let TypeScript see that non-null-ness without a `!`
+            // assertion.
+            (() => {
+              const bannerView = mergeabilityView(mergeability);
+              return (
+                <>
+                  <span className={cn("inline-flex items-center gap-1.5 text-[11px]", MERGE_TONE_CLASS[bannerView.tone])}>
+                    <span className={cn("size-2 shrink-0 rounded-full bg-current")} />
+                    {bannerView.label}
+                  </span>
+                  {canResolveConflicts && (
+                    <Button size="sm" variant="outline" onClick={() => setResolveOpen(true)}>
+                      <GitMerge className="mr-2 size-3.5" />
+                      Resolve with Agetor
+                    </Button>
+                  )}
+                  {resolveConfirmed && (
+                    <span className="inline-flex items-center gap-1 text-[11px] text-success">
+                      <CheckCircle2 className="size-3.5" />
+                      Task created and started — check the board
+                    </span>
+                  )}
+                </>
+              );
+            })()
           )}
           <div className="ml-auto flex items-center gap-2">
             {caps.updateBranch && view?.showUpdateBranch && (
@@ -7841,7 +7941,7 @@ function PullActions({
       )}
 
       {merged ? (
-        <MergedPullCard item={item} />
+        <MergedPullCard item={item} justMerged={justMerged} />
       ) : (
         <PullActionGrid
           caps={caps}
@@ -8085,13 +8185,24 @@ function PullActionGrid({
  *  unmounts the grid, the browser drops focus to `<body>`, and the effect
  *  below reclaims it for keyboard/screen-reader users rather than leaving
  *  them stranded on the document body. */
-function MergedPullCard({ item }: { item: GitHubListItem }) {
+function MergedPullCard({ item, justMerged }: { item: GitHubListItem; justMerged: boolean }) {
   const cardRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (document.activeElement === document.body) {
-      cardRef.current?.focus({ preventScroll: true });
+    // Only steal focus on the actual open -> merged transition (`justMerged`,
+    // computed by the caller) that happens while this card is mounted — never
+    // on an ordinary mount. The list row is a `<button>` that unmounts on
+    // click, so `document.activeElement === document.body` is ALSO true when
+    // the user simply navigates into an already-merged PR's detail view;
+    // without the `justMerged` gate this effect would steal focus on every
+    // such entry, not just the moment a PR flips to merged in front of the
+    // user. No `preventScroll` on the `.focus()` call (dropped from the
+    // previous `{ preventScroll: true }`) so the browser's default
+    // scroll-into-view behavior kicks in — a focus target hidden below the
+    // fold defeats the point of moving focus to it.
+    if (justMerged && document.activeElement === document.body) {
+      cardRef.current?.focus();
     }
-  }, []);
+  }, [justMerged]);
   const mergedWhen = fmtRelativeDate(item.mergedAt ?? "");
   return (
     <div

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -673,6 +673,13 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   // or the view leaves "detail", so detail(A) -> list -> detail(A) and a
   // dialog reopen onto a surviving detail view both refresh again.
   const lastDetailRefreshKeyRef = useRef<string | null>(null);
+  // Bumped by every local write to `result.items` (see `upsertListItem`). The
+  // refresh-on-detail-entry effect below snapshots this before awaiting
+  // `getGitHubPullDetail` and re-checks it before applying the response — if
+  // the user clicks Merge while the entry fetch is in flight, the merge's
+  // local upsert lands first and bumps this ref, so the (now-stale) pre-merge
+  // detail response is dropped instead of reverting the just-merged card.
+  const itemMutationSeq = useRef(0);
   const [view, setView] = useState<GitHubDialogView>({ kind: "list" });
   // Mirrors `view` for the async prefill effect below, which needs to check
   // "has the user navigated away from the list?" from inside a promise
@@ -2327,21 +2334,48 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     mergeabilityRetries.current[key] = 0;
     setMergeability((cur) => ({ ...cur, [key]: undefined }));
     setMergeabilityErrors((cur) => ({ ...cur, [key]: undefined }));
+    // Invalidation must also defeat any mergeability request already in
+    // flight for this key — bumping the seq makes its .then/.catch/.finally
+    // no-ops, which means its `finally` will no longer clear the loading
+    // flag, so clear it explicitly here (matches the manual refresh handler).
+    mergeabilitySeq.current += 1;
+    setMergeabilityLoading((cur) => ({ ...cur, [key]: false }));
 
+    // Snapshot before the await so a local mutation that lands mid-flight
+    // (e.g. the user clicks Merge while this entry fetch is in flight) is
+    // detectable once the response comes back — see `itemMutationSeq`.
+    const epoch = itemMutationSeq.current;
     const itemPath = item.sourcePath ?? projectPath;
     if (!itemPath) return;
     let cancelled = false;
     void (async () => {
       try {
-        const result = await api.getGitHubPullDetail(itemPath, item.number);
-        if (cancelled || !result?.ok || !result.item) return;
-        const fresh = result.item;
-        upsertListItem(fresh, false, true);
+        const detail = await api.getGitHubPullDetail(itemPath, item.number);
+        if (cancelled || !detail?.ok || !detail.item) return;
+        // A local mutation (merge, close, reopen, edit, ...) landed while this
+        // fetch was in flight and already reflects the newer truth — applying
+        // this now-stale response would revert it (e.g. un-merge a just-merged
+        // card). Drop it.
+        if (itemMutationSeq.current !== epoch) return;
+        const fresh = detail.item;
+        // Update-only: a "View PR" deep-link can open a PR that was never in
+        // the filtered/paged list, and inserting it here would append an
+        // out-of-sort row. Only reconcile items already present.
+        if (result?.items.some((it) => sameItem(it, fresh))) {
+          upsertListItem(fresh, false, true);
+        }
         if (viewRef.current.kind === "detail" && itemKey(viewRef.current.item) === key) {
           setView(openDetail(fresh));
         }
       } catch {
-        // Silent — cached data stays, mergeability banner surfaces its own error.
+        // Silent — cached data stays, mergeability banner surfaces its own
+        // error. Reset the entry-refresh bookkeeping (only if it still points
+        // at this entry — don't clobber a newer entry's) so the next natural
+        // navigation into this detail view (open/view/projectPath change)
+        // retries instead of the failure sticking forever.
+        if (lastDetailRefreshKeyRef.current === key) {
+          lastDetailRefreshKeyRef.current = null;
+        }
       }
     })();
     return () => {
@@ -2901,6 +2935,10 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   // reopen) so the user sees the result instead of the row silently vanishing;
   // it drops out naturally on the next refresh.
   const upsertListItem = (replacement: GitHubListItem, prepend = false, keepIfPresent = false) => {
+    // Every local item write goes through here — bump so an in-flight refresh
+    // fetch (the refresh-on-detail-entry effect) can detect a newer local
+    // mutation landed while it was awaiting and drop its now-stale response.
+    itemMutationSeq.current += 1;
     setResult((cur) => {
       if (!cur) return cur;
       // Match on kind+number+sourcePath (G8) so a write to repo B's #5 can't
@@ -3719,6 +3757,11 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
               mergeabilityRetries.current[itemKey(expandedItem)] = 0;
               setMergeability((cur) => ({ ...cur, [itemKey(expandedItem)]: undefined }));
               setMergeabilityErrors((cur) => ({ ...cur, [itemKey(expandedItem)]: undefined }));
+              // Defeat any request already in flight for this key — bumping
+              // the seq makes its .then/.catch/.finally no-ops, so the loading
+              // flag must be cleared manually here or it would stay stuck.
+              mergeabilitySeq.current += 1;
+              setMergeabilityLoading((cur) => ({ ...cur, [itemKey(expandedItem)]: false }));
             }}
             onRetryCommits={() => {
               if (expandedItem.kind !== "pulls") return;
@@ -6345,7 +6388,7 @@ function GitHubItemRow({
   // Navigates to the detail subpage for this item (GitHubDialogView).
   onToggle: () => void;
 }) {
-  const merged = item.kind === "pulls" && !!item.mergedAt;
+  const merged = isMergedPull(item);
   const stateClass = item.state === "open"
     ? "text-success"
     : merged
@@ -7700,7 +7743,12 @@ function PullActions({
         <div className="flex flex-col items-center justify-center gap-2 rounded-md border border-merged/30 bg-merged/10 px-4 py-6 text-center">
           <GitMerge className="size-6 text-merged" />
           <span className="text-sm font-medium text-merged">Pull request successfully merged</span>
-          {item.mergedAt && <span className="text-[11px] text-merged/80">Merged on {fmtDate(item.mergedAt)}</span>}
+          {(() => {
+            // Only render once `fmtDate` produces something — an unparsable
+            // `mergedAt` would otherwise leave a dangling "Merged on ".
+            const mergedOn = fmtDate(item.mergedAt ?? "");
+            return mergedOn && <span className="text-[11px] text-merged/80">Merged on {mergedOn}</span>;
+          })()}
         </div>
       ) : (
       <div className="grid gap-3 lg:grid-cols-3">
@@ -7832,7 +7880,7 @@ function PullActions({
       </div>
       )}
 
-      {!merged && pendingCount > 0 && (
+      {pendingCount > 0 && (
         <div className="mt-3 flex items-start gap-1.5 text-[11px] text-warning">
           <AlertCircle className="mt-px size-3.5 shrink-0" />
           {pendingCount} review comment{pendingCount === 1 ? "" : "s"} queued — submit via Approve / Comment / Request; merging or closing won't post {pendingCount === 1 ? "it" : "them"}.

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -226,9 +226,13 @@ const basename = (p: string) => {
  *  per-repo, so an aggregated list routinely holds two items with the same
  *  kind+number (repo A PR #5 and repo B PR #5). Keying anything on number alone
  *  collides — React row keys, the detail-view lookup, and every per-item state map. The
- *  composite key disambiguates by the item's own repo path. In single-repo mode
- *  `sourcePath` is null, so the key is exactly the historical `${kind}-${number}`
- *  — existing behavior (and tests) unchanged. */
+ *  composite key disambiguates by the item's own repo path. `sourcePath` is
+ *  stamped with that repo's dir on every item regardless of single-repo vs
+ *  aggregate mode — github.ts's `normalizeItem` and the git-host.ts/gitlab.ts
+ *  wrappers' `withSourcePath` both thread `input.dir` through unconditionally
+ *  — so in practice the composite form is always used; the bare
+ *  `${kind}-${number}` fallback only applies to a hand-built item that
+ *  bypasses those paths (none currently do). */
 function itemKey(item: Pick<GitHubListItem, "kind" | "number" | "sourcePath">): string {
   return item.sourcePath
     ? `${item.sourcePath}::${item.kind}-${item.number}`
@@ -673,7 +677,8 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   // or the view leaves "detail", so detail(A) -> list -> detail(A) and a
   // dialog reopen onto a surviving detail view both refresh again.
   const lastDetailRefreshKeyRef = useRef<string | null>(null);
-  // Bumped by every local write to `result.items` (see `upsertListItem`). The
+  // Bumped by every local write to `result.items` (see `mutateItems`, which
+  // `upsertListItem` and the other direct writers all route through). The
   // refresh-on-detail-entry effect below snapshots this before awaiting
   // `getGitHubPullDetail` and re-checks it before applying the response — if
   // the user clicks Merge while the entry fetch is in flight, the merge's
@@ -715,6 +720,25 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   const [mergeability, setMergeability] = useState<Record<string, GitHubPullMergeability | undefined>>({});
   const [mergeabilityLoading, setMergeabilityLoading] = useState<Record<string, boolean | undefined>>({});
   const [mergeabilityErrors, setMergeabilityErrors] = useState<Record<string, string | undefined>>({});
+  // True while `refreshPullDetail` (below) has an in-flight fetch for a given
+  // item — surfaced in the panel header as a spinner and used to hold the
+  // Merge button (only Merge; the other actions stay live) so a user can't
+  // merge against mergeability/state that's mid-refresh.
+  const [detailRefreshing, setDetailRefreshing] = useState<Record<string, boolean | undefined>>({});
+  // Clears the mergeability cache for `key` and defeats any request already
+  // in flight for it. Shared by the manual "Refresh" button, the
+  // refresh-on-detail-entry effect, and the "View PR" prefill path — all
+  // three need the exact same invalidation the old manual-only handler used
+  // to do inline. Bumping `mergeabilitySeq` makes an in-flight request's
+  // .then/.catch/.finally no-ops, which means its `finally` will no longer
+  // clear the loading flag, so it's cleared explicitly here too.
+  const invalidateMergeability = (key: string) => {
+    mergeabilityRetries.current[key] = 0;
+    setMergeability((cur) => ({ ...cur, [key]: undefined }));
+    setMergeabilityErrors((cur) => ({ ...cur, [key]: undefined }));
+    mergeabilitySeq.current += 1;
+    setMergeabilityLoading((cur) => ({ ...cur, [key]: false }));
+  };
   const [commits, setCommits] = useState<Record<string, GitHubPullCommit[] | undefined>>({});
   const [commitsLoading, setCommitsLoading] = useState<Record<string, boolean | undefined>>({});
   const [commitsErrors, setCommitsErrors] = useState<Record<string, string | undefined>>({});
@@ -1205,6 +1229,13 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
         if (normalizePrUrl(result.item.htmlUrl) !== normalizePrUrl(pending.prUrl)) {
           throw new Error("That pull request URL points at a different repository — opening in browser.");
         }
+        // This fetch already IS a fresh detail fetch — mark the entry-refresh
+        // bookkeeping as done for this key so the refresh-on-detail-entry
+        // effect doesn't immediately re-fetch the same thing, while still
+        // invalidating mergeability (that effect only ever fetches
+        // mergeability, never invalidates a cache it didn't populate).
+        lastDetailRefreshKeyRef.current = itemKey(result.item);
+        invalidateMergeability(itemKey(result.item));
         setView(openDetail(result.item));
       } catch (err) {
         if (cancelled || viewRef.current.kind !== "list") return;
@@ -1371,13 +1402,13 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     setRepoLabels((cur) => sortLabels([...cur.filter((l) => l.name !== name), label]));
     // Reconcile the renamed/recolored label on any loaded item so its badge
     // doesn't show the stale name/color.
-    setResult((cur) => cur && {
+    mutateItems((cur) => ({
       ...cur,
       items: cur.items.map((it) => ({
         ...it,
         labels: it.labels.map((l) => (l.name === name ? { name: label.name, color: label.color } : l)),
       })),
-    });
+    }));
   };
 
   const removeLabel = async (name: string) => {
@@ -1385,10 +1416,10 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     await api.deleteGitHubLabel({ path: projectPath, name });
     setRepoLabels((cur) => cur.filter((l) => l.name !== name));
     // Drop the deleted label from any loaded item that carried it.
-    setResult((cur) => cur && {
+    mutateItems((cur) => ({
       ...cur,
       items: cur.items.map((it) => ({ ...it, labels: it.labels.filter((l) => l.name !== name) })),
-    });
+    }));
   };
 
   useEffect(() => {
@@ -1441,14 +1472,14 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     const { milestone } = await api.updateGitHubMilestone({ path: projectPath, number, ...patch });
     setRepoMilestones((cur) => sortMilestones(cur.map((m) => (m.number === number ? milestone : m))));
     // Reconcile the renamed milestone on any loaded item so its badge stays fresh.
-    setResult((cur) => cur && {
+    mutateItems((cur) => ({
       ...cur,
       items: cur.items.map((it) =>
         it.milestone && it.milestone.number === number
           ? { ...it, milestone: { number: milestone.number, title: milestone.title } }
           : it,
       ),
-    });
+    }));
   };
 
   const removeMilestone = async (number: number) => {
@@ -1456,12 +1487,12 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     await api.deleteGitHubMilestone({ path: projectPath, number });
     setRepoMilestones((cur) => cur.filter((m) => m.number !== number));
     // Drop the deleted milestone from any loaded item that carried it.
-    setResult((cur) => cur && {
+    mutateItems((cur) => ({
       ...cur,
       items: cur.items.map((it) =>
         it.milestone && it.milestone.number === number ? { ...it, milestone: null } : it,
       ),
-    });
+    }));
   };
 
   useEffect(() => {
@@ -2261,6 +2292,105 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
       });
   }, [open, projectPath, expandedItem, checks, mergeability, commitStatus, commitStatusLoading, commitStatusErrors]);
 
+  // Fetches a fresh copy of `item` via the same `getGitHubPullDetail`
+  // endpoint the "View PR" prefill effect above uses, and reconciles it into
+  // `result.items` (update-only — never inserts a row that isn't already
+  // loaded/paged, since a "View PR" deep-link can open a PR the current
+  // filters would never have returned) and the view snapshot, if the user is
+  // still looking at this item. Shared by the refresh-on-detail-entry effect
+  // below and the manual header "Refresh" button so there's exactly one
+  // place that knows how to safely apply a fresh pull detail. Silent on
+  // failure — cached data stays on screen, and open PRs have their own
+  // mergeability error surface; a toast on every entry would be noisy
+  // offline.
+  const refreshPullDetail = (item: GitHubListItem): Promise<void> => {
+    const key = itemKey(item);
+    const itemPath = item.sourcePath ?? projectPath;
+    // `item.sourcePath` should always be set (see itemKey's doc comment) so
+    // this is a defensive guard, not the common case: never fetch against the
+    // aggregate sentinel.
+    if (!itemPath || itemPath === AGGREGATE_PROJECT_PATH) return Promise.resolve();
+    // Snapshot before the await so a local mutation that lands mid-flight
+    // (e.g. the user clicks Merge while this fetch is in flight) is
+    // detectable once the response comes back — see `itemMutationSeq`.
+    const epoch = itemMutationSeq.current;
+    setDetailRefreshing((cur) => ({ ...cur, [key]: true }));
+    return (async () => {
+      try {
+        const detail = await api.getGitHubPullDetail(itemPath, item.number);
+        if (!detail?.ok || !detail.item) {
+          // Reset the entry-refresh bookkeeping (only if it still points at
+          // this entry — don't clobber a newer entry's) so the next natural
+          // navigation into this detail view retries instead of a
+          // well-formed-but-`ok:false` response sticking forever — same
+          // recovery as the thrown-error path below.
+          if (lastDetailRefreshKeyRef.current === key) lastDetailRefreshKeyRef.current = null;
+          return;
+        }
+        // Pin identity to the cached item's own sourcePath rather than
+        // trusting whatever the response carries, and bail on any resulting
+        // key shift — a shift here would orphan every per-item cache/draft
+        // (mergeability, drafts, action state, ...) keyed off the old key.
+        const fresh = { ...detail.item, sourcePath: item.sourcePath };
+        if (itemKey(fresh) !== key) return;
+        // A local mutation (merge, close, reopen, edit, ...) landed while
+        // this fetch was in flight and already reflects the newer truth —
+        // applying this now-stale response would revert it (e.g. un-merge a
+        // just-merged card). Drop it.
+        if (itemMutationSeq.current !== epoch) return;
+        upsertListItem(fresh, false, true, true);
+        if (viewRef.current.kind === "detail" && itemKey(viewRef.current.item) === key) {
+          setView(openDetail(fresh));
+        }
+      } catch {
+        // Silent — cached data stays, mergeability banner surfaces its own
+        // error. Same reset-for-retry as the `!detail.ok` path above.
+        if (lastDetailRefreshKeyRef.current === key) lastDetailRefreshKeyRef.current = null;
+      } finally {
+        setDetailRefreshing((cur) => ({ ...cur, [key]: false }));
+      }
+    })();
+  };
+
+  // Refresh-on-detail-entry: detail views deliberately survive dialog
+  // close/reopen (see the close effect above `resetComposers`), and the
+  // mergeability effect below never invalidates its own cache once
+  // populated — it's gated on the cached item's `state === "open"` and
+  // skips entirely once a value/error/loading flag is already set. So
+  // opening back into a detail view for a PR that was merged (or otherwise
+  // changed) somewhere else — another agetor window, the GitHub web UI —
+  // would show a stale mergeability banner and a live action grid forever.
+  // This effect fires once per *entry* into a pulls detail view (tracked via
+  // `lastDetailRefreshKeyRef`, reset whenever the dialog closes or the view
+  // leaves "detail", so detail(A) -> list -> detail(A) and a dialog reopen
+  // onto a surviving detail view both refresh again) and does two things:
+  // (1) invalidates the mergeability cache via `invalidateMergeability` — the
+  // fetch effect below then refetches on its own for open PRs, and correctly
+  // skips merged/closed ones; (2) fetches a fresh copy of the item itself via
+  // `refreshPullDetail`, since mergeability alone can't detect a PR merged
+  // outside agetor. Declared *above* the mergeability fetch effect on
+  // purpose: on a fresh entry this effect's invalidation must land before the
+  // mergeability effect's own gate is evaluated, or a first entry fires the
+  // mergeability GET once here-triggered and a second time when this effect
+  // bumps the seq.
+  useEffect(() => {
+    if (!open || view.kind !== "detail" || view.item.kind !== "pulls") {
+      lastDetailRefreshKeyRef.current = null;
+      return;
+    }
+    const item = view.item;
+    const key = itemKey(item);
+    if (lastDetailRefreshKeyRef.current === key) return;
+    lastDetailRefreshKeyRef.current = key;
+    invalidateMergeability(key);
+    void refreshPullDetail(item);
+    // Deliberately omits `invalidateMergeability`/`refreshPullDetail` (and
+    // `upsertListItem`, transitively) — none are memoized, so listing them
+    // would refire this effect on every render and defeat the
+    // once-per-entry gating above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, view, projectPath]);
+
   useEffect(() => {
     // Only open PRs surface a mergeability verdict — skip closed/merged ones so
     // we don't burn the server-side poll on data the UI never shows.
@@ -2296,92 +2426,6 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
         setMergeabilityLoading((cur) => ({ ...cur, [key]: false }));
       });
   }, [open, projectPath, expandedItem, mergeability, mergeabilityLoading, mergeabilityErrors]);
-
-  // Refresh-on-detail-entry: detail views deliberately survive dialog
-  // close/reopen (see the close effect above `resetComposers`), and the
-  // mergeability effect above never invalidates its own cache once
-  // populated — it's gated on the cached item's `state === "open"` and
-  // skips entirely once a value/error/loading flag is already set. So
-  // opening back into a detail view for a PR that was merged (or otherwise
-  // changed) somewhere else — another agetor window, the GitHub web UI —
-  // would show a stale mergeability banner and a live action grid forever.
-  // This effect fires once per *entry* into a pulls detail view (tracked via
-  // `lastDetailRefreshKeyRef`, reset whenever the dialog closes or the view
-  // leaves "detail", so detail(A) -> list -> detail(A) and a dialog reopen
-  // onto a surviving detail view both refresh again) and does two things:
-  // (1) invalidates the mergeability cache exactly like the manual refresh
-  // handler (`onRefreshMergeability` below) does — the fetch effect above
-  // then refetches on its own for open PRs, and correctly skips merged/closed
-  // ones; (2) fetches a fresh copy of the item itself via the same
-  // `getGitHubPullDetail` endpoint the "View PR" prefill effect above uses,
-  // since mergeability alone can't detect a PR merged outside agetor.
-  // Failure is silent — no toast, no error state — cached data stays on
-  // screen and the mergeability banner has its own error surface for open
-  // PRs; a toast on every detail-view entry would be noisy offline. Guarded
-  // against navigation clobber via `viewRef` (a plain closure over `view`
-  // would only see the value from the render that started the fetch), same
-  // idiom as the "View PR" prefill effect.
-  useEffect(() => {
-    if (!open || view.kind !== "detail" || view.item.kind !== "pulls") {
-      lastDetailRefreshKeyRef.current = null;
-      return;
-    }
-    const item = view.item;
-    const key = itemKey(item);
-    if (lastDetailRefreshKeyRef.current === key) return;
-    lastDetailRefreshKeyRef.current = key;
-
-    mergeabilityRetries.current[key] = 0;
-    setMergeability((cur) => ({ ...cur, [key]: undefined }));
-    setMergeabilityErrors((cur) => ({ ...cur, [key]: undefined }));
-    // Invalidation must also defeat any mergeability request already in
-    // flight for this key — bumping the seq makes its .then/.catch/.finally
-    // no-ops, which means its `finally` will no longer clear the loading
-    // flag, so clear it explicitly here (matches the manual refresh handler).
-    mergeabilitySeq.current += 1;
-    setMergeabilityLoading((cur) => ({ ...cur, [key]: false }));
-
-    // Snapshot before the await so a local mutation that lands mid-flight
-    // (e.g. the user clicks Merge while this entry fetch is in flight) is
-    // detectable once the response comes back — see `itemMutationSeq`.
-    const epoch = itemMutationSeq.current;
-    const itemPath = item.sourcePath ?? projectPath;
-    if (!itemPath) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const detail = await api.getGitHubPullDetail(itemPath, item.number);
-        if (cancelled || !detail?.ok || !detail.item) return;
-        // A local mutation (merge, close, reopen, edit, ...) landed while this
-        // fetch was in flight and already reflects the newer truth — applying
-        // this now-stale response would revert it (e.g. un-merge a just-merged
-        // card). Drop it.
-        if (itemMutationSeq.current !== epoch) return;
-        const fresh = detail.item;
-        // Update-only: a "View PR" deep-link can open a PR that was never in
-        // the filtered/paged list, and inserting it here would append an
-        // out-of-sort row. Only reconcile items already present.
-        if (result?.items.some((it) => sameItem(it, fresh))) {
-          upsertListItem(fresh, false, true);
-        }
-        if (viewRef.current.kind === "detail" && itemKey(viewRef.current.item) === key) {
-          setView(openDetail(fresh));
-        }
-      } catch {
-        // Silent — cached data stays, mergeability banner surfaces its own
-        // error. Reset the entry-refresh bookkeeping (only if it still points
-        // at this entry — don't clobber a newer entry's) so the next natural
-        // navigation into this detail view (open/view/projectPath change)
-        // retries instead of the failure sticking forever.
-        if (lastDetailRefreshKeyRef.current === key) {
-          lastDetailRefreshKeyRef.current = null;
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [open, view, projectPath]);
 
   useEffect(() => {
     if (!open || !projectPath || !expandedItem || expandedItem.kind !== "pulls") return;
@@ -2662,6 +2706,12 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
   const markPullClosed = (target: GitHubListItem, replacement?: GitHubListItem) => {
     const next = replacement ?? { ...target, state: "closed" as const, closedAt: new Date().toISOString() };
     upsertListItem(next, false, true);
+    // Also patch the view snapshot: when the PR isn't in the loaded list,
+    // `upsertListItem` above drops it (filters don't match) and `expandedItem`
+    // falls back to the frozen navigation snapshot — without this, the
+    // merged/closed card would never appear after an in-app merge/close of a
+    // PR outside the current filter.
+    setView((cur) => (cur.kind === "detail" && sameItem(cur.item, next) ? openDetail(next) : cur));
   };
 
   const runPullReview = async (item: GitHubListItem, event: GitHubPullReviewEvent) => {
@@ -2736,6 +2786,9 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
       const result = await api.mergeGitHubPull({ path: itemPath, number: item.number, method });
       if (result.merged) markPullClosed(item, mergedPullReplacement(item));
       setActionMessages((cur) => ({ ...cur, [itemKey(item)]: result.message ?? "Pull request merged." }));
+      // Any queued (unsubmitted) review note is now moot — mirrors
+      // `runPullClose` clearing `closeDrafts` on success.
+      setReviewDrafts((cur) => ({ ...cur, [itemKey(item)]: "" }));
     } catch (e) {
       setActionErrors((cur) => ({ ...cur, [itemKey(item)]: e instanceof Error ? e.message : String(e) }));
     } finally {
@@ -2919,7 +2972,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
       setTransferNotice({ message: result.message ?? `Issue transferred to ${targetRepo}.`, url: result.url });
       // The issue no longer lives in this repo — drop it from the list rather
       // than reconciling it in place.
-      setResult((cur) => cur && { ...cur, items: cur.items.filter((it) => !sameItem(it, item)) });
+      mutateItems((cur) => ({ ...cur, items: cur.items.filter((it) => !sameItem(it, item)) }));
       setView((cur) => (cur.kind === "detail" && sameItem(cur.item, item) ? backToList() : cur));
       setTransferDrafts((cur) => ({ ...cur, [itemKey(item)]: "" }));
       setTransferConfirm((cur) => ({ ...cur, [itemKey(item)]: false }));
@@ -2930,20 +2983,39 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
     }
   };
 
+  // Every local write to `result.items` goes through this wrapper — both
+  // `upsertListItem` below and the handful of direct `setResult` writers
+  // (label/milestone reconciliation, issue transfer) — so the
+  // `itemMutationSeq` bump (see its doc comment above) is structurally
+  // guaranteed rather than something each call site has to remember. No-ops
+  // if there's no result to mutate yet.
+  const mutateItems = (updater: (cur: GitHubListResult) => GitHubListResult) => {
+    itemMutationSeq.current += 1;
+    setResult((cur) => (cur ? updater(cur) : cur));
+  };
+
   // `keepIfPresent` updates an existing row in place even when the replacement no
   // longer matches the active filters — used by in-panel state changes (e.g.
   // reopen) so the user sees the result instead of the row silently vanishing;
-  // it drops out naturally on the next refresh.
-  const upsertListItem = (replacement: GitHubListItem, prepend = false, keepIfPresent = false) => {
-    // Every local item write goes through here — bump so an in-flight refresh
-    // fetch (the refresh-on-detail-entry effect) can detect a newer local
-    // mutation landed while it was awaiting and drop its now-stale response.
-    itemMutationSeq.current += 1;
-    setResult((cur) => {
-      if (!cur) return cur;
+  // it drops out naturally on the next refresh. `updateOnly` is the opposite
+  // shape for the entry-refresh path (`refreshPullDetail`): a "View PR"
+  // deep-link can open a PR that was never in the filtered/paged list, and
+  // inserting it here would append an out-of-sort row, so when the item isn't
+  // already present this does nothing at all (no insert, no removal). Both
+  // flags are evaluated inside the `setResult` updater against the freshest
+  // state rather than a render closure, so a caller doesn't need its own
+  // "is it still present" check racing against concurrent local mutations.
+  const upsertListItem = (
+    replacement: GitHubListItem,
+    prepend = false,
+    keepIfPresent = false,
+    updateOnly = false,
+  ) => {
+    mutateItems((cur) => {
       // Match on kind+number+sourcePath (G8) so a write to repo B's #5 can't
       // overwrite repo A's #5 in an aggregated list.
       const exists = cur.items.some((item) => sameItem(item, replacement));
+      if (updateOnly && !exists) return cur;
       if (!itemMatchesActiveFilters(replacement) && !(keepIfPresent && exists)) {
         return {
           ...cur,
@@ -3733,6 +3805,11 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
               if (expandedItem.kind !== "pulls") return;
               setCommitStatusErrors((cur) => ({ ...cur, [itemKey(expandedItem)]: undefined }));
             }}
+            // Unlike the full "Refresh" below, these three sibling refresh
+            // handlers don't bump `itemMutationSeq`/a request seq of their
+            // own — their buttons are `disabled` while their own `*Loading`
+            // flag is set, so there's no in-flight request they'd need to
+            // race against. Intentional asymmetry, not an oversight.
             onRefreshDiff={() => {
               if (expandedItem.kind !== "pulls") return;
               setDiffs((cur) => ({ ...cur, [itemKey(expandedItem)]: undefined }));
@@ -3752,17 +3829,13 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
               setCommitStatus((cur) => ({ ...cur, [itemKey(expandedItem)]: undefined }));
               setCommitStatusErrors((cur) => ({ ...cur, [itemKey(expandedItem)]: undefined }));
             }}
-            onRefreshMergeability={() => {
+            onRefresh={() => {
               if (expandedItem.kind !== "pulls") return;
-              mergeabilityRetries.current[itemKey(expandedItem)] = 0;
-              setMergeability((cur) => ({ ...cur, [itemKey(expandedItem)]: undefined }));
-              setMergeabilityErrors((cur) => ({ ...cur, [itemKey(expandedItem)]: undefined }));
-              // Defeat any request already in flight for this key — bumping
-              // the seq makes its .then/.catch/.finally no-ops, so the loading
-              // flag must be cleared manually here or it would stay stuck.
-              mergeabilitySeq.current += 1;
-              setMergeabilityLoading((cur) => ({ ...cur, [itemKey(expandedItem)]: false }));
+              const key = itemKey(expandedItem);
+              invalidateMergeability(key);
+              void refreshPullDetail(expandedItem);
             }}
+            refreshing={expandedItem.kind === "pulls" ? !!detailRefreshing[itemKey(expandedItem)] : false}
             onRetryCommits={() => {
               if (expandedItem.kind !== "pulls") return;
               setCommitsErrors((cur) => ({ ...cur, [itemKey(expandedItem)]: undefined }));
@@ -6599,7 +6672,8 @@ function GitHubItemDetail({
   onRefreshDiff,
   onRefreshChecks,
   onRefreshCommitStatus,
-  onRefreshMergeability,
+  onRefresh,
+  refreshing,
   onRetryCommits,
 }: {
   item: GitHubListItem;
@@ -6713,7 +6787,12 @@ function GitHubItemDetail({
   onRefreshDiff: () => void;
   onRefreshChecks: () => void;
   onRefreshCommitStatus: () => void;
-  onRefreshMergeability: () => void;
+  // Full item + mergeability refresh, not just mergeability — see
+  // `refreshPullDetail`/`invalidateMergeability` above. Rendered for every PR
+  // state (open/closed/merged), unlike the old mergeability-only button which
+  // only ever showed for an open PR.
+  onRefresh: () => void;
+  refreshing: boolean;
   onRetryCommits: () => void;
 }) {
   // The item's own author may close/reopen and edit the title/body of their own
@@ -6807,7 +6886,8 @@ function GitHubItemDetail({
             onToggleDraft={onToggleDraft}
             onToggleAutoMerge={onToggleAutoMerge}
             onClosePull={onClosePull}
-            onRefreshMergeability={onRefreshMergeability}
+            onRefresh={onRefresh}
+            refreshing={refreshing}
             canPush={canPush}
             canModifyOwn={canModifyOwn}
           />
@@ -7571,7 +7651,8 @@ function PullActions({
   onToggleDraft,
   onToggleAutoMerge,
   onClosePull,
-  onRefreshMergeability,
+  onRefresh,
+  refreshing,
   canPush,
   canModifyOwn,
 }: {
@@ -7603,7 +7684,8 @@ function PullActions({
   onToggleDraft: () => void;
   onToggleAutoMerge: () => void;
   onClosePull: () => void;
-  onRefreshMergeability: () => void;
+  onRefresh: () => void;
+  refreshing: boolean;
   canPush: boolean;
   // Push access OR being the PR's own author — gates close/reopen only.
   // Merge, auto-merge, update-branch and draft-toggle stay push-only.
@@ -7616,8 +7698,14 @@ function PullActions({
   const merged = isMergedPull(item);
   const disabled = item.state !== "open" || !!busy;
   const view = item.state === "open" && mergeability ? mergeabilityView(mergeability) : null;
-  const mergeDisabled = disabled || !canPush || (view ? !view.canMerge : false);
-  const mergeTitle = !canPush ? PUSH_ONLY_TITLE : view && !view.canMerge ? view.label : undefined;
+  // Held while an entry/manual refresh is in flight — merging against a
+  // mergeability verdict or state that's mid-refresh could act on stale
+  // data. Only Merge is held; Approve/Comment/Request/Close stay live since
+  // they don't depend on the mergeability verdict.
+  const mergeDisabled = disabled || !canPush || (view ? !view.canMerge : false) || refreshing;
+  const mergeTitle = refreshing
+    ? "Checking latest state…"
+    : !canPush ? PUSH_ONLY_TITLE : view && !view.canMerge ? view.label : undefined;
   const pushDisabled = disabled || !canPush;
   const pushTitle = canPush ? undefined : PUSH_ONLY_TITLE;
   const ownTitle = canModifyOwn ? undefined : PUSH_ONLY_TITLE;
@@ -7651,7 +7739,7 @@ function PullActions({
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
           <GitPullRequest className="size-3.5" />
-          Actions
+          {merged ? "Merge status" : "Actions"}
         </div>
         {item.state === "open" && provider === "github" && (
           <Button size="sm" variant="ghost" className="h-7" disabled={!!busy || !canPush} title={pushTitle} onClick={onToggleDraft}>
@@ -7671,7 +7759,26 @@ function PullActions({
             Reopen
           </Button>
         )}
-        {message && (
+        {/* Full item + mergeability refresh (C3) — rendered for every PR
+            state, not just open, so a closed/merged PR that was reopened or
+            re-merged elsewhere has a way to catch up without leaving the
+            detail view. */}
+        <Button
+          size="icon"
+          variant="ghost"
+          className="size-6"
+          title="Refresh"
+          aria-label="Refresh"
+          disabled={refreshing}
+          onClick={onRefresh}
+        >
+          {refreshing ? <Loader2 className="size-3.5 animate-spin text-muted-foreground" aria-hidden /> : <RefreshCw className="size-3.5" />}
+        </Button>
+        {/* Suppressed once merged — the purple "Merged" tag above and the
+            card below already say everything a success line would; the
+            error line stays unconditional since a failed action still needs
+            surfacing regardless of merge state. */}
+        {message && !merged && (
           <span className="inline-flex items-center gap-1 text-[11px] text-success">
             <CheckCircle2 className="size-3.5" />
             {message}
@@ -7687,13 +7794,18 @@ function PullActions({
 
       {item.state === "open" && (
         <div className="mb-3 flex flex-wrap items-center gap-2 rounded-md border border-border/50 bg-background/40 px-3 py-2">
-          {mergeabilityLoading && !mergeability ? (
-            <span className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
-              <Loader2 className="size-3.5 animate-spin" /> Checking mergeability…
-            </span>
-          ) : mergeabilityError ? (
+          {mergeabilityError ? (
             <span className="inline-flex items-center gap-1.5 text-[11px] text-danger">
               <AlertCircle className="size-3.5" /> {mergeabilityError}
+            </span>
+          ) : !mergeability ? (
+            // Covers both the initial fetch and the brief window right after
+            // an invalidation (entry-refresh, manual Refresh) clears the
+            // cache but before the mergeability effect's own request has set
+            // `mergeabilityLoading` back to true — without this, that one
+            // frame fell through to "Mergeability unavailable." below.
+            <span className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin" /> Checking mergeability…
             </span>
           ) : view ? (
             <>
@@ -7724,166 +7836,46 @@ function PullActions({
                 Update branch
               </Button>
             )}
-            <Button
-              size="icon"
-              variant="ghost"
-              className="size-6"
-              title="Refresh mergeability"
-              aria-label="Refresh mergeability"
-              disabled={mergeabilityLoading}
-              onClick={onRefreshMergeability}
-            >
-              {mergeabilityLoading ? <Loader2 className="size-3.5 animate-spin" /> : <RefreshCw className="size-3.5" />}
-            </Button>
           </div>
         </div>
       )}
 
       {merged ? (
-        <div className="flex flex-col items-center justify-center gap-2 rounded-md border border-merged/30 bg-merged/10 px-4 py-6 text-center">
-          <GitMerge className="size-6 text-merged" />
-          <span className="text-sm font-medium text-merged">Pull request successfully merged</span>
-          {(() => {
-            // Only render once `fmtDate` produces something — an unparsable
-            // `mergedAt` would otherwise leave a dangling "Merged on ".
-            const mergedOn = fmtDate(item.mergedAt ?? "");
-            return mergedOn && <span className="text-[11px] text-merged/80">Merged on {mergedOn}</span>;
-          })()}
-        </div>
+        <MergedPullCard item={item} />
       ) : (
-      <div className="grid gap-3 lg:grid-cols-3">
-        <div className="min-w-0">
-          <div className="mb-1 flex items-center justify-between gap-2">
-            <span className="text-[11px] font-medium uppercase text-muted-foreground">Review</span>
-            {pendingCount > 0 && (
-              <span className="inline-flex items-center gap-1 text-[11px] text-info">
-                <MessageSquare className="size-3 shrink-0" />
-                {pendingCount} inline comment{pendingCount === 1 ? "" : "s"} queued
-              </span>
-            )}
-          </div>
-          <Textarea
-            value={reviewDraft}
-            onChange={(e) => onReviewDraftChange(e.target.value)}
-            placeholder={pendingCount > 0 ? "Optional review summary — submits the queued comments" : "Review note..."}
-            className="min-h-20 resize-y text-xs"
-            disabled={disabled}
-          />
-          <div className="mt-2 flex flex-wrap gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={disabled}
-              onClick={() => onReview("APPROVE")}
-            >
-              {busy === "APPROVE" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <CheckCircle2 className="mr-2 size-3.5" />}
-              Approve
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={disabled || (!reviewDraft.trim() && pendingCount === 0)}
-              onClick={() => onReview("COMMENT")}
-            >
-              {busy === "COMMENT" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <MessageSquare className="mr-2 size-3.5" />}
-              Comment
-            </Button>
-            {caps.requestChanges && (
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={disabled || (!reviewDraft.trim() && pendingCount === 0)}
-                onClick={() => onReview("REQUEST_CHANGES")}
-              >
-                {busy === "REQUEST_CHANGES" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <XCircle className="mr-2 size-3.5" />}
-                Request
-              </Button>
-            )}
-          </div>
-        </div>
-
-        <div className="min-w-0">
-          <div className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">Merge</div>
-          <Select
-            value={mergeMethod}
-            onChange={(e) => onMergeMethodChange(e.target.value as GitHubPullMergeMethod)}
-            className="h-8 text-xs"
-            disabled={disabled}
-            title="Merge method"
-            aria-label="Merge method"
-          >
-            {caps.mergeMethods.map((method) => (
-              <option key={method} value={method}>
-                {mergeMethodLabel(method, provider)}
-              </option>
-            ))}
-          </Select>
-          <Button
-            size="sm"
-            className="mt-2"
-            disabled={mergeDisabled}
-            title={mergeTitle}
-            onClick={onMerge}
-          >
-            {busy === "merge" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <GitMerge className="mr-2 size-3.5" />}
-            Merge
-          </Button>
-          {item.state === "open" && caps.autoMerge && (
-            <div className="mt-2 flex items-center gap-2">
-              {mergeability?.autoMerge ? (
-                <>
-                  <span className="inline-flex items-center gap-1 text-[11px] text-success">
-                    <CheckCircle2 className="size-3.5" /> Auto-merge enabled
-                  </span>
-                  <Button size="sm" variant="outline" disabled={pushDisabled} title={pushTitle} onClick={onToggleAutoMerge}>
-                    {busy === "auto-merge" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : null}
-                    Disable
-                  </Button>
-                </>
-              ) : (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={pushDisabled || !mergeability}
-                  title={!canPush ? PUSH_ONLY_TITLE : !mergeability ? "Waiting for mergeability…" : undefined}
-                  onClick={onToggleAutoMerge}
-                >
-                  {busy === "auto-merge" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <GitMerge className="mr-2 size-3.5" />}
-                  Enable auto-merge
-                </Button>
-              )}
-            </div>
-          )}
-        </div>
-
-        <div className="min-w-0">
-          <div className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">Close</div>
-          <Textarea
-            value={closeDraft}
-            onChange={(e) => onCloseDraftChange(e.target.value)}
-            placeholder="Optional close comment..."
-            className="min-h-20 resize-y text-xs"
-            disabled={disabled}
-          />
-          <Button
-            size="sm"
-            variant="outline"
-            className="mt-2"
-            disabled={closeDisabled}
-            title={ownTitle}
-            onClick={onClosePull}
-          >
-            {busy === "close" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <XCircle className="mr-2 size-3.5" />}
-            Close PR
-          </Button>
-        </div>
-      </div>
+        <PullActionGrid
+          caps={caps}
+          provider={provider}
+          item={item}
+          reviewDraft={reviewDraft}
+          onReviewDraftChange={onReviewDraftChange}
+          pendingCount={pendingCount}
+          disabled={disabled}
+          busy={busy}
+          onReview={onReview}
+          mergeMethod={mergeMethod}
+          onMergeMethodChange={onMergeMethodChange}
+          mergeDisabled={mergeDisabled}
+          mergeTitle={mergeTitle}
+          onMerge={onMerge}
+          mergeability={mergeability}
+          pushDisabled={pushDisabled}
+          pushTitle={pushTitle}
+          onToggleAutoMerge={onToggleAutoMerge}
+          closeDraft={closeDraft}
+          onCloseDraftChange={onCloseDraftChange}
+          closeDisabled={closeDisabled}
+          ownTitle={ownTitle}
+          onClosePull={onClosePull}
+        />
       )}
 
       {pendingCount > 0 && (
         <div className="mt-3 flex items-start gap-1.5 text-[11px] text-warning">
           <AlertCircle className="mt-px size-3.5 shrink-0" />
-          {pendingCount} review comment{pendingCount === 1 ? "" : "s"} queued — submit via Approve / Comment / Request; merging or closing won't post {pendingCount === 1 ? "it" : "them"}.
+          {merged
+            ? <>{pendingCount} review comment{pendingCount === 1 ? "" : "s"} queued but never submitted — this pull request is merged, so {pendingCount === 1 ? "it" : "they"} can no longer be posted. Discard {pendingCount === 1 ? "it" : "them"} under "Pending review" below.</>
+            : <>{pendingCount} review comment{pendingCount === 1 ? "" : "s"} queued — submit via Approve / Comment / Request; merging or closing won't post {pendingCount === 1 ? "it" : "them"}.</>}
         </div>
       )}
       <ResolveConflictsDialog
@@ -7895,6 +7887,224 @@ function PullActions({
           setTimeout(() => setResolveConfirmed(false), 5_000);
         }}
       />
+    </div>
+  );
+}
+
+/** The Review/Merge/Close 3-column action grid — split out of `PullActions`
+ *  (C11) so the merged/unmerged branch reads as a plain ternary between two
+ *  named components instead of an un-indented else-branch. Receives the
+ *  derived enable/disable flags and titles `PullActions` already computed
+ *  (mergeDisabled, pushDisabled, ...) rather than recomputing them, so
+ *  there's exactly one place that owns that logic. */
+function PullActionGrid({
+  caps,
+  provider,
+  item,
+  reviewDraft,
+  onReviewDraftChange,
+  pendingCount,
+  disabled,
+  busy,
+  onReview,
+  mergeMethod,
+  onMergeMethodChange,
+  mergeDisabled,
+  mergeTitle,
+  onMerge,
+  mergeability,
+  pushDisabled,
+  pushTitle,
+  onToggleAutoMerge,
+  closeDraft,
+  onCloseDraftChange,
+  closeDisabled,
+  ownTitle,
+  onClosePull,
+}: {
+  caps: ProviderCaps;
+  provider: GitProvider | "mixed" | null;
+  item: GitHubListItem;
+  reviewDraft: string;
+  onReviewDraftChange: (body: string) => void;
+  pendingCount: number;
+  disabled: boolean;
+  busy?: string;
+  onReview: (event: GitHubPullReviewEvent) => void;
+  mergeMethod: GitHubPullMergeMethod;
+  onMergeMethodChange: (method: GitHubPullMergeMethod) => void;
+  mergeDisabled: boolean;
+  mergeTitle?: string;
+  onMerge: () => void;
+  mergeability?: GitHubPullMergeability;
+  pushDisabled: boolean;
+  pushTitle?: string;
+  onToggleAutoMerge: () => void;
+  closeDraft: string;
+  onCloseDraftChange: (body: string) => void;
+  closeDisabled: boolean;
+  ownTitle?: string;
+  onClosePull: () => void;
+}) {
+  return (
+    <div className="grid gap-3 lg:grid-cols-3">
+      <div className="min-w-0">
+        <div className="mb-1 flex items-center justify-between gap-2">
+          <span className="text-[11px] font-medium uppercase text-muted-foreground">Review</span>
+          {pendingCount > 0 && (
+            <span className="inline-flex items-center gap-1 text-[11px] text-info">
+              <MessageSquare className="size-3 shrink-0" />
+              {pendingCount} inline comment{pendingCount === 1 ? "" : "s"} queued
+            </span>
+          )}
+        </div>
+        <Textarea
+          value={reviewDraft}
+          onChange={(e) => onReviewDraftChange(e.target.value)}
+          placeholder={pendingCount > 0 ? "Optional review summary — submits the queued comments" : "Review note..."}
+          className="min-h-20 resize-y text-xs"
+          disabled={disabled}
+        />
+        <div className="mt-2 flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={disabled}
+            onClick={() => onReview("APPROVE")}
+          >
+            {busy === "APPROVE" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <CheckCircle2 className="mr-2 size-3.5" />}
+            Approve
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={disabled || (!reviewDraft.trim() && pendingCount === 0)}
+            onClick={() => onReview("COMMENT")}
+          >
+            {busy === "COMMENT" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <MessageSquare className="mr-2 size-3.5" />}
+            Comment
+          </Button>
+          {caps.requestChanges && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={disabled || (!reviewDraft.trim() && pendingCount === 0)}
+              onClick={() => onReview("REQUEST_CHANGES")}
+            >
+              {busy === "REQUEST_CHANGES" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <XCircle className="mr-2 size-3.5" />}
+              Request
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="min-w-0">
+        <div className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">Merge</div>
+        <Select
+          value={mergeMethod}
+          onChange={(e) => onMergeMethodChange(e.target.value as GitHubPullMergeMethod)}
+          className="h-8 text-xs"
+          disabled={disabled}
+          title="Merge method"
+          aria-label="Merge method"
+        >
+          {caps.mergeMethods.map((method) => (
+            <option key={method} value={method}>
+              {mergeMethodLabel(method, provider)}
+            </option>
+          ))}
+        </Select>
+        <Button
+          size="sm"
+          className="mt-2"
+          disabled={mergeDisabled}
+          title={mergeTitle}
+          onClick={onMerge}
+        >
+          {busy === "merge" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <GitMerge className="mr-2 size-3.5" />}
+          Merge
+        </Button>
+        {item.state === "open" && caps.autoMerge && (
+          <div className="mt-2 flex items-center gap-2">
+            {mergeability?.autoMerge ? (
+              <>
+                <span className="inline-flex items-center gap-1 text-[11px] text-success">
+                  <CheckCircle2 className="size-3.5" /> Auto-merge enabled
+                </span>
+                <Button size="sm" variant="outline" disabled={pushDisabled} title={pushTitle} onClick={onToggleAutoMerge}>
+                  {busy === "auto-merge" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : null}
+                  Disable
+                </Button>
+              </>
+            ) : (
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={pushDisabled || !mergeability}
+                title={pushTitle ?? (!mergeability ? "Waiting for mergeability…" : undefined)}
+                onClick={onToggleAutoMerge}
+              >
+                {busy === "auto-merge" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <GitMerge className="mr-2 size-3.5" />}
+                Enable auto-merge
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="min-w-0">
+        <div className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">Close</div>
+        <Textarea
+          value={closeDraft}
+          onChange={(e) => onCloseDraftChange(e.target.value)}
+          placeholder="Optional close comment..."
+          className="min-h-20 resize-y text-xs"
+          disabled={disabled}
+        />
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-2"
+          disabled={closeDisabled}
+          title={ownTitle}
+          onClick={onClosePull}
+        >
+          {busy === "close" ? <Loader2 className="mr-2 size-3.5 animate-spin" /> : <XCircle className="mr-2 size-3.5" />}
+          Close PR
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** Replaces the mergeability banner + `PullActionGrid` once a PR has
+ *  actually been merged (as opposed to closed-unmerged, which keeps the
+ *  ordinary grid via `isMergedPull`'s guard) — there's nothing actionable
+ *  left to show once GitHub has merged the branches. `role="status"` +
+ *  `tabIndex={-1}` so it can take focus itself: when an in-app merge
+ *  unmounts the grid, the browser drops focus to `<body>`, and the effect
+ *  below reclaims it for keyboard/screen-reader users rather than leaving
+ *  them stranded on the document body. */
+function MergedPullCard({ item }: { item: GitHubListItem }) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (document.activeElement === document.body) {
+      cardRef.current?.focus({ preventScroll: true });
+    }
+  }, []);
+  const mergedWhen = fmtRelativeDate(item.mergedAt ?? "");
+  return (
+    <div
+      ref={cardRef}
+      role="status"
+      tabIndex={-1}
+      className="flex min-h-[7.5rem] flex-col items-center justify-center gap-2 rounded-md border border-merged/40 bg-merged/10 px-3 py-6 text-center"
+    >
+      <GitMerge className="size-6 text-merged" aria-hidden />
+      <span className="text-sm font-medium text-foreground">Pull request successfully merged</span>
+      {/* Only render once `fmtRelativeDate` produces something — an
+          unparsable `mergedAt` would otherwise leave a dangling "Merged ". */}
+      {mergedWhen && <span className="text-xs text-muted-foreground">Merged {mergedWhen}</span>}
     </div>
   );
 }

--- a/src/mainview/lib/pull-merged.test.ts
+++ b/src/mainview/lib/pull-merged.test.ts
@@ -76,6 +76,11 @@ describe("mergedPullReplacement", () => {
     expect(parsed).toBeLessThanOrEqual(after);
   });
 
+  test("stamps mergedAt with a freshly-generated ISO when given an empty string", () => {
+    const pr = item({ state: "open", mergedAt: null });
+    expect(isMergedPull(mergedPullReplacement(pr, ""))).toBe(true);
+  });
+
   test("preserves an existing closedAt", () => {
     const pr = item({ state: "open", closedAt: "2026-01-05T00:00:00Z" });
     const result = mergedPullReplacement(pr, "2026-03-04T05:06:07Z");

--- a/src/mainview/lib/pull-merged.test.ts
+++ b/src/mainview/lib/pull-merged.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { isMergedPull, mergedPullReplacement } from "./pull-merged.ts";
+import type { GitHubListItem } from "../../shared/types.ts";
+
+function item(overrides: Partial<GitHubListItem>): GitHubListItem {
+  return {
+    kind: "pulls",
+    number: 1,
+    title: "Add feature",
+    state: "open",
+    draft: false,
+    htmlUrl: "https://github.com/o/r/pull/1",
+    author: null,
+    assignees: [],
+    milestone: null,
+    body: "",
+    labels: [],
+    comments: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    closedAt: null,
+    mergedAt: null,
+    locked: false,
+    sourcePath: null,
+    ...overrides,
+  };
+}
+
+describe("isMergedPull", () => {
+  test("true for a pulls item with mergedAt set", () => {
+    const pr = item({ kind: "pulls", mergedAt: "2026-01-02T00:00:00Z", state: "closed" });
+    expect(isMergedPull(pr)).toBe(true);
+  });
+
+  test("false for a pulls item with mergedAt null (open or closed-unmerged)", () => {
+    const openPr = item({ kind: "pulls", mergedAt: null, state: "open" });
+    expect(isMergedPull(openPr)).toBe(false);
+
+    const closedUnmergedPr = item({ kind: "pulls", mergedAt: null, state: "closed" });
+    expect(isMergedPull(closedUnmergedPr)).toBe(false);
+  });
+
+  test("false for an issues-kind item even with mergedAt set", () => {
+    const issue = item({ kind: "issues", mergedAt: "2026-01-02T00:00:00Z", state: "closed" });
+    expect(isMergedPull(issue)).toBe(false);
+  });
+
+  test("false for an open PR", () => {
+    const openPr = item({ kind: "pulls", state: "open", mergedAt: null });
+    expect(isMergedPull(openPr)).toBe(false);
+  });
+});
+
+describe("mergedPullReplacement", () => {
+  test("flips state to closed", () => {
+    const pr = item({ state: "open" });
+    expect(mergedPullReplacement(pr).state).toBe("closed");
+  });
+
+  test("stamps mergedAt with the provided ISO when given", () => {
+    const pr = item({ state: "open", mergedAt: null });
+    const result = mergedPullReplacement(pr, "2026-03-04T05:06:07Z");
+    expect(result.mergedAt).toBe("2026-03-04T05:06:07Z");
+  });
+
+  test("stamps mergedAt with a freshly-generated ISO when omitted", () => {
+    const pr = item({ state: "open", mergedAt: null });
+    const before = Date.now();
+    const result = mergedPullReplacement(pr);
+    const after = Date.now();
+
+    expect(result.mergedAt).not.toBeNull();
+    const parsed = new Date(result.mergedAt as string).getTime();
+    expect(Number.isNaN(parsed)).toBe(false);
+    expect(parsed).toBeGreaterThanOrEqual(before);
+    expect(parsed).toBeLessThanOrEqual(after);
+  });
+
+  test("preserves an existing closedAt", () => {
+    const pr = item({ state: "open", closedAt: "2026-01-05T00:00:00Z" });
+    const result = mergedPullReplacement(pr, "2026-03-04T05:06:07Z");
+    expect(result.closedAt).toBe("2026-01-05T00:00:00Z");
+  });
+
+  test("stamps closedAt when it was null, matching the mergedAt stamp", () => {
+    const pr = item({ state: "open", closedAt: null });
+    const result = mergedPullReplacement(pr, "2026-03-04T05:06:07Z");
+    expect(result.closedAt).toBe("2026-03-04T05:06:07Z");
+  });
+
+  test("preserves all other fields untouched", () => {
+    const pr = item({
+      number: 42,
+      title: "Add feature",
+      htmlUrl: "https://github.com/o/r/pull/42",
+      labels: [{ name: "bug", color: "ff0000" } as GitHubListItem["labels"][number]],
+      sourcePath: "/repo/path",
+    });
+    const result = mergedPullReplacement(pr, "2026-03-04T05:06:07Z");
+
+    expect(result.number).toBe(42);
+    expect(result.title).toBe("Add feature");
+    expect(result.htmlUrl).toBe("https://github.com/o/r/pull/42");
+    expect(result.labels).toBe(pr.labels);
+    expect(result.sourcePath).toBe("/repo/path");
+  });
+
+  test("does not mutate the input item", () => {
+    const pr = item({ state: "open", closedAt: null, mergedAt: null });
+    const snapshot = { ...pr };
+    mergedPullReplacement(pr, "2026-03-04T05:06:07Z");
+    expect(pr).toEqual(snapshot);
+  });
+});

--- a/src/mainview/lib/pull-merged.test.ts
+++ b/src/mainview/lib/pull-merged.test.ts
@@ -44,6 +44,11 @@ describe("isMergedPull", () => {
     const issue = item({ kind: "issues", mergedAt: "2026-01-02T00:00:00Z", state: "closed" });
     expect(isMergedPull(issue)).toBe(false);
   });
+
+  test("false for a pulls item with mergedAt as an empty string", () => {
+    const pr = item({ kind: "pulls", mergedAt: "", state: "closed" });
+    expect(isMergedPull(pr)).toBe(false);
+  });
 });
 
 describe("mergedPullReplacement", () => {
@@ -88,7 +93,7 @@ describe("mergedPullReplacement", () => {
       number: 42,
       title: "Add feature",
       htmlUrl: "https://github.com/o/r/pull/42",
-      labels: [{ name: "bug", color: "ff0000" } as GitHubListItem["labels"][number]],
+      labels: [{ name: "bug", color: "ff0000" }],
       sourcePath: "/repo/path",
     });
     const result = mergedPullReplacement(pr, "2026-03-04T05:06:07Z");
@@ -105,5 +110,14 @@ describe("mergedPullReplacement", () => {
     const snapshot = { ...pr };
     mergedPullReplacement(pr, "2026-03-04T05:06:07Z");
     expect(pr).toEqual(snapshot);
+  });
+
+  test("leaves an issues-kind item unchanged", () => {
+    const issue = item({ kind: "issues", state: "open", closedAt: null, mergedAt: null });
+    const result = mergedPullReplacement(issue, "2026-03-04T05:06:07Z");
+    expect(result).toBe(issue);
+    expect(result.state).toBe("open");
+    expect(result.mergedAt).toBeNull();
+    expect(result.closedAt).toBeNull();
   });
 });

--- a/src/mainview/lib/pull-merged.test.ts
+++ b/src/mainview/lib/pull-merged.test.ts
@@ -44,11 +44,6 @@ describe("isMergedPull", () => {
     const issue = item({ kind: "issues", mergedAt: "2026-01-02T00:00:00Z", state: "closed" });
     expect(isMergedPull(issue)).toBe(false);
   });
-
-  test("false for an open PR", () => {
-    const openPr = item({ kind: "pulls", state: "open", mergedAt: null });
-    expect(isMergedPull(openPr)).toBe(false);
-  });
 });
 
 describe("mergedPullReplacement", () => {

--- a/src/mainview/lib/pull-merged.ts
+++ b/src/mainview/lib/pull-merged.ts
@@ -17,8 +17,14 @@ export function isMergedPull(item: GitHubListItem): boolean {
  *  it with GitHub's actual timestamp. `closedAt` is preserved if the item
  *  already carries one; otherwise it's stamped with the same timestamp,
  *  matching what `markPullClosed`'s default replacement does for a plain
- *  close. Every other field on `item` is passed through unchanged. */
+ *  close. Every other field on `item` is passed through unchanged.
+ *
+ *  Same `kind === "pulls"` guard as `isMergedPull` above — a merge action is
+ *  only ever invoked on a pulls item in practice, but keeping the two
+ *  predicates symmetric means a caller can't accidentally stamp merge fields
+ *  onto an issue. Returns `item` unchanged for a non-pulls item. */
 export function mergedPullReplacement(item: GitHubListItem, mergedAtIso?: string): GitHubListItem {
+  if (item.kind !== "pulls") return item;
   const stamp = mergedAtIso ?? new Date().toISOString();
   return {
     ...item,

--- a/src/mainview/lib/pull-merged.ts
+++ b/src/mainview/lib/pull-merged.ts
@@ -1,0 +1,29 @@
+import type { GitHubListItem } from "../../shared/types.ts";
+
+/** Whether `item` is a pull request that has actually been merged (as opposed
+ *  to closed-unmerged) — the one signal `state: "closed"` alone can't give,
+ *  since GitHub collapses both outcomes into the same `state` value. Drives
+ *  whether the GitHub dialog's PR detail view shows the purple "merged" card
+ *  in place of the mergeability banner + Review/Merge/Close action grid. */
+export function isMergedPull(item: GitHubListItem): boolean {
+  return item.kind === "pulls" && !!item.mergedAt;
+}
+
+/** Builds the optimistic list-item replacement for a PR just merged from
+ *  inside agetor. GitHub's merge endpoint response (`{merged, sha, message}`)
+ *  carries no `mergedAt` — so the UI stamps an approximate one (default: now)
+ *  to flip the card to "merged" immediately, and the next real fetch (the
+ *  refresh-on-detail-entry effect, or a manual mergeability refresh) corrects
+ *  it with GitHub's actual timestamp. `closedAt` is preserved if the item
+ *  already carries one; otherwise it's stamped with the same timestamp,
+ *  matching what `markPullClosed`'s default replacement does for a plain
+ *  close. Every other field on `item` is passed through unchanged. */
+export function mergedPullReplacement(item: GitHubListItem, mergedAtIso?: string): GitHubListItem {
+  const stamp = mergedAtIso ?? new Date().toISOString();
+  return {
+    ...item,
+    state: "closed",
+    closedAt: item.closedAt ?? stamp,
+    mergedAt: stamp,
+  };
+}

--- a/src/mainview/lib/pull-merged.ts
+++ b/src/mainview/lib/pull-merged.ts
@@ -25,7 +25,10 @@ export function isMergedPull(item: GitHubListItem): boolean {
  *  onto an issue. Returns `item` unchanged for a non-pulls item. */
 export function mergedPullReplacement(item: GitHubListItem, mergedAtIso?: string): GitHubListItem {
   if (item.kind !== "pulls") return item;
-  const stamp = mergedAtIso ?? new Date().toISOString();
+  // `||`, not `??` — an empty string is falsy but not nullish, and must not be
+  // stamped as-is (it would fail `isMergedPull`'s truthiness check, leaving the
+  // "merged" replacement item reporting as not-merged).
+  const stamp = mergedAtIso || new Date().toISOString();
   return {
     ...item,
     state: "closed",


### PR DESCRIPTION
## What

Two fixes to the Git dialog's PR detail view, plus a hardening pass and a real e2e.

**1. Merge status refreshes every time a PR's detail view is entered** — row click, "View PR" from a task, in-dialog re-navigation, or reopening the dialog onto a surviving detail view. The PR itself is re-fetched (state / `mergedAt`) and the mergeability cache is invalidated, so the "Mergeability hasn't been verified" banner can no longer go stale and a PR merged outside agetor is detected.

**2. Merged PRs get a purple "merged" card instead of the action area** — the Review/Merge/Close grid and the mergeability banner are replaced by a `role="status"` card (GitMerge icon, "Pull request successfully merged", "Merged 3d ago"), using the existing `--merged` GitHub-purple token for the icon/border/tint with neutral text (AA in both themes). The panel header reads "Merge status", the green "Pull request merged." line is suppressed when merged, and merging from inside agetor flips to the card immediately via a local `mergedAt` stamp.

## Why

The cached list item kept reading `state: "open"` forever, and mergeability was only fetched for cached-open items and then cache-guarded — so a merged PR showed a disabled action grid under a stale "hasn't been verified" banner (see the screenshot that prompted this). `runPullMerge` also never stamped `mergedAt`, so even an in-app merge didn't show the merged state until a refetch.

## Notable implementation details

- `refreshPullDetail(item)` / `invalidateMergeability(key)` helpers shared by the entry effect, a header **Refresh** button (now rendered for every PR state, not just open), and the "View PR" prefill path (deduped — one detail fetch).
- Guards for any async fetch landing in `result.items`: `viewRef` navigation-clobber check, item-key pinning (`sourcePath`), an `itemMutationSeq` epoch (bumped via a `mutateItems()` wrapper every item writer uses) with retry-once on a stale drop, update-only upsert so deep-linked PRs can't be inserted out of filter, and the refresh effect declared *before* the mergeability effect so a fresh entry issues exactly one mergeability GET.
- `patchDetailView(next)` keeps the view snapshot in sync for merge/close/reopen/draft/lock (deep-linked items may not be in the list).
- `PullActions` split into `PullActionGrid` + `MergedPullCard`; Merge is disabled (with a header spinner) while the entry refresh is in flight; "Checking mergeability…" replaces the one-frame "Mergeability unavailable." flicker; focus is recovered onto the card only on the merged transition (not on ordinary navigation); queued-review hint copy branches on merged.
- New pure helper `src/mainview/lib/pull-merged.ts` (`isMergedPull`, `mergedPullReplacement`) with unit tests.

## Test seam + e2e

- `src/bun/github.ts`: all request URLs now derive from `GITHUB_API_BASE` (`AGETOR_GITHUB_API_BASE` override, dev/e2e only — default byte-identical; documented in README with a note never to point it at a non-loopback host since the token is sent there).
- `e2e/github-stub.ts`: small `node:http` stub GitHub API (route table, `Accept`-aware matching, call log); `e2e/fixtures.ts` launches each per-worker backend with `AGETOR_GITHUB_API_BASE` → its stub port and a fake `GITHUB_TOKEN`.
- `e2e/pr-merged-state.spec.ts`: 3 Playwright tests — merged-elsewhere card on entry, refresh on every re-entry (hit-count asserted), in-app merge flips the card in place.

## Verification

- `bun run typecheck` clean
- Playwright full suite: 31/31 passed (`bun node_modules/@playwright/test/cli.js test`)
- `bun test`: 3022 pass / 3 skip; one timing-sensitive test in untouched `terminals.test.ts` flaked under a load average of ~280 from other sessions and passed on re-run (baseline before this branch was 3020/0)

Plan: `docs/plans/pr-modal-refresh-merge-status-and-merged-banner.md` (§10 = hardening pass).