### PR TITLE
fix: task card header — 3-row layout (type icon + count badges / model·mode / title)

### DIFF
--- a/docs/plans/task-card-header-rows.md
+++ b/docs/plans/task-card-header-rows.md
@@ -1,0 +1,152 @@
+# Plan — TaskCard header: 3-row layout
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-09-01 |
+| Source | /implement request + screenshot (Desktop/Screenshot 2026-09-01 at 12.40.12 PM.png) |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Flags | none |
+| Gates | grilled + approved by owner |
+| Branch | fix/fix-task-card-header-ui (pre-existing agetor worktree branch) |
+| Base SHA | e2d95dfa9f07d39bc8e6d5781b17788711ffdd8c |
+
+## 1. Objective & success criteria
+
+Restructure the kanban board task card's header (`CardHeader` in
+`src/mainview/components/kanban/TaskCard.tsx`) from today's 2-column layout
+(icon+title left, badge stack right) into 3 rows:
+
+- **Row 1**: `[type_icon] [agents_badge] [shell_badge] [todo_badge]` … space-between … `[harness_badge]`
+- **Row 2**: right-aligned `[model · mode]` (row collapses entirely when both absent)
+- **Row 3**: `[task_title]` (full card width)
+
+Everything outside `CardHeader` (unread dot, prompt preview, workdir, branch row,
+action buttons) stays untouched. Success = new layout renders per spec, no badge
+or tooltip lost, all existing e2e selectors still pass, typecheck green.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- Current header JSX: `TaskCard.tsx:135-191`. Left cluster (`TypeIcon` + `CardTitle`)
+  at :137-143; right `flex-col items-end` stack at :144-189 holding, in order:
+  harness badge (:145-148), `model · mode` span (:149-153), terminal badge
+  (:154-163), subagents badge (:164-173), todo badge (:174-188).
+- The squeezed title in the screenshot is caused by the right badge stack taking
+  horizontal space from the title (`flex-1` vs `shrink-0` column).
+- `type_icon` = `taskTypeIcon(type.icon)` (`src/mainview/lib/task-type-icon.ts`),
+  semantic color via `type.iconClass` (`text-info`/`text-danger`/`text-spike`).
+  Its `mt-0.5` exists only to align with the title's first line — drop it when
+  the icon moves into a badge row (`items-center` handles alignment).
+- `agents_badge` = `Bot` + `runningSubagents` count, shown when > 0,
+  `title="N background task(s) running"` — **e2e-load-bearing**
+  (`e2e/monitor-hold.spec.ts:207,256`).
+- `shell_badge` = `Terminal` + `task.openTerminalCount`, shown when > 0,
+  `title="N open terminal(s)"` (only accessible label — preserve).
+- `todo_badge` = `ListTodo` + `completed/total`, `text-success` when complete,
+  `title="X of Y tasks done"` — **e2e-load-bearing** (`e2e/todo-progress.spec.ts:141`,
+  `e2e/fx-interactions.spec.ts:196`).
+- `harness_badge` = `Badge variant="secondary"` + `AgentIcon kind={task.agent}` +
+  raw `task.agent` string (harness aliases fall back to claude-code glyph by design).
+- `model`/`mode` = `[task.model, task.mode].filter(Boolean).join(" · ")`,
+  `text-[10px] font-mono text-muted-foreground`, rendered only when at least one set.
+- Title = `CardTitle` `text-sm break-words`, no clamp — keep behavior (full wrap);
+  it now gets the full card width, which is the fix for the screenshot's
+  one-word-per-line wrapping.
+- Unread dot (`:120-134`) is a sibling of `CardHeader`, absolutely positioned on the
+  card corner — untouched; visual overlap check with the row-1 harness badge is part
+  of acceptance (dot sits half outside the card edge; header padding should clear it).
+- Memoization: pure JSX/class reshuffle of already-read `task.*` fields — no prop or
+  callback changes, so `memo(TaskCardImpl)` and `Column`'s comparator are unaffected.
+- Conventions: semantic tokens only (no literal palette classes); badge idiom is
+  `variant="outline"`, `text-[10px]`, icon `size-3`, count, `title` tooltip.
+- No `data-testid` in TaskCard; e2e keys off `.cursor-grab`, exact title text, and
+  `title` attributes — all layout-independent. DOM order of title vs. prompt
+  paragraph doesn't matter to specs as long as both render inside the card.
+- Unit tests in this repo are pure-function tests (`src/mainview/lib/*.test.ts`) —
+  there is no React component-rendering harness, and this change introduces none.
+- E2E harness: Playwright under `e2e/` — run with
+  `bun node_modules/@playwright/test/cli.js test <spec>` (never `bunx`), one
+  Playwright run at a time, no concurrent dev/HMR session.
+
+## 3. Approach & key decisions
+
+- Pure JSX restructure inside `CardHeader` (lines 135-191). No state, props, data,
+  or server changes. No new components.
+- Row 1: `flex items-center justify-between gap-2`; left cluster
+  `flex min-w-0 items-center gap-1.5` holding type icon + the three conditional
+  count badges (order: agents, shell, todo — owner-confirmed todo placement);
+  harness badge `shrink-0` on the right.
+  - Badge order changes from today's DOM order (shell before agents) to the spec's
+    (agents before shell) — deliberate, per the requested layout.
+- Row 2: rendered only when `task.model || task.mode`; `flex justify-end` wrapper
+  around the existing span (unchanged classes/format).
+- Row 3: `CardTitle` keeps `text-sm break-words`, drops `min-w-0 flex-1`
+  (no longer in a flex row).
+- Vertical rhythm: rely on `CardHeader`'s base column layout; implementer checks
+  `src/mainview/components/ui/card.tsx` base classes and, if needed, tightens
+  spacing (e.g. `space-y-1` / `gap-1`) to match today's compact density.
+  **Decision rests on reading, not spike** — trivial CSS, verified by e2e + eyes.
+- All `title` tooltip strings, icons, conditional rendering guards, and semantic
+  color classes are moved verbatim, not rewritten.
+
+## 4. Work breakdown — implementation tasks
+
+- **T1** — Restructure `CardHeader` into the 3-row layout.
+  - Owns: `src/mainview/components/kanban/TaskCard.tsx` (only file).
+  - Scope: lines 135-191 only; everything else in the file untouched.
+  - Acceptance: layout per §1; all five header elements + todo badge present with
+    verbatim `title` attributes and guards; semantic tokens only; typecheck green.
+
+## 5. Work breakdown — test tasks
+
+- **TT1** — New Playwright spec `e2e/task-card-header.spec.ts`.
+  - Owns: `e2e/task-card-header.spec.ts` (new file only).
+  - Seeds a task (via the existing e2e fixtures/backend, `isolation: none`) with a
+    `bug` type, `model`, and `mode`; asserts on the board card (`.cursor-grab`):
+    1. type icon (`aria-label`) and harness badge render, and their bounding boxes
+       overlap vertically (same row), icon left of badge;
+    2. `model · mode` text renders below row 1 (its `y` > row-1 elements' `y`);
+    3. title renders below the model·mode row and starts at the card's left content
+       edge (x ≈ type icon's x), i.e. full-width row 3;
+    4. badge tooltips that are seedable without live runs are asserted by `title`
+       attribute presence where applicable.
+  - Robustness: y-ordering + presence assertions only (no pixel-tolerance
+    geometry), per the repo's e2e flake caveats. Runtime-dependent badges
+    (subagents/terminals/todo) stay covered by the existing
+    `monitor-hold`/`todo-progress` specs — not duplicated here.
+- **E2E applicability**: applies (user-visible UI in the webview; harness exists).
+  Unit layer: not applicable — no component-render harness exists and the change
+  has no extractable pure logic; existing `lib` unit tests are unaffected but run
+  anyway as regression.
+
+## 6. Execution waves
+
+- **Wave 1**: T1 (single agent, `implementation` runner: claude/sonnet).
+- Phase 5: code review (claude/opus) of `git diff <base>...HEAD`.
+- **Wave 2**: TT1 (single agent, `tests_creation` runner: claude/sonnet) —
+  file-disjoint from T1, runs after review so the spec targets the final DOM.
+- Phase 7 (`tests_running` runner: claude/haiku): `bun run typecheck`, `bun test`,
+  then targeted Playwright: `task-card-header.spec.ts`, `todo-progress.spec.ts`,
+  `monitor-hold.spec.ts`, `unread-indicator.spec.ts` (the specs that touch card
+  header selectors). Full e2e suite is skipped deliberately: serial-only Playwright
+  + known load-flakes make the targeted set the higher-signal regression net for a
+  header-scoped change.
+
+## 7. Blast radius & risks
+
+- Single component; no callers/contract changes. Board-only surface (RunPanel
+  header is a different component, untouched).
+- e2e selector risk: none identified (selectors are layout-independent), but the
+  three selector-bearing specs run in Phase 7 to prove it.
+- Visual risks: unread-dot/harness-badge corner proximity; long harness alias in
+  row 1 (same `shrink-0` behavior as today — parity, not regression). Checked
+  visually via the new spec's screenshots on failure + owner's dev run.
+- Rollback: single-file revert.
+
+## 8. Open questions / assumptions
+
+- Todo badge placement — **resolved by owner**: row 1 left cluster, after shell badge.
+- Assumption (low risk): keep title full-wrap (`break-words`, no clamp) — now that
+  it owns a full row, the screenshot's pathological wrapping disappears; clamping
+  is a separate design decision nobody asked for.
+- Assumption (low risk): row 2 collapses when model & mode are both null
+  (mirrors today's conditional span).

--- a/e2e/task-card-header.spec.ts
+++ b/e2e/task-card-header.spec.ts
@@ -1,0 +1,191 @@
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { test, expect, type APIRequestContext, type E2EBackend, type Locator, type Page } from "./fixtures";
+import { gotoApp } from "./helpers";
+
+/**
+ * E2E coverage for the kanban `TaskCard` header's 3-row layout
+ * (src/mainview/components/kanban/TaskCard.tsx `CardHeader`):
+ *
+ *   row 1 — `justify-between` flex row: left cluster (task-type icon +
+ *           conditional count badges), right (the harness badge).
+ *   row 2 — only when `model`/`mode` is set: a right-aligned
+ *           `[model, mode].join(" · ")` span.
+ *   row 3 — the full-width title (`CardTitle`), no longer indented beside
+ *           the icon.
+ *
+ * Seeds a task directly through the backend API (isolation "none", a plain
+ * non-git temp dir as workdir — this spec never starts a run, so nothing
+ * ever touches the filesystem or spawns an agent) with a task type, model,
+ * and mode set, then asserts both presence (every row's content renders)
+ * and geometry (the three rows stack in the right order, row 2 is right-
+ * aligned, row 3 is full-width) via `boundingBox()` reads — coarse
+ * tolerances only, no pixel-perfect assertions, per quote.spec.ts's own
+ * "no pixel/screenshot assertions" convention for this harness (WKWebView,
+ * the app's real target, renders differently from Chromium).
+ */
+
+test.describe.configure({ mode: "serial" });
+
+interface TaskRow {
+  id: string;
+  title: string;
+}
+
+/** Create (but never start) a task with a task type + model + mode set, so
+ *  the board card renders every header row this spec asserts on. isolation
+ *  "none" + a plain temp dir keeps this a pure API/DB round-trip — no git,
+ *  no worktree, no agent process. */
+async function createHeaderTask(
+  request: APIRequestContext,
+  backend: E2EBackend,
+  title: string,
+): Promise<TaskRow> {
+  const auth = { authorization: `Bearer ${backend.apiToken}` };
+  const createRes = await request.post(`${backend.apiBase}/tasks`, {
+    headers: auth,
+    data: {
+      title,
+      prompt: "investigate and fix the reported defect",
+      isolation: "none",
+      workdir: tmpdir(),
+      agent: "claude-code",
+      taskType: "bug",
+      model: "opus",
+      mode: "auto",
+    },
+  });
+  expect(createRes.ok(), `POST /tasks -> ${createRes.status()}: ${await createRes.text()}`).toBeTruthy();
+  return (await createRes.json()) as TaskRow;
+}
+
+/** Scopes a locator to the board `TaskCard` for the given exact title —
+ *  mirrors `e2e/unread-indicator.spec.ts`'s `taskCard` helper: the root
+ *  `<Card>` carries `cursor-grab` (drag-handle styling unique to board
+ *  cards; the run panel's `<aside>` never has it), so this can't
+ *  accidentally match anything else in the DOM. */
+function taskCard(page: Page, title: string) {
+  return page.locator(".cursor-grab").filter({ has: page.getByText(title, { exact: true }) });
+}
+
+/** The row-1 harness badge (`<Badge variant="secondary">` in TaskCard.tsx).
+ *  Not locatable via `getByText("claude-code", { exact: true })`:
+ *  `@lobehub/icons`' `ClaudeCode.Color` glyph renders a hidden SVG
+ *  `<title>Claude Code</title>` node, which DOM `textContent` (what
+ *  Playwright's text matching reads) concatenates with the badge's own
+ *  `claude-code` text node — the badge's real `textContent` is
+ *  `"Claude Codeclaude-code"`, not `"claude-code"`, so an exact match never
+ *  hits. `rounded-full` (Badge's pill shape) + `bg-secondary` (this badge's
+ *  variant) is unique within the card — every button in `TaskCard.tsx` uses
+ *  `rounded-md`, never `rounded-full` — and unambiguously selects the whole
+ *  pill (icon + text), which is also what geometry assertions want. */
+function harnessBadge(card: Locator) {
+  return card.locator(".rounded-full.bg-secondary");
+}
+
+/** Bounding boxes are asserted repeatedly below; a thin wrapper keeps every
+ *  call site honest about non-null (Playwright returns null only for a
+ *  detached/invisible element, which every locator here has already been
+ *  proven visible before this is called). */
+async function box(locator: Locator) {
+  const b = await locator.boundingBox();
+  expect(b, "expected a visible element with a bounding box").not.toBeNull();
+  return b!;
+}
+
+test.describe("task card header layout", () => {
+  test("renders the type icon, harness badge, model·mode line, and title inside the card", async ({
+    page,
+    request,
+    backend,
+  }) => {
+    const title = `header-e2e ${randomUUID()} verify the header layout renders`;
+    await createHeaderTask(request, backend, title);
+
+    await gotoApp(page, backend.bootBase);
+    const card = taskCard(page, title);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // Row 1, left cluster: task-type icon. "bug" -> TASK_TYPES' "Bug" label
+    // (src/shared/types.ts), applied verbatim as the icon's aria-label.
+    await expect(card.locator('[aria-label="Bug"]')).toBeVisible();
+
+    // Row 1, right: the harness badge renders `task.agent` verbatim (in
+    // amongst the brand glyph's own hidden SVG <title> text — see
+    // `harnessBadge`'s doc comment — hence `toContainText`, not an exact
+    // match).
+    await expect(harnessBadge(card)).toContainText("claude-code");
+
+    // Row 2: `[model, mode].join(" · ")`.
+    await expect(card.getByText("opus · auto", { exact: true })).toBeVisible();
+
+    // Row 3: the full title.
+    await expect(card.getByText(title, { exact: true })).toBeVisible();
+  });
+
+  test("lays the header out as three stacked rows: icon+badge, right-aligned model·mode, full-width title", async ({
+    page,
+    request,
+    backend,
+  }) => {
+    const title = `header-e2e ${randomUUID()} confirm the three row geometry`;
+    await createHeaderTask(request, backend, title);
+
+    await gotoApp(page, backend.bootBase);
+    const card = taskCard(page, title);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    const icon = card.locator('[aria-label="Bug"]');
+    const badge = harnessBadge(card);
+    const modelMode = card.getByText("opus · auto", { exact: true });
+    const cardTitle = card.getByText(title, { exact: true });
+    await expect(icon).toBeVisible();
+    await expect(badge).toBeVisible();
+    await expect(modelMode).toBeVisible();
+    await expect(cardTitle).toBeVisible();
+
+    const [iconBox, badgeBox, modelModeBox, titleBox] = await Promise.all([
+      box(icon),
+      box(badge),
+      box(modelMode),
+      box(cardTitle),
+    ]);
+
+    // --- Row 1: type icon and harness badge share a visual row -----------
+    // Vertical overlap (both sit on the same `items-center` flex row) and
+    // the icon comes first (left cluster) with the badge to its right.
+    const iconMidY = iconBox.y + iconBox.height / 2;
+    const badgeMidY = badgeBox.y + badgeBox.height / 2;
+    expect(Math.abs(iconMidY - badgeMidY), "icon and harness badge should sit on the same row").toBeLessThan(8);
+    expect(iconBox.x, "type icon should sit left of the harness badge").toBeLessThan(badgeBox.x);
+
+    // --- Strict top-y row ordering: row 1 < row 2 < row 3 -----------------
+    expect(modelModeBox.y, "model·mode row should sit below the icon/badge row").toBeGreaterThan(iconBox.y);
+    expect(
+      modelModeBox.y + modelModeBox.height,
+      "model·mode row should sit entirely above the title row",
+    ).toBeLessThan(titleBox.y);
+
+    // --- Row 2 is right-aligned -------------------------------------------
+    // Its right edge tracks the harness badge's right edge (both anchored
+    // to the header's right content edge)...
+    const modelModeRight = modelModeBox.x + modelModeBox.width;
+    const badgeRight = badgeBox.x + badgeBox.width;
+    expect(
+      Math.abs(modelModeRight - badgeRight),
+      "model·mode row's right edge should line up with the harness badge's right edge",
+    ).toBeLessThan(8);
+    // ...and it sits well clear of the header's left content edge (proving
+    // it's right-aligned, not left-aligned like the title below it).
+    expect(
+      modelModeRight - iconBox.x,
+      "model·mode row should be offset well clear of the left content edge",
+    ).toBeGreaterThan(40);
+
+    // --- Row 3 (title) is full-width: its left edge matches row 1's ------
+    expect(
+      Math.abs(titleBox.x - iconBox.x),
+      "title should start at the same left edge as the type icon (no longer indented beside it)",
+    ).toBeLessThan(4);
+  });
+});

--- a/src/mainview/components/kanban/TaskCard.tsx
+++ b/src/mainview/components/kanban/TaskCard.tsx
@@ -122,7 +122,7 @@ function TaskCardImpl({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDi
         // deliberately unanimated (the amber awaiting-pulse ring is the only
         // animated attention state). Pinned to the corner so it coexists
         // with that ring (an outline) without visual conflict, and sits
-        // above the header badge stack in the DOM/paint order.
+        // above the header's row-1 harness badge in the DOM/paint order.
         <span
           // -1.5 offsets keep the dot's background halo clear of the
           // awaiting state's ring-offset outline instead of notching it.
@@ -134,7 +134,7 @@ function TaskCardImpl({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDi
       )}
       <CardHeader className="pb-2 space-y-1">
         <div className="flex items-center justify-between gap-2">
-          <div className="flex min-w-0 items-center gap-1.5">
+          <div className="flex min-w-0 flex-wrap items-center gap-1.5">
             <TypeIcon
               className={cn("size-3.5 shrink-0", type.iconClass)}
               aria-label={type.label}
@@ -142,7 +142,7 @@ function TaskCardImpl({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDi
             {runningSubagents > 0 && (
               <Badge
                 variant="outline"
-                className="gap-1 text-[10px]"
+                className="gap-1 text-[10px] shrink-0"
                 title={`${runningSubagents} background task${runningSubagents > 1 ? "s" : ""} running`}
               >
                 <Bot className="size-3" />
@@ -152,7 +152,7 @@ function TaskCardImpl({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDi
             {task.openTerminalCount > 0 && (
               <Badge
                 variant="outline"
-                className="gap-1 text-[10px]"
+                className="gap-1 text-[10px] shrink-0"
                 title={`${task.openTerminalCount} open terminal${task.openTerminalCount > 1 ? "s" : ""}`}
               >
                 <Terminal className="size-3" />
@@ -163,7 +163,7 @@ function TaskCardImpl({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDi
               <Badge
                 variant="outline"
                 className={cn(
-                  "gap-1 text-[10px]",
+                  "gap-1 text-[10px] shrink-0",
                   task.todoProgress.completed === task.todoProgress.total
                     ? "text-success"
                     : "text-muted-foreground",
@@ -181,11 +181,9 @@ function TaskCardImpl({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDi
           </Badge>
         </div>
         {(task.model || task.mode) && (
-          <div className="flex justify-end">
-            <span className="text-[10px] font-mono text-muted-foreground">
-              {[task.model, task.mode].filter(Boolean).join(" · ")}
-            </span>
-          </div>
+          <span className="self-end text-[10px] font-mono text-muted-foreground">
+            {[task.model, task.mode].filter(Boolean).join(" · ")}
+          </span>
         )}
         <CardTitle className="text-sm break-words">{task.title}</CardTitle>
       </CardHeader>

--- a/src/mainview/components/kanban/TaskCard.tsx
+++ b/src/mainview/components/kanban/TaskCard.tsx
@@ -132,24 +132,22 @@ function TaskCardImpl({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDi
           aria-label="New messages"
         />
       )}
-      <CardHeader className="pb-2">
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex min-w-0 flex-1 items-start gap-1.5">
+      <CardHeader className="pb-2 space-y-1">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-1.5">
             <TypeIcon
-              className={cn("mt-0.5 size-3.5 shrink-0", type.iconClass)}
+              className={cn("size-3.5 shrink-0", type.iconClass)}
               aria-label={type.label}
             />
-            <CardTitle className="text-sm min-w-0 flex-1 break-words">{task.title}</CardTitle>
-          </div>
-          <div className="flex shrink-0 flex-col items-end gap-1">
-            <Badge variant="secondary" className="gap-1">
-              <AgentIcon kind={task.agent} className="size-3" />
-              {task.agent}
-            </Badge>
-            {(task.model || task.mode) && (
-              <span className="text-[10px] font-mono text-muted-foreground">
-                {[task.model, task.mode].filter(Boolean).join(" · ")}
-              </span>
+            {runningSubagents > 0 && (
+              <Badge
+                variant="outline"
+                className="gap-1 text-[10px]"
+                title={`${runningSubagents} background task${runningSubagents > 1 ? "s" : ""} running`}
+              >
+                <Bot className="size-3" />
+                {runningSubagents}
+              </Badge>
             )}
             {task.openTerminalCount > 0 && (
               <Badge
@@ -159,16 +157,6 @@ function TaskCardImpl({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDi
               >
                 <Terminal className="size-3" />
                 {task.openTerminalCount}
-              </Badge>
-            )}
-            {runningSubagents > 0 && (
-              <Badge
-                variant="outline"
-                className="gap-1 text-[10px]"
-                title={`${runningSubagents} background task${runningSubagents > 1 ? "s" : ""} running`}
-              >
-                <Bot className="size-3" />
-                {runningSubagents}
               </Badge>
             )}
             {task.todoProgress && task.todoProgress.total > 0 && (
@@ -187,7 +175,19 @@ function TaskCardImpl({ task, homeDir, onStart, onCancel, onDelete, onOpen, onDi
               </Badge>
             )}
           </div>
+          <Badge variant="secondary" className="gap-1 shrink-0">
+            <AgentIcon kind={task.agent} className="size-3" />
+            {task.agent}
+          </Badge>
         </div>
+        {(task.model || task.mode) && (
+          <div className="flex justify-end">
+            <span className="text-[10px] font-mono text-muted-foreground">
+              {[task.model, task.mode].filter(Boolean).join(" · ")}
+            </span>
+          </div>
+        )}
+        <CardTitle className="text-sm break-words">{task.title}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-2">
         <p className="text-xs text-muted-foreground line-clamp-2">{task.prompt}</p>


### PR DESCRIPTION
## What

Restructures the kanban task card's header (`CardHeader` in `src/mainview/components/kanban/TaskCard.tsx`) from a 2-column layout into 3 stacked rows:

- **Row 1** — type icon + count badges (subagents, open terminals, todo progress) on the left, harness badge pinned right (`justify-between`). The left cluster wraps (`flex-wrap`, `shrink-0` badges) so a crowded card grows taller instead of overlapping.
- **Row 2** — right-aligned `model · mode` (e.g. `fable-5 · auto`); the row collapses entirely when both are unset.
- **Row 3** — the task title, now full card width.

Everything below the header (prompt preview, workdir, branch row, action buttons) and the absolutely-positioned unread dot are untouched.

## Why

The old layout put the title in a flex row against a `shrink-0` vertical badge stack (harness badge, model·mode, terminal/subagent/todo badges). With a few badges present the stack ate most of the card's width and squeezed the title into one-word-per-line wrapping. Giving the title its own full-width row fixes that; grouping the count badges beside the type icon and right-pinning the harness badge keeps the identity info scannable.

## Details

- All badge `title` tooltip strings, conditional guards, icons, and semantic color tokens moved verbatim — verified byte-identical against the pre-change file. Existing e2e selectors (`monitor-hold`, `todo-progress`, `unread-indicator` specs key off those `title` attributes) are unaffected.
- Review-driven fix folded in: without `flex-wrap`, two or three count badges (or a long user-defined harness alias) exceeded the ~225px row inside the `w-72` column and painted under the harness badge — the new failure mode wraps instead.
- Badge order in row 1 is subagents → terminals → todo (spec order; the old stack rendered terminals first).
- Pure JSX/class reshuffle: no prop, state, or callback changes, so the `memo`/`Column` comparator boundaries are unaffected.
- Plan doc: `docs/plans/task-card-header-rows.md`.

## Tests

- New `e2e/task-card-header.spec.ts`: presence assertions plus bounding-box geometry (row ordering, right-aligned model·mode, full-width title). Note: the harness badge is located structurally (`.rounded-full.bg-secondary` + `toContainText`) because `@lobehub/icons` glyphs embed an SVG `<title>` that pollutes `textContent`, so exact text matches never resolve.
- `bun run typecheck` clean · `bun test` 3976 pass / 0 fail · targeted Playwright 6/6 pass (new spec + `todo-progress` + `monitor-hold` + `unread-indicator`).