### PR TITLE
feature: hide disabled harnesses from the window topbar

### DIFF
--- a/docs/plans/hide-disabled-harnesses-topbar.md
+++ b/docs/plans/hide-disabled-harnesses-topbar.md
@@ -1,0 +1,90 @@
+# Plan — Hide disabled harnesses from the window topbar
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-28 |
+| Source | /implement: "don’t show disabled harnesses in the agetor window topbar" |
+| Config | AGENTS_CONFIG.yml (v1 balanced-style; `/implement --update` available) |
+| Flags | none (grill questions skipped — assumptions in §8) |
+| Gates | grill skipped by owner; plan approved |
+| Branch | feature/don-t-show-disabled-harnesses-in-topbar |
+| Base SHA | 36b46ff070337d4c28d5c2353423dcd8482a2caf |
+
+## 1. Objective & success criteria
+
+Disabled harnesses (`Harness.enabled === false`, the Settings toggle) must not appear as chips in the Agetor window topbar. Enabled-but-unavailable chips (binary missing / not logged in) still render. Settings, the Kanban harness filter, and `agetor harness ls` are unchanged.
+
+Success:
+
+- Default boot (only `claude-code` enabled) shows that chip and not Codex / Cursor / Gemini / fx.
+- Toggling a harness off in Settings removes its chip on the next harness refresh (15s poll, or immediately after the Settings mutation already refreshes the list).
+- Toggling it back on restores the chip.
+- `bun test` covers the filter helper; `e2e/usage-tracker.spec.ts` asserts disabled chips are absent from the banner; `bun run typecheck` stays green.
+
+## 2. Context & constraints
+
+- **Render site:** inlined app-bar in `src/mainview/App.tsx` (~1386–1439). `agents.map(...)` walks every `AgentStatus` from `GET /harnesses` with **no `enabled` filter**. The matching `Harness` row is only used for label + an `enabled` check that feeds a usage-popover *placeholder*, not visibility.
+- **Disabled ≠ unavailable.** `Harness.enabled` is the persisted Settings toggle (`src/shared/types.ts` ~169–175). `HarnessStatus.available` / `loggedIn` are live probes. This change is only about `enabled`.
+- **Existing hide-disabled convention** (inline `.filter((h) => h.enabled)`): New Task form, `TaskLaunchPickers`, Settings default-harness selector, onboarding `enabledHarnessIds`, CLI `agetor add`. No shared helper exists; this plan adds one only for the topbar (usage-chip list), not a drive-by refactor of those call sites.
+- **Deliberate show-disabled surfaces (out of scope):** Settings harness list, `KanbanFilters` (find tasks on a since-disabled harness), CLI `agetor harness ls`.
+- **#179 (`6ba316c`) chose explain-don’t-hide** for disabled chips (“Usage tracking is off because this harness is disabled — enable it in Settings…”). This request reverses that for the topbar. After hide, that `!enabled` placeholder branch is dead and must be removed.
+- **Server:** `harnesses.list()` / `checkAllHarnesses()` return every row. Client-side filter matches New Task and keeps probe/usage SSE behavior intact. Do not skip server probes in this run.
+- **Tests:** webview unit tests are pure `src/mainview/lib/*.ts` under `bun test`. Playwright e2e exists (`bunx playwright test`); `e2e/usage-tracker.spec.ts` currently *documents* that disabled Codex/Cursor/Gemini chips still render.
+
+## 3. Approach & key decisions
+
+1. **Client-side filter only.** `visibleTopbarAgents(agents, harnesses)` returns statuses whose harness row is `enabled`. Missing harness id → hidden (same as today’s `harness?.enabled ?? false`).
+2. **Put the helper in `src/mainview/lib/usage.ts`.** That module already owns topbar-chip presentation; `App.tsx` stays thin wiring. Do not invent a new file for a one-function filter.
+3. **Drop the #179 disabled placeholder** once those chips never render. Keep the unsupported-kind and “first poll pending” placeholders.
+4. **Do not hide unavailable/logged-out enabled chips.** Status dots stay.
+5. **Immediate hide on disable**, including while a task on that harness is still running. In-flight runs keep going (existing orchestrator policy); the topbar is not a run indicator.
+6. **No shared `getEnabledHarnesses` refactor** of New Task / pickers / CLI. Different ticket.
+
+Decision 1–3 rest on codebase evidence; 4–6 are the §8 assumptions from the skipped grill.
+
+## 4. Work breakdown — implementation tasks
+
+- **T1 — Filter topbar chips and delete dead disabled copy.**
+  - **Owns:** `src/mainview/lib/usage.ts`, `src/mainview/App.tsx`, `src/mainview/components/usage/UsagePopover.tsx`, `src/shared/types.ts` (doc comment on `Harness.enabled` only — add “window topbar” to the hide list).
+  - **Does:** export `visibleTopbarAgents(agents, harnesses)`; `App.tsx` maps that list instead of raw `agents`; remove the `!enabled` placeholder branch and the now-unused `enabled` local; tighten the UsagePopover `quota === null` comment so it no longer lists “disabled harness” as a reason a chip is shown.
+  - **Does not:** change `GET /harnesses`, Settings, KanbanFilters, CLI, onboarding derivation, usage poller.
+  - **Acceptance:** disabled ids never enter the chip map; enabled-but-unavailable still do; no remaining string “this harness is disabled — enable it in Settings”.
+
+## 5. Work breakdown — test tasks
+
+- **T2 — Unit tests for the helper.** Owns `src/mainview/lib/usage.test.ts`. Covers: enabled pass through; disabled dropped; missing harness id dropped; empty lists; does **not** drop an enabled-but-we-don’t-have-status-fields agent (helper only looks at `harness.enabled`). Layer: unit (`bun test src/mainview/lib/usage.test.ts`). Covers T1.
+- **T3 — E2E: banner shows enabled only.** Owns `e2e/usage-tracker.spec.ts`. Update the file comment (disabled chips no longer render). After goto, assert the banner’s Claude Code chip is visible and that Codex / Cursor / Gemini / fx labels are **not** in `getByRole("banner")`. Existing popover/mini-bar assertions stay. **E2e applies** — this is the user-visible topbar flow; harness already exists.
+
+**E2e run recipe:** `bunx playwright test e2e/usage-tracker.spec.ts` (no package.json script). Playwright config starts Vite (`bun run hmr`, :5173) and one isolated headless Bun backend per worker (`e2e/fixtures.ts`: own `AGETOR_DATA_DIR` / port / token, claude/tmux stubbed to `/bin/echo`). No extra credentials.
+
+**Full suite:** `bun test` and `bun run typecheck`. E2e targeted spec above; full `bunx playwright test` only if the targeted spec is green and time allows — not required to close the loop given the change is banner-local.
+
+## 6. Execution waves
+
+- **Wave 1:** T1 (single agent). Barrier: typecheck optional sanity.
+- **Then Phase 5 review** of the impl diff.
+- **Wave 2 (Phase 6):** T2 + T3 in parallel (disjoint files).
+- **Phase 7:** `bun test` + targeted Playwright spec.
+- **Phase 8:** fix if needed.
+
+## 7. Blast radius & risks
+
+- **#179 UX reversal:** users who clicked a disabled chip to learn they must enable it in Settings lose that in-topbar hint. Settings remains the enable surface. Accepted by the request.
+- **E2e locator drift:** other chips becoming buttons (all chips are already `UsagePopover` `<button>`s) is why T3 must use the banner scope and `exact: true`, same as the existing Claude Code query.
+- **SSE `harness_usage` for hidden ids:** still updates `usage` state; no chip reads it until re-enabled. Harmless; leave it.
+- **Onboarding / New Task:** already enabled-only. No change expected.
+- **Rollback:** revert the four files.
+
+## 8. Open questions / assumptions
+
+Grill questions were presented and skipped. Assumptions used for this plan:
+
+| Question | Answer | Source | Confidence |
+| --- | --- | --- | --- |
+| Hide vs dim vs keep #179 copy? | Hide entirely; delete the disabled placeholder as dead code. | Literal request + New Task filter convention | High (request wording); medium that #179’s hint is expendable |
+| Chip while an in-flight run still uses a just-disabled harness? | Hide immediately. | Reversible default; topbar is not a run list | Medium |
+| Enabled-but-unavailable / logged-out? | Still show. | Request named *disabled*, not unavailable | High |
+| Client-only vs also skip server probes? | Client-only. | Minimal blast radius; matches pickers | High |
+| Settings / Kanban filter / `harness ls`? | Out of scope. | Those surfaces need disabled rows | High |
+
+No one-way doors in this run.

--- a/e2e/usage-tracker.spec.ts
+++ b/e2e/usage-tracker.spec.ts
@@ -21,11 +21,12 @@ import type { HarnessQuota } from "../src/shared/types.ts";
  * migration 038's seed data), and `AGETOR_CLAUDE_BIN`/`AGETOR_TMUX_BIN`
  * point at `/bin/echo` in every worker's backend (e2e/fixtures.ts), so its
  * chip is deterministically available and rendered — no dependency on a real
- * `claude`/`tmux` install on the machine running these tests. `codex`/
- * `cursor`/`gemini` still render their own (usage-less) chips alongside it,
- * but with no seeded snapshot they stay plain spans rather than
- * `UsagePopover`-wrapped buttons, so they can't be confused with the
- * claude-code chip under test.
+ * `claude`/`tmux` install on the machine running these tests. The other
+ * built-ins seeded by migration 046 (`codex`, `cursor`, `gemini`, `fx`) ship
+ * `enabled=0` and `visibleTopbarAgents` (src/mainview/lib/usage.ts) filters
+ * the topbar to enabled harnesses only, so none of them render a chip at
+ * all — not even a plain, usage-less span (docs/plans
+ * /hide-disabled-harnesses-topbar.md).
  *
  * Assert DOM structure/classes/text — same convention as theme.spec.ts and
  * font-size.spec.ts (real Chromium against the real webview + a real Bun
@@ -71,8 +72,19 @@ test("renders the claude-code chip's worst-meter mini-bar and its popover's mete
   // Scoped to the app-bar (`<header>`, implicit role "banner") — the New
   // Task form's agent picker also has a button named "Claude Code", and an
   // unscoped role query would hit both (strict-mode violation).
-  const chip = page.getByRole("banner").getByRole("button", { name: "Claude Code", exact: true });
+  const banner = page.getByRole("banner");
+  const chip = banner.getByRole("button", { name: "Claude Code", exact: true });
   await expect(chip).toBeVisible();
+
+  // The other built-in harnesses (Codex, Cursor, Gemini CLI, fx.sh) are
+  // disabled by default and must not render a chip — not a button, not any
+  // other element — in the topbar (docs/plans
+  // /hide-disabled-harnesses-topbar.md). Labels per src/bun/migrations
+  // /046_fx_harness.sql; `exact: true` so "Gemini CLI" doesn't collide with
+  // a future "Gemini" label elsewhere.
+  for (const label of ["Codex", "Cursor", "Gemini CLI", "fx.sh"]) {
+    await expect(banner.getByRole("button", { name: label, exact: true })).toHaveCount(0);
+  }
 
   // Mini-bar: a fixed-size track (`bg-muted`) with a fill span colored by
   // the worst meter's tier. aria-hidden on both spans (decorative), so they

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -33,6 +33,7 @@ import { DiffDialog } from "@/components/kanban/DiffDialog";
 import { GitHubDialog, type GitHubItemDetailPrefill, type GitHubPullPrefill } from "@/components/kanban/GitHubDialog";
 import { UsageMeter } from "@/components/usage/UsageMeter";
 import { UsagePopover } from "@/components/usage/UsagePopover";
+import { visibleTopbarAgents } from "@/lib/usage";
 import { KanbanFilters } from "@/components/kanban/KanbanFilters";
 import { NewTaskForm } from "@/components/kanban/NewTaskForm";
 import { EXIT_DURATION_MS as RUN_PANEL_EXIT_MS, RunPanel } from "@/components/kanban/RunPanel";
@@ -1383,7 +1384,7 @@ const runTaskMenuAction = useCallback((action: TaskMenuAction, snapshot: Task) =
             <h1 className="font-geist text-base font-semibold leading-none tracking-tight">Agetor</h1>
           </div>
           <div className="electrobun-webkit-app-region-no-drag flex items-center gap-2 text-xs text-muted-foreground">
-            {agents.map((a) => {
+            {visibleTopbarAgents(agents, harnesses).map((a) => {
               const harness = harnesses.find((h) => h.id === a.harnessId);
               const displayName = harness?.label ?? a.harnessId;
               const q = usage[a.harnessId];
@@ -1397,20 +1398,14 @@ const runTaskMenuAction = useCallback((action: TaskMenuAction, snapshot: Task) =
                 />
               );
               // Every chip is clickable: with a snapshot the popover shows
-              // meters; without one it explains WHY there's no data (harness
-              // disabled / kind unsupported / first poll pending) instead of
-              // silently rendering a bare chip — "no bar and no explanation"
-              // reads as broken.
+              // meters; without one it explains WHY there's no data (kind
+              // unsupported / first poll pending) instead of silently
+              // rendering a bare chip — "no bar and no explanation" reads as
+              // broken.
               const kindSupported = (USAGE_SUPPORTED_KINDS as readonly string[]).includes(a.kind);
-              const enabled = harness?.enabled ?? false;
               const placeholder = !kindSupported
                 ? { message: "Usage tracking isn't supported for this harness yet.", canRefresh: false }
-                : !enabled
-                  ? {
-                      message: "Usage tracking is off because this harness is disabled — enable it in Settings → Harnesses to see its meters.",
-                      canRefresh: false,
-                    }
-                  : { message: "No usage data yet — the first poll runs shortly, or refresh now.", canRefresh: true };
+                : { message: "No usage data yet — the first poll runs shortly, or refresh now.", canRefresh: true };
               const chip = (
                 <span
                   className="flex items-center gap-1"

--- a/src/mainview/components/usage/UsagePopover.tsx
+++ b/src/mainview/components/usage/UsagePopover.tsx
@@ -7,8 +7,8 @@ import type { HarnessQuota } from "../../../shared/types.ts";
 
 interface Props {
   /** The harness's latest usage snapshot, or `null` when none exists yet
-   *  (disabled harness, unsupported kind, or first poll still pending) —
-   *  the popover then renders `placeholder` guidance instead of meters. */
+   *  (unsupported kind, or first poll still pending) — the popover then
+   *  renders `placeholder` guidance instead of meters. */
   quota: HarnessQuota | null;
   harnessLabel: string;
   children: ReactNode;

--- a/src/mainview/lib/usage.test.ts
+++ b/src/mainview/lib/usage.test.ts
@@ -4,6 +4,7 @@ import {
   formatResetsIn,
   formatUpdatedAgo,
   tierColorVar,
+  visibleTopbarAgents,
   warnTier,
   worstMeter,
   worstTier,
@@ -161,5 +162,81 @@ describe("formatUpdatedAgo", () => {
 
   test("a fetchedAtMs in the future (clock skew) still renders 'updated just now'", () => {
     expect(formatUpdatedAgo(now + 60_000, now)).toBe("updated just now");
+  });
+});
+
+describe("visibleTopbarAgents", () => {
+  function harness(id: string, enabled: boolean): { id: string; enabled: boolean } {
+    return { id, enabled };
+  }
+
+  test("enabled harnesses pass through, order preserved", () => {
+    const agents = [{ harnessId: "claude-code" }, { harnessId: "codex" }];
+    const harnesses = [harness("claude-code", true), harness("codex", true)];
+    expect(visibleTopbarAgents(agents, harnesses)).toEqual(agents);
+  });
+
+  test("disabled harnesses are dropped", () => {
+    const agents = [{ harnessId: "claude-code" }, { harnessId: "codex" }];
+    const harnesses = [harness("claude-code", true), harness("codex", false)];
+    expect(visibleTopbarAgents(agents, harnesses)).toEqual([{ harnessId: "claude-code" }]);
+  });
+
+  test("an agent whose harnessId has no matching harness row is dropped", () => {
+    const agents = [{ harnessId: "claude-code" }, { harnessId: "ghost" }];
+    const harnesses = [harness("claude-code", true)];
+    expect(visibleTopbarAgents(agents, harnesses)).toEqual([{ harnessId: "claude-code" }]);
+  });
+
+  test("empty agents returns an empty list", () => {
+    const harnesses = [harness("claude-code", true)];
+    expect(visibleTopbarAgents([], harnesses)).toEqual([]);
+  });
+
+  test("empty harnesses returns an empty list even if agents is non-empty", () => {
+    const agents = [{ harnessId: "claude-code" }, { harnessId: "codex" }];
+    expect(visibleTopbarAgents(agents, [])).toEqual([]);
+  });
+
+  test("mixed list: enabled kept, disabled and unknown dropped, order preserved among keepers", () => {
+    const agents = [
+      { harnessId: "claude-code" },
+      { harnessId: "codex" },
+      { harnessId: "cursor" },
+      { harnessId: "ghost" },
+      { harnessId: "gemini" },
+    ];
+    const harnesses = [
+      harness("claude-code", true),
+      harness("codex", false),
+      harness("cursor", true),
+      harness("gemini", false),
+    ];
+    expect(visibleTopbarAgents(agents, harnesses)).toEqual([
+      { harnessId: "claude-code" },
+      { harnessId: "cursor" },
+    ]);
+  });
+
+  test("extra fields on the agent objects are preserved", () => {
+    const agents = [
+      { harnessId: "claude-code", kind: "claude-code" as const },
+      { harnessId: "codex", kind: "codex" as const },
+    ];
+    const harnesses = [harness("claude-code", true), harness("codex", false)];
+    expect(visibleTopbarAgents(agents, harnesses)).toEqual([
+      { harnessId: "claude-code", kind: "claude-code" },
+    ]);
+  });
+
+  test("availability/loggedIn fields on an agent do not affect inclusion", () => {
+    const agents = [
+      { harnessId: "claude-code", available: false, loggedIn: false },
+      { harnessId: "codex", available: true, loggedIn: true },
+    ];
+    const harnesses = [harness("claude-code", true), harness("codex", false)];
+    expect(visibleTopbarAgents(agents, harnesses)).toEqual([
+      { harnessId: "claude-code", available: false, loggedIn: false },
+    ]);
   });
 });

--- a/src/mainview/lib/usage.ts
+++ b/src/mainview/lib/usage.ts
@@ -70,6 +70,22 @@ export function clampPercent(p: number): number {
   return p;
 }
 
+/**
+ * Filter a list of agent statuses down to the ones whose harness is
+ * `enabled` — this is what drives the window topbar's chip list. An agent
+ * whose harness id has no matching row (or whose row is disabled) is
+ * dropped, same as today's `harness?.enabled ?? false` inline check.
+ * Enabled-but-unavailable/logged-out harnesses still pass through; this
+ * only looks at the Settings toggle, not live probe state. Input order is
+ * preserved.
+ */
+export function visibleTopbarAgents<A extends { harnessId: string }>(
+  agents: readonly A[],
+  harnesses: readonly { id: string; enabled: boolean }[],
+): A[] {
+  return agents.filter((a) => harnesses.find((h) => h.id === a.harnessId)?.enabled ?? false);
+}
+
 const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -167,11 +167,12 @@ export interface Harness {
    *  the home-derived block. Power-user surface. */
   env: Record<string, string>;
   /** Soft-delete flag. Disabled harnesses are hidden from the New Task
-   *  picker and the default-harness selector, but the row stays in the DB
-   *  so historical `tasks.agent = <id>` references keep resolving. The
-   *  orchestrator refuses to start new runs on a disabled harness;
-   *  in-flight runs are unaffected. Built-ins are toggleable too — this
-   *  is the one carve-out from the built-in immutability rule. */
+   *  picker, the default-harness selector, and the window topbar, but the
+   *  row stays in the DB so historical `tasks.agent = <id>` references
+   *  keep resolving. The orchestrator refuses to start new runs on a
+   *  disabled harness; in-flight runs are unaffected. Built-ins are
+   *  toggleable too — this is the one carve-out from the built-in
+   *  immutability rule. */
   enabled: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Topbar chips now use `visibleTopbarAgents`, so Settings-disabled harnesses no longer appear next to usage meters.
- Matches the New Task / launch-picker convention; Settings, Kanban filters, and `agetor harness ls` still list disabled harnesses.
- Removes the leftover “disabled — enable in Settings” usage-popover copy, which is dead once those chips are gone.

## Test plan
- [ ] Boot with default seeds: banner shows Claude Code only, not Codex / Cursor / Gemini CLI / fx.sh
- [ ] Disable Claude Code in Settings → Harnesses: its chip disappears on the next harness refresh
- [ ] Re-enable it: the chip returns
- [ ] Enabled-but-unavailable / logged-out chips still render (status dot)
- [ ] `bun test` and `e2e/usage-tracker.spec.ts` stay green