### PR TITLE
feature: task-details header — icon-only button row with hover tooltips, title/subtitle below

### DIFF
--- a/docs/plans/task-details-header-icon-row.md
+++ b/docs/plans/task-details-header-icon-row.md
@@ -1,0 +1,60 @@
+# Plan — Task-details header: icon-only button row, title/subtitle below
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-31 |
+| Source | /implement conversation + screenshot `screenshot-2026-08-31_19-51-34-b3d12184.png` |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Flags | none |
+| Gates | grilled + approved by owner |
+| Branch | feature/better-task-details-header-ui (pre-existing, clean) |
+| Base SHA | 9b23119179bac6150dc05ae4f388f303d842341f |
+
+## 1. Objective & success criteria
+
+Restructure the RunPanel ("Task details") header so that:
+- **Row 1** contains only buttons, all **icon-only** (no visible text labels), **right-aligned in today's order**.
+- **Row 2** is the task title; **Row 3** is the subtitle (`agent · column · branch · base`), both full-width below the buttons.
+- Every icon-only button carries `title` + `aria-label` (the app's established convention — GitHubDialog/DiffDialog pattern), fixing the header Close button which today has neither.
+- No behavior change: same handlers, same render conditions, same search bar / Cmd+F / Escape-layering wiring.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- Header: `src/mainview/components/kanban/RunPanel.tsx:2560-2709`. Container `flex items-start justify-between gap-2 border-b border-border/60 p-3`; left block `min-w-0 flex-1` (title `truncate text-sm font-semibold`, subtitle `truncate text-xs text-muted-foreground` with `font-mono` branch + `opacity-70` base spans); right block `flex items-center gap-2`.
+- Buttons in order (conditions preserved verbatim): **View PR** (`GitPullRequest`, outline/sm, Button-or-ExternalLink depending on `parsePullNumber`), **View issue** (`CircleDot`, outline/sm, `data-testid="view-issue"` on both branches), **PR re-check** (`RefreshCw`, ghost/icon, already icon-only), **Diff** (`GitCompare`, outline/sm), **Open** (`FolderOpen`, outline/sm, dynamic path `title`), **Stop** (`Square`, destructive/sm), **Archive** (`Archive`, outline/sm) / **Unarchive** (`ArchiveRestore`, outline/sm), **Search** (`Search`, ghost/icon, `title` only), **Close** (`X`, ghost/icon, no title/aria-label).
+- `Button` (`ui/button.tsx`) has `size="icon"` (`h-9 w-9`). Icon-only convention elsewhere: `title` + `aria-label` together; no tooltip primitive.
+- Max realistic simultaneous buttons ≈ 9 → ~388px at h-9 w-9 + gap-2, fits the 520px panel; add `flex-wrap` as safety.
+- **Tests:** no e2e/unit selector targets header buttons by visible label; `view-issue` testid and the backdrop's `aria-label="Close task panel"` (RunPanel.tsx:335 — a different element) are the only header-adjacent selectors. Label removal breaks nothing.
+- Sibling convention: GitHubDialog detail header uses `mt-0.5` title→subtitle spacing.
+- Known repo traps honored: no undefined Tailwind tokens; no `position:fixed` descendants (transform ancestor); search bar rows below keep `border-b border-border/60`.
+
+## 3. Approach & key decisions
+
+- **Single-file JSX restructure** — header becomes a stacked block: buttons row (`flex flex-wrap items-center justify-end gap-2`), then title (`mt-2 truncate text-sm font-semibold`), then subtitle (`mt-0.5 truncate text-xs text-muted-foreground`, content unchanged). `min-w-0 flex-1` left-block wrapper goes away (truncate works on full-width block divs).
+- **Icon-only conversion**: drop label text + `mr-1` from icons; normalize icons to `size-4`; switch labeled buttons from `size="sm"` to `size="icon"`. **Keep each button's variant** (outline / ghost / destructive) so Stop stays visually destructive and action-vs-utility distinction survives (owner chose "all icon-only" incl. Stop).
+- **Accessibility**: static `aria-label` on every button ("View PR", "View issue", "Re-check PR status", "View diff", "Open working folder", "Stop", "Archive", "Unarchive", "Search messages", "Close task details"); keep existing dynamic `title`s (Open's path, Archive's mode, PR re-check error) and add static `title`s where missing. `ExternalLink` fallback branches of View PR / View issue get the identical treatment.
+- Decision rests on owner answers (icon scope, right-aligned) + Phase 1 evidence (no label-based selectors; convention anchors).
+
+## 4. Work breakdown — implementation tasks
+
+- **T1** — Restructure RunPanel header per §3. Owns `src/mainview/components/kanban/RunPanel.tsx` (header block only, ~lines 2560–2709). Acceptance: buttons-only right-aligned first row, all icon-only with title+aria-label, title/subtitle rows below, all render conditions/handlers/testids unchanged, typecheck green.
+
+## 5. Work breakdown — test tasks
+
+- **T2** — New `e2e/run-panel-header.spec.ts` (disjoint file): opens a task panel (reuse `e2e/fixtures.ts`/`helpers.ts` idioms), asserts (a) icon-only buttons expose accessible names (`getByRole("button", { name: "View diff" })` etc. visible, no visible "Diff"/"Open" text), (b) title + subtitle render below and show task title/agent, (c) Close via its new aria-label closes the panel. E2e applies (user-visible flow, Playwright harness exists; recipe: `bun node_modules/@playwright/test/cli.js test e2e/run-panel-header.spec.ts`, one Playwright run at a time). Unit layer: none — no DOM unit harness for RunPanel exists.
+
+## 6. Execution waves
+
+- Wave 1: T1 (1 sonnet agent) → typecheck checkpoint → commit.
+- Review (opus) on the diff.
+- Wave 2: T2 (1 sonnet agent) → commit.
+- Test run (haiku): `bun run typecheck`, `bun test`, targeted `e2e/run-panel-header.spec.ts`.
+
+## 7. Blast radius & risks
+
+- Pure layout; no server/API/data change. Risks: (a) losing a render condition or handler in the JSX move — mitigated by verbatim-condition instruction + opus review; (b) discoverability drop from removing labels — mitigated by titles (hover) + aria-labels; (c) e2e flake — targeted spec, retry-once rule; (d) subagent tabs/archived states share this header — conditions preserved verbatim so unaffected.
+
+## 8. Open questions / assumptions
+
+- Owner answered: all buttons icon-only (incl. Stop); row right-aligned in current order.
+- Assumption (low risk): keeping per-button variants (outline/ghost/destructive) rather than flattening to all-ghost; matches the "least surprise" reading of the screenshot. Reversible in one line per button.

--- a/docs/plans/task-details-header-icon-row.md
+++ b/docs/plans/task-details-header-icon-row.md
@@ -58,3 +58,7 @@ Restructure the RunPanel ("Task details") header so that:
 
 - Owner answered: all buttons icon-only (incl. Stop); row right-aligned in current order.
 - Assumption (low risk): keeping per-button variants (outline/ghost/destructive) rather than flattening to all-ghost; matches the "least surprise" reading of the screenshot. Reversible in one line per button.
+
+## 10. Addendum — hover tooltips (owner follow-up, 2026-08-31)
+
+Owner asked for real tooltips after the icon-only conversion (native `title` shows only on ~1s mouse hover, never on keyboard focus/touch). Delivered as `src/mainview/components/ui/tooltip.tsx` wrapped around all 13 icon buttons (10 header + search-bar prev/next/close), replacing their `title` attrs; the search-bar trio gained the `aria-label`s they never had (their `title` had been their only accessible name). Contract decisions: absolute-positioned bubble (never fixed — aside transform), `bg-card` styling, `aria-hidden` bubble + permanent `sr-only` twin wired via `aria-describedby` (keeps the descriptive channel `title` used to provide), no `data-popover-open` (transient bubbles must not block Escape layering), 300ms hover delay, `:focus-visible`-gated keyboard show, split hover/focus state, module-level single-open token, viewport-left clamp. Opus-reviewed (2 medium + 4 low, all addressed or consciously declined); e2e extended for hover show/hide + no-native-title. Out of scope (different ticket): sweeping RunPanel's remaining ~12 native-`title` icon buttons (backlog tray etc.) onto the new primitive.

--- a/e2e/run-panel-header.spec.ts
+++ b/e2e/run-panel-header.spec.ts
@@ -156,7 +156,10 @@ test.describe("task details header", () => {
     await openTask(page, prompt);
     const header = panelHeader(page);
     const viewDiffButton = header.getByRole("button", { name: "View diff" });
-    const tooltip = header.getByTestId("tooltip");
+    // The bubble portals to document.body (scroll-container clipping + the
+    // aside's transform), so it is looked up page-wide — safe from strict-mode
+    // ambiguity because the Tooltip primitive only ever paints one bubble.
+    const tooltip = page.getByTestId("tooltip");
 
     // --- (1) hovering the button shows the `Tooltip` bubble (auto-waiting
     // covers the 300ms `TOOLTIP_SHOW_DELAY_MS` from tooltip.tsx) with the

--- a/e2e/run-panel-header.spec.ts
+++ b/e2e/run-panel-header.spec.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { test, expect, type APIRequestContext, type E2EBackend, type Page } from "./fixtures";
+import { gotoApp } from "./helpers";
+
+/**
+ * E2E coverage for the restructured task-details header in
+ * `RunPanel.tsx` (~lines 2562-2716): row 1 is a right-aligned row of
+ * icon-only buttons (each carrying a static `aria-label`), row 2 the task
+ * title, row 3 the subtitle (`agent · column ...`).
+ *
+ * Mirrors the boot/task-creation/panel-opening idiom from
+ * `e2e/quote.spec.ts` and `e2e/unread-indicator.spec.ts`: a per-worker
+ * headless backend (`e2e/fixtures.ts`'s `backend` fixture) with
+ * `AGETOR_CLAUDE_DRIVER=fake`, an isolation:"none" task in a plain temp dir
+ * (the fake driver never touches the filesystem), started via the real
+ * HTTP API so the run panel has real content to render.
+ */
+
+test.describe.configure({ mode: "serial" });
+
+interface TaskRow {
+  id: string;
+  title: string;
+}
+
+/** Create a task (isolation "none", a plain non-git temp dir as workdir)
+ *  and start it — same idiom as `e2e/quote.spec.ts`'s
+ *  `createAndStartFakeClaudeTask`. Agent is left unset so the server's
+ *  default (`"claude-code"`, `src/bun/orchestrator.ts`) applies, which is
+ *  what the subtitle-row assertion below checks for. */
+async function createAndStartFakeClaudeTask(
+  request: APIRequestContext,
+  backend: E2EBackend,
+  prompt: string,
+): Promise<TaskRow> {
+  const auth = { authorization: `Bearer ${backend.apiToken}` };
+  const createRes = await request.post(`${backend.apiBase}/tasks`, {
+    headers: auth,
+    data: { title: prompt, prompt, isolation: "none", workdir: tmpdir() },
+  });
+  expect(createRes.ok(), `POST /tasks -> ${createRes.status()}: ${await createRes.text()}`).toBeTruthy();
+  const task = (await createRes.json()) as TaskRow;
+
+  const startRes = await request.post(`${backend.apiBase}/tasks/${task.id}/start`, {
+    headers: auth,
+  });
+  expect(
+    startRes.ok(),
+    `POST /tasks/${task.id}/start -> ${startRes.status()}: ${await startRes.text()}`,
+  ).toBeTruthy();
+
+  return task;
+}
+
+/** The run panel's slide-over `<aside>` — see `e2e/quote.spec.ts`'s
+ *  identical helper for why `.last()` is the right pick (NewTaskForm's
+ *  sidebar is also an `<aside>`, mounted first in App.tsx's JSX). */
+function runPanel(page: Page) {
+  return page.locator("aside").last();
+}
+
+/** Click a task card by its exact title and wait for the composer textarea
+ *  to mount as proof the panel is open — same idiom as `e2e/quote.spec.ts`'s
+ *  `openTask`. */
+async function openTask(page: Page, title: string) {
+  await page.getByText(title, { exact: true }).first().click();
+  const panel = runPanel(page);
+  await expect(panel.locator("textarea")).toBeVisible();
+  return panel;
+}
+
+/** The header `<header>` element at the top of the run panel — scoping
+ *  queries here (rather than to the whole panel or the whole page) is what
+ *  keeps "Close task details" (the header button, RunPanel.tsx:2704) from
+ *  colliding with "Close task panel" (a *different* element: the backdrop
+ *  button at RunPanel.tsx:335, present at the same time the panel is
+ *  open). */
+function panelHeader(page: Page) {
+  return runPanel(page).locator("header").first();
+}
+
+test.describe("task details header", () => {
+  test("row 1 is icon-only header buttons, row 2/3 are title/subtitle, and Close task details closes the panel", async ({
+    page,
+    request,
+    backend,
+  }) => {
+    const prompt = `header-e2e ${randomUUID()}`;
+    await createAndStartFakeClaudeTask(request, backend, prompt);
+
+    await gotoApp(page, backend.bootBase);
+    const panel = await openTask(page, prompt);
+    const header = panelHeader(page);
+
+    // --- (1) always-present header buttons are visible by accessible name,
+    // scoped to the header row (not the whole page, not the whole panel —
+    // see panelHeader()'s doc comment for the "Close task panel" backdrop
+    // button this must not match). ------------------------------------
+    const viewDiffButton = header.getByRole("button", { name: "View diff" });
+    const openFolderButton = header.getByRole("button", { name: "Open working folder" });
+    const searchButton = header.getByRole("button", { name: "Search messages" });
+    const closeButton = header.getByRole("button", { name: "Close task details" });
+
+    await expect(viewDiffButton).toBeVisible();
+    await expect(openFolderButton).toBeVisible();
+    await expect(searchButton).toBeVisible();
+    await expect(closeButton).toBeVisible();
+
+    // The distinct backdrop "Close task panel" button also exists while the
+    // panel is open, but only outside the header — confirms the two labels
+    // really are two different elements, not a scoping fluke.
+    await expect(page.getByRole("button", { name: "Close task panel" })).toBeVisible();
+    await expect(header.getByRole("button", { name: "Close task panel" })).toHaveCount(0);
+
+    // --- (2) icon-only: no visible text on the icon buttons ---------------
+    await expect(async () => {
+      expect((await viewDiffButton.innerText()).trim()).toBe("");
+      expect((await openFolderButton.innerText()).trim()).toBe("");
+    }).toPass();
+
+    // --- (3) title row (task title) and subtitle row (agent · column),
+    // both rendered below the button row. ----------------------------------
+    const buttonRowBox = await header.locator("div").first().boundingBox();
+    const titleRow = header.getByText(prompt, { exact: true });
+    const subtitleRow = header.getByText(/claude-code/);
+
+    await expect(titleRow).toBeVisible();
+    await expect(subtitleRow).toBeVisible();
+    await expect(subtitleRow).toContainText("claude-code");
+
+    expect(buttonRowBox, "header's button row should have a bounding box").not.toBeNull();
+    const titleBox = await titleRow.boundingBox();
+    const subtitleBox = await subtitleRow.boundingBox();
+    expect(titleBox, "title row should have a bounding box").not.toBeNull();
+    expect(subtitleBox, "subtitle row should have a bounding box").not.toBeNull();
+    if (buttonRowBox && titleBox && subtitleBox) {
+      expect(titleBox.y).toBeGreaterThan(buttonRowBox.y);
+      expect(subtitleBox.y).toBeGreaterThan(titleBox.y);
+    }
+
+    // --- (4) clicking "Close task details" closes the panel ---------------
+    await closeButton.click();
+    await expect(panel).toHaveClass(/translate-x-full/);
+  });
+});

--- a/e2e/run-panel-header.spec.ts
+++ b/e2e/run-panel-header.spec.ts
@@ -143,4 +143,36 @@ test.describe("task details header", () => {
     await closeButton.click();
     await expect(panel).toHaveClass(/translate-x-full/);
   });
+
+  test("header icon buttons show a hover tooltip and carry no native title", async ({
+    page,
+    request,
+    backend,
+  }) => {
+    const prompt = `header-tooltip-e2e ${randomUUID()}`;
+    await createAndStartFakeClaudeTask(request, backend, prompt);
+
+    await gotoApp(page, backend.bootBase);
+    await openTask(page, prompt);
+    const header = panelHeader(page);
+    const viewDiffButton = header.getByRole("button", { name: "View diff" });
+    const tooltip = header.getByTestId("tooltip");
+
+    // --- (1) hovering the button shows the `Tooltip` bubble (auto-waiting
+    // covers the 300ms `TOOLTIP_SHOW_DELAY_MS` from tooltip.tsx) with the
+    // expected label text. -------------------------------------------------
+    await expect(tooltip).not.toBeVisible();
+    await viewDiffButton.hover();
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toHaveText("View this task's changes (git diff)");
+
+    // --- (2) moving the mouse away hides the bubble (mouseleave) -----------
+    await page.mouse.move(0, 0);
+    await expect(tooltip).not.toBeVisible();
+
+    // --- (3) the wrapped button no longer carries a native `title` attribute
+    // — guards against the double-tooltip regression (native title tooltip
+    // stacking on top of the new hover bubble). -----------------------------
+    await expect(viewDiffButton).not.toHaveAttribute("title");
+  });
 });

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -2559,18 +2559,8 @@ function RunPanelBody({
 
   return (
     <>
-      <header className="flex items-start justify-between gap-2 border-b border-border/60 p-3">
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-semibold">{task.title}</div>
-          <div className="truncate text-xs text-muted-foreground">
-            {task.agent} · {task.column}
-            {task.branch && <> · <span className="font-mono">{task.branch}</span></>}
-            {task.baseRef && (
-              <> · <span className="font-mono opacity-70">base {task.baseRef.slice(0, 7)}</span></>
-            )}
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
+      <header className="border-b border-border/60 p-3">
+        <div className="flex flex-wrap items-center justify-end gap-2">
           {/* Lives in the header (not the composer chip row) so the link stays
               reachable on archived tasks and after orphan reconciliation
               clears the resumable run — pr_url is durable, the link must be
@@ -2580,20 +2570,22 @@ function RunPanelBody({
           {prUrl && (
             parsePullNumber(prUrl) != null ? (
               <Button
-                size="sm"
+                size="icon"
                 variant="outline"
                 onClick={() => onViewPullRequest({ projectPath: task.workdir, prUrl })}
                 title="Open the pull request created for this task"
+                aria-label="View PR"
               >
-                <GitPullRequest className="mr-1 size-3" /> View PR
+                <GitPullRequest className="size-4" />
               </Button>
             ) : (
               <ExternalLink
                 href={prUrl}
-                className={cn(buttonVariants({ variant: "outline", size: "sm" }), "no-underline hover:no-underline")}
+                className={cn(buttonVariants({ variant: "outline", size: "icon" }), "no-underline hover:no-underline")}
                 title="Open the pull request created for this task"
+                aria-label="View PR"
               >
-                <GitPullRequest className="mr-1 size-3" /> View PR
+                <GitPullRequest className="size-4" />
               </ExternalLink>
             )
           )}
@@ -2604,22 +2596,24 @@ function RunPanelBody({
           {issueUrl && (
             parseIssueUrl(issueUrl) != null ? (
               <Button
-                size="sm"
+                size="icon"
                 variant="outline"
                 onClick={() => onViewIssue({ projectPath: task.workdir, issueUrl })}
                 title="Open the issue this task was created from"
+                aria-label="View issue"
                 data-testid="view-issue"
               >
-                <CircleDot className="mr-1 size-3" /> View issue
+                <CircleDot className="size-4" />
               </Button>
             ) : (
               <ExternalLink
                 href={issueUrl}
-                className={cn(buttonVariants({ variant: "outline", size: "sm" }), "no-underline hover:no-underline")}
+                className={cn(buttonVariants({ variant: "outline", size: "icon" }), "no-underline hover:no-underline")}
                 title="Open the issue this task was created from"
+                aria-label="View issue"
                 data-testid="view-issue"
               >
-                <CircleDot className="mr-1 size-3" /> View issue
+                <CircleDot className="size-4" />
               </ExternalLink>
             )
           )}
@@ -2632,20 +2626,22 @@ function RunPanelBody({
               onClick={refreshPrStatus}
               disabled={prStatusLoading}
               title={prStatusError ?? "Re-check PR mergeability"}
+              aria-label="Re-check PR status"
             >
-              <RefreshCw className="size-3.5" />
+              <RefreshCw className="size-4" />
             </Button>
           )}
           <Button
-            size="sm"
+            size="icon"
             variant="outline"
             onClick={() => onShowDiff(task)}
             title="View this task's changes (git diff)"
+            aria-label="View diff"
           >
-            <GitCompare className="mr-1 size-3" /> Diff
+            <GitCompare className="size-4" />
           </Button>
           <Button
-            size="sm"
+            size="icon"
             variant="outline"
             onClick={() =>
               void api.openPath({
@@ -2658,36 +2654,39 @@ function RunPanelBody({
                 ? `Open the worktree in your file manager: ${task.worktreePath}`
                 : `Open the project workdir in your file manager: ${task.workdir}`
             }
+            aria-label="Open working folder"
           >
-            <FolderOpen className="mr-1 size-3" /> Open
+            <FolderOpen className="size-4" />
           </Button>
           {/* Stop targets the main run. Hide it while viewing a read-only
               background-agent tab so the control doesn't read as "stop this
               agent" — switch back to Main to stop the task. */}
           {!archived && canControl && activeStream === "main" && (
-            <Button size="sm" variant="destructive" onClick={stop}>
-              <Square className="mr-1 size-3" /> Stop
+            <Button size="icon" variant="destructive" onClick={stop} title="Stop" aria-label="Stop">
+              <Square className="size-4" />
             </Button>
           )}
           {!archived && (task.column === "done" || active) && (
             <Button
-              size="sm"
+              size="icon"
               variant="outline"
               onClick={() => onArchive(task)}
               title={active ? "Stop the running agent and archive task" : "Archive task"}
+              aria-label="Archive"
             >
-              <Archive className="mr-1 size-3" /> Archive
+              <Archive className="size-4" />
             </Button>
           )}
           {archived && (
-            <Button size="sm" variant="outline" onClick={() => onUnarchive(task)} title="Unarchive task">
-              <ArchiveRestore className="mr-1 size-3" /> Unarchive
+            <Button size="icon" variant="outline" onClick={() => onUnarchive(task)} title="Unarchive task" aria-label="Unarchive">
+              <ArchiveRestore className="size-4" />
             </Button>
           )}
           <Button
             size="icon"
             variant="ghost"
             title="Search messages"
+            aria-label="Search messages"
             onClick={() => {
               if (searchOpen) {
                 closeSearch();
@@ -2702,9 +2701,17 @@ function RunPanelBody({
           >
             <Search className="size-4" />
           </Button>
-          <Button size="icon" variant="ghost" onClick={onClose}>
+          <Button size="icon" variant="ghost" onClick={onClose} title="Close task details" aria-label="Close task details">
             <X className="size-4" />
           </Button>
+        </div>
+        <div className="mt-2 truncate text-sm font-semibold">{task.title}</div>
+        <div className="mt-0.5 truncate text-xs text-muted-foreground">
+          {task.agent} · {task.column}
+          {task.branch && <> · <span className="font-mono">{task.branch}</span></>}
+          {task.baseRef && (
+            <> · <span className="font-mono opacity-70">base {task.baseRef.slice(0, 7)}</span></>
+          )}
         </div>
       </header>
 

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -2581,7 +2581,7 @@ function RunPanelBody({
             ) : (
               <ExternalLink
                 href={prUrl}
-                className={cn(buttonVariants({ variant: "outline", size: "icon" }), "no-underline hover:no-underline")}
+                className={cn(buttonVariants({ variant: "outline", size: "icon" }), "text-foreground no-underline hover:no-underline")}
                 title="Open the pull request created for this task"
                 aria-label="View PR"
               >
@@ -2608,7 +2608,7 @@ function RunPanelBody({
             ) : (
               <ExternalLink
                 href={issueUrl}
-                className={cn(buttonVariants({ variant: "outline", size: "icon" }), "no-underline hover:no-underline")}
+                className={cn(buttonVariants({ variant: "outline", size: "icon" }), "text-foreground no-underline hover:no-underline")}
                 title="Open the issue this task was created from"
                 aria-label="View issue"
                 data-testid="view-issue"
@@ -2626,7 +2626,7 @@ function RunPanelBody({
               onClick={refreshPrStatus}
               disabled={prStatusLoading}
               title={prStatusError ?? "Re-check PR mergeability"}
-              aria-label="Re-check PR status"
+              aria-label={prStatusError ? `Re-check PR status — ${prStatusError}` : "Re-check PR status"}
             >
               <RefreshCw className="size-4" />
             </Button>
@@ -2672,7 +2672,7 @@ function RunPanelBody({
               variant="outline"
               onClick={() => onArchive(task)}
               title={active ? "Stop the running agent and archive task" : "Archive task"}
-              aria-label="Archive"
+              aria-label={active ? "Stop the running agent and archive task" : "Archive task"}
             >
               <Archive className="size-4" />
             </Button>
@@ -2687,6 +2687,7 @@ function RunPanelBody({
             variant="ghost"
             title="Search messages"
             aria-label="Search messages"
+            aria-expanded={searchOpen}
             onClick={() => {
               if (searchOpen) {
                 closeSearch();

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -20,6 +20,7 @@ import { reconcileById } from "@/lib/reconcile";
 import { QuoteSelectionButton } from "./QuoteSelectionButton";
 import type { GitHubPullPrefill } from "./GitHubDialog";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
 import { Badge, badgeVariants } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
@@ -2569,24 +2570,26 @@ function RunPanelBody({
               shape) fall back to the plain external link, as before. */}
           {prUrl && (
             parsePullNumber(prUrl) != null ? (
-              <Button
-                size="icon"
-                variant="outline"
-                onClick={() => onViewPullRequest({ projectPath: task.workdir, prUrl })}
-                title="Open the pull request created for this task"
-                aria-label="View PR"
-              >
-                <GitPullRequest className="size-4" />
-              </Button>
+              <Tooltip align="end" label="Open the pull request created for this task">
+                <Button
+                  size="icon"
+                  variant="outline"
+                  onClick={() => onViewPullRequest({ projectPath: task.workdir, prUrl })}
+                  aria-label="View PR"
+                >
+                  <GitPullRequest className="size-4" />
+                </Button>
+              </Tooltip>
             ) : (
-              <ExternalLink
-                href={prUrl}
-                className={cn(buttonVariants({ variant: "outline", size: "icon" }), "text-foreground no-underline hover:no-underline")}
-                title="Open the pull request created for this task"
-                aria-label="View PR"
-              >
-                <GitPullRequest className="size-4" />
-              </ExternalLink>
+              <Tooltip align="end" label="Open the pull request created for this task">
+                <ExternalLink
+                  href={prUrl}
+                  className={cn(buttonVariants({ variant: "outline", size: "icon" }), "text-foreground no-underline hover:no-underline")}
+                  aria-label="View PR"
+                >
+                  <GitPullRequest className="size-4" />
+                </ExternalLink>
+              </Tooltip>
             )
           )}
           {/* Durable "View issue" sibling of "View PR" above — same
@@ -2595,116 +2598,132 @@ function RunPanelBody({
               `issueUrl` parses to a recognized provider issue URL. */}
           {issueUrl && (
             parseIssueUrl(issueUrl) != null ? (
-              <Button
-                size="icon"
-                variant="outline"
-                onClick={() => onViewIssue({ projectPath: task.workdir, issueUrl })}
-                title="Open the issue this task was created from"
-                aria-label="View issue"
-                data-testid="view-issue"
-              >
-                <CircleDot className="size-4" />
-              </Button>
+              <Tooltip align="end" label="Open the issue this task was created from">
+                <Button
+                  size="icon"
+                  variant="outline"
+                  onClick={() => onViewIssue({ projectPath: task.workdir, issueUrl })}
+                  aria-label="View issue"
+                  data-testid="view-issue"
+                >
+                  <CircleDot className="size-4" />
+                </Button>
+              </Tooltip>
             ) : (
-              <ExternalLink
-                href={issueUrl}
-                className={cn(buttonVariants({ variant: "outline", size: "icon" }), "text-foreground no-underline hover:no-underline")}
-                title="Open the issue this task was created from"
-                aria-label="View issue"
-                data-testid="view-issue"
-              >
-                <CircleDot className="size-4" />
-              </ExternalLink>
+              <Tooltip align="end" label="Open the issue this task was created from">
+                <ExternalLink
+                  href={issueUrl}
+                  className={cn(buttonVariants({ variant: "outline", size: "icon" }), "text-foreground no-underline hover:no-underline")}
+                  aria-label="View issue"
+                  data-testid="view-issue"
+                >
+                  <CircleDot className="size-4" />
+                </ExternalLink>
+              </Tooltip>
             )
           )}
           {/* Manual re-check — only once a first fetch has settled, so it
               doesn't appear (and immediately duplicate) the initial load. */}
           {parsedPrUrl && (prStatus != null || prStatusError != null) && (
+            <Tooltip align="end" label={prStatusError ?? "Re-check PR mergeability"}>
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={refreshPrStatus}
+                disabled={prStatusLoading}
+                aria-label={prStatusError ? `Re-check PR status — ${prStatusError}` : "Re-check PR status"}
+              >
+                <RefreshCw className="size-4" />
+              </Button>
+            </Tooltip>
+          )}
+          <Tooltip align="end" label="View this task's changes (git diff)">
             <Button
               size="icon"
-              variant="ghost"
-              onClick={refreshPrStatus}
-              disabled={prStatusLoading}
-              title={prStatusError ?? "Re-check PR mergeability"}
-              aria-label={prStatusError ? `Re-check PR status — ${prStatusError}` : "Re-check PR status"}
+              variant="outline"
+              onClick={() => onShowDiff(task)}
+              aria-label="View diff"
             >
-              <RefreshCw className="size-4" />
+              <GitCompare className="size-4" />
             </Button>
-          )}
-          <Button
-            size="icon"
-            variant="outline"
-            onClick={() => onShowDiff(task)}
-            title="View this task's changes (git diff)"
-            aria-label="View diff"
-          >
-            <GitCompare className="size-4" />
-          </Button>
-          <Button
-            size="icon"
-            variant="outline"
-            onClick={() =>
-              void api.openPath({
-                path: task.worktreePath ?? task.workdir,
-                taskId: task.id,
-              }).catch(() => { /* swallowed — openPath failures are best-effort */ })
-            }
-            title={
+          </Tooltip>
+          <Tooltip
+            align="end"
+            label={
               task.worktreePath
                 ? `Open the worktree in your file manager: ${task.worktreePath}`
                 : `Open the project workdir in your file manager: ${task.workdir}`
             }
-            aria-label="Open working folder"
           >
-            <FolderOpen className="size-4" />
-          </Button>
+            <Button
+              size="icon"
+              variant="outline"
+              onClick={() =>
+                void api.openPath({
+                  path: task.worktreePath ?? task.workdir,
+                  taskId: task.id,
+                }).catch(() => { /* swallowed — openPath failures are best-effort */ })
+              }
+              aria-label="Open working folder"
+            >
+              <FolderOpen className="size-4" />
+            </Button>
+          </Tooltip>
           {/* Stop targets the main run. Hide it while viewing a read-only
               background-agent tab so the control doesn't read as "stop this
               agent" — switch back to Main to stop the task. */}
           {!archived && canControl && activeStream === "main" && (
-            <Button size="icon" variant="destructive" onClick={stop} title="Stop" aria-label="Stop">
-              <Square className="size-4" />
-            </Button>
+            <Tooltip align="end" label="Stop">
+              <Button size="icon" variant="destructive" onClick={stop} aria-label="Stop">
+                <Square className="size-4" />
+              </Button>
+            </Tooltip>
           )}
           {!archived && (task.column === "done" || active) && (
-            <Button
-              size="icon"
-              variant="outline"
-              onClick={() => onArchive(task)}
-              title={active ? "Stop the running agent and archive task" : "Archive task"}
-              aria-label={active ? "Stop the running agent and archive task" : "Archive task"}
-            >
-              <Archive className="size-4" />
-            </Button>
+            <Tooltip align="end" label={active ? "Stop the running agent and archive task" : "Archive task"}>
+              <Button
+                size="icon"
+                variant="outline"
+                onClick={() => onArchive(task)}
+                aria-label={active ? "Stop the running agent and archive task" : "Archive task"}
+              >
+                <Archive className="size-4" />
+              </Button>
+            </Tooltip>
           )}
           {archived && (
-            <Button size="icon" variant="outline" onClick={() => onUnarchive(task)} title="Unarchive task" aria-label="Unarchive">
-              <ArchiveRestore className="size-4" />
-            </Button>
+            <Tooltip align="end" label="Unarchive task">
+              <Button size="icon" variant="outline" onClick={() => onUnarchive(task)} aria-label="Unarchive">
+                <ArchiveRestore className="size-4" />
+              </Button>
+            </Tooltip>
           )}
-          <Button
-            size="icon"
-            variant="ghost"
-            title="Search messages"
-            aria-label="Search messages"
-            aria-expanded={searchOpen}
-            onClick={() => {
-              if (searchOpen) {
-                closeSearch();
-                return;
-              }
-              setSearchOpen(true);
-              // The input isn't mounted yet on the render this triggers (the
-              // bar renders conditionally on `searchOpen`) — focus after the
-              // next paint.
-              requestAnimationFrame(() => searchInputRef.current?.focus());
-            }}
-          >
-            <Search className="size-4" />
-          </Button>
-          <Button size="icon" variant="ghost" onClick={onClose} title="Close task details" aria-label="Close task details">
-            <X className="size-4" />
-          </Button>
+          <Tooltip align="end" label="Search messages">
+            <Button
+              size="icon"
+              variant="ghost"
+              aria-label="Search messages"
+              aria-expanded={searchOpen}
+              onClick={() => {
+                if (searchOpen) {
+                  closeSearch();
+                  return;
+                }
+                setSearchOpen(true);
+                // The input isn't mounted yet on the render this triggers (the
+                // bar renders conditionally on `searchOpen`) — focus after the
+                // next paint.
+                requestAnimationFrame(() => searchInputRef.current?.focus());
+              }}
+            >
+              <Search className="size-4" />
+            </Button>
+          </Tooltip>
+          <Tooltip align="end" label="Close task details">
+            <Button size="icon" variant="ghost" onClick={onClose} aria-label="Close task details">
+              <X className="size-4" />
+            </Button>
+          </Tooltip>
         </div>
         <div className="mt-2 truncate text-sm font-semibold">{task.title}</div>
         <div className="mt-0.5 truncate text-xs text-muted-foreground">
@@ -2742,29 +2761,35 @@ function RunPanelBody({
           <span aria-live="polite" className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
             {matches.length === 0 ? "0/0" : `${activeMatchPosition + 1}/${matches.length}`}
           </span>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="size-7"
-            disabled={matches.length === 0}
-            title="Previous match"
-            onClick={() => stepSearch(-1)}
-          >
-            <ChevronUp className="size-3.5" />
-          </Button>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="size-7"
-            disabled={matches.length === 0}
-            title="Next match"
-            onClick={() => stepSearch(1)}
-          >
-            <ChevronDown className="size-3.5" />
-          </Button>
-          <Button size="icon" variant="ghost" className="size-7" title="Close search" onClick={closeSearch}>
-            <X className="size-3.5" />
-          </Button>
+          <Tooltip align="end" label="Previous match">
+            <Button
+              size="icon"
+              variant="ghost"
+              className="size-7"
+              disabled={matches.length === 0}
+              onClick={() => stepSearch(-1)}
+              aria-label="Previous match"
+            >
+              <ChevronUp className="size-3.5" />
+            </Button>
+          </Tooltip>
+          <Tooltip align="end" label="Next match">
+            <Button
+              size="icon"
+              variant="ghost"
+              className="size-7"
+              disabled={matches.length === 0}
+              onClick={() => stepSearch(1)}
+              aria-label="Next match"
+            >
+              <ChevronDown className="size-3.5" />
+            </Button>
+          </Tooltip>
+          <Tooltip align="end" label="Close search">
+            <Button size="icon" variant="ghost" className="size-7" onClick={closeSearch} aria-label="Close search">
+              <X className="size-3.5" />
+            </Button>
+          </Tooltip>
         </div>
       )}
 

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -3182,13 +3182,14 @@ function RunPanelBody({
               <Tooltip
                 align="end"
                 side="top"
+                className="shrink-0"
                 label={liveRunId ? "Send to the live agent" : "Resume the conversation with this message"}
               >
                 <Button
                   size="icon"
                   onClick={() => void send()}
                   disabled={!canSend || sending || backlogBusy || modalPending || (!input.trim() && sendRefs.length === 0)}
-                  aria-label={liveRunId ? "Send to the live agent" : "Resume the conversation with this message"}
+                  aria-label="Send"
                   className="h-16 w-12 shrink-0"
                 >
                   <Send className="size-4" />
@@ -3547,11 +3548,7 @@ function BacklogItemRow({
               className={BACKLOG_ICON_BTN}
               disabled={!canSend || busy}
               onClick={onSend}
-              aria-label={
-                canSend
-                  ? "Send now"
-                  : "Can't send right now — run the task, or answer the pending prompt first"
-              }
+              aria-label="Send now"
             >
               <Send className="size-3.5" />
             </button>

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -2569,8 +2569,8 @@ function RunPanelBody({
               subpage directly; otherwise (an unrecognized provider URL
               shape) fall back to the plain external link, as before. */}
           {prUrl && (
-            parsePullNumber(prUrl) != null ? (
-              <Tooltip align="end" label="Open the pull request created for this task">
+            <Tooltip align="end" label="Open the pull request created for this task">
+              {parsePullNumber(prUrl) != null ? (
                 <Button
                   size="icon"
                   variant="outline"
@@ -2579,9 +2579,7 @@ function RunPanelBody({
                 >
                   <GitPullRequest className="size-4" />
                 </Button>
-              </Tooltip>
-            ) : (
-              <Tooltip align="end" label="Open the pull request created for this task">
+              ) : (
                 <ExternalLink
                   href={prUrl}
                   className={cn(buttonVariants({ variant: "outline", size: "icon" }), "text-foreground no-underline hover:no-underline")}
@@ -2589,16 +2587,16 @@ function RunPanelBody({
                 >
                   <GitPullRequest className="size-4" />
                 </ExternalLink>
-              </Tooltip>
-            )
+              )}
+            </Tooltip>
           )}
           {/* Durable "View issue" sibling of "View PR" above — same
               rationale (header, not the composer chip row) and the same
               in-app-detail-vs-external-link branch, keyed on whether
               `issueUrl` parses to a recognized provider issue URL. */}
           {issueUrl && (
-            parseIssueUrl(issueUrl) != null ? (
-              <Tooltip align="end" label="Open the issue this task was created from">
+            <Tooltip align="end" label="Open the issue this task was created from">
+              {parseIssueUrl(issueUrl) != null ? (
                 <Button
                   size="icon"
                   variant="outline"
@@ -2608,9 +2606,7 @@ function RunPanelBody({
                 >
                   <CircleDot className="size-4" />
                 </Button>
-              </Tooltip>
-            ) : (
-              <Tooltip align="end" label="Open the issue this task was created from">
+              ) : (
                 <ExternalLink
                   href={issueUrl}
                   className={cn(buttonVariants({ variant: "outline", size: "icon" }), "text-foreground no-underline hover:no-underline")}
@@ -2619,8 +2615,8 @@ function RunPanelBody({
                 >
                   <CircleDot className="size-4" />
                 </ExternalLink>
-              </Tooltip>
-            )
+              )}
+            </Tooltip>
           )}
           {/* Manual re-check — only once a first fetch has settled, so it
               doesn't appear (and immediately duplicate) the initial load. */}

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -3173,25 +3173,27 @@ function RunPanelBody({
               />
             }
             trailing={
-              <Button
-                size="icon"
-                onClick={() => void send()}
-                disabled={!canSend || sending || backlogBusy || modalPending || (!input.trim() && sendRefs.length === 0)}
-                title={
-                  // Distinguish "live session exists" from "needs resume" — not
-                  // "turn in flight". `liveRunId` (task.runId) stays set while the
-                  // tmux session is alive (including between turns) and is only
-                  // null once the session is gone (orphan-reconciled), which is the
-                  // resume path. Keying off `canControl` here would mislabel the
-                  // common "session alive, no turn in flight" state as a resume.
-                  liveRunId
-                    ? "Send to the live agent"
-                    : "Resume the conversation with this message"
-                }
-                className="h-16 w-12 shrink-0"
+              // Distinguish "live session exists" from "needs resume" — not
+              // "turn in flight". `liveRunId` (task.runId) stays set while the
+              // tmux session is alive (including between turns) and is only
+              // null once the session is gone (orphan-reconciled), which is the
+              // resume path. Keying off `canControl` here would mislabel the
+              // common "session alive, no turn in flight" state as a resume.
+              <Tooltip
+                align="end"
+                side="top"
+                label={liveRunId ? "Send to the live agent" : "Resume the conversation with this message"}
               >
-                <Send className="size-4" />
-              </Button>
+                <Button
+                  size="icon"
+                  onClick={() => void send()}
+                  disabled={!canSend || sending || backlogBusy || modalPending || (!input.trim() && sendRefs.length === 0)}
+                  aria-label={liveRunId ? "Send to the live agent" : "Resume the conversation with this message"}
+                  className="h-16 w-12 shrink-0"
+                >
+                  <Send className="size-4" />
+                </Button>
+              </Tooltip>
             }
             rows={2}
             textareaClassName="h-16 min-h-0 w-full resize-none text-xs pr-8"
@@ -3496,57 +3498,75 @@ function BacklogItemRow({
       </div>
       {!readOnly && (
         <div className="flex shrink-0 items-center gap-0.5 opacity-60 transition-opacity group-hover:opacity-100">
-          <button
-            type="button"
-            className={BACKLOG_ICON_BTN}
-            disabled={index === 0 || busy}
-            onClick={() => onMove(-1)}
-            title="Move up"
-          >
-            <ArrowUp className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            className={BACKLOG_ICON_BTN}
-            disabled={index === total - 1 || busy}
-            onClick={() => onMove(1)}
-            title="Move down"
-          >
-            <ArrowDown className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            className={BACKLOG_ICON_BTN}
-            onClick={onStartEdit}
-            title="Edit"
-          >
-            <FilePenLine className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            className={BACKLOG_ICON_BTN}
-            disabled={!canSend || busy}
-            onClick={onSend}
-            // `canSend` here is the parent's `canSend && !modalPending`, so it
-            // goes false for two different reasons — no live/resumable session,
-            // or a prompt is waiting. Keep the copy true for both.
-            title={
+          <Tooltip align="end" side="top" label="Move up">
+            <button
+              type="button"
+              className={BACKLOG_ICON_BTN}
+              disabled={index === 0 || busy}
+              onClick={() => onMove(-1)}
+              aria-label="Move up"
+            >
+              <ArrowUp className="size-3.5" />
+            </button>
+          </Tooltip>
+          <Tooltip align="end" side="top" label="Move down">
+            <button
+              type="button"
+              className={BACKLOG_ICON_BTN}
+              disabled={index === total - 1 || busy}
+              onClick={() => onMove(1)}
+              aria-label="Move down"
+            >
+              <ArrowDown className="size-3.5" />
+            </button>
+          </Tooltip>
+          <Tooltip align="end" side="top" label="Edit">
+            <button
+              type="button"
+              className={BACKLOG_ICON_BTN}
+              onClick={onStartEdit}
+              aria-label="Edit"
+            >
+              <FilePenLine className="size-3.5" />
+            </button>
+          </Tooltip>
+          {/* `canSend` here is the parent's `canSend && !modalPending`, so it
+              goes false for two different reasons — no live/resumable session,
+              or a prompt is waiting. Keep the copy true for both. */}
+          <Tooltip
+            align="end"
+            side="top"
+            label={
               canSend
                 ? "Send now"
                 : "Can't send right now — run the task, or answer the pending prompt first"
             }
           >
-            <Send className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            className={cn(BACKLOG_ICON_BTN, "hover:bg-destructive/10 hover:text-destructive")}
-            disabled={busy}
-            onClick={onDelete}
-            title="Delete"
-          >
-            <Trash2 className="size-3.5" />
-          </button>
+            <button
+              type="button"
+              className={BACKLOG_ICON_BTN}
+              disabled={!canSend || busy}
+              onClick={onSend}
+              aria-label={
+                canSend
+                  ? "Send now"
+                  : "Can't send right now — run the task, or answer the pending prompt first"
+              }
+            >
+              <Send className="size-3.5" />
+            </button>
+          </Tooltip>
+          <Tooltip align="end" side="top" label="Delete">
+            <button
+              type="button"
+              className={cn(BACKLOG_ICON_BTN, "hover:bg-destructive/10 hover:text-destructive")}
+              disabled={busy}
+              onClick={onDelete}
+              aria-label="Delete"
+            >
+              <Trash2 className="size-3.5" />
+            </button>
+          </Tooltip>
         </div>
       )}
     </div>
@@ -5359,29 +5379,30 @@ function TaskDetails({
           <dt className="flex items-center gap-1 text-muted-foreground">
             Model
             {editable && (
-              <button
-                type="button"
-                title="Refresh model list"
-                aria-label="Refresh model list"
-                data-testid="refresh-models-details"
-                disabled={refreshingModels}
-                className={cn(
-                  "text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
-                  refreshingModels && "animate-spin",
-                )}
-                onClick={async () => {
-                  setRefreshingModels(true);
-                  try {
-                    await onRefreshModels(task.agent);
-                  } catch {
-                    // The SSE / ready-retry paths also refetch.
-                  } finally {
-                    setRefreshingModels(false);
-                  }
-                }}
-              >
-                <RefreshCw className="size-3" />
-              </button>
+              <Tooltip label="Refresh model list">
+                <button
+                  type="button"
+                  aria-label="Refresh model list"
+                  data-testid="refresh-models-details"
+                  disabled={refreshingModels}
+                  className={cn(
+                    "text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
+                    refreshingModels && "animate-spin",
+                  )}
+                  onClick={async () => {
+                    setRefreshingModels(true);
+                    try {
+                      await onRefreshModels(task.agent);
+                    } catch {
+                      // The SSE / ready-retry paths also refetch.
+                    } finally {
+                      setRefreshingModels(false);
+                    }
+                  }}
+                >
+                  <RefreshCw className="size-3" />
+                </button>
+              </Tooltip>
             )}
           </dt>
           <dd className="min-w-0">

--- a/src/mainview/components/ui/tooltip.tsx
+++ b/src/mainview/components/ui/tooltip.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  label: string;
+  /** Horizontal alignment of the bubble relative to the trigger. */
+  align?: "center" | "end";
+  className?: string;
+  children: ReactNode;
+}
+
+/** Hover/focus delay before the bubble appears — long enough that a cursor
+ *  passing over the trigger on its way elsewhere doesn't flash a tooltip. */
+export const TOOLTIP_SHOW_DELAY_MS = 300;
+
+/**
+ * Lightweight hover/focus tooltip for icon-only buttons — a `title`
+ * attribute equivalent that actually shows on keyboard focus (native title
+ * never does) and shows sooner than a browser's ~1s hover delay.
+ *
+ * Every trigger this wraps already carries its own `aria-label` as the
+ * accessible name, so the bubble below is a purely visual aid: it renders
+ * with `aria-hidden`, not `role="tooltip"`, and there is no `aria-describedby`
+ * plumbing back to the trigger.
+ *
+ * Deliberately does NOT set `data-popover-open` and does NOT handle Escape.
+ * That marker/contract is for real popovers (dialogs, menus, SearchSelect…)
+ * whose Escape should be caught before an enclosing panel's Escape handler
+ * closes the whole panel — see ui/context-menu.tsx and dialog.tsx. A
+ * transient hover bubble must never participate in that: it should just
+ * disappear on mouseleave/blur, not block Escape-to-close-panel.
+ */
+export function Tooltip({ label, align = "center", className, children }: Props) {
+  const [open, setOpen] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = () => {
+    if (timerRef.current != null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  useEffect(() => clearTimer, []);
+
+  return (
+    <span
+      className={cn("relative inline-flex", className)}
+      onMouseEnter={() => {
+        clearTimer();
+        timerRef.current = setTimeout(() => setOpen(true), TOOLTIP_SHOW_DELAY_MS);
+      }}
+      onMouseLeave={() => {
+        clearTimer();
+        setOpen(false);
+      }}
+      onFocusCapture={(e) => {
+        // Only a keyboard-driven focus should show the bubble immediately —
+        // a mouse click that happens to focus the trigger already has the
+        // hover path (with its delay) covering it, and showing on every
+        // programmatic/mouse focus too would make click targets feel noisy.
+        if ((e.target as HTMLElement).matches?.(":focus-visible")) {
+          clearTimer();
+          setOpen(true);
+        }
+      }}
+      onBlurCapture={() => {
+        clearTimer();
+        setOpen(false);
+      }}
+      onMouseDown={() => {
+        // A click is about to happen — don't leave a stale bubble hanging
+        // over whatever it opens (e.g. a dialog).
+        clearTimer();
+        setOpen(false);
+      }}
+    >
+      {children}
+      {open && (
+        <span
+          aria-hidden="true"
+          data-testid="tooltip"
+          className={cn(
+            "pointer-events-none absolute top-full z-50 mt-1 max-w-64 break-words rounded border border-border bg-card px-2 py-1 text-xs text-card-foreground shadow-md",
+            align === "end" ? "right-0" : "left-1/2 -translate-x-1/2",
+          )}
+        >
+          {label}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/mainview/components/ui/tooltip.tsx
+++ b/src/mainview/components/ui/tooltip.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  cloneElement,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -6,22 +14,40 @@ interface Props {
   /** Horizontal alignment of the bubble relative to the trigger. */
   align?: "center" | "end";
   className?: string;
-  children: ReactNode;
+  /** A single trigger element — it receives `aria-describedby` pointing at a
+   *  visually-hidden twin of the label, so the descriptive text stays
+   *  reachable by assistive tech (the trigger's own `aria-label` remains the
+   *  accessible name). */
+  children: ReactElement<{ "aria-describedby"?: string }>;
 }
 
-/** Hover/focus delay before the bubble appears — long enough that a cursor
- *  passing over the trigger on its way elsewhere doesn't flash a tooltip. */
-export const TOOLTIP_SHOW_DELAY_MS = 300;
+/** Hover delay before the bubble appears — long enough that a cursor passing
+ *  over the trigger on its way elsewhere doesn't flash a tooltip. */
+const TOOLTIP_SHOW_DELAY_MS = 300;
+
+/** Bubbles never sit closer than this to the viewport edge (same margin as
+ *  ui/info-tip.tsx uses for its clamp). */
+const VIEWPORT_MARGIN_PX = 8;
+
+// Only one bubble should ever be painted at once — a keyboard-focused tooltip
+// on trigger A plus a hover-opened one on trigger B would double up (and turn
+// the shared data-testid into a Playwright strict-mode violation). Each
+// instance registers a closer when it opens and closes the previous one.
+let closeActive: (() => void) | null = null;
 
 /**
  * Lightweight hover/focus tooltip for icon-only buttons — a `title`
  * attribute equivalent that actually shows on keyboard focus (native title
  * never does) and shows sooner than a browser's ~1s hover delay.
  *
- * Every trigger this wraps already carries its own `aria-label` as the
- * accessible name, so the bubble below is a purely visual aid: it renders
- * with `aria-hidden`, not `role="tooltip"`, and there is no `aria-describedby`
- * plumbing back to the trigger.
+ * The visible bubble is `aria-hidden`: the trigger keeps its `aria-label` as
+ * the accessible name, and a permanent `sr-only` twin of the label is wired
+ * to the trigger via `aria-describedby`, preserving the descriptive channel
+ * the native `title` used to provide (worktree paths, longer explanations).
+ *
+ * Current scope: RunPanel's header + search-bar icon buttons. Other icon-only
+ * buttons in the app (e.g. the backlog tray) intentionally still use native
+ * `title` — converting them is a separate sweep, not an oversight here.
  *
  * Deliberately does NOT set `data-popover-open` and does NOT handle Escape.
  * That marker/contract is for real popovers (dialogs, menus, SearchSelect…)
@@ -31,7 +57,15 @@ export const TOOLTIP_SHOW_DELAY_MS = 300;
  * disappear on mouseleave/blur, not block Escape-to-close-panel.
  */
 export function Tooltip({ label, align = "center", className, children }: Props) {
-  const [open, setOpen] = useState(false);
+  const descId = useId();
+  // Hover and keyboard focus are independent show reasons: a mouse passing
+  // over (and off) a keyboard-focused trigger must not kill its bubble, and
+  // focus wandering must not kill a hover-opened one.
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const open = hovered || focused;
+  const [shiftX, setShiftX] = useState(0);
+  const bubbleRef = useRef<HTMLSpanElement | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearTimer = () => {
@@ -43,16 +77,45 @@ export function Tooltip({ label, align = "center", className, children }: Props)
 
   useEffect(() => clearTimer, []);
 
+  useEffect(() => {
+    if (!open) return;
+    const close = () => {
+      setHovered(false);
+      setFocused(false);
+    };
+    if (closeActive !== null && closeActive !== close) closeActive();
+    closeActive = close;
+    return () => {
+      if (closeActive === close) closeActive = null;
+    };
+  }, [open]);
+
+  // Clamp against the viewport's left edge: an `align="end"` bubble under a
+  // left-most trigger can extend past the window on narrow panels. Measured
+  // with shiftX reset to 0 (the close path below resets it), so the rect is
+  // the bubble's natural position.
+  useLayoutEffect(() => {
+    if (!open) {
+      setShiftX(0);
+      return;
+    }
+    const el = bubbleRef.current;
+    if (el == null) return;
+    const rect = el.getBoundingClientRect();
+    const overflowLeft = Math.max(0, VIEWPORT_MARGIN_PX - rect.left);
+    if (overflowLeft > 0) setShiftX(overflowLeft);
+  }, [open, label]);
+
   return (
     <span
       className={cn("relative inline-flex", className)}
       onMouseEnter={() => {
         clearTimer();
-        timerRef.current = setTimeout(() => setOpen(true), TOOLTIP_SHOW_DELAY_MS);
+        timerRef.current = setTimeout(() => setHovered(true), TOOLTIP_SHOW_DELAY_MS);
       }}
       onMouseLeave={() => {
         clearTimer();
-        setOpen(false);
+        setHovered(false);
       }}
       onFocusCapture={(e) => {
         // Only a keyboard-driven focus should show the bubble immediately —
@@ -60,30 +123,39 @@ export function Tooltip({ label, align = "center", className, children }: Props)
         // hover path (with its delay) covering it, and showing on every
         // programmatic/mouse focus too would make click targets feel noisy.
         if ((e.target as HTMLElement).matches?.(":focus-visible")) {
-          clearTimer();
-          setOpen(true);
+          setFocused(true);
         }
       }}
-      onBlurCapture={() => {
-        clearTimer();
-        setOpen(false);
-      }}
+      onBlurCapture={() => setFocused(false)}
       onMouseDown={() => {
         // A click is about to happen — don't leave a stale bubble hanging
-        // over whatever it opens (e.g. a dialog).
+        // over whatever it opens (e.g. a dialog). Clears both show reasons;
+        // hover re-arms only on the next mouseenter.
         clearTimer();
-        setOpen(false);
+        setHovered(false);
+        setFocused(false);
       }}
     >
-      {children}
+      {cloneElement(children, { "aria-describedby": descId })}
+      <span id={descId} className="sr-only">
+        {label}
+      </span>
       {open && (
         <span
+          ref={bubbleRef}
           aria-hidden="true"
           data-testid="tooltip"
           className={cn(
             "pointer-events-none absolute top-full z-50 mt-1 max-w-64 break-words rounded border border-border bg-card px-2 py-1 text-xs text-card-foreground shadow-md",
             align === "end" ? "right-0" : "left-1/2 -translate-x-1/2",
           )}
+          style={
+            shiftX > 0
+              ? align === "end"
+                ? { right: -shiftX }
+                : { left: `calc(50% + ${shiftX}px)` }
+              : undefined
+          }
         >
           {label}
         </span>

--- a/src/mainview/components/ui/tooltip.tsx
+++ b/src/mainview/components/ui/tooltip.tsx
@@ -5,14 +5,19 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type CSSProperties,
   type ReactElement,
 } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 
 interface Props {
   label: string;
   /** Horizontal alignment of the bubble relative to the trigger. */
   align?: "center" | "end";
+  /** Which side of the trigger the bubble appears on. Use `"top"` for
+   *  triggers near the bottom of the viewport (composer send, backlog tray). */
+  side?: "bottom" | "top";
   className?: string;
   /** A single trigger element — it receives `aria-describedby` pointing at a
    *  visually-hidden twin of the label, so the descriptive text stays
@@ -29,6 +34,9 @@ const TOOLTIP_SHOW_DELAY_MS = 300;
  *  ui/info-tip.tsx uses for its clamp). */
 const VIEWPORT_MARGIN_PX = 8;
 
+/** Gap between the trigger and the bubble. */
+const GAP_PX = 4;
+
 // Only one bubble should ever be painted at once — a keyboard-focused tooltip
 // on trigger A plus a hover-opened one on trigger B would double up (and turn
 // the shared data-testid into a Playwright strict-mode violation). Each
@@ -40,14 +48,24 @@ let closeActive: (() => void) | null = null;
  * attribute equivalent that actually shows on keyboard focus (native title
  * never does) and shows sooner than a browser's ~1s hover delay.
  *
- * The visible bubble is `aria-hidden`: the trigger keeps its `aria-label` as
- * the accessible name, and a permanent `sr-only` twin of the label is wired
- * to the trigger via `aria-describedby`, preserving the descriptive channel
- * the native `title` used to provide (worktree paths, longer explanations).
+ * The bubble PORTALS to `document.body` with `position: fixed`. Two reasons,
+ * both repo traps: an in-place `absolute` bubble clips inside any
+ * `overflow-y-auto` ancestor (the backlog tray's capped scroll window), and
+ * `fixed` inside the RunPanel `<aside>` would be rebased by its `translate-x`
+ * transform — but `document.body` is untransformed, so `fixed` is safe there
+ * (same reasoning as ui/context-menu.tsx). Position is measured from the
+ * trigger on open, clamped to the viewport horizontally, and the bubble hides
+ * on any scroll/resize rather than tracking (it re-shows on the next hover).
  *
- * Current scope: RunPanel's header + search-bar icon buttons. Other icon-only
- * buttons in the app (e.g. the backlog tray) intentionally still use native
- * `title` — converting them is a separate sweep, not an oversight here.
+ * The visible bubble is `aria-hidden`: the trigger keeps its `aria-label` as
+ * the accessible name, and a permanent `sr-only` twin of the label (inside
+ * the wrapper, not portaled) is wired to the trigger via `aria-describedby`,
+ * preserving the descriptive channel the native `title` used to provide
+ * (worktree paths, longer explanations).
+ *
+ * Current scope: RunPanel's icon-only buttons (header, search bar, backlog
+ * tray, composer send, refresh-models). Text-labeled buttons intentionally
+ * keep native `title` — their visible text is already the label.
  *
  * Deliberately does NOT set `data-popover-open` and does NOT handle Escape.
  * That marker/contract is for real popovers (dialogs, menus, SearchSelect…)
@@ -56,7 +74,7 @@ let closeActive: (() => void) | null = null;
  * transient hover bubble must never participate in that: it should just
  * disappear on mouseleave/blur, not block Escape-to-close-panel.
  */
-export function Tooltip({ label, align = "center", className, children }: Props) {
+export function Tooltip({ label, align = "center", side = "bottom", className, children }: Props) {
   const descId = useId();
   // Hover and keyboard focus are independent show reasons: a mouse passing
   // over (and off) a keyboard-focused trigger must not kill its bubble, and
@@ -64,7 +82,12 @@ export function Tooltip({ label, align = "center", className, children }: Props)
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
   const open = hovered || focused;
+  // Anchor position measured from the trigger when the bubble opens; the
+  // bubble renders only once this is known (layout effects run before paint,
+  // so there is no unpositioned flash).
+  const [pos, setPos] = useState<CSSProperties | null>(null);
   const [shiftX, setShiftX] = useState(0);
+  const wrapperRef = useRef<HTMLSpanElement | null>(null);
   const bubbleRef = useRef<HTMLSpanElement | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -90,24 +113,67 @@ export function Tooltip({ label, align = "center", className, children }: Props)
     };
   }, [open]);
 
-  // Clamp against the viewport's left edge: an `align="end"` bubble under a
-  // left-most trigger can extend past the window on narrow panels. Measured
-  // with shiftX reset to 0 (the close path below resets it), so the rect is
-  // the bubble's natural position.
+  // Anchor the bubble to the trigger's current rect.
   useLayoutEffect(() => {
     if (!open) {
+      setPos(null);
       setShiftX(0);
       return;
     }
+    const rect = wrapperRef.current?.getBoundingClientRect();
+    if (rect == null) return;
+    const style: CSSProperties =
+      side === "top"
+        ? { bottom: window.innerHeight - rect.top + GAP_PX }
+        : { top: rect.bottom + GAP_PX };
+    if (align === "end") {
+      style.right = Math.max(VIEWPORT_MARGIN_PX, window.innerWidth - rect.right);
+    } else {
+      style.left = rect.left + rect.width / 2;
+    }
+    setPos(style);
+  }, [open, align, side, label]);
+
+  // Clamp horizontally once the bubble has a size: keep both edges inside the
+  // viewport margin (a long label on a left-most trigger would otherwise run
+  // past the window edge).
+  useLayoutEffect(() => {
+    if (pos == null) return;
     const el = bubbleRef.current;
     if (el == null) return;
     const rect = el.getBoundingClientRect();
     const overflowLeft = Math.max(0, VIEWPORT_MARGIN_PX - rect.left);
-    if (overflowLeft > 0) setShiftX(overflowLeft);
-  }, [open, label]);
+    const overflowRight = Math.min(0, window.innerWidth - VIEWPORT_MARGIN_PX - rect.right);
+    const shift = overflowLeft > 0 ? overflowLeft : overflowRight;
+    if (shift !== 0) setShiftX((prev) => prev + shift);
+  }, [pos]);
+
+  // A stale fixed-position bubble after a scroll or resize would float over
+  // the wrong content — hide instead of tracking.
+  useEffect(() => {
+    if (!open) return;
+    const hide = () => {
+      setHovered(false);
+      setFocused(false);
+    };
+    window.addEventListener("scroll", hide, { capture: true, passive: true });
+    window.addEventListener("resize", hide);
+    return () => {
+      window.removeEventListener("scroll", hide, { capture: true });
+      window.removeEventListener("resize", hide);
+    };
+  }, [open]);
+
+  const translate =
+    align === "center"
+      ? `translateX(calc(-50% + ${shiftX}px))`
+      : shiftX !== 0
+        ? `translateX(${shiftX}px)`
+        : undefined;
 
   return (
     <span
+      ref={wrapperRef}
       className={cn("relative inline-flex", className)}
       onMouseEnter={() => {
         clearTimer();
@@ -140,26 +206,19 @@ export function Tooltip({ label, align = "center", className, children }: Props)
       <span id={descId} className="sr-only">
         {label}
       </span>
-      {open && (
-        <span
-          ref={bubbleRef}
-          aria-hidden="true"
-          data-testid="tooltip"
-          className={cn(
-            "pointer-events-none absolute top-full z-50 mt-1 max-w-64 break-words rounded border border-border bg-card px-2 py-1 text-xs text-card-foreground shadow-md",
-            align === "end" ? "right-0" : "left-1/2 -translate-x-1/2",
-          )}
-          style={
-            shiftX > 0
-              ? align === "end"
-                ? { right: -shiftX }
-                : { left: `calc(50% + ${shiftX}px)` }
-              : undefined
-          }
-        >
-          {label}
-        </span>
-      )}
+      {open && pos != null &&
+        createPortal(
+          <span
+            ref={bubbleRef}
+            aria-hidden="true"
+            data-testid="tooltip"
+            className="pointer-events-none fixed z-50 max-w-64 break-words rounded border border-border bg-card px-2 py-1 text-xs text-card-foreground shadow-md"
+            style={{ ...pos, transform: translate }}
+          >
+            {label}
+          </span>,
+          document.body,
+        )}
     </span>
   );
 }

--- a/src/mainview/components/ui/tooltip.tsx
+++ b/src/mainview/components/ui/tooltip.tsx
@@ -23,7 +23,7 @@ interface Props {
    *  visually-hidden twin of the label, so the descriptive text stays
    *  reachable by assistive tech (the trigger's own `aria-label` remains the
    *  accessible name). */
-  children: ReactElement<{ "aria-describedby"?: string }>;
+  children: ReactElement<{ "aria-describedby"?: string; "aria-label"?: string }>;
 }
 
 /** Hover delay before the bubble appears — long enough that a cursor passing
@@ -55,7 +55,11 @@ let closeActive: (() => void) | null = null;
  * transform — but `document.body` is untransformed, so `fixed` is safe there
  * (same reasoning as ui/context-menu.tsx). Position is measured from the
  * trigger on open, clamped to the viewport horizontally, and the bubble hides
- * on any scroll/resize rather than tracking (it re-shows on the next hover).
+ * rather than tracking — on scroll of any container enclosing the trigger
+ * (NOT unrelated scrolls: the transcript's per-chunk auto-pin must not kill
+ * header tooltips), on window resize, and on Enter/Space/Escape keydown
+ * (activation can move the trigger; Escape slides the panel out from under a
+ * fixed bubble). It re-shows on the next hover/focus.
  *
  * The visible bubble is `aria-hidden`: the trigger keeps its `aria-label` as
  * the accessible name, and a permanent `sr-only` twin of the label (inside
@@ -132,6 +136,10 @@ export function Tooltip({ label, align = "center", side = "bottom", className, c
       style.left = rect.left + rect.width / 2;
     }
     setPos(style);
+    // Every re-anchor starts the clamp from a clean baseline — a shift that
+    // corrected a previous (e.g. longer) label must not linger once the
+    // overflow it fixed is gone.
+    setShiftX(0);
   }, [open, align, side, label]);
 
   // Clamp horizontally once the bubble has a size: keep both edges inside the
@@ -149,17 +157,25 @@ export function Tooltip({ label, align = "center", side = "bottom", className, c
   }, [pos]);
 
   // A stale fixed-position bubble after a scroll or resize would float over
-  // the wrong content — hide instead of tracking.
+  // the wrong content — hide instead of tracking. The scroll hide is scoped
+  // to containers that actually enclose the trigger: RunPanel's transcript
+  // auto-pin fires a scroll on its log container for every streamed chunk,
+  // and an unscoped capture-phase listener would kill every tooltip in the
+  // panel for the whole duration of a run.
   useEffect(() => {
     if (!open) return;
     const hide = () => {
       setHovered(false);
       setFocused(false);
     };
-    window.addEventListener("scroll", hide, { capture: true, passive: true });
+    const onScroll = (e: Event) => {
+      const wrapper = wrapperRef.current;
+      if (wrapper != null && e.target instanceof Node && e.target.contains(wrapper)) hide();
+    };
+    window.addEventListener("scroll", onScroll, { capture: true, passive: true });
     window.addEventListener("resize", hide);
     return () => {
-      window.removeEventListener("scroll", hide, { capture: true });
+      window.removeEventListener("scroll", onScroll, { capture: true });
       window.removeEventListener("resize", hide);
     };
   }, [open]);
@@ -170,6 +186,12 @@ export function Tooltip({ label, align = "center", side = "bottom", className, c
       : shiftX !== 0
         ? `translateX(${shiftX}px)`
         : undefined;
+
+  // When the trigger's own aria-label is the same string as the tooltip,
+  // wiring it again as the accessible description would make AT announce it
+  // twice ("Move up, Move up") — only wire the description when it adds
+  // information beyond the name.
+  const describe = children.props["aria-label"] !== label;
 
   return (
     <span
@@ -201,18 +223,32 @@ export function Tooltip({ label, align = "center", side = "bottom", className, c
         setHovered(false);
         setFocused(false);
       }}
+      onKeyDownCapture={(e) => {
+        // Keyboard mirror of the mousedown hide: Enter/Space activation can
+        // move the trigger (a tray row reorder, a sent draft) and would leave
+        // the fixed bubble parked at the old coordinates; Escape closes the
+        // enclosing panel, whose slide-out the portaled bubble no longer
+        // travels with. Never preventDefault — the key still does its job.
+        if (e.key === "Enter" || e.key === " " || e.key === "Escape") {
+          clearTimer();
+          setHovered(false);
+          setFocused(false);
+        }
+      }}
     >
-      {cloneElement(children, { "aria-describedby": descId })}
-      <span id={descId} className="sr-only">
-        {label}
-      </span>
+      {describe ? cloneElement(children, { "aria-describedby": descId }) : children}
+      {describe && (
+        <span id={descId} className="sr-only">
+          {label}
+        </span>
+      )}
       {open && pos != null &&
         createPortal(
           <span
             ref={bubbleRef}
             aria-hidden="true"
             data-testid="tooltip"
-            className="pointer-events-none fixed z-50 max-w-64 break-words rounded border border-border bg-card px-2 py-1 text-xs text-card-foreground shadow-md"
+            className="pointer-events-none fixed z-[60] max-w-64 break-words rounded border border-border bg-card px-2 py-1 text-xs text-card-foreground shadow-md"
             style={{ ...pos, transform: translate }}
           >
             {label}


### PR DESCRIPTION
## What

Restructures the task-details (RunPanel) header and gives the panel's icon-only buttons real tooltips:

- **Header layout**: the first row is now buttons only — all icon-only, right-aligned, in the existing order (View PR, View issue, PR re-check, Diff, Open, Stop, Archive/Unarchive, Search, Close). The task title and the `agent · column · branch · base` subtitle moved to full-width rows below the buttons. Every render condition, handler, and testid preserved verbatim.
- **New `ui/tooltip.tsx` primitive**: hover (300ms delay) and keyboard-focus (`:focus-visible`-gated) tooltips replace the native `title` attribute, which only shows after ~1s of mouse hover and never on keyboard focus or touch.
- **Sweep**: the primitive is wired around all of RunPanel's icon-only buttons — the 10 header buttons, the search bar's prev/next/close, the 5 backlog-tray row buttons, the composer Send button, and refresh-models. Text-labeled buttons (Attach, "+N", Save for later, Commit & push, Create PR…) deliberately keep native `title`.

## Why

The header was crowded (labels + title competing for one row), and once buttons went icon-only the native `title` tooltips were the only labels left — invisible to keyboard and touch users. Along the way this fixes pre-existing a11y gaps: the header Close button and the backlog-tray buttons had **no accessible name at all** (the tray's `title` was doing double duty as the name), and the search-bar trio lacked `aria-label`s.

## Design notes (each encodes a repo trap)

- The bubble **portals to `document.body` with `position: fixed`**: an in-place `absolute` bubble clips inside the backlog tray's `overflow-y-auto` scroll cap, and `fixed` inside the panel `<aside>` is rebased by its `translate-x` transform — body is untransformed (same reasoning as `ui/context-menu.tsx`). `side="top"` for bottom-of-viewport triggers.
- **Scroll-hide is scoped** to containers enclosing the trigger — an unscoped listener was killed by the transcript's per-chunk auto-scroll pin, making tooltips dead during live runs.
- Short `aria-label` = accessible name; the tooltip text doubles as the accessible **description** via a permanent `sr-only` twin + `aria-describedby`, deduped when the two strings match. Dynamic state (PR-status errors, archive mode) stays announced.
- No `data-popover-open` — a transient bubble must never block the panel's Escape layering. `z-[60]` so a body-portaled bubble can't tie with the in-tree dialog overlay's `z-50`. Single-open token, split hover/focus state, viewport clamp with reset on re-anchor, hide on Enter/Space/Escape.

## Testing

- New `e2e/run-panel-header.spec.ts` (2 tests): accessible names + icon-only rendering + stacked row order + close via header X; tooltip shows on hover with exact text, hides on mouseleave, and wrapped buttons carry no native `title` (double-tooltip guard).
- `bun run typecheck` green; `bun test` 3957 pass (one pre-existing environmental timeout in `pane-pid.test.ts`, passes in isolation).
- Two review passes were applied along the way (a11y name/description wiring, scroll-hide scoping, z-order, clamp lifecycle).

Plan doc: `docs/plans/task-details-header-icon-row.md`.