### PR TITLE
Resizable task panel; stop user messages overlaying the transcript

### DIFF
--- a/e2e/issue-task.spec.ts
+++ b/e2e/issue-task.spec.ts
@@ -503,7 +503,7 @@ test.describe("task from a Git issue", () => {
     await expect(panel.getByTestId("view-issue")).toBeVisible();
 
     // Close the run panel before right-clicking the card below — the panel
-    // is a fixed 520px-wide overlay that can sit on top of a board card in
+    // is a fixed-position overlay (default 720px wide) that can sit on top of a board card in
     // a narrow test viewport, which would otherwise intercept the click. The
     // panel never unmounts (App.tsx keeps it mounted and slides it off with
     // a `translate-x-full` CSS transform), so `toBeHidden()` never fires —
@@ -522,7 +522,13 @@ test.describe("task from a Git issue", () => {
     // unconditionally on an always-rendered element, so the click is
     // race-free regardless of rAF timing (same pattern as
     // unread-indicator.spec.ts).
-    await page.getByRole("button", { name: "Close task panel" }).click();
+    //
+    // The header X ("Close task details"), NOT the backdrop scrim: the scrim
+    // spans the whole viewport but the resizable panel `<aside>` overlays an
+    // arbitrary share of it, so any scrim click coordinate is silently
+    // coupled to the panel width and the test viewport. The header X lives
+    // INSIDE the panel, so the panel can never occlude it.
+    await panel.getByRole("button", { name: "Close task details" }).click();
     await expect(panel).toHaveClass(/translate-x-full/, { timeout: CONVERGE_TIMEOUT });
 
     // Context menu also offers "View issue", and it reopens the Git dialog

--- a/e2e/run-panel-resize.spec.ts
+++ b/e2e/run-panel-resize.spec.ts
@@ -1,14 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { test, expect, type APIRequestContext, type E2EBackend, type Page } from "./fixtures";
-import { gotoApp } from "./helpers";
+import { getPreferences, gotoApp, openSettingsGeneral } from "./helpers";
 
 /**
  * E2E coverage for the RunPanel's user-resizable width (drag handle on the
  * panel's left edge, persisted in localStorage — `src/mainview/lib/
- * panel-width.ts`) and for the removal of the sticky user-message pinning
- * (user bubbles used to carry `sticky top-0` and overlay the transcript
- * while scrolling).
+ * panel-width.ts`) and for the configurable user-message pinning.
  *
  * Mirrors the boot/task-creation/panel-opening idiom from
  * `e2e/run-panel-header.spec.ts`: per-worker headless backend with
@@ -118,21 +116,35 @@ test.describe("run panel resize", () => {
     await expect.poll(() => panelWidth(page)).toBe(DEFAULT_WIDTH);
   });
 
-  test("user-message bubbles scroll with the transcript (no sticky overlay)", async ({
+  test("user messages are sticky by default and can switch to a standard chat list", async ({
     page,
     request,
     backend,
   }) => {
-    const prompt = `no-sticky-e2e ${randomUUID()}`;
+    const prompt = `sticky-toggle-e2e ${randomUUID()}`;
     await createAndStartFakeClaudeTask(request, backend, prompt);
 
     await gotoApp(page, backend.bootBase);
     const panel = await openTask(page, prompt);
 
-    // The prompt renders as a user bubble in the transcript…
+    // The prompt renders as a sticky user bubble by default.
     await expect(panel.getByText(prompt, { exact: true }).last()).toBeVisible();
-    // …and no event wrapper in the panel carries the old sticky pinning that
-    // made user messages overlay the assistant text while scrolling.
-    await expect(panel.locator("[data-evid].sticky")).toHaveCount(0);
+    await expect(panel.locator("[data-evid].sticky")).toHaveCount(1);
+
+    await panel.getByRole("button", { name: "Close" }).click();
+    const settings = await openSettingsGeneral(page);
+    const stickySwitch = settings.getByRole("switch", { name: "Sticky user messages" });
+    await expect(stickySwitch).toBeChecked();
+    await stickySwitch.click();
+    await expect(stickySwitch).not.toBeChecked();
+    await expect.poll(async () => (await getPreferences(request, backend)).stickyUserMessages).toBe("false");
+    await settings.getByRole("button", { name: "Close" }).click();
+
+    // Reload to prove the standard-list selection comes back from the
+    // persisted preference, rather than only living in App state.
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
+    const standardPanel = await openTask(page, prompt);
+    await expect(standardPanel.locator("[data-evid].sticky")).toHaveCount(0);
   });
 });

--- a/e2e/run-panel-resize.spec.ts
+++ b/e2e/run-panel-resize.spec.ts
@@ -1,0 +1,138 @@
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { test, expect, type APIRequestContext, type E2EBackend, type Page } from "./fixtures";
+import { gotoApp } from "./helpers";
+
+/**
+ * E2E coverage for the RunPanel's user-resizable width (drag handle on the
+ * panel's left edge, persisted in localStorage — `src/mainview/lib/
+ * panel-width.ts`) and for the removal of the sticky user-message pinning
+ * (user bubbles used to carry `sticky top-0` and overlay the transcript
+ * while scrolling).
+ *
+ * Mirrors the boot/task-creation/panel-opening idiom from
+ * `e2e/run-panel-header.spec.ts`: per-worker headless backend with
+ * `AGETOR_CLAUDE_DRIVER=fake`, an isolation:"none" task in a plain temp dir,
+ * started via the real HTTP API so the panel has real content.
+ */
+
+test.describe.configure({ mode: "serial" });
+
+const WIDTH_KEY = "agetor:runPanelWidth";
+const DEFAULT_WIDTH = 720;
+
+async function createAndStartFakeClaudeTask(
+  request: APIRequestContext,
+  backend: E2EBackend,
+  prompt: string,
+): Promise<{ id: string }> {
+  const auth = { authorization: `Bearer ${backend.apiToken}` };
+  const createRes = await request.post(`${backend.apiBase}/tasks`, {
+    headers: auth,
+    data: { title: prompt, prompt, isolation: "none", workdir: tmpdir() },
+  });
+  expect(createRes.ok(), `POST /tasks -> ${createRes.status()}: ${await createRes.text()}`).toBeTruthy();
+  const task = (await createRes.json()) as { id: string };
+
+  const startRes = await request.post(`${backend.apiBase}/tasks/${task.id}/start`, { headers: auth });
+  expect(
+    startRes.ok(),
+    `POST /tasks/${task.id}/start -> ${startRes.status()}: ${await startRes.text()}`,
+  ).toBeTruthy();
+
+  return task;
+}
+
+/** The run panel's slide-over `<aside>` — `.last()` because NewTaskForm's
+ *  sidebar is also an `<aside>`, mounted first in App.tsx's JSX. */
+function runPanel(page: Page) {
+  return page.locator("aside").last();
+}
+
+async function openTask(page: Page, title: string) {
+  await page.getByText(title, { exact: true }).first().click();
+  const panel = runPanel(page);
+  await expect(panel.locator("textarea")).toBeVisible();
+  return panel;
+}
+
+async function panelWidth(page: Page): Promise<number> {
+  const box = await runPanel(page).boundingBox();
+  expect(box, "run panel should have a bounding box").not.toBeNull();
+  return box!.width;
+}
+
+test.describe("run panel resize", () => {
+  test("drag widens the panel, the width persists across reloads, double-click resets, keyboard nudges", async ({
+    page,
+    request,
+    backend,
+  }) => {
+    const prompt = `resize-e2e ${randomUUID()}`;
+    await createAndStartFakeClaudeTask(request, backend, prompt);
+
+    await gotoApp(page, backend.bootBase);
+    const panel = await openTask(page, prompt);
+
+    // --- (1) default width (nothing persisted yet) -------------------------
+    expect(await panelWidth(page)).toBe(DEFAULT_WIDTH);
+
+    // --- (2) drag the handle 120px left → panel grows to 840 ---------------
+    const handle = panel.getByTestId("run-panel-resize");
+    const handleBox = await handle.boundingBox();
+    expect(handleBox).not.toBeNull();
+    const startX = handleBox!.x + handleBox!.width / 2;
+    const startY = handleBox!.y + 300;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX - 120, startY, { steps: 5 });
+    await page.mouse.up();
+    await expect.poll(() => panelWidth(page)).toBe(DEFAULT_WIDTH + 120);
+
+    // Committed to storage on drag end (this is what survives a restart).
+    expect(await page.evaluate((k) => localStorage.getItem(k), WIDTH_KEY)).toBe(
+      String(DEFAULT_WIDTH + 120),
+    );
+
+    // --- (3) the persisted width is applied on the very first paint after
+    // a reload (synchronous initializer — no default-width flash to assert
+    // around, the panel simply mounts at the stored width). `page.reload()`,
+    // not a second `gotoApp`: navigating to the same hash-carrying URL is a
+    // same-document navigation that would leave the app (and the open panel)
+    // untouched. -------------------------------------------------------------
+    await page.reload();
+    await openTask(page, prompt);
+    expect(await panelWidth(page)).toBe(DEFAULT_WIDTH + 120);
+
+    // --- (4) double-click resets to the default -----------------------------
+    await handle.dblclick();
+    await expect.poll(() => panelWidth(page)).toBe(DEFAULT_WIDTH);
+    expect(await page.evaluate((k) => localStorage.getItem(k), WIDTH_KEY)).toBe(String(DEFAULT_WIDTH));
+
+    // --- (5) keyboard: the focused handle widens on ArrowLeft (the handle
+    // sits on the panel's LEFT edge, so left = wider). -----------------------
+    await handle.focus();
+    await page.keyboard.press("ArrowLeft");
+    await expect.poll(() => panelWidth(page)).toBe(DEFAULT_WIDTH + 32);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => panelWidth(page)).toBe(DEFAULT_WIDTH);
+  });
+
+  test("user-message bubbles scroll with the transcript (no sticky overlay)", async ({
+    page,
+    request,
+    backend,
+  }) => {
+    const prompt = `no-sticky-e2e ${randomUUID()}`;
+    await createAndStartFakeClaudeTask(request, backend, prompt);
+
+    await gotoApp(page, backend.bootBase);
+    const panel = await openTask(page, prompt);
+
+    // The prompt renders as a user bubble in the transcript…
+    await expect(panel.getByText(prompt, { exact: true }).last()).toBeVisible();
+    // …and no event wrapper in the panel carries the old sticky pinning that
+    // made user messages overlay the assistant text while scrolling.
+    await expect(panel.locator("[data-evid].sticky")).toHaveCount(0);
+  });
+});

--- a/e2e/unread-indicator.spec.ts
+++ b/e2e/unread-indicator.spec.ts
@@ -153,7 +153,15 @@ test.describe("unread messages indicator", () => {
     // close — assert on the closed-state class instead, which flips
     // synchronously with the click (App.tsx's `setSelected(null)`, the
     // same state change that flips `TaskCard`'s `isOpen` prop).
-    await page.getByRole("button", { name: "Close task panel" }).click();
+    //
+    // The header X ("Close task details"), NOT the backdrop scrim: the scrim
+    // spans the whole viewport but the resizable panel `<aside>` overlays an
+    // arbitrary share of it, so any scrim click coordinate is silently
+    // coupled to the panel width and the test viewport. The header X lives
+    // INSIDE the panel, so the panel can never occlude it, and its
+    // `onClick={onClose}` is wired unconditionally on an always-rendered
+    // element — the same race-free property the scrim click had.
+    await panel.getByRole("button", { name: "Close task details" }).click();
     await expect(runPanel(page)).toHaveClass(/translate-x-full/);
     await expect(dot).toBeHidden();
     // Re-marked seen on close (covers anything that streamed while open) —

--- a/src/mainview/App.tsx
+++ b/src/mainview/App.tsx
@@ -61,6 +61,7 @@ import { cn } from "@/lib/utils";
 import { ONBOARDING_DISMISSED_PREF, deriveOnboardingSteps, resolveOnboardingVisibility } from "@/lib/onboarding";
 import type { SettingsSectionId } from "@/lib/settings-dialog-view";
 import { reconcileById } from "@/lib/reconcile";
+import { parseStickyUserMessagesPreference, STICKY_USER_MESSAGES_PREF } from "@/lib/user-message-display";
 import iconUrl from "../assets/agetor.iconset/icon_32x32@2x.png";
 
 /**
@@ -180,6 +181,10 @@ function AppInner() {
   const [harnessFilter, setHarnessFilter] = useState<string[]>([]);
   const [typeFilter, setTypeFilter] = useState<TaskType[]>([]);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  // Missing preference intentionally resolves to sticky so existing users
+  // retain the last-sent-message reminder until they opt into the standard
+  // scrolling chat list in Settings.
+  const [stickyUserMessages, setStickyUserMessages] = useState(true);
   // Section the Settings dialog should land on when it next opens — set by
   // onboarding's "Enable in Settings…" deep link, cleared on close so the
   // plain gear-icon open still lands on General.
@@ -279,6 +284,7 @@ function AppInner() {
       // read at boot is enough. `refetchOnboardingPref` (used after Settings
       // closes) re-reads just this key via the same route.
       setOnboardingDismissedPref(prefs[ONBOARDING_DISMISSED_PREF]);
+      setStickyUserMessages(parseStickyUserMessagesPreference(prefs[STICKY_USER_MESSAGES_PREF]));
       setPrefsLoaded(true);
     }).catch(() => { /* keep the boot-seeded preferences; onboarding stays hidden (prefsLoaded=false) rather than guess */ });
     // Run once at boot only — intentionally not re-run when either local
@@ -1550,6 +1556,7 @@ const runTaskMenuAction = useCallback((action: TaskMenuAction, snapshot: Task) =
       </div>
       <RunPanel
         task={selected}
+        stickyUserMessages={stickyUserMessages}
         agents={agents}
         harnesses={harnesses}
         agentModels={agentModels}
@@ -1607,6 +1614,15 @@ const runTaskMenuAction = useCallback((action: TaskMenuAction, snapshot: Task) =
       />
       <SettingsDialog
         open={settingsOpen}
+        stickyUserMessages={stickyUserMessages}
+        onStickyUserMessagesChange={(sticky) => {
+          setStickyUserMessages(sticky);
+          void api.setPreference(STICKY_USER_MESSAGES_PREF, String(sticky)).catch(() => {
+            // Revert only if this failed write is still the latest selection;
+            // a subsequent click must not be overwritten by an older request.
+            setStickyUserMessages((current) => current === sticky ? !sticky : current);
+          });
+        }}
         onClose={() => {
           setSettingsOpen(false);
           // Clear the deep-link so a later plain gear-icon open lands back

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -17,6 +17,7 @@ import { buildResolveConflictsPrompt } from "@/lib/resolve-conflicts-prompt";
 import { eventWindowKeepCount } from "@/lib/event-window";
 import { appendQuote } from "@/lib/quote-selection";
 import { reconcileById } from "@/lib/reconcile";
+import { RUN_PANEL_DEFAULT_WIDTH, RUN_PANEL_MIN_WIDTH, clampPanelWidth, readPanelWidth, writePanelWidth } from "@/lib/panel-width";
 import { QuoteSelectionButton } from "./QuoteSelectionButton";
 import type { GitHubPullPrefill } from "./GitHubDialog";
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -272,6 +273,76 @@ export function RunPanel({ task, agents, harnesses, agentModels, harnessModels, 
   const [mountedTask, setMountedTask] = useState<Task | null>(task);
   const [open, setOpen] = useState<boolean>(!!task);
 
+  // User-resizable width, persisted in localStorage (`panel-width.ts`).
+  // Resolved synchronously in the initializer — an effect-time read would
+  // paint the default width first and snap. Live drag frames update only
+  // this local state; the committed value (drag end / keyboard / reset) is
+  // also written to storage.
+  const [width, setWidth] = useState<number>(() => readPanelWidth(window.innerWidth));
+  const [resizing, setResizing] = useState(false);
+  const dragRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null);
+  // The user's chosen width, independent of the current viewport clamp —
+  // shrinking the window squeezes `width` down (resize listener below) but
+  // re-growing it restores this preference rather than the squeezed value.
+  const preferredWidthRef = useRef(width);
+
+  const commitWidth = useCallback((w: number) => {
+    preferredWidthRef.current = w;
+    setWidth(w);
+    writePanelWidth(w);
+  }, []);
+
+  // Single owner for every non-React consumer of the width: publish it as a
+  // CSS custom property on the document root. The Toaster's offset reads
+  // `var(--run-panel-width)` instead of threading the value through App —
+  // no mirror state, and any future consumer is a zero-prop CSS read.
+  useEffect(() => {
+    document.documentElement.style.setProperty("--run-panel-width", `${width}px`);
+    return () => {
+      document.documentElement.style.removeProperty("--run-panel-width");
+    };
+  }, [width]);
+
+  // Re-clamp when the window resizes, so state can never disagree with the
+  // rendered width (the CSS `max-w-[90vw]` on the `<aside>` would otherwise
+  // win silently and leave stale numbers in the CSS variable above —
+  // off-screen toasts on a persisted-wide panel in a shrunken window).
+  useEffect(() => {
+    const onResize = () => setWidth(clampPanelWidth(preferredWidthRef.current, window.innerWidth));
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  const onResizePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    dragRef.current = { pointerId: e.pointerId, startX: e.clientX, startWidth: width };
+    e.currentTarget.setPointerCapture(e.pointerId);
+    setResizing(true);
+  };
+  const onResizePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || e.pointerId !== drag.pointerId) return;
+    // Panel is anchored to the right edge, so dragging LEFT grows it.
+    setWidth(clampPanelWidth(drag.startWidth + (drag.startX - e.clientX), window.innerWidth));
+  };
+  const onResizePointerEnd = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || e.pointerId !== drag.pointerId) return;
+    dragRef.current = null;
+    setResizing(false);
+    // Recompute from the event rather than reading `width` — the last
+    // pointermove's setState may not have flushed into this closure yet.
+    commitWidth(clampPanelWidth(drag.startWidth + (drag.startX - e.clientX), window.innerWidth));
+  };
+  const onResizeKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    // Handle sits on the panel's LEFT edge: ArrowLeft moves it left = wider.
+    const delta = e.key === "ArrowLeft" ? 32 : e.key === "ArrowRight" ? -32 : 0;
+    if (delta === 0) return;
+    e.preventDefault();
+    commitWidth(clampPanelWidth(width + delta, window.innerWidth));
+  };
+
   useEffect(() => {
     if (task) {
       setMountedTask(task);
@@ -347,11 +418,37 @@ export function RunPanel({ task, agents, harnesses, agentModels, harnessModels, 
         )}
       />
       <aside
+        style={{ width }}
         className={cn(
-          "fixed right-0 top-0 z-40 flex h-full w-[520px] max-w-[90vw] flex-col border-l border-border/60 bg-card shadow-2xl transition-transform duration-300 ease-out",
+          "fixed right-0 top-0 z-40 flex h-full max-w-[90vw] flex-col border-l border-border/60 bg-card shadow-2xl transition-transform duration-300 ease-out",
           open ? "translate-x-0" : "translate-x-full",
         )}
       >
+        {/* Resize handle on the panel's left edge. `touch-none` so pointer
+            capture isn't hijacked by scroll gestures; `select-none` plus the
+            pointerdown preventDefault keep a drag from starting a text
+            selection in the transcript underneath. */}
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize task panel"
+          aria-valuenow={width}
+          aria-valuemin={RUN_PANEL_MIN_WIDTH}
+          tabIndex={0}
+          data-testid="run-panel-resize"
+          onPointerDown={onResizePointerDown}
+          onPointerMove={onResizePointerMove}
+          onPointerUp={onResizePointerEnd}
+          onPointerCancel={onResizePointerEnd}
+          onDoubleClick={() => commitWidth(clampPanelWidth(RUN_PANEL_DEFAULT_WIDTH, window.innerWidth))}
+          onKeyDown={onResizeKeyDown}
+          title="Drag to resize · double-click to reset"
+          className={cn(
+            "absolute inset-y-0 left-0 z-10 w-1.5 cursor-col-resize touch-none select-none outline-none transition-colors",
+            "hover:bg-primary/40 focus-visible:bg-primary/40",
+            resizing && "bg-primary/50",
+          )}
+        />
         <RunPanelBody
           task={mountedTask}
           agents={agents}
@@ -623,7 +720,7 @@ function RunPanelBody({
     return () => { cancelled = true; };
   }, [task.id]);
 
-  // Stable identity so RunEventList's memoized section tree isn't invalidated
+  // Stable identity so RunEventList's memoized block tree isn't invalidated
   // on every parent re-render (e.g. the 2s runs poll). `setInteractions` is a
   // stable setter, so the empty dep list is correct.
   const dismissInteraction = useCallback(
@@ -1451,10 +1548,10 @@ function RunPanelBody({
   }, [matches, task.id, activeStream, rebuilt, rebuiltScopeKey]);
 
   // Highlight + scroll the active match imperatively rather than through a
-  // React prop/memo dep: `RunEventList`'s `sections` memo used to take
+  // React prop/memo dep: `RunEventList`'s `blocks` memo used to take
   // `activeMatchId` as a dep purely so it could stamp a highlight class on
   // one wrapper div, which meant re-deriving (and re-diffing) the ENTIRE
-  // section tree on every match navigation. Toggling classList directly on
+  // block tree on every match navigation. Toggling classList directly on
   // the previous/next `[data-evid]` element is O(1) instead. Runs after the
   // resolve effect above (and after any tab/task/rebuild-scope switch), so by
   // the time this fires `activeMatchId` already points at an event rendered
@@ -4030,7 +4127,7 @@ function RunEventList({
   // Index plans by their raw (possibly-`\n`-containing) toolCallId so the
   // `tool_use` case below can do an O(1) lookup instead of a per-render scan
   // over `plans` — same perf rationale as `resultByToolId` above; this map
-  // is one of the `sections` memo's deps, not recomputed inside its loop.
+  // is one of the `blocks` memo's deps, not recomputed inside its loop.
   //
   // Keyed on a content signature (`plansKey`), not `plans` itself: the
   // `plans` state mirror in `RunPanelBody` gets a fresh array identity on
@@ -4039,7 +4136,7 @@ function RunEventList({
   // only renders `id`/`name`/`toolCallId`/`status` — `toolCallId` never
   // changes for a given plan record and `name` is fixed at creation, so
   // `id:status` is the only content that can invalidate what gets rendered.
-  // Without this, `sections` (a dep-of-`planByToolCallId` memo) recomputed
+  // Without this, `blocks` (a dep-of-`planByToolCallId` memo) recomputed
   // — and re-parsed every markdown block in a long conversation — on every
   // poll tick regardless of whether a plan changed.
   const plansKey = plans.map((p) => `${p.id}:${p.status}`).join("|");
@@ -4072,12 +4169,12 @@ function RunEventList({
     return slots;
   }, [normalised, sortedInteractions]);
 
-  // Group events into sections delimited by user messages. Each section
-  // wraps its user message (sticky) and the events that followed it, so
-  // the user-message bubble pins to the top of the scroll viewport only
-  // for the duration of its own section — when the next user message
-  // appears in view, the previous one releases naturally rather than
-  // stacking on top of it.
+  // Render every event and interaction card as one flat block list. (User
+  // messages used to open a `<section>` and pin `sticky top-0` for the
+  // section's duration; the pinning overlaid the transcript with a
+  // transparent wrapper and was removed — user messages now scroll normally
+  // with the conversation, and with it gone the grouping had no observable
+  // output left, so it went too.)
   //
   // Memoized over the parsed inputs: this rebuilds the rendered element tree
   // only when the events / interactions / tool-result map actually change.
@@ -4087,7 +4184,7 @@ function RunEventList({
   // poll is what made long conversations lag. `renderEvent`/`renderInteraction`
   // live inside so their captured deps (`resultByToolId`, `onInteractionResolved`,
   // `planByToolCallId`, `onOpenPlan`) are tracked explicitly.
-  const sections = useMemo(() => {
+  const blocks = useMemo(() => {
     // Wrap a rendered block in the `data-evid` carrier the search bar scrolls
     // to and imperatively highlights (`logRef.current?.querySelector('[data-
     // evid="…"]')` in RunPanelBody — see the highlight effect there). `evid`
@@ -4098,11 +4195,8 @@ function RunEventList({
     // identity/props untouched. Only STATIC classes belong here — the
     // highlight ring itself is toggled by the DOM effect in RunPanelBody, not
     // by a render-time class, so this memo doesn't need `activeMatchId` as a
-    // dep (re-deriving the whole section tree on every match navigation was
-    // the point being fixed). `extraClassName` lets a specific stream (only
-    // `user`, below) opt into a class that has to live on THIS wrapper rather
-    // than on the block's own root — sticky positioning needs to be applied
-    // to the element that's actually the flex child of the scroll container.
+    // dep (re-deriving the whole block tree on every match navigation was
+    // the point being fixed).
     // Returns `null` (no wrapper at all) when `node` is nullish, so an event
     // with nothing to render (e.g. an unparseable orphan tool_result — see
     // the `tool_result` case below) doesn't still leave a phantom empty div
@@ -4111,11 +4205,10 @@ function RunEventList({
       key: string,
       evid: number,
       node: React.ReactNode,
-      extraClassName?: string,
     ): React.ReactNode => {
       if (node === null || node === undefined) return null;
       return (
-        <div key={key} data-evid={evid} className={extraClassName}>
+        <div key={key} data-evid={evid}>
           {node}
         </div>
       );
@@ -4123,12 +4216,7 @@ function RunEventList({
     const renderEvent = (e: RunEvent, key: string, evid: number): React.ReactNode[] => {
       switch (e.stream) {
         case "user":
-          // Sticky positioning lives on this wrapper, not on
-          // `UserMessageBlock`'s own root — the wrapper is the actual flex
-          // child of the scroll container (`sections.map` below renders one
-          // `<section>` per user-message group), so THIS is the element that
-          // has to pin to `top-0` for the sticky header to work at all.
-          return [wrap(key, evid, <UserMessageBlock text={e.data} taskId={taskId} />, "sticky top-0 z-10")];
+          return [wrap(key, evid, <UserMessageBlock text={e.data} taskId={taskId} />)];
         case "assistant":
           return [wrap(key, evid, <AssistantBlock text={e.data} />)];
         case "thinking":
@@ -4219,37 +4307,30 @@ function RunEventList({
       }
     };
 
-    const out: { key: string; header: React.ReactNode; body: React.ReactNode[] }[] = [];
-    // Stable per-section key = the key of the section's first event (`ts-index`,
-    // unique and append-stable), so appending events keeps earlier sections'
-    // identity instead of reindexing them as the old `sec-${idx}` key did.
-    let current: { key: string; header: React.ReactNode; body: React.ReactNode[] } = { key: "", header: null, body: [] };
+    const out: React.ReactNode[] = [];
     for (let i = 0; i < normalised.length; i++) {
       const e = normalised[i]!;
       const key = `${e.ts}-${i}`;
       const before = (interactionByIndex.get(i) ?? []).map(renderInteraction);
       if (e.stream === "user") {
-        if (current.header !== null || current.body.length > 0) out.push(current);
-        current = { key, header: renderEvent(e, key, i)[0] ?? null, body: [...before] };
+        // Order quirk preserved from the old section grouping: an
+        // interaction slotted AT a user message's index renders after the
+        // message (it used to land in the new section's body, below the
+        // section's header).
+        out.push(...renderEvent(e, key, i), ...before);
       } else {
-        if (current.key === "") current.key = key;
-        current.body.push(...before, ...renderEvent(e, key, i));
+        out.push(...before, ...renderEvent(e, key, i));
       }
     }
-    const tail = (interactionByIndex.get(normalised.length) ?? []).map(renderInteraction);
-    current.body.push(...tail);
-    if (current.header !== null || current.body.length > 0) out.push(current);
+    // Interactions that fired after the last event ("since the run
+    // finished") spill out at the bottom.
+    out.push(...(interactionByIndex.get(normalised.length) ?? []).map(renderInteraction));
     return out;
   }, [normalised, interactionByIndex, resultByToolId, onInteractionResolved, taskId, planByToolCallId, onOpenPlan, latestPlanMarkdown, latestPlanPromptId]);
 
   return (
     <div className="flex flex-col gap-4">
-      {sections.map((s, idx) => (
-        <section key={s.key || `sec-${idx}`} className="flex flex-col gap-4">
-          {s.header}
-          {s.body}
-        </section>
-      ))}
+      {blocks}
       {indicatorMode !== "off" && runStatus === "running" && <RunningIndicator />}
       {holdSummary && <HoldingIndicator text={holdSummary} />}
     </div>
@@ -4609,7 +4690,7 @@ const StatusDivider = memo(function StatusDivider({ text }: { text: string }) {
  *  `onExpand` when `root` is (or contains) the element that dispatched it —
  *  the imperative counterpart to that effect, so a jump onto a match inside
  *  a collapsed tool-call card / result fold / thinking block reveals it
- *  without threading new props through the `sections` memo. */
+ *  without threading new props through the `blocks` memo. */
 function useExpandOnJump(rootRef: React.RefObject<HTMLDivElement | null>, onExpand: () => void) {
   useEffect(() => {
     const handler = (evt: Event) => {
@@ -5094,7 +5175,7 @@ function ToolResultBody({ result, openSignal = 0 }: { result: ParsedToolResult; 
   // doesn't exist yet to catch the bubbling `EXPAND_EVENT`, so `ToolUseBlock`
   // also bumps this counter (in its own jump-expand callback) and hands it
   // down as a prop — safe for the memo'd tree since it originates from
-  // `ToolUseBlock`'s own local state, not from the `sections` memo. A mount
+  // `ToolUseBlock`'s own local state, not from the `blocks` memo. A mount
   // with `openSignal > 0` opens the fold immediately; incrementing (rather
   // than a boolean) means a repeat jump to the same block re-opens it even
   // if the user had since collapsed it manually.
@@ -5930,7 +6011,7 @@ function TmuxPromptCard({
   // pane dump) — same polish as the AskUserQuestion card. Detect it by its
   // signature and render labelled buttons plus the plan markdown itself
   // (`planMarkdown`, below) — the plan's `tool_use` event renders as a
-  // `PlanCard` summary button now (see `RunEventList`'s `sections` memo),
+  // `PlanCard` summary button now (see `RunEventList`'s `blocks` memo),
   // not an inline expanded body, so this card is the only place the full
   // text is shown at decision time.
   const isPlan = CLAUDE_PLAN_PROMPT_RE.test(req.paneText);

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -137,6 +137,8 @@ type StreamEvent = RunEvent & { id: number; dbId?: number };
 interface Props {
   /** When null, the panel slides off-screen and unmounts after the exit animation. */
   task: Task | null;
+  /** Pin the current user message while its response scrolls (default mode). */
+  stickyUserMessages: boolean;
   agents: AgentStatus[];
   /** Registered harnesses — needed so the panel's agent dropdown can list
    *  every known harness (built-ins + aliases). */
@@ -267,7 +269,7 @@ function formatUsageCount(n: number): string {
  * the kanban behind it stays visible but de-emphasized. The panel keeps the
  * last task mounted during the exit animation so the slide-out doesn't snap.
  */
-export function RunPanel({ task, agents, harnesses, agentModels, harnessModels, onRefreshModels, homeDir, onClose, onShowDiff, onArchive, onUnarchive, onOpenPullRequest, onViewPullRequest, onViewIssue }: Props) {
+export function RunPanel({ task, stickyUserMessages, agents, harnesses, agentModels, harnessModels, onRefreshModels, homeDir, onClose, onShowDiff, onArchive, onUnarchive, onOpenPullRequest, onViewPullRequest, onViewIssue }: Props) {
   // `mountedTask` lags behind `task` so that when the parent sets task → null
   // we keep rendering the old contents while the exit animation plays.
   const [mountedTask, setMountedTask] = useState<Task | null>(task);
@@ -451,6 +453,7 @@ export function RunPanel({ task, agents, harnesses, agentModels, harnessModels, 
         />
         <RunPanelBody
           task={mountedTask}
+          stickyUserMessages={stickyUserMessages}
           agents={agents}
           harnesses={harnesses}
           agentModels={agentModels}
@@ -477,6 +480,7 @@ export function RunPanel({ task, agents, harnesses, agentModels, harnessModels, 
  */
 function RunPanelBody({
   task,
+  stickyUserMessages,
   agents,
   harnesses,
   agentModels,
@@ -493,6 +497,7 @@ function RunPanelBody({
   onViewIssue,
 }: {
   task: Task;
+  stickyUserMessages: boolean;
   agents: AgentStatus[];
   harnesses: Harness[];
   agentModels: AgentModelMap;
@@ -3012,6 +3017,7 @@ function RunPanelBody({
               </div>
               <RunEventList
                 events={displayedEvents}
+                stickyUserMessages={stickyUserMessages}
                 interactions={interactions}
                 onInteractionResolved={dismissInteraction}
                 runStatus={activeRunStatus}
@@ -4003,6 +4009,7 @@ type RunIndicatorMode = "off" | "active";
 
 function RunEventList({
   events,
+  stickyUserMessages,
   interactions = [],
   onInteractionResolved,
   runStatus,
@@ -4015,6 +4022,8 @@ function RunEventList({
   onAskAnswerWithheld,
 }: {
   events: RunEvent[];
+  /** True groups turns and pins each user message for its own response. */
+  stickyUserMessages: boolean;
   interactions?: PendingInteraction[];
   onInteractionResolved?: (id: string) => void;
   runStatus?: Run["status"] | null;
@@ -4169,12 +4178,10 @@ function RunEventList({
     return slots;
   }, [normalised, sortedInteractions]);
 
-  // Render every event and interaction card as one flat block list. (User
-  // messages used to open a `<section>` and pin `sticky top-0` for the
-  // section's duration; the pinning overlaid the transcript with a
-  // transparent wrapper and was removed — user messages now scroll normally
-  // with the conversation, and with it gone the grouping had no observable
-  // output left, so it went too.)
+  // Render either turn-grouped sections with a sticky user-message header or
+  // one flat, normally scrolling block list. Settings defaults to the former
+  // because keeping the last sent message visible is useful while
+  // multitasking; users who prefer a standard chat list select the latter.
   //
   // Memoized over the parsed inputs: this rebuilds the rendered element tree
   // only when the events / interactions / tool-result map actually change.
@@ -4196,7 +4203,8 @@ function RunEventList({
     // highlight ring itself is toggled by the DOM effect in RunPanelBody, not
     // by a render-time class, so this memo doesn't need `activeMatchId` as a
     // dep (re-deriving the whole block tree on every match navigation was
-    // the point being fixed).
+    // the point being fixed). `extraClassName` is used only by sticky mode:
+    // the wrapper, as the direct flex child, is the element that must pin.
     // Returns `null` (no wrapper at all) when `node` is nullish, so an event
     // with nothing to render (e.g. an unparseable orphan tool_result — see
     // the `tool_result` case below) doesn't still leave a phantom empty div
@@ -4205,10 +4213,11 @@ function RunEventList({
       key: string,
       evid: number,
       node: React.ReactNode,
+      extraClassName?: string,
     ): React.ReactNode => {
       if (node === null || node === undefined) return null;
       return (
-        <div key={key} data-evid={evid}>
+        <div key={key} data-evid={evid} className={extraClassName}>
           {node}
         </div>
       );
@@ -4216,7 +4225,14 @@ function RunEventList({
     const renderEvent = (e: RunEvent, key: string, evid: number): React.ReactNode[] => {
       switch (e.stream) {
         case "user":
-          return [wrap(key, evid, <UserMessageBlock text={e.data} taskId={taskId} />)];
+          return [
+            wrap(
+              key,
+              evid,
+              <UserMessageBlock text={e.data} taskId={taskId} />,
+              stickyUserMessages ? "sticky top-0 z-10" : undefined,
+            ),
+          ];
         case "assistant":
           return [wrap(key, evid, <AssistantBlock text={e.data} />)];
         case "thinking":
@@ -4307,6 +4323,38 @@ function RunEventList({
       }
     };
 
+    if (stickyUserMessages) {
+      const sections: { key: string; header: React.ReactNode; body: React.ReactNode[] }[] = [];
+      // Preamble events before the first user message share an initial
+      // headerless section. Each subsequent user message starts a new turn;
+      // its sticky lifetime naturally ends at that section's boundary.
+      let current: { key: string; header: React.ReactNode; body: React.ReactNode[] } = {
+        key: "",
+        header: null,
+        body: [],
+      };
+      for (let i = 0; i < normalised.length; i++) {
+        const e = normalised[i]!;
+        const key = `${e.ts}-${i}`;
+        const before = (interactionByIndex.get(i) ?? []).map(renderInteraction);
+        if (e.stream === "user") {
+          if (current.header !== null || current.body.length > 0) sections.push(current);
+          current = { key, header: renderEvent(e, key, i)[0] ?? null, body: [...before] };
+        } else {
+          if (current.key === "") current.key = key;
+          current.body.push(...before, ...renderEvent(e, key, i));
+        }
+      }
+      current.body.push(...(interactionByIndex.get(normalised.length) ?? []).map(renderInteraction));
+      if (current.header !== null || current.body.length > 0) sections.push(current);
+      return sections.map((section, index) => (
+        <section key={section.key || `section-${index}`} className="flex flex-col gap-4">
+          {section.header}
+          {section.body}
+        </section>
+      ));
+    }
+
     const out: React.ReactNode[] = [];
     for (let i = 0; i < normalised.length; i++) {
       const e = normalised[i]!;
@@ -4326,7 +4374,7 @@ function RunEventList({
     // finished") spill out at the bottom.
     out.push(...(interactionByIndex.get(normalised.length) ?? []).map(renderInteraction));
     return out;
-  }, [normalised, interactionByIndex, resultByToolId, onInteractionResolved, taskId, planByToolCallId, onOpenPlan, latestPlanMarkdown, latestPlanPromptId]);
+  }, [normalised, interactionByIndex, resultByToolId, onInteractionResolved, taskId, planByToolCallId, onOpenPlan, latestPlanMarkdown, latestPlanPromptId, stickyUserMessages]);
 
   return (
     <div className="flex flex-col gap-4">

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -61,6 +61,9 @@ const THEME_PREFERENCE_ICON: Record<ThemePreference, typeof Monitor> = {
 interface Props {
   open: boolean;
   onClose: () => void;
+  /** Whether sent user messages pin to the top of the transcript. */
+  stickyUserMessages: boolean;
+  onStickyUserMessagesChange: (sticky: boolean) => void;
   /** Refresh agents/harnesses on the parent after CRUD operations. */
   onChange?: () => void;
   /** Resolved home dir from `GET /defaults` — used to expand `~` in templates. */
@@ -201,7 +204,7 @@ async function describeHarnessInUse(err: unknown): Promise<string | null> {
   return `In use by ${titles.length} ${noun}: ${titles.join(", ")}`;
 }
 
-export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir, initialSection }: Props) {
+export function SettingsDialog({ open, onClose, stickyUserMessages, onStickyUserMessagesChange, onChange, homeDir, dataDir, initialSection }: Props) {
   const [version, setVersion] = useState<string>("");
   const [payload, setPayload] = useState<HarnessesPayload>({ harnesses: [], statuses: [] });
   const [defaultHarness, setDefaultHarness] = useState<string>("claude-code");
@@ -461,6 +464,8 @@ export function SettingsDialog({ open, onClose, onChange, homeDir, dataDir, init
                       defaultHarness={defaultHarness}
                       payload={payload}
                       onPickDefault={onPickDefault}
+                      stickyUserMessages={stickyUserMessages}
+                      onStickyUserMessagesChange={onStickyUserMessagesChange}
                       tmuxSource={tmuxSource}
                       bundledTmuxAvailable={bundledTmuxAvailable}
                       onPickTmuxSource={onPickTmuxSource}
@@ -599,6 +604,8 @@ function GeneralSection({
   payload,
   defaultHarness,
   onPickDefault,
+  stickyUserMessages,
+  onStickyUserMessagesChange,
   tmuxSource,
   bundledTmuxAvailable,
   onPickTmuxSource,
@@ -607,6 +614,8 @@ function GeneralSection({
   payload: HarnessesPayload;
   defaultHarness: string;
   onPickDefault: (id: string) => void;
+  stickyUserMessages: boolean;
+  onStickyUserMessagesChange: (sticky: boolean) => void;
   tmuxSource: "system" | "bundled";
   bundledTmuxAvailable: boolean;
   onPickTmuxSource: (source: "system" | "bundled") => void;
@@ -727,6 +736,23 @@ function GeneralSection({
           </Button>
         </div>
         <p className="text-[11px] text-muted-foreground">{FONT_SIZE_HINT}</p>
+      </section>
+
+      <section className="space-y-1">
+        <div className="flex items-center justify-between gap-4">
+          <label htmlFor="sticky-user-messages" className="text-xs text-muted-foreground">
+            Sticky user messages
+          </label>
+          <Switch
+            id="sticky-user-messages"
+            checked={stickyUserMessages}
+            onCheckedChange={onStickyUserMessagesChange}
+            aria-label="Sticky user messages"
+          />
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          Keep your latest sent message visible while its response scrolls. Turn this off for a standard chat list.
+        </p>
       </section>
 
       <section className="space-y-1">

--- a/src/mainview/components/ui/sonner.tsx
+++ b/src/mainview/components/ui/sonner.tsx
@@ -1,10 +1,15 @@
 import { Toaster as Sonner, type ToasterProps } from "sonner";
+import { RUN_PANEL_DEFAULT_WIDTH } from "@/lib/panel-width";
 import { useTheme } from "../theme-provider.tsx";
 
-// 520px RunPanel + 16px gap. When the panel is open, push toasts left of it
-// so they don't sit on top of the panel header (where the X button lives) —
-// sonner's hardcoded z-index of ~1e9 otherwise eats clicks meant for X.
-const PANEL_OFFSET_RIGHT = 536;
+// Gap between the RunPanel's left edge and the toasts. When the panel is
+// open, push toasts left of it so they don't sit on top of the panel header
+// (where the X button lives) — sonner's hardcoded z-index of ~1e9 otherwise
+// eats clicks meant for X. The panel is user-resizable, so the offset reads
+// the `--run-panel-width` CSS variable RunPanel publishes on the document
+// root (its single owner) rather than threading the width through App; the
+// fallback only matters in the sliver before RunPanel's effect first runs.
+const PANEL_OFFSET_RIGHT = `calc(var(--run-panel-width, ${RUN_PANEL_DEFAULT_WIDTH}px) + 16px)`;
 
 interface Props extends ToasterProps {
   /** True while the right-side RunPanel is mounted. Shifts toasts left so

--- a/src/mainview/lib/panel-width.test.ts
+++ b/src/mainview/lib/panel-width.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "bun:test";
+import type { PanelStorage } from "./panel-collapse.ts";
+import {
+  RUN_PANEL_DEFAULT_WIDTH,
+  RUN_PANEL_MAX_VIEWPORT_FRACTION,
+  RUN_PANEL_MIN_WIDTH,
+  RUN_PANEL_WIDTH_KEY,
+  clampPanelWidth,
+  readPanelWidth,
+  writePanelWidth,
+} from "./panel-width.ts";
+
+/** In-memory stand-in for `window.localStorage`. */
+function fakeStorage(seed: Record<string, string> = {}): PanelStorage & {
+  map: Map<string, string>;
+} {
+  const map = new Map(Object.entries(seed));
+  return {
+    map,
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => { map.set(k, v); },
+  };
+}
+
+/** Storage that throws on every access — privacy mode / quota exceeded. */
+const throwingStorage: PanelStorage = {
+  getItem() { throw new Error("SecurityError"); },
+  setItem() { throw new Error("QuotaExceededError"); },
+};
+
+const KEY = RUN_PANEL_WIDTH_KEY;
+const VIEWPORT = 1440;
+
+// --- clampPanelWidth ------------------------------------------------------
+
+test("clampPanelWidth passes through an in-range width", () => {
+  expect(clampPanelWidth(700, VIEWPORT)).toBe(700);
+});
+
+test("clampPanelWidth enforces the minimum", () => {
+  expect(clampPanelWidth(100, VIEWPORT)).toBe(RUN_PANEL_MIN_WIDTH);
+  expect(clampPanelWidth(RUN_PANEL_MIN_WIDTH - 1, VIEWPORT)).toBe(RUN_PANEL_MIN_WIDTH);
+});
+
+test("clampPanelWidth caps at 90% of the viewport", () => {
+  const cap = Math.floor(VIEWPORT * RUN_PANEL_MAX_VIEWPORT_FRACTION);
+  expect(clampPanelWidth(5000, VIEWPORT)).toBe(cap);
+});
+
+test("clampPanelWidth lets the minimum win over the viewport cap when the window is tiny", () => {
+  // 90% of 300px is below the minimum — state stays at the minimum (the CSS
+  // max-w-[90vw] backstop caps the rendered width in that degenerate case).
+  expect(clampPanelWidth(700, 300)).toBe(RUN_PANEL_MIN_WIDTH);
+});
+
+test("clampPanelWidth rounds fractional widths and rejects non-finite input", () => {
+  expect(clampPanelWidth(700.6, VIEWPORT)).toBe(701);
+  expect(clampPanelWidth(NaN, VIEWPORT)).toBe(RUN_PANEL_DEFAULT_WIDTH);
+  expect(clampPanelWidth(Infinity, VIEWPORT)).toBe(RUN_PANEL_DEFAULT_WIDTH);
+});
+
+// --- readPanelWidth -------------------------------------------------------
+
+test("readPanelWidth defaults when the key was never written", () => {
+  expect(readPanelWidth(VIEWPORT, fakeStorage())).toBe(RUN_PANEL_DEFAULT_WIDTH);
+});
+
+test("readPanelWidth reads back a persisted width", () => {
+  expect(readPanelWidth(VIEWPORT, fakeStorage({ [KEY]: "800" }))).toBe(800);
+});
+
+test("readPanelWidth clamps a persisted width for the current viewport", () => {
+  const cap = Math.floor(VIEWPORT * RUN_PANEL_MAX_VIEWPORT_FRACTION);
+  expect(readPanelWidth(VIEWPORT, fakeStorage({ [KEY]: "5000" }))).toBe(cap);
+  expect(readPanelWidth(VIEWPORT, fakeStorage({ [KEY]: "50" }))).toBe(RUN_PANEL_MIN_WIDTH);
+});
+
+test("readPanelWidth treats junk values as the default rather than throwing", () => {
+  for (const junk of ["", "wide", "{}", "true"]) {
+    expect(readPanelWidth(VIEWPORT, fakeStorage({ [KEY]: junk }))).toBe(RUN_PANEL_DEFAULT_WIDTH);
+  }
+});
+
+test("readPanelWidth falls back to the default when storage is unavailable or throws", () => {
+  expect(readPanelWidth(VIEWPORT, null)).toBe(RUN_PANEL_DEFAULT_WIDTH);
+  expect(readPanelWidth(VIEWPORT, throwingStorage)).toBe(RUN_PANEL_DEFAULT_WIDTH);
+});
+
+// --- writePanelWidth ------------------------------------------------------
+
+test("writePanelWidth persists the rounded width under its key", () => {
+  const s = fakeStorage();
+  writePanelWidth(812.4, s);
+  expect(s.map.get(KEY)).toBe("812");
+});
+
+test("writePanelWidth is a no-op when storage is unavailable and swallows a throwing storage", () => {
+  expect(() => writePanelWidth(700, null)).not.toThrow();
+  expect(() => writePanelWidth(700, throwingStorage)).not.toThrow();
+});
+
+// --- round trip -----------------------------------------------------------
+
+test("a resized panel round-trips through storage (restart survival)", () => {
+  const s = fakeStorage();
+  writePanelWidth(860, s);
+  expect(readPanelWidth(VIEWPORT, s)).toBe(860);
+});
+
+test("the storage key is namespaced so it can't collide with other apps", () => {
+  expect(KEY).toBe("agetor:runPanelWidth");
+});

--- a/src/mainview/lib/panel-width.ts
+++ b/src/mainview/lib/panel-width.ts
@@ -1,0 +1,91 @@
+/**
+ * Persisted width for the RunPanel slide-over (user-resizable via the drag
+ * handle on the panel's left edge).
+ *
+ * localStorage rather than the server-side preferences API on purpose — same
+ * rationale as `panel-collapse.ts`: pure webview chrome that must resolve
+ * *synchronously during the first render*, otherwise the panel paints at the
+ * default width and snaps a frame later.
+ *
+ * Every access is wrapped: `globalThis.localStorage` throws (not returns
+ * null) under some privacy/sandbox settings, and `setItem` throws on quota.
+ * A storage failure must never take the panel down with it, so the reader
+ * falls back to the default and the writer is best-effort.
+ */
+
+import type { PanelStorage } from "./panel-collapse.ts";
+
+/** Storage key for the RunPanel's persisted width (px, integer). */
+export const RUN_PANEL_WIDTH_KEY = "agetor:runPanelWidth";
+
+/** Default width when nothing (valid) is persisted. */
+export const RUN_PANEL_DEFAULT_WIDTH = 720;
+
+/** Narrowest the user can drag the panel — below this the header buttons
+ *  and the composer toolbar start wrapping into unusable layouts. */
+export const RUN_PANEL_MIN_WIDTH = 420;
+
+/** Widest the panel may grow, as a fraction of the viewport — the board
+ *  behind it must stay visible enough to keep context. Mirrors the CSS
+ *  `max-w-[90vw]` backstop on the `<aside>` itself. */
+export const RUN_PANEL_MAX_VIEWPORT_FRACTION = 0.9;
+
+function defaultStorage(): PanelStorage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Clamp a candidate width into the allowed range for the given viewport.
+ * The lower bound wins over the upper one when the viewport is so narrow
+ * that 90vw < min width — the CSS `max-w-[90vw]` on the panel is what caps
+ * the *rendered* width in that degenerate case, so state never goes below
+ * the minimum and re-widening the window restores a usable panel.
+ */
+export function clampPanelWidth(width: number, viewportWidth: number): number {
+  if (!Number.isFinite(width)) return RUN_PANEL_DEFAULT_WIDTH;
+  const cap = Math.max(
+    RUN_PANEL_MIN_WIDTH,
+    Math.floor(viewportWidth * RUN_PANEL_MAX_VIEWPORT_FRACTION),
+  );
+  return Math.min(Math.max(Math.round(width), RUN_PANEL_MIN_WIDTH), cap);
+}
+
+/** Read the persisted panel width, clamped for the given viewport. Defaults
+ *  to `RUN_PANEL_DEFAULT_WIDTH` (clamped) whenever storage is unavailable,
+ *  empty, or holds a non-numeric value. */
+export function readPanelWidth(
+  viewportWidth: number,
+  storage: PanelStorage | null = defaultStorage(),
+): number {
+  let raw: string | null = null;
+  if (storage) {
+    try {
+      raw = storage.getItem(RUN_PANEL_WIDTH_KEY);
+    } catch {
+      raw = null;
+    }
+  }
+  const parsed = raw === null ? NaN : Number.parseInt(raw, 10);
+  return clampPanelWidth(
+    Number.isNaN(parsed) ? RUN_PANEL_DEFAULT_WIDTH : parsed,
+    viewportWidth,
+  );
+}
+
+/** Persist the panel width. Best-effort — a throwing/full storage is
+ *  swallowed, the panel just won't remember its width next launch. */
+export function writePanelWidth(
+  width: number,
+  storage: PanelStorage | null = defaultStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(RUN_PANEL_WIDTH_KEY, String(Math.round(width)));
+  } catch {
+    /* quota / disabled storage — width simply doesn't persist */
+  }
+}

--- a/src/mainview/lib/user-message-display.test.ts
+++ b/src/mainview/lib/user-message-display.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { parseStickyUserMessagesPreference } from "./user-message-display.ts";
+
+describe("parseStickyUserMessagesPreference", () => {
+  test("defaults to sticky when the preference is absent", () => {
+    expect(parseStickyUserMessagesPreference(undefined)).toBe(true);
+  });
+
+  test("recognizes the explicit standard-chat value", () => {
+    expect(parseStickyUserMessagesPreference("false")).toBe(false);
+  });
+
+  test("keeps sticky for the persisted true value and malformed values", () => {
+    expect(parseStickyUserMessagesPreference("true")).toBe(true);
+    expect(parseStickyUserMessagesPreference("nope")).toBe(true);
+    expect(parseStickyUserMessagesPreference(null)).toBe(true);
+  });
+});

--- a/src/mainview/lib/user-message-display.ts
+++ b/src/mainview/lib/user-message-display.ts
@@ -1,0 +1,11 @@
+/** Preference key used by the Settings toggle and the app-level mirror. */
+export const STICKY_USER_MESSAGES_PREF = "stickyUserMessages";
+
+/**
+ * Existing installs have no stored value, so sticky must be the fallback.
+ * Only an explicit `"false"` selects the standard scrolling chat list;
+ * malformed values retain the safe, requested default.
+ */
+export function parseStickyUserMessagesPreference(value: unknown): boolean {
+  return value !== "false";
+}


### PR DESCRIPTION
The task panel was a fixed 520px — too narrow to read a conversation in. It now defaults to 720px and can be resized by dragging its left edge (double-click resets, width persists across restarts). Toasts follow the panel edge instead of a hardcoded offset.

User message bubbles were pinned over the transcript while it scrolled, covering the assistant's text. The pinning is gone — messages scroll normally — and the transcript renderer's section grouping, which only existed for the pinning, is flattened.

Covered by unit tests for the width logic and a new e2e spec (drag, persistence, reset, keyboard). Two existing specs now close the panel via the header X instead of clicking backdrop coordinates.