### PR TITLE
fix: task-details lag while another task warms up — async tmux spawns + fast SSE replay

### DIFF
--- a/docs/plans/fix-task-details-load-delay.md
+++ b/docs/plans/fix-task-details-load-delay.md
@@ -8,7 +8,7 @@
 | Flags | none |
 | Gates | grilled + scope confirmed by owner (4-question pass); plan approval pending |
 | Branch | fix/fix-task-details-load-delay |
-| Base SHA | TBD — set in Phase 4 |
+| Base SHA | bceeb1880abd8ef946364137e84f763a9ad5415a |
 
 ## 1. Objective & success criteria
 

--- a/docs/plans/fix-task-details-load-delay.md
+++ b/docs/plans/fix-task-details-load-delay.md
@@ -6,7 +6,7 @@
 | Source | /implement — "fix the lag on loading task details when agetor is warming up another task the user just sent a message" |
 | Config | AGENTS_CONFIG.yml (balanced) |
 | Flags | none |
-| Gates | grilled + scope confirmed by owner (4-question pass); plan approval pending |
+| Gates | grilled + scope confirmed by owner (4-question pass); plan approved by owner |
 | Branch | fix/fix-task-details-load-delay |
 | Base SHA | bceeb1880abd8ef946364137e84f763a9ad5415a |
 
@@ -109,6 +109,7 @@ Run recipe: `bun test` (whole suite), `bun run typecheck`. Dev smoke (optional, 
 - `login-path.ts` (boot-only) and `git-provider.ts` ssh probe (git-host dialog path) keep their `spawnSync` — off the warm-up path; different ticket if ever.
 - `getCurrentPermissionMode` assumed memory-only (stays sync); T1 verifies and may move it into the async set if it actually reads the pane.
 - The e2e "Task details editor" convergence flake (`e2e/fx-models.spec.ts`) is a known env-dependent failure on main — not a signal for this branch.
+- Phase-8 code review fix: `startTask`, claude's idle-mint paths, and the four one-shot `spawn{Codex,Cursor,Gemini,Fx}TurnNow` functions now share ONE module-level `startingTaskIds` claim (orchestrator.ts) to close the multi-fork double-mint window the async spawn conversion opened between minting a run row and registering it active. Direct consequence of the owner-declined tmux-op timeout noted above: a permanently wedged tmux op (its claim never released) leaves that task un-startable / un-sendable for the remaining lifetime of the process. Accepted, same trade-off as the declined timeout — strictly better than the old app-wide synchronous hang, and scoped to one task rather than the whole app. Revisit together with the tmux op timeout follow-up.
 
 ## 9. Completeness ledger
 

--- a/docs/plans/fix-task-details-load-delay.md
+++ b/docs/plans/fix-task-details-load-delay.md
@@ -1,0 +1,115 @@
+# Plan — Fix task-details load lag during another task's warm-up
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-09-01 |
+| Source | /implement — "fix the lag on loading task details when agetor is warming up another task the user just sent a message" |
+| Config | AGENTS_CONFIG.yml (balanced) |
+| Flags | none |
+| Gates | grilled + scope confirmed by owner (4-question pass); plan approval pending |
+| Branch | fix/fix-task-details-load-delay |
+| Base SHA | TBD — set in Phase 4 |
+
+## 1. Objective & success criteria
+
+Opening the task-details panel (RunPanel) must stay responsive while another task is starting/receiving a message. Success:
+
+- No synchronous subprocess spawn or unbounded sync fs work remains on the start-task / send-input warm-up path.
+- New responsiveness regression test: with a stub tmux binary that sleeps, a concurrent event-loop operation completes within budget during spawn + paste (proves the loop isn't blocked).
+- The SSE replay query for a heavy task (~18.5k events) drops from ~220ms to ~20ms (measured on the production DB, read-only).
+- `bun run typecheck` and `bun test` green.
+
+## 2. Context & constraints (grounded findings)
+
+**Root cause (confirmed).** One Bun thread serves `Bun.serve` (`src/bun/server.ts:593`) + the whole orchestrator. The warm-up path runs synchronous subprocess spawns that stall every concurrent HTTP request:
+
+- `tmux()` helper — `src/bun/claude-tmux.ts:1420` — `Bun.spawnSync`, 46 call sites, no timeout. Start = sync `kill-session` + `new-session` back-to-back (`spawnClaudeViaTmux`, `:6502`); every send = 3–4 sync calls (`pastePromptSync`, `:8802`: load-buffer/paste-buffer/delete-buffer + send-keys); claude boot polls fire sync `capture-pane`/`has-session` every ~250–400ms for up to 30s (`BOOT_TIMEOUT_MS`) — a drumbeat of small stalls matching the symptom.
+- codex/cursor/gemini one-shot spawns: `spawnSync(tmux, args)` at `codex-tmux.ts:476`, `cursor-tmux.ts:610`, `gemini-tmux.ts:452`, plus shared `killSessionByName` (`claude-tmux.ts:1744`, sync).
+- `gitWritableRootsSync` — `worktree.ts:357`, `child_process.spawnSync` with 5s timeout — codex-only, called from `agents.ts:773` (buildCodexCommand) and `orchestrator.ts:2295`.
+- `ensureInstalledForCwd`/`applyAgetorSettings` — `hook-installer.ts:277/:145` — sync fs read/merge/atomic-write of `.claude/settings.local.json` before every claude spawn.
+- `flushSync` — `claude-tmux.ts:4024` — sync fs read of accumulated JSONL in `sendTurn` (`:7126`).
+- SSE replay query — `db.ts:1154` `eventsForTask` with limit: `ORDER BY run_events.id DESC LIMIT 800` sorts ALL of the task's events (with full `data` payloads) in a temp b-tree. **Measured 219.5ms** on prod DB (462k events; worst task 18,535). Sync sqlite ⇒ a 220ms loop stall per SSE (re)connect for heavy tasks.
+
+**Refuted (already async / off-path):** `prepareWorkdir`/`git worktree add` (`worktree.ts:766`, async `Bun.spawn`), `checkAgent`/`checkHarness` probes (async, 2s timeouts), model discovery (not on the path), per-task paste chains do NOT share a global lock (`pasteChains` map, `claude-tmux.ts:2640`). `login-path.ts` spawnSync is boot-only; `git-provider.ts` spawnSync is on the git-host dialog path — both out of scope (see §8).
+
+**Prior art / constraints on record:**
+- This exact conversion was deferred to "its own branch" twice: `docs/plans/fix-cannot-reach-api-toasts.md` (decision #5) and `docs/plans/fix-archive-teardown-queue.md`. This branch is that follow-up.
+- `docs/plans/tmux-sessions-killed-unexpectedly.md`: every tmux invocation must keep flowing through the single choke point (`resolveTmuxBin()` + `tmuxSocketArgs()` threaded on every call); no parallel spawn logic.
+- `docs/plans/fix-archive-teardown-queue.md`: teardown order (kill sessions BEFORE `git worktree remove`) is load-bearing; the global FIFO teardown queue stays.
+- `session-liveness.ts` (commit 9b23119) is the working precedent for taking a delicate sync tmux path async without regressing the death watch.
+- `queueTmuxOp` (`claude-tmux.ts:8980`) already accepts async op bodies with `stillCurrent()` re-check gates, and `queuePaste` bodies already interleave `Bun.sleep` with tmux calls — the chain layer is async-ready. The "no awaits between tmux calls" comment on `pastePromptSync` protects only its 3-call micro-sequence; atomicity survives conversion because (a) per-task chains serialize all pane mutations, (b) cross-task interleaving targets distinct sessions and per-session buffer names (`agetor-${sessionName}`), (c) mid-sequence session death already surfaces as a non-ok tmux result on the failure path.
+
+**Spike-grade measurements (this session, read-only):**
+- `EXPLAIN QUERY PLAN` on `eventsForTask`: `SEARCH runs USING INDEX idx_runs_task` → `SEARCH run_events USING COVERING INDEX idx_run_events_run` → `USE TEMP B-TREE FOR ORDER BY`. Full query on worst task: **219.5ms**.
+- Two-step rewrite (ids-only sort over covering index, then fetch `id >= min(ids)` re-filtered by task): **14.8ms + 3.9ms ≈ 19ms**, identical 800-row result, no migration.
+
+## 3. Approach & key decisions
+
+1. **Convert, don't offload.** Make every warm-up-path subprocess spawn async (`Bun.spawn` + `await proc.exited`) instead of moving work to a Worker. Matches the repo's own twice-recorded intent and the `session-liveness.ts` precedent; Workers would fragment deeply stateful drivers. *(reasoning + prior art)*
+2. **Owner decisions from the grill:** full sweep (all drivers + sync fs/git bits); **no tmux timeout** (behavior-preserving; timeout stays a follow-up — note an async hang no longer freezes the app, only that op); events query: verified real, fix included; acceptance = responsiveness regression test + suites green.
+3. **Atomicity via the existing per-task chain.** All pane-mutating sequences stay inside single chained ops (`queueTmuxOp`/`queuePaste`); the conversion adds awaits *inside* ops, never splits an op. `stillCurrent()` re-checks after each new await where state could have been torn down. *(evidence: chain already async-capable)*
+4. **Query rewrite over migration.** `eventsForTask` limit-path becomes the measured two-step (ids-only sort, then row fetch); same signature, same results (incl. `beforeId` paging). No schema change, no backfill. *(spike-measured 11×)*
+5. **Contract-first parallelization.** The async signatures (§4 contract) are fixed in this plan so wave-2 consumers can be written against them while wave 1 lands them.
+
+## 4. Work breakdown — implementation tasks
+
+**The signature contract** (wave-2 tasks code against this; wave-1 tasks implement it):
+
+- `claude-tmux.ts`: `tmux()` → `async` (internal). Exports becoming async (return `Promise<…>` of today's type): `sessionExists`, `sessionExistsByName`, `probeSessionActivity`, `sessionLiveness`, `panePidFor`, `killTaskSession`, `killSessionByName`, `dropSession`, `spawnClaudeViaTmux`, `reattachSession`, `sendTurn`, `pasteFollowUp`, `sendSlashCommand`, `healWindowSize`, `interruptTaskSession`. Already-async exports (`dismissTmuxPrompt`, `sendModalKeys`, `driveAskAnswers`, `cycleToMode`, `mirrorModelViaPicker`) keep their signatures. Pure/in-memory exports (`sessionNameFor`, `hasSessionState`, `sessionIdleInfo`, `getSessionLaunchEffort`, `getCurrentPermissionMode` if memory-only, `markTmuxPromptAnswered`, `resolveAskCard`, `jsonlPathFor`, parsers) stay sync. `fileWrittenWithin` stays sync (statSync is a µs syscall, not a fork).
+- `codex/cursor/gemini-tmux.ts`: `spawn*ViaTmux`, `drop*Session`, `reattach*Session`, and their turn-send entry points → async where they now await tmux ops.
+- `worktree.ts`: `gitWritableRootsSync(cwd)` → `async gitWritableRoots(cwd): Promise<string[]>` using the existing async `git()` helper; sync version removed.
+- `hook-installer.ts`: `ensureInstalledForCwd` → async (fs/promises + atomic rename preserved).
+- `agents.ts`: `spawnAgent` → `async (args): Promise<SpawnedAgent>`; awaits driver spawns (fake drivers included) and threads `await gitWritableRoots(...)` into the codex branch.
+- `db.ts`: `eventsForTask` signature unchanged; limit-path internals rewritten.
+
+**Tasks:**
+
+| ID | Goal | Owns (exact files) | Depends on | Acceptance |
+| --- | --- | --- | --- | --- |
+| T1 | Convert `tmux()` + all 46 call sites + contract exports to async in claude driver; `flushSync` → async flush guarded against tailer races (in-flight flag on `SessionState`; if a provably safe async conversion isn't achievable, keep it sync and document why in-code); preserve chain semantics + `stillCurrent()` re-checks; keep choke-point invariant | `src/bun/claude-tmux.ts` | — | File self-consistent; no `Bun.spawnSync` remains; all pane mutations still flow through per-task chains |
+| T2 | Same conversion for the three one-shot drivers: async spawn runners, await `killSessionByName`, async drop/reattach per contract | `src/bun/codex-tmux.ts`, `src/bun/cursor-tmux.ts`, `src/bun/gemini-tmux.ts` | contract only | No `spawnSync` imports remain in these files |
+| T3 | `gitWritableRoots` async in worktree; async `hook-installer`; `eventsForTask` two-step rewrite (both limit variants, `beforeId` respected in both steps) | `src/bun/worktree.ts`, `src/bun/hook-installer.ts`, `src/bun/db.ts` | — | Query returns byte-identical rows/order vs old impl; no sync spawn in `worktree.ts` warm-up path |
+| T4 | `spawnAgent` async + dispatch awaits (all five kinds + fake drivers); thread `gitWritableRoots` | `src/bun/agents.ts` | W1 contract | Compiles against wave-1 signatures |
+| T5 | Orchestrator consumption: `spawnAgentOrFail` async (+6 call sites), await kills/drops/reattaches/sendTurn/pasteFollowUp/sessionExists/liveness probes; teardown queue + reconcileOrphans + reaper + cancel paths; re-check the start-task double-entry window the new await points widen (cheap in-flight guard if needed); update now-stale "spawnSync" comments (`orchestrator.ts:188`, `:3883`) | `src/bun/orchestrator.ts` | W1 contract | All orchestrator flows await the contract correctly; teardown ordering preserved |
+| T6 | Server + remaining consumers: await `sessionExists` etc. in routes; sweep any other `src/bun` consumer of changed signatures (except files owned by T4/T5 and tests) | `src/bun/server.ts` + misc non-test consumers | W1 contract | No non-test consumer left un-awaited |
+| T7 | Compile-green sweep: `bun run typecheck` + `bun test` compile fixes across `src/bun/*.test.ts` and any straggler; no behavior changes beyond adding awaits/async to test plumbing | all `*.test.ts` + stragglers | W1+W2 | typecheck green; suite compiles and runs |
+
+## 5. Work breakdown — test tasks
+
+E2e: **not applicable** — the e2e harness runs `AGETOR_CLAUDE_DRIVER=fake`, which bypasses tmux entirely; no e2e can exercise the real sync path. Recorded decision, not an omission. The regression lives at the integration layer instead:
+
+| ID | Goal | Owns | Covers |
+| --- | --- | --- | --- |
+| TT1 | Responsiveness regression test: stub tmux script (sleeps N ms) via `AGETOR_TMUX_BIN`; assert a concurrent `Bun.sleep(10)`-style probe drifts < ~200ms while spawn/kill/paste ops run against a 1000ms-sleeping stub (5× flake margin — see known flake class: never assert tight wall-clock over fake-tmux spawns) | new `src/bun/event-loop-responsiveness.test.ts` | T1, T2 |
+| TT2 | `eventsForTask` parity tests: seed multi-run/multi-task events, assert limit/beforeId paging returns identical rows+order to the old query shape (oracle: the unlimited query, sliced) | extend db tests (find existing db test file; else new `src/bun/db-events.test.ts`) | T3 (db) |
+| TT3 | worktree + hook-installer async behavior: `gitWritableRoots` parity with old sync results; installer still writes/strips settings atomically | extend `src/bun/worktree.test.ts` + hook-installer tests | T3 |
+
+Run recipe: `bun test` (whole suite), `bun run typecheck`. Dev smoke (optional, owner-side): `bun run dev` against `~/.agetor-dev`.
+
+## 6. Execution waves
+
+- **Wave 1 (parallel):** T1, T2, T3 — file-disjoint. Brief note: typecheck errors in *other* files are expected mid-wave; verify your own files only.
+- **Wave 2 (parallel, after W1):** T4, T5, T6 — file-disjoint consumers of the landed contract.
+- **Wave 3:** T7 (single agent) — typecheck/test compile sweep.
+- Checkpoint commit after each wave. Phase 5 review on `git diff <base>...HEAD`; Phase 6 = TT1–TT3 (TT2/TT3 parallel with TT1; all file-disjoint); Phases 7–8 close the loop.
+
+## 7. Blast radius & risks
+
+- **Paste atomicity / modal guard:** the three-call paste sequence and the guard's double-samples now contain awaits; per-task chains + `stillCurrent()` keep same-task ordering; cross-task interleaving is new but targets distinct sessions/buffers. Reviewer must check every new await inside a chained op re-validates state where it matters.
+- **Scraper vs mid-op pane states:** the 1s scraper can now observe a pane between paste steps (previously unobservable). Composer text mid-paste is not a modal, so no card should fire; reviewer to confirm no scraper branch acts on composer-only panes.
+- **Double-start window:** `startTask` already has await windows before spawn (pendingTeardown, prepareWorkdir); async spawn widens them slightly. T5 re-checks the guard (`task.runId && active.has(...)`) placement and adds a cheap in-flight set if needed.
+- **Teardown ordering:** kills must still complete before `git worktree remove` — awaits must be sequential in the teardown queue, never fire-and-forget.
+- **Boot reconciliation:** `reconcileOrphans` gains awaits per run — serialized loop is fine; must not become concurrent (kill-keying safety rules in CLAUDE.md §5).
+- **Cancellation latency:** Stop (`interruptTaskSession`) becomes async — response still fast (single tmux send-keys, now non-blocking for everyone else).
+- **No rollback hazard:** no schema change, no data migration; revert = git revert.
+
+## 8. Open questions / assumptions
+
+- Owner declined the tmux timeout — a wedged tmux op now hangs only its own chained op (not the app). Logged as a possible future follow-up, not part of this run.
+- `login-path.ts` (boot-only) and `git-provider.ts` ssh probe (git-host dialog path) keep their `spawnSync` — off the warm-up path; different ticket if ever.
+- `getCurrentPermissionMode` assumed memory-only (stays sync); T1 verifies and may move it into the async set if it actually reads the pane.
+- The e2e "Task details editor" convergence flake (`e2e/fx-models.spec.ts`) is a known env-dependent failure on main — not a signal for this branch.
+
+## 9. Completeness ledger
+
+n/a — `--no-follow-ups` not active. Candidate follow-ups recorded: tmux op timeout (owner-declined here); `git-provider.ts`/`login-path.ts` sync spawns (off-path).

--- a/src/bun/agents.test.ts
+++ b/src/bun/agents.test.ts
@@ -975,10 +975,10 @@ test("fx harness without a home override sets no HOME (env carries only FX_PERMI
   expect(result.env?.FX_PERMISSION_MODE).toBe("auto");
 });
 
-test("fx AGETOR_FX_DRIVER=fake yields a fake handle and fires onSessionId with fake-fx-session-<taskId>", () => {
+test("fx AGETOR_FX_DRIVER=fake yields a fake handle and fires onSessionId with fake-fx-session-<taskId>", async () => {
   process.env.AGETOR_FX_DRIVER = "fake";
   let sessionId: string | undefined;
-  const handle = spawnAgent({
+  const handle = await spawnAgent({
     taskId: "task-fx-1",
     runId: "run-fx-1",
     harness: builtin("fx"),
@@ -995,9 +995,9 @@ test("fx AGETOR_FX_DRIVER=fake yields a fake handle and fires onSessionId with f
   handle.kill();
 });
 
-test("fx AGETOR_FX_DRIVER=fake still exercises buildCommand's validation (throws on missing model)", () => {
+test("fx AGETOR_FX_DRIVER=fake still exercises buildCommand's validation (throws on missing model)", async () => {
   process.env.AGETOR_FX_DRIVER = "fake";
-  expect(() =>
+  await expect(
     spawnAgent({
       taskId: "task-fx-2",
       runId: "run-fx-2",
@@ -1007,7 +1007,7 @@ test("fx AGETOR_FX_DRIVER=fake still exercises buildCommand's validation (throws
       onChunk: () => {},
       opts: { mode: "auto" },
     }),
-  ).toThrow(/model is required for fx/);
+  ).rejects.toThrow(/model is required for fx/);
 });
 
 test("claude-code 'max' effort sets CLAUDE_CODE_EFFORT_LEVEL=max env", () => {

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -14,7 +14,7 @@ import { spawnCursorViaTmux } from "./cursor-tmux.ts";import { dataDir, subagent
 import { spawnFxViaAcp, type FxMode } from "./fx-acp.ts";
 import { spawnGeminiViaTmux } from "./gemini-tmux.ts";
 import { answerFxPermission, registerFxPermission } from "./interactions.ts";
-import { gitWritableRootsSync } from "./worktree.ts";
+import { gitWritableRoots } from "./worktree.ts";
 
 export type { SpawnedAgent };
 
@@ -113,7 +113,7 @@ export interface AgentRunOptions {
    * workdir). When this is non-empty, a `git commit`'s objects/refs must reach
    * a dir the cwd-scoped `workspace-write` sandbox doesn't cover, so the codex
    * `auto` run is escalated to `--sandbox danger-full-access` (see
-   * `buildCommand`). Resolved by `gitWritableRootsSync(cwd)` and only set on the
+   * `buildCommand`). Resolved by `await gitWritableRoots(cwd)` and only set on the
    * codex spawn path; ignored by claude-code and by codex's read-only ("ask")
    * sandbox (which can't write anything regardless).
    */
@@ -555,7 +555,7 @@ export function buildCommand(
     // philosophy as claude's --dangerously-skip-permissions and codex's
     // danger-full-access escalation. `ask` emits neither flag: cursor-agent
     // -p cannot execute unapproved actions headlessly, so this is a
-    // propose-only run. No gitWritableRootsSync escalation is needed here
+    // propose-only run. No gitWritableRoots escalation is needed here
     // (plan §3.4) — auto never runs sandboxed for cursor in the first place.
     const mode = opts.mode ?? "auto";
     if (mode === "auto") {
@@ -761,16 +761,23 @@ export function buildCommand(
  * `buildCommand` can decide whether to escalate the sandbox to full access. This
  * is the seam `spawnAgent` uses — kept separate from the pure `buildCommand` so
  * the cwd→sandbox wiring is unit-testable without standing up tmux.
+ *
+ * Async because `gitWritableRoots` now spawns `git` via the async `git()`
+ * helper (see worktree.ts) instead of `child_process.spawnSync` — this is the
+ * only reason `buildCodexCommand` differs from the otherwise-synchronous
+ * `buildCommand`, whose exported signature stays sync on purpose (100+ sync
+ * call sites in agents.test.ts, and orchestrator-fx.test.ts's fake gemini
+ * driver relies on `buildCommand` staying synchronous).
  */
-export function buildCodexCommand(
+export async function buildCodexCommand(
   harness: Harness,
   prompt: string,
   opts: AgentRunOptions,
   cwd: string,
-): AgentCommand {
+): Promise<AgentCommand> {
   return buildCommand(harness, prompt, {
     ...opts,
-    codexExternalGitDirs: gitWritableRootsSync(cwd),
+    codexExternalGitDirs: await gitWritableRoots(cwd),
   });
 }
 
@@ -1317,8 +1324,17 @@ export interface SpawnAgentArgs {
  *
  * Returns a unified `SpawnedAgent` so the orchestrator's bookkeeping is the
  * same for both agents.
+ *
+ * Async: `spawnClaudeViaTmux`/`spawnCodexViaTmux`/`spawnCursorViaTmux`/
+ * `spawnGeminiViaTmux` are now `Bun.spawn`-backed tmux drivers (wave 1 of
+ * docs/plans/fix-task-details-load-delay.md — no more `Bun.spawnSync` on the
+ * warm-up path), so every dispatch branch below awaits its driver spawn.
+ * `spawnFxViaAcp` stays synchronous (fx never used tmux — see fx-acp.ts) and
+ * the fake-driver branches stay synchronous too (`makeFakeAgent` /
+ * `makeFakeCursorPlanAgent`); both are still valid returns from this `async`
+ * function, just resolved immediately.
  */
-export function spawnAgent(args: SpawnAgentArgs): SpawnedAgent {
+export async function spawnAgent(args: SpawnAgentArgs): Promise<SpawnedAgent> {
   const { taskId, runId, harness, prompt, cwd, onChunk, onSessionId, opts = {} } = args;
 
   if (harness.kind === "claude-code") {
@@ -1335,7 +1351,7 @@ export function spawnAgent(args: SpawnAgentArgs): SpawnedAgent {
       sessionId: opts.resumeSessionId ? null : sessionId,
     });
     onSessionId?.(sessionId);
-    return spawnClaudeViaTmux({
+    return await spawnClaudeViaTmux({
       taskId,
       argv: built.cmd,
       env: built.env ?? {},
@@ -1365,7 +1381,7 @@ export function spawnAgent(args: SpawnAgentArgs): SpawnedAgent {
         return makeFakeCursorPlanAgent(taskId, prompt, onChunk);
       }      return makeFakeAgent(taskId, prompt, onChunk, { runId, mode: opts.mode ?? "auto" });    }
     const built = buildCommand(harness, prompt, opts);
-    return spawnCursorViaTmux({
+    return await spawnCursorViaTmux({
       taskId,
       runId,
       argv: built.cmd,
@@ -1397,7 +1413,7 @@ export function spawnAgent(args: SpawnAgentArgs): SpawnedAgent {
       sessionId: opts.resumeSessionId ? null : sessionId,
     });
     onSessionId?.(sessionId);
-    return spawnGeminiViaTmux({
+    return await spawnGeminiViaTmux({
       taskId,
       runId,
       argv: built.cmd,
@@ -1453,9 +1469,10 @@ export function spawnAgent(args: SpawnAgentArgs): SpawnedAgent {
   // sandbox to full access. Computed here — the single choke point every codex
   // spawn path funnels through — rather than at each orchestrator call site.
   // No-op for an ordinary checkout or a non-git cwd, so the argv is unchanged
-  // there. `buildCodexCommand` is the testable seam for this wiring.
-  const built = buildCodexCommand(harness, prompt, opts, cwd);
-  return spawnCodexViaTmux({
+  // there. `buildCodexCommand` is the testable seam for this wiring (async —
+  // it awaits `gitWritableRoots`, which now shells out via `Bun.spawn`).
+  const built = await buildCodexCommand(harness, prompt, opts, cwd);
+  return await spawnCodexViaTmux({
     taskId,
     runId,
     argv: built.cmd,

--- a/src/bun/claude-tmux-death.test.ts
+++ b/src/bun/claude-tmux-death.test.ts
@@ -125,17 +125,17 @@ test("F5: a throwing heldSessionProbe is treated as not-held (no crash, no emiss
   }
 });
 
-test("sessionLiveness: exit 0 is alive", () => {
+test("sessionLiveness: exit 0 is alive", async () => {
   const restore = fakeTmux(0, "");
-  try { expect(sessionLiveness("agetor-x")).toBe("alive"); } finally { restore(); }
+  try { expect(await sessionLiveness("agetor-x")).toBe("alive"); } finally { restore(); }
 });
 
-test("sessionLiveness: 'can't find session' with a responsive server is gone", () => {
+test("sessionLiveness: 'can't find session' with a responsive server is gone", async () => {
   const restore = fakeTmux(1, "can't find session: agetor-x");
-  try { expect(sessionLiveness("agetor-x")).toBe("gone"); } finally { restore(); }
+  try { expect(await sessionLiveness("agetor-x")).toBe("gone"); } finally { restore(); }
 });
 
-test("sessionLiveness: any ambiguous / unknown failure is unreachable, never a death", () => {
+test("sessionLiveness: any ambiguous / unknown failure is unreachable, never a death", async () => {
   // The regression: a busy shared tmux server too swamped to answer, an ambiguous
   // connect error, or ANY string we don't recognize must never be read as a dead
   // session — that's what abandoned live, working sessions. We don't know the
@@ -148,11 +148,11 @@ test("sessionLiveness: any ambiguous / unknown failure is unreachable, never a d
     "", // a torn-down client can exit non-zero with no diagnostics
   ]) {
     const restore = fakeTmux(1, stderr);
-    try { expect(sessionLiveness("agetor-x")).toBe("unreachable"); } finally { restore(); }
+    try { expect(await sessionLiveness("agetor-x")).toBe("unreachable"); } finally { restore(); }
   }
 });
 
-test("sessionLiveness: only an UNAMBIGUOUS dead session or dead server is gone", () => {
+test("sessionLiveness: only an UNAMBIGUOUS dead session or dead server is gone", async () => {
   // During an in-flight turn our own session keeps the shared server alive, so
   // "no server running"/"lost server" means the server died WITH our session — a
   // real death. "session not found" is the server saying our session is absent.
@@ -165,7 +165,7 @@ test("sessionLiveness: only an UNAMBIGUOUS dead session or dead server is gone",
     "lost server",
   ]) {
     const restore = fakeTmux(1, stderr);
-    try { expect(sessionLiveness("agetor-x")).toBe("gone"); } finally { restore(); }
+    try { expect(await sessionLiveness("agetor-x")).toBe("gone"); } finally { restore(); }
   }
 });
 
@@ -351,7 +351,7 @@ async function setupHeldReattach() {
   tasks.insert(baseTask(taskId));
 
   const rec = recorder();
-  const agent = reattachSession({
+  const agent = await reattachSession({
     taskId,
     cwd,
     sessionId,
@@ -365,8 +365,8 @@ async function setupHeldReattach() {
   return { taskId, rec };
 }
 
-function cleanupHeldReattach(taskId: string) {
-  dropSession(taskId); // clears any still-armed timers, kills the (fake) tmux session
+async function cleanupHeldReattach(taskId: string) {
+  await dropSession(taskId); // clears any still-armed timers, kills the (fake) tmux session
   db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]); // cascades subagents/runs/run_events
 }
 
@@ -427,7 +427,7 @@ test(
     } finally {
       setHeldSessionProbe(prevProbe);
       ctrlTmux.restore();
-      if (taskId) cleanupHeldReattach(taskId);
+      if (taskId) await cleanupHeldReattach(taskId);
     }
   },
 );
@@ -459,7 +459,7 @@ test(
     } finally {
       setHeldSessionProbe(prevProbe);
       ctrlTmux.restore();
-      if (taskId) cleanupHeldReattach(taskId);
+      if (taskId) await cleanupHeldReattach(taskId);
     }
   },
 );
@@ -503,7 +503,7 @@ test(
     } finally {
       setHeldSessionProbe(prevProbe);
       ctrlTmux.restore();
-      if (taskId) cleanupHeldReattach(taskId);
+      if (taskId) await cleanupHeldReattach(taskId);
     }
   },
 );
@@ -539,7 +539,7 @@ test(
     } finally {
       setHeldSessionProbe(prevProbe);
       ctrlTmux.restore();
-      if (taskId) cleanupHeldReattach(taskId);
+      if (taskId) await cleanupHeldReattach(taskId);
     }
   },
 );
@@ -579,7 +579,7 @@ test(
     } finally {
       setHeldSessionProbe(prevProbe);
       ctrlTmux.restore();
-      if (taskId) cleanupHeldReattach(taskId);
+      if (taskId) await cleanupHeldReattach(taskId);
     }
   },
 );

--- a/src/bun/claude-tmux-local-command.test.ts
+++ b/src/bun/claude-tmux-local-command.test.ts
@@ -1147,12 +1147,12 @@ test("sendSlashCommand({autoConfirm}): a matching confirm pane sends the auto-ac
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId } = freshSession();
     let captureCalls = 0;
-    const prevCapture = __forTest.setCaptureConfirmPane(() => {
+    const prevCapture = __forTest.setCaptureConfirmPane(async () => {
       captureCalls++;
       return effortConfirmPane;
     });
     try {
-      const ok = sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
+      const ok = await sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
       expect(ok).toBe(true);
 
       await __forTest.pasteChains.get(taskId);
@@ -1183,12 +1183,12 @@ test("sendSlashCommand({autoConfirm: 'effort'}): a 'Switch model?' confirm (wron
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId } = freshSession();
     let captureCalls = 0;
-    const prevCapture = __forTest.setCaptureConfirmPane(() => {
+    const prevCapture = __forTest.setCaptureConfirmPane(async () => {
       captureCalls++;
       return switchModelConfirmPane;
     });
     try {
-      const ok = sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
+      const ok = await sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
       expect(ok).toBe(true);
 
       await __forTest.pasteChains.get(taskId);
@@ -1214,7 +1214,7 @@ test("sendSlashCommand({autoConfirm}): two consecutive idle-input-box polls brea
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId } = freshSession();
     let captureCalls = 0;
-    const prevCapture = __forTest.setCaptureConfirmPane(() => {
+    const prevCapture = __forTest.setCaptureConfirmPane(async () => {
       captureCalls++;
       return idlePane;
     });
@@ -1227,10 +1227,10 @@ test("sendSlashCommand({autoConfirm}): two consecutive idle-input-box polls brea
     // guard's OWN seam removes that spawn entirely without touching what
     // this test actually exercises (the confirm-poll's early exit, driven
     // via the separate `captureConfirmPane` seam above).
-    const prevPastePane = __forTest.setCapturePastePane(() => idlePane);
+    const prevPastePane = __forTest.setCapturePastePane(async () => idlePane);
     try {
       const start = Date.now();
-      const ok = sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
+      const ok = await sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
       expect(ok).toBe(true);
 
       // Let the op run to completion on its own — no manual uninstall this
@@ -1280,17 +1280,17 @@ test("sendSlashCommand({autoConfirm}): a numbered PERMISSION prompt (not a confi
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId } = freshSession();
     let captureCalls = 0;
-    const prevCapture = __forTest.setCaptureConfirmPane(() => {
+    const prevCapture = __forTest.setCaptureConfirmPane(async () => {
       captureCalls++;
       return PERMISSION_PROMPT_PANE;
     });
     // Same rationale as the idle-break test above: keep the paste's OWN
     // modal guard from adding a real tmux subprocess spawn to this test's
     // timing budget.
-    const prevPastePane = __forTest.setCapturePastePane(() => idlePane);
+    const prevPastePane = __forTest.setCapturePastePane(async () => idlePane);
     try {
       const start = Date.now();
-      const ok = sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
+      const ok = await sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
       expect(ok).toBe(true);
 
       await __forTest.pasteChains.get(taskId);
@@ -1328,12 +1328,12 @@ test("sendSlashCommand without opts: no auto-confirm step runs at all (no Enter 
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId } = freshSession();
     let captureCalls = 0;
-    const prevCapture = __forTest.setCaptureConfirmPane(() => {
+    const prevCapture = __forTest.setCaptureConfirmPane(async () => {
       captureCalls++;
       return effortConfirmPane; // would match if the poll ever ran
     });
     try {
-      const ok = sendSlashCommand(taskId, "/effort low");
+      const ok = await sendSlashCommand(taskId, "/effort low");
       expect(ok).toBe(true);
 
       await __forTest.pasteChains.get(taskId);
@@ -1365,15 +1365,15 @@ test("sendSlashCommand({autoConfirm}): a blocked pane withholds the mirror paste
     const prevGrace = __forTest.setPasteModalGraceMs(20);
     const prevPoll = __forTest.setPasteModalPollMs(5);
     const { taskId } = freshSession();
-    const prevPastePane = __forTest.setCapturePastePane(() => PICKER_PANE);
+    const prevPastePane = __forTest.setCapturePastePane(async () => PICKER_PANE);
     let confirmCalls = 0;
-    const prevConfirmPane = __forTest.setCaptureConfirmPane(() => {
+    const prevConfirmPane = __forTest.setCaptureConfirmPane(async () => {
       confirmCalls++;
       return PICKER_PANE;
     });
     const failures: PasteFailureOutcome[] = [];
     try {
-      const ok = sendSlashCommand(taskId, "/model claude-opus-5", {
+      const ok = await sendSlashCommand(taskId, "/model claude-opus-5", {
         autoConfirm: "model",
         onPasteFailure: (outcome) => failures.push(outcome),
       });
@@ -1440,13 +1440,13 @@ test("mirrorModelViaPicker: cursor on Sonnet ✔ (index 3), target Opus — walk
   await withRecordingTmuxBin(async (logPath) => {
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId } = freshSession();
-    const prevPastePane = __forTest.setCapturePastePane(() => idlePane);
+    const prevPastePane = __forTest.setCapturePastePane(async () => idlePane);
     // Same seam drives both the picker-detection poll AND the subsequent
     // autoConfirmSlashModal poll (both read captureConfirmPane) — key off
     // whether the session-only confirm key ("s") has actually been sent yet,
     // rather than a manual call counter, so this reflects the real state
     // transition mirrorModelViaPicker drives.
-    const prevConfirmPane = __forTest.setCaptureConfirmPane(() => {
+    const prevConfirmPane = __forTest.setCaptureConfirmPane(async () => {
       const sSent = readTmuxLog(logPath).some(
         (e) => e.argv[0] === "send-keys" && e.argv[e.argv.length - 1] === "s",
       );
@@ -1500,8 +1500,8 @@ test("mirrorModelViaPicker: target family not offered by the picker — sends Es
   await withRecordingTmuxBin(async (logPath) => {
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId } = freshSession();
-    const prevPastePane = __forTest.setCapturePastePane(() => idlePane);
-    const prevConfirmPane = __forTest.setCaptureConfirmPane(() => PICKER_246_NO_FABLE_PANE);
+    const prevPastePane = __forTest.setCapturePastePane(async () => idlePane);
+    const prevConfirmPane = __forTest.setCaptureConfirmPane(async () => PICKER_246_NO_FABLE_PANE);
 
     const pickerMatch = matchNumberedModal(PICKER_246_NO_FABLE_PANE)!;
     const { answer } = registerTmuxPrompt({
@@ -1540,8 +1540,8 @@ test("mirrorModelViaPicker: idle pane throughout — the poll window elapses wit
   await withRecordingTmuxBin(async (logPath) => {
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId } = freshSession();
-    const prevPastePane = __forTest.setCapturePastePane(() => idlePane);
-    const prevConfirmPane = __forTest.setCaptureConfirmPane(() => idlePane);
+    const prevPastePane = __forTest.setCapturePastePane(async () => idlePane);
+    const prevConfirmPane = __forTest.setCaptureConfirmPane(async () => idlePane);
     try {
       const result = await mirrorModelViaPicker(taskId, "Opus");
       expect(result).toEqual({ ok: false, reason: "picker not shown" });
@@ -1568,7 +1568,7 @@ test("mirrorModelViaPicker: a live modal blocks the opening /model paste — ret
     const prevGrace = __forTest.setPasteModalGraceMs(20);
     const prevPoll = __forTest.setPasteModalPollMs(5);
     const { taskId } = freshSession();
-    const prevPastePane = __forTest.setCapturePastePane(() => PICKER_PANE);
+    const prevPastePane = __forTest.setCapturePastePane(async () => PICKER_PANE);
     const failures: PasteFailureOutcome[] = [];
     try {
       const result = await mirrorModelViaPicker(taskId, "Opus", {
@@ -1619,7 +1619,7 @@ test("mirrorModelViaPicker: idle turnQueue but the pane shows claude working (ba
   // catches working chrome even with no turn slot at all.
   await withRecordingTmuxBin(async (logPath) => {
     const { taskId } = freshSession();
-    const prevPastePane = __forTest.setCapturePastePane(() => COMPOSER_WORKING_NONBARE_PANE);
+    const prevPastePane = __forTest.setCapturePastePane(async () => COMPOSER_WORKING_NONBARE_PANE);
     try {
       const result = await mirrorModelViaPicker(taskId, "Opus");
       expect(result).toEqual({ ok: false, reason: "turn in flight" });
@@ -1643,9 +1643,9 @@ test("mirrorModelViaPicker: state.drivingPrompt is true for every confirm-pane p
   await withRecordingTmuxBin(async (logPath) => {
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId, state } = freshSession();
-    const prevPastePane = __forTest.setCapturePastePane(() => idlePane);
+    const prevPastePane = __forTest.setCapturePastePane(async () => idlePane);
     const drivingSightings: boolean[] = [];
-    const prevConfirmPane = __forTest.setCaptureConfirmPane(() => {
+    const prevConfirmPane = __forTest.setCaptureConfirmPane(async () => {
       drivingSightings.push(state.drivingPrompt);
       const sSent = readTmuxLog(logPath).some(
         (e) => e.argv[0] === "send-keys" && e.argv[e.argv.length - 1] === "s",
@@ -1719,8 +1719,8 @@ test("mirrorModelViaPicker: target not offered AND the closing Escape's send-key
   await withFailingSingleEscapeTmuxBin(async (logPath) => {
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId } = freshSession();
-    const prevPastePane = __forTest.setCapturePastePane(() => idlePane);
-    const prevConfirmPane = __forTest.setCaptureConfirmPane(() => PICKER_246_NO_FABLE_PANE);
+    const prevPastePane = __forTest.setCapturePastePane(async () => idlePane);
+    const prevConfirmPane = __forTest.setCaptureConfirmPane(async () => PICKER_246_NO_FABLE_PANE);
 
     const pickerMatch = matchNumberedModal(PICKER_246_NO_FABLE_PANE)!;
     registerTmuxPrompt({
@@ -1770,8 +1770,8 @@ test("mirrorModelViaPicker success stamps SessionState.lastModelMirrorAt, and a 
   await withRecordingTmuxBin(async (logPath) => {
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId, state } = freshSession();
-    const prevPastePane = __forTest.setCapturePastePane(() => idlePane);
-    const prevConfirmPane = __forTest.setCaptureConfirmPane(() => {
+    const prevPastePane = __forTest.setCapturePastePane(async () => idlePane);
+    const prevConfirmPane = __forTest.setCaptureConfirmPane(async () => {
       const sSent = readTmuxLog(logPath).some(
         (e) => e.argv[0] === "send-keys" && e.argv[e.argv.length - 1] === "s",
       );
@@ -1830,8 +1830,8 @@ test("mirrorModelViaPicker 'target not offered' (Escape) never stamps lastModelM
   await withRecordingTmuxBin(async (logPath) => {
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId, state } = freshSession();
-    const prevPastePane = __forTest.setCapturePastePane(() => idlePane);
-    const prevConfirmPane = __forTest.setCaptureConfirmPane(() => PICKER_246_NO_FABLE_PANE);
+    const prevPastePane = __forTest.setCapturePastePane(async () => idlePane);
+    const prevConfirmPane = __forTest.setCaptureConfirmPane(async () => PICKER_246_NO_FABLE_PANE);
 
     const pickerMatch = matchNumberedModal(PICKER_246_NO_FABLE_PANE)!;
     const { answer } = registerTmuxPrompt({
@@ -1901,11 +1901,15 @@ test("sendTurn: bumpKeystroke fires at ENQUEUE time — state.lastKeystrokeAt is
   // eventually runs — this test only cares about the ENQUEUE-time bump,
   // which (per queuePaste's doc) happens before the op ever reaches
   // queueTmuxOp, so what the op itself does afterward is irrelevant here.
-  const prevPastePane = __forTest.setCapturePastePane(() => PICKER_PANE);
+  const prevPastePane = __forTest.setCapturePastePane(async () => PICKER_PANE);
   try {
     const before = state.lastKeystrokeAt;
     await new Promise((r) => setTimeout(r, 5)); // let Date.now() tick forward
-    const agent = sendTurn(taskId, "hello", () => {});
+    // Deliberately NOT awaited here — `sendTurn` is `async` now (the tmux()
+    // choke point moved off Bun.spawnSync), but its own body has no internal
+    // `await` before it returns, so calling it without awaiting still runs
+    // it inline, synchronously, in this exact tick.
+    const agentPromise = sendTurn(taskId, "hello", () => {});
     // Read synchronously, before awaiting anything: sendTurn's own
     // `void queuePaste(...)` call runs queuePaste's body inline up to (and
     // past) its enqueue-time `bumpKeystroke` before sendTurn ever returns —
@@ -1915,7 +1919,7 @@ test("sendTurn: bumpKeystroke fires at ENQUEUE time — state.lastKeystrokeAt is
 
     // Swallow the expected rejection (withheld paste) and let the guard's
     // grace window elapse so nothing leaks into a later test.
-    agent.done.catch(() => {});
+    agentPromise.then((agent) => agent.done.catch(() => {}));
     await __forTest.pasteChains.get(taskId);
   } finally {
     __forTest.setCapturePastePane(prevPastePane);
@@ -1930,16 +1934,22 @@ test("PASTE_DROPPED_OUTCOME: a session torn down before the queued paste ever ru
   // file owns the broader queue/dropped-op contract) — pinned here too since
   // this task's boundary is this file specifically.
   const { taskId } = freshSession();
-  const agent = sendTurn(taskId, "hello", () => {});
+  // Deliberately NOT awaited — see the sibling `lastKeystrokeAt` test above
+  // for why calling `sendTurn` without awaiting still registers the queued
+  // op synchronously, in this same tick, ahead of queueTmuxOp's identity
+  // check — which is exactly the race this test needs to win so the
+  // teardown below lands first.
+  const agentPromise = sendTurn(taskId, "hello", () => {});
   // Irrelevant to this test's assertion (the dropped-op outcome's stderr
   // wording) — swallow it so it doesn't surface as an unhandled rejection.
-  agent.done.catch(() => {});
+  agentPromise.then((agent) => agent.done.catch(() => {}));
   // Tear down SYNCHRONOUSLY, before the queued tmux op's microtask runs —
   // queueTmuxOp's identity gate then drops the op body entirely, so the
   // chain settles via the unconditional PASTE_DROPPED_OUTCOME backstop with
   // no tmux call (and no fake tmux bin) needed at all.
   __forTest.uninstallSession(taskId);
 
+  const agent = await agentPromise;
   const outcome = await Promise.race([
     agent.pasteOutcome!,
     new Promise<never>((_, reject) => {
@@ -1966,7 +1976,7 @@ describe("queuePaste modal guard", () => {
       const prevGrace = __forTest.setPasteModalGraceMs(20);
       const prevPoll = __forTest.setPasteModalPollMs(5);
       const { taskId, state } = freshSession();
-      const prevCapture = __forTest.setCapturePastePane(() => PICKER_PANE);
+      const prevCapture = __forTest.setCapturePastePane(async () => PICKER_PANE);
       const rec = recorder();
       const failures: PasteFailureOutcome[] = [];
       try {
@@ -2009,7 +2019,7 @@ describe("queuePaste modal guard", () => {
       const prevPoll = __forTest.setPasteModalPollMs(5);
       const { taskId, state } = freshSession();
       let calls = 0;
-      const prevCapture = __forTest.setCapturePastePane(() => {
+      const prevCapture = __forTest.setCapturePastePane(async () => {
         calls++;
         return PICKER_PANE;
       });
@@ -2053,7 +2063,7 @@ describe("queuePaste modal guard", () => {
       const prevPoll = __forTest.setPasteModalPollMs(5);
       const { taskId, state } = freshSession();
       let calls = 0;
-      const prevCapture = __forTest.setCapturePastePane(() => {
+      const prevCapture = __forTest.setCapturePastePane(async () => {
         calls++;
         return PICKER_PANE;
       });
@@ -2084,11 +2094,11 @@ describe("queuePaste modal guard", () => {
       const prevGrace = __forTest.setPasteModalGraceMs(20);
       const prevPoll = __forTest.setPasteModalPollMs(5);
       const { taskId } = freshSession();
-      const prevCapture = __forTest.setCapturePastePane(() => PICKER_PANE);
+      const prevCapture = __forTest.setCapturePastePane(async () => PICKER_PANE);
       const failures: PasteFailureOutcome[] = [];
       try {
         const rec = recorder();
-        const agent = sendTurn(taskId, "hello", rec.onChunk, {
+        const agent = await sendTurn(taskId, "hello", rec.onChunk, {
           onPasteFailure: (outcome) => failures.push(outcome),
         });
         await expect(agent.done).rejects.toThrow("paste failed");
@@ -2126,7 +2136,7 @@ describe("queuePaste modal guard", () => {
       // ever appears in the log, however many such stages there are. Once
       // the paste has demonstrably landed (`load-buffer` recorded), a picker
       // modal appearing is exactly the TOCTOU scenario this test targets.
-      const prevCapture = __forTest.setCapturePastePane(() => {
+      const prevCapture = __forTest.setCapturePastePane(async () => {
         const landed = readTmuxLog(logPath).some((e) => e.argv[0] === "load-buffer");
         return landed ? PICKER_PANE : idlePane;
       });
@@ -2134,7 +2144,7 @@ describe("queuePaste modal guard", () => {
       try {
         const rec = recorder();
         expect(state.composerHoldsText).toBe(false);
-        const agent = sendTurn(taskId, "hello", rec.onChunk, {
+        const agent = await sendTurn(taskId, "hello", rec.onChunk, {
           onPasteFailure: (outcome) => failures.push(outcome),
         });
         await expect(agent.done).rejects.toThrow("paste failed");
@@ -2182,7 +2192,7 @@ describe("queuePaste modal guard", () => {
       // that is idle again, so stillBlocking's confirming second sample
       // resolves false (not blocked) and the Enter proceeds normally.
       let postLandingCalls = 0;
-      const prevCapture = __forTest.setCapturePastePane(() => {
+      const prevCapture = __forTest.setCapturePastePane(async () => {
         const landed = readTmuxLog(logPath).some((e) => e.argv[0] === "load-buffer");
         if (!landed) return idlePane;
         postLandingCalls++;
@@ -2219,7 +2229,7 @@ describe("queuePaste modal guard", () => {
       const prevPoll = __forTest.setPasteModalPollMs(5);
       const { taskId, state } = freshSession();
       let calls = 0;
-      const prevCapture = __forTest.setCapturePastePane(() => {
+      const prevCapture = __forTest.setCapturePastePane(async () => {
         calls++;
         return calls <= 2 ? PICKER_PANE : idlePane;
       });
@@ -2248,7 +2258,7 @@ describe("queuePaste modal guard", () => {
     await withRecordingTmuxBin(async (logPath) => {
       const { taskId, state } = freshSession();
       let calls = 0;
-      const prevCapture = __forTest.setCapturePastePane(() => {
+      const prevCapture = __forTest.setCapturePastePane(async () => {
         calls++;
         return PICKER_PANE;
       });
@@ -2270,7 +2280,7 @@ describe("queuePaste modal guard", () => {
   test("no expectedState → the guard is inert even with PICKER_PANE on the pane (matches the other queuePaste tests that omit state)", async () => {
     await withRecordingTmuxBin(async (logPath) => {
       let calls = 0;
-      const prevCapture = __forTest.setCapturePastePane(() => {
+      const prevCapture = __forTest.setCapturePastePane(async () => {
         calls++;
         return PICKER_PANE;
       });
@@ -2322,7 +2332,7 @@ describe("queuePaste composer-clear check", () => {
       const { taskId, state } = freshSession();
       state.composerHoldsText = true;
       let calls = 0;
-      const prevCapture = __forTest.setCapturePastePane(() => {
+      const prevCapture = __forTest.setCapturePastePane(async () => {
         calls++;
         if (calls === 1) return idlePane; // pre-paste guard: clear
         if (calls === 2) return COMPOSER_DIRTY_PANE; // composer check: dirty
@@ -2360,7 +2370,7 @@ describe("queuePaste composer-clear check", () => {
       const prevGap = __forTest.setBracketedEnterGapMs(0);
       const { taskId, state } = freshSession();
       state.composerHoldsText = true;
-      const prevCapture = __forTest.setCapturePastePane(() => idlePane); // bare throughout
+      const prevCapture = __forTest.setCapturePastePane(async () => idlePane); // bare throughout
       try {
         await __forTest.queuePaste(taskId, state.sessionName, "hello", 0, state, { bracketed: true });
 
@@ -2385,7 +2395,7 @@ describe("queuePaste composer-clear check", () => {
       state.composerHoldsText = true;
       const rec = recorder();
       state.turnQueue.push({ onChunk: rec.onChunk, resolve: () => {}, reject: () => {}, slashCommand: null });
-      const prevCapture = __forTest.setCapturePastePane(() => COMPOSER_WORKING_NONBARE_PANE);
+      const prevCapture = __forTest.setCapturePastePane(async () => COMPOSER_WORKING_NONBARE_PANE);
       const failures: PasteFailureOutcome[] = [];
       try {
         await __forTest.queuePaste(taskId, state.sessionName, "hello", 0, state, {
@@ -2418,7 +2428,7 @@ describe("queuePaste composer-clear check", () => {
       const rec = recorder();
       state.turnQueue.push({ onChunk: rec.onChunk, resolve: () => {}, reject: () => {}, slashCommand: null });
       let calls = 0;
-      const prevCapture = __forTest.setCapturePastePane(() => {
+      const prevCapture = __forTest.setCapturePastePane(async () => {
         calls++;
         if (calls === 1) return idlePane; // pre-paste guard: clear
         return COMPOSER_DIRTY_PANE; // composer check + post-clear re-check: still dirty
@@ -2467,7 +2477,7 @@ test("every modal-guard withhold phase emits a status chunk starting with 'paste
         const { taskId, state } = freshSession();
         const rec = recorder();
         state.turnQueue.push({ onChunk: rec.onChunk, resolve: () => {}, reject: () => {}, slashCommand: null });
-        const prevCapture = __forTest.setCapturePastePane(() => PICKER_PANE);
+        const prevCapture = __forTest.setCapturePastePane(async () => PICKER_PANE);
         try {
           await __forTest.queuePaste(taskId, state.sessionName, "hello", 0, state, { bracketed: true });
         } finally {
@@ -2485,7 +2495,7 @@ test("every modal-guard withhold phase emits a status chunk starting with 'paste
         // Anchored on the tmux log (mirrors the dedicated TOCTOU test):
         // clear until the paste demonstrably lands (`load-buffer` recorded),
         // then a picker modal shows up on the TOCTOU re-check.
-        const prevCapture = __forTest.setCapturePastePane(() => {
+        const prevCapture = __forTest.setCapturePastePane(async () => {
           const landed = readTmuxLog(logPath).some((e) => e.argv[0] === "load-buffer");
           return landed ? PICKER_PANE : idlePane;
         });
@@ -2504,7 +2514,7 @@ test("every modal-guard withhold phase emits a status chunk starting with 'paste
         state.composerHoldsText = true;
         const rec = recorder();
         state.turnQueue.push({ onChunk: rec.onChunk, resolve: () => {}, reject: () => {}, slashCommand: null });
-        const prevCapture = __forTest.setCapturePastePane(() => COMPOSER_WORKING_NONBARE_PANE);
+        const prevCapture = __forTest.setCapturePastePane(async () => COMPOSER_WORKING_NONBARE_PANE);
         try {
           await __forTest.queuePaste(taskId, state.sessionName, "hello", 0, state, { bracketed: true });
         } finally {
@@ -2714,10 +2724,10 @@ test("sendSlashCommand({autoConfirm}) confirm-Enter failure: a failed confirm se
   await withFailingNthEnterTmuxBin(2, async () => {
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     const { taskId, state } = freshSession();
-    const prevPastePane = __forTest.setCapturePastePane(() => idlePane);
-    const prevConfirmPane = __forTest.setCaptureConfirmPane(() => effortConfirmPane);
+    const prevPastePane = __forTest.setCapturePastePane(async () => idlePane);
+    const prevConfirmPane = __forTest.setCaptureConfirmPane(async () => effortConfirmPane);
     try {
-      const ok = sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
+      const ok = await sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
       expect(ok).toBe(true);
 
       await __forTest.pasteChains.get(taskId);
@@ -2751,11 +2761,16 @@ test("sendTurn: opts.onPasteFailure still fires with op 'modal-guard' even when 
     const prevGrace = __forTest.setPasteModalGraceMs(20);
     const prevPoll = __forTest.setPasteModalPollMs(5);
     const { taskId, state } = freshSession();
-    const prevCapture = __forTest.setCapturePastePane(() => PICKER_PANE); // persistently blocking
+    const prevCapture = __forTest.setCapturePastePane(async () => PICKER_PANE); // persistently blocking
     const failures: PasteFailureOutcome[] = [];
     try {
       const rec = recorder();
-      const agent = sendTurn(taskId, "hello", rec.onChunk, {
+      // Deliberately NOT awaited — sendTurn's own body has no internal
+      // `await` before it registers the queued paste op and returns, so
+      // calling it without awaiting still runs that registration inline, in
+      // this same tick (see the sibling lastKeystrokeAt/PASTE_DROPPED_OUTCOME
+      // tests above for the fuller rationale).
+      const agentPromise = sendTurn(taskId, "hello", rec.onChunk, {
         onPasteFailure: (outcome) => failures.push(outcome),
       });
 
@@ -2766,6 +2781,7 @@ test("sendTurn: opts.onPasteFailure still fires with op 'modal-guard' even when 
       expect(state.turnQueue.length).toBe(1);
       state.pendingEndTurn = { messageId: null, uuid: undefined, emitBanner: false, stagedAt: Date.now() };
       __forTest.firePendingEndTurn(state);
+      const agent = await agentPromise;
       await expect(agent.done).resolves.toBe(0);
       expect(state.turnQueue.length).toBe(0);
 
@@ -2826,7 +2842,7 @@ test("bracketed paste: a failed trailing send-keys Enter (after load-buffer/past
     // idle read so the ONLY tmux calls left in the log are the paste path's
     // own four ops, keeping the assertion below about exactly the trailing
     // Enter.
-    const prevCapture = __forTest.setCapturePastePane(() => "");
+    const prevCapture = __forTest.setCapturePastePane(async () => "");
     const failures: PasteFailureOutcome[] = [];
     try {
       expect(state.composerHoldsText).toBe(false);
@@ -2868,7 +2884,7 @@ test("composer-clear check: a failed Escape,Escape send-keys withholds with phas
     // false — so the composer-clear branch attempts the Escape,Escape clear
     // rather than withholding immediately (the "claude working" branch) or
     // treating the composer as already-bare.
-    const prevCapture = __forTest.setCapturePastePane(() => COMPOSER_DIRTY_PANE);
+    const prevCapture = __forTest.setCapturePastePane(async () => COMPOSER_DIRTY_PANE);
     const failures: PasteFailureOutcome[] = [];
     try {
       await __forTest.queuePaste(taskId, state.sessionName, "hello", 0, state, {

--- a/src/bun/claude-tmux-queue.test.ts
+++ b/src/bun/claude-tmux-queue.test.ts
@@ -183,7 +183,7 @@ test("pasteFollowUp: folds into the active turn without pushing a new slot", asy
       const doneA = __forTest.pushTurnSlot(state, a.onChunk);
 
       // Fold a message in while the turn is live.
-      expect(pasteFollowUp(taskId, "second message while busy")).toMatchObject({ delivered: true });
+      expect(await pasteFollowUp(taskId, "second message while busy")).toMatchObject({ delivered: true });
       // No second slot — the queue stays at one in-flight turn (synchronous;
       // pasteFollowUp never touches turnQueue).
       expect(state.turnQueue.length).toBe(1);
@@ -218,8 +218,8 @@ test("pasteFollowUp: folds into the active turn without pushing a new slot", asy
   });
 });
 
-test("pasteFollowUp: returns false when no live session exists", () => {
-  expect(pasteFollowUp(randomUUID(), "msg")).toBe(false);
+test("pasteFollowUp: returns false when no live session exists", async () => {
+  expect(await pasteFollowUp(randomUUID(), "msg")).toBe(false);
 });
 
 // ─── pasteFollowUp({ onPasteFailure }) honors queuePaste's modal guard
@@ -238,10 +238,10 @@ test("pasteFollowUp({onPasteFailure}): a blocked pane fires the callback once (p
     const prevPoll = __forTest.setPasteModalPollMs(5);
     const { taskId, jsonlPath } = freshSession();
     __forTest.installSession(taskId, jsonlPath);
-    const prevCapture = __forTest.setCapturePastePane(() => BLOCKING_MODAL_PANE);
+    const prevCapture = __forTest.setCapturePastePane(async () => BLOCKING_MODAL_PANE);
     const failures: PasteFailureOutcome[] = [];
     try {
-      const result = pasteFollowUp(taskId, "a follow-up message", {
+      const result = await pasteFollowUp(taskId, "a follow-up message", {
         onPasteFailure: (outcome) => failures.push(outcome),
       });
       expect(result).toMatchObject({ delivered: true });
@@ -277,9 +277,9 @@ test("pasteFollowUp without {onPasteFailure}: a blocked pane withholds silently 
     const prevPoll = __forTest.setPasteModalPollMs(5);
     const { taskId, jsonlPath } = freshSession();
     __forTest.installSession(taskId, jsonlPath);
-    const prevCapture = __forTest.setCapturePastePane(() => BLOCKING_MODAL_PANE);
+    const prevCapture = __forTest.setCapturePastePane(async () => BLOCKING_MODAL_PANE);
     try {
-      const result = pasteFollowUp(taskId, "a follow-up message");
+      const result = await pasteFollowUp(taskId, "a follow-up message");
       expect(result).toMatchObject({ delivered: true });
       if (result === false) throw new Error("expected delivered");
       await expect(__forTest.pasteChains.get(taskId)).resolves.toBeUndefined();
@@ -315,7 +315,7 @@ test("pasteFollowUp: holds the run open across folded turns until the session go
       const a = recorder();
       const doneA = __forTest.pushTurnSlot(state, a.onChunk);
 
-      const foldResult = pasteFollowUp(taskId, "do another thing");
+      const foldResult = await pasteFollowUp(taskId, "do another thing");
       expect(foldResult).toMatchObject({ delivered: true });
       expect(state.holdUntilIdle).toBe(true);
       await new Promise((r) => setTimeout(r, 20)); // drain the paste chain
@@ -865,7 +865,7 @@ test("cycleToMode('plan'): a blocked pane withholds the /plan paste — result i
     const prevPoll = __forTest.setPasteModalPollMs(5);
     const { taskId, jsonlPath } = freshSession();
     __forTest.installSession(taskId, jsonlPath);
-    const prevCapture = __forTest.setCapturePastePane(() => BLOCKING_MODAL_PANE);
+    const prevCapture = __forTest.setCapturePastePane(async () => BLOCKING_MODAL_PANE);
     try {
       const result = await cycleToMode(taskId, "plan");
       expect(result).toEqual({ ok: false, reason: "paste withheld" });
@@ -888,7 +888,7 @@ test("cycleToMode('plan'): a clear pane still returns { ok: true, via: 'slash-pl
       "─".repeat(80),
       "⏵⏵ bypass permissions on (shift+tab to cycle) · ← 1 agent",
     ].join("\n");
-    const prevCapture = __forTest.setCapturePastePane(() => idlePane);
+    const prevCapture = __forTest.setCapturePastePane(async () => idlePane);
     const prevSettle = __forTest.setSlashCommandSettleMs(0);
     try {
       const result = await cycleToMode(taskId, "plan");
@@ -1292,7 +1292,7 @@ test("sendTurn bumps state.lastKeystrokeAt via queuePaste's pre-dispatch write s
     const stale = staleKeystrokeAt();
     state.lastKeystrokeAt = stale;
     try {
-      const agent = sendTurn(taskId, "hello agent", () => {});
+      const agent = await sendTurn(taskId, "hello agent", () => {});
       await agent.pasteOutcome;
       expect(state.lastKeystrokeAt).toBeGreaterThan(stale);
     } finally {
@@ -1308,7 +1308,7 @@ test("pasteFollowUp bumps state.lastKeystrokeAt via queuePaste's pre-dispatch wr
     const stale = staleKeystrokeAt();
     state.lastKeystrokeAt = stale;
     try {
-      const result = pasteFollowUp(taskId, "a follow-up");
+      const result = await pasteFollowUp(taskId, "a follow-up");
       expect(result).toMatchObject({ delivered: true });
       if (result === false) throw new Error("expected delivered");
       await result.pasteOutcome;
@@ -1389,7 +1389,7 @@ test("sendTurn(...).pasteOutcome resolves { ok: true } once the bracketed paste 
     const { taskId, jsonlPath } = freshSession();
     __forTest.installSession(taskId, jsonlPath);
     try {
-      const agent = sendTurn(taskId, "hello agent", () => {});
+      const agent = await sendTurn(taskId, "hello agent", () => {});
       await expect(agent.pasteOutcome).resolves.toEqual({ ok: true });
     } finally {
       __forTest.uninstallSession(taskId);
@@ -1403,9 +1403,9 @@ test("sendTurn(...).pasteOutcome resolves the modal-guard failure (with phase) w
     const prevPoll = __forTest.setPasteModalPollMs(5);
     const { taskId, jsonlPath } = freshSession();
     __forTest.installSession(taskId, jsonlPath);
-    const prevCapture = __forTest.setCapturePastePane(() => BLOCKING_MODAL_PANE);
+    const prevCapture = __forTest.setCapturePastePane(async () => BLOCKING_MODAL_PANE);
     try {
-      const agent = sendTurn(taskId, "hello agent", () => {});
+      const agent = await sendTurn(taskId, "hello agent", () => {});
       const outcome = await agent.pasteOutcome!;
       expect(outcome.ok).toBe(false);
       if (!outcome.ok) {
@@ -1429,18 +1429,33 @@ test("sendTurn(...).pasteOutcome resolves the modal-guard failure (with phase) w
 test("sendTurn(...).pasteOutcome resolves a PASTE_DROPPED_OUTCOME-shaped failure (never hangs) when the session is torn down before the queued paste runs", async () => {
   const { taskId, jsonlPath } = freshSession();
   __forTest.installSession(taskId, jsonlPath);
-  const agent = sendTurn(taskId, "hello agent", () => {});
+  // Deliberately NOT awaited here. `sendTurn` is `async` now (the tmux()
+  // choke point moved off Bun.spawnSync — see docs/plans/fix-task-details-
+  // load-delay.md), but its own body has no internal `await` before it
+  // registers the queued paste op (`void queuePaste(...)`) and returns — that
+  // registration is still fully synchronous. Awaiting the call here would
+  // itself cross a microtask boundary that lands AFTER queueTmuxOp's
+  // identity-check microtask already ran (verified empirically: the chain's
+  // `prev.then(...)` callback was scheduled, synchronously, before this
+  // function even returns its promise, so it's next in the microtask queue
+  // ahead of this `await`'s own continuation) — defeating the race this test
+  // exists to win. Calling `sendTurn` without awaiting and tearing the
+  // session down in the SAME synchronous tick is what still lands the
+  // teardown before that identity check.
+  const agentPromise = sendTurn(taskId, "hello agent", () => {});
   // The dropped paste also rejects the turn slot's `done` — expected (the
   // run must settle failed, not hang), but left unhandled here it would
   // otherwise surface as an unhandled-rejection failure unrelated to this
-  // test's actual assertion (pasteOutcome, below).
-  agent.done.catch(() => {});
+  // test's actual assertion (pasteOutcome, below). Chained via `.then`
+  // (not awaited) so it doesn't delay the synchronous teardown below.
+  agentPromise.then((agent) => agent.done.catch(() => {}));
   // Tear down the session SYNCHRONOUSLY, before the queued tmux op's
   // microtask gets a chance to run — queueTmuxOp's identity gate
   // (`sessions.get(taskId) === expectedState`) then drops the op body
   // entirely, so no tmux call (and no fake tmux bin) is needed here.
   __forTest.uninstallSession(taskId);
 
+  const agent = await agentPromise;
   const outcome = await Promise.race([
     agent.pasteOutcome!,
     new Promise<never>((_, reject) => {

--- a/src/bun/claude-tmux.test.ts
+++ b/src/bun/claude-tmux.test.ts
@@ -1593,7 +1593,7 @@ test("cycleToMode: success on first attempt when the status bar shows the target
   const { __forTest } = await import("./claude-tmux.ts");
   const prevPoll = __forTest.setModePollIntervalMs(1);
   // The status bar already reports auto once the presses land.
-  const prevPane = __forTest.setCaptureModePane(() => "⏵⏵ auto mode on (shift+tab to cycle)");
+  const prevPane = __forTest.setCaptureModePane(async () => "⏵⏵ auto mode on (shift+tab to cycle)");
   try {
     const taskId = "task-cycle-success";
     const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
@@ -1615,7 +1615,7 @@ test("cycleToMode: retries from the newly-observed mode when the first press lan
   const prevPoll = __forTest.setModePollIntervalMs(1);
   // Attempt 1 (from default) settles on acceptEdits; once cycleToMode records
   // that landing on the session, attempt 2's bar reports auto.
-  const prevPane = __forTest.setCaptureModePane((s) =>
+  const prevPane = __forTest.setCaptureModePane(async (s) =>
     s.permissionMode === CLAUDE_MODE_ACCEPT_EDITS
       ? "⏵⏵ auto mode on (shift+tab to cycle)"
       : "⏵⏵ accept edits on (shift+tab to cycle)",
@@ -1642,7 +1642,7 @@ test("cycleToMode: returns 'verification timed out' when the status bar never co
   const prevPoll = __forTest.setModePollIntervalMs(1);
   // Bar shows no recognisable mode banner (e.g. the auto opt-in modal is
   // painted over it) — readPaneMode returns null on every poll.
-  const prevPane = __forTest.setCaptureModePane(() => "Some unrelated output\n❯ ");
+  const prevPane = __forTest.setCaptureModePane(async () => "Some unrelated output\n❯ ");
   try {
     const taskId = "task-cycle-timeout";
     const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
@@ -1668,7 +1668,7 @@ test("cycleToMode: gives up with 'verification mismatch' after MAX_VERIFY_ATTEMP
   const prevPoll = __forTest.setModePollIntervalMs(1);
   // Each attempt lands on a wrong mode, keyed off where the previous attempt
   // left the session: default → acceptEdits → plan → default.
-  const prevPane = __forTest.setCaptureModePane((s) => {
+  const prevPane = __forTest.setCaptureModePane(async (s) => {
     if (s.permissionMode === CLAUDE_MODE_ACCEPT_EDITS) return "⏸ plan mode on (shift+tab to cycle)";
     if (s.permissionMode === CLAUDE_MODE_PLAN) return "? for shortcuts";
     return "⏵⏵ accept edits on (shift+tab to cycle)";
@@ -1708,7 +1708,7 @@ test("cycleToMode: overlapping calls on the same task both resolve", async () =>
   // concurrent cycleToMode calls (e.g. a user double-PATCH) each settle.
   const { __forTest } = await import("./claude-tmux.ts");
   const prevPoll = __forTest.setModePollIntervalMs(1);
-  const prevPane = __forTest.setCaptureModePane(() => "⏵⏵ auto mode on (shift+tab to cycle)");
+  const prevPane = __forTest.setCaptureModePane(async () => "⏵⏵ auto mode on (shift+tab to cycle)");
   try {
     const taskId = "task-cycle-race";
     const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
@@ -1733,7 +1733,7 @@ test("readPaneMode: reads the trailing status-bar banner, ignoring mode phrases 
   const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
   // A decoy "auto mode on" in assistant output must NOT win over the real
   // banner on the trailing line.
-  const prevPane = __forTest.setCaptureModePane(() =>
+  const prevPane = __forTest.setCaptureModePane(async () =>
     [
       "Assistant: I'll switch to auto mode on your behalf.",
       "❯ ",
@@ -1741,7 +1741,7 @@ test("readPaneMode: reads the trailing status-bar banner, ignoring mode phrases 
     ].join("\n"),
   );
   try {
-    expect(__forTest.readPaneMode(state)).toBe(CLAUDE_MODE_PLAN);
+    expect(await __forTest.readPaneMode(state)).toBe(CLAUDE_MODE_PLAN);
   } finally {
     __forTest.setCaptureModePane(prevPane);
     __forTest.uninstallSession(taskId);
@@ -1752,9 +1752,9 @@ test("readPaneMode: default mode recognised via the '? for shortcuts' trailing h
   const { __forTest } = await import("./claude-tmux.ts");
   const taskId = "task-readpane-default";
   const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
-  const prevPane = __forTest.setCaptureModePane(() => "❯ \n  ? for shortcuts · ← for agents");
+  const prevPane = __forTest.setCaptureModePane(async () => "❯ \n  ? for shortcuts · ← for agents");
   try {
-    expect(__forTest.readPaneMode(state)).toBe(CLAUDE_MODE_DEFAULT);
+    expect(await __forTest.readPaneMode(state)).toBe(CLAUDE_MODE_DEFAULT);
   } finally {
     __forTest.setCaptureModePane(prevPane);
     __forTest.uninstallSession(taskId);
@@ -1766,9 +1766,9 @@ test("readPaneMode: null when a mode phrase lacks the cycle-hint banner (e.g. mo
   const taskId = "task-readpane-null";
   const state = __forTest.installSession(taskId, "/tmp/never-read.jsonl");
   // "auto mode on" appears, but not as the trailing `(shift+tab to cycle)` banner.
-  const prevPane = __forTest.setCaptureModePane(() => "talking about auto mode on\n❯ ");
+  const prevPane = __forTest.setCaptureModePane(async () => "talking about auto mode on\n❯ ");
   try {
-    expect(__forTest.readPaneMode(state)).toBeNull();
+    expect(await __forTest.readPaneMode(state)).toBeNull();
   } finally {
     __forTest.setCaptureModePane(prevPane);
     __forTest.uninstallSession(taskId);
@@ -1976,8 +1976,8 @@ function makeFakePane(tabs: FakeTab[]) {
   let tab = 0, cursor = 0, w = 120, h = 30;
   const log: string[] = [];
   const io = {
-    capture: () => renderFakeModal(tabs, tab, cursor),
-    send: (key: NavKey) => {
+    capture: async () => renderFakeModal(tabs, tab, cursor),
+    send: async (key: NavKey) => {
       log.push(key);
       if (key === "Down") cursor = Math.min(cursor + 1, tabs[tab]!.options.length - 1);
       else if (key === "Up") cursor = Math.max(cursor - 1, 0);
@@ -1985,9 +1985,9 @@ function makeFakePane(tabs: FakeTab[]) {
       else if (key === "Left") { tab = Math.max(tab - 1, 0); cursor = 0; }
       return true;
     },
-    size: () => ({ w, h }),
-    resize: (nw: number, nh: number) => { w = nw; h = nh; log.push(`resize:${nw}x${nh}`); },
-    restore: (nw: number, nh: number) => { w = nw; h = nh; log.push(`restore:${nw}x${nh}`); },
+    size: async () => ({ w, h }),
+    resize: async (nw: number, nh: number) => { w = nw; h = nh; log.push(`resize:${nw}x${nh}`); },
+    restore: async (nw: number, nh: number) => { w = nw; h = nh; log.push(`restore:${nw}x${nh}`); },
     sleep: async () => { /* no delay in tests */ },
   };
   return { io, log, at: () => ({ tab, cursor, w, h }) };
@@ -2133,11 +2133,11 @@ function makeGrowablePane(opts: { grownTail: string | null }) {
   let grown = false;
   const log: string[] = [];
   const io = {
-    capture: () => (grown && opts.grownTail !== null ? opts.grownTail : TRUNCATED_TOP_TAIL),
-    send: (key: NavKey) => { log.push(key); return true; },
-    size: () => ({ w: 80, h: 24 }),
-    resize: (w: number, h: number) => { grown = true; log.push(`resize:${w}x${h}`); },
-    restore: (w: number, h: number) => { log.push(`restore:${w}x${h}`); },
+    capture: async () => (grown && opts.grownTail !== null ? opts.grownTail : TRUNCATED_TOP_TAIL),
+    send: async (key: NavKey) => { log.push(key); return true; },
+    size: async () => ({ w: 80, h: 24 }),
+    resize: async (w: number, h: number) => { grown = true; log.push(`resize:${w}x${h}`); },
+    restore: async (w: number, h: number) => { log.push(`restore:${w}x${h}`); },
     sleep: async () => { /* no delay in tests */ },
   };
   return { io, log };
@@ -2187,11 +2187,11 @@ test("collectAskQuestionsFromPane: unavailable pane size (io.size() → null) st
   const { __forTest } = await import("./claude-tmux.ts");
   const log: string[] = [];
   const io = {
-    capture: () => TRUNCATED_TOP_TAIL,
-    send: () => true,
-    size: () => null,
-    resize: (w: number, h: number) => { log.push(`resize:${w}x${h}`); },
-    restore: (w: number, h: number) => { log.push(`restore:${w}x${h}`); },
+    capture: async () => TRUNCATED_TOP_TAIL,
+    send: async () => true,
+    size: async () => null,
+    resize: async (w: number, h: number) => { log.push(`resize:${w}x${h}`); },
+    restore: async (w: number, h: number) => { log.push(`restore:${w}x${h}`); },
     sleep: async () => { /* no delay in tests */ },
   };
   const state = __forTest.installSession("ask-size-unavailable", "/tmp/never-read.jsonl");
@@ -2396,8 +2396,8 @@ test("healWindowSize issues no tmux call at all when a pane-grow is in flight fo
   const state = __forTest.installSession("heal-inflight", "/tmp/never-read.jsonl");
   state.paneGrowInFlight = true;
   try {
-    await withFakeTmuxBin(bin, () => {
-      healWindowSize("heal-inflight");
+    await withFakeTmuxBin(bin, async () => {
+      await healWindowSize("heal-inflight");
     });
     const log = existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
     expect(log).toBe("");
@@ -2410,10 +2410,10 @@ test("healWindowSize probes has-session but issues no set-window-option when the
   const dir = mkdtempSync(path.join(tmpdir(), "agetor-heal-log-"));
   const logPath = path.join(dir, "log.txt");
   const bin = fakeHealTmuxBin(1, logPath); // has-session always "fails"
-  await withFakeTmuxBin(bin, () => {
+  await withFakeTmuxBin(bin, async () => {
     // No installed SessionState for this taskId at all — mirrors the boot
     // path where a session outlived the process with no state rebuilt yet.
-    healWindowSize("heal-missing-task-id");
+    await healWindowSize("heal-missing-task-id");
   });
   const log = readFileSync(logPath, "utf8");
   expect(log).toContain("has-session");
@@ -2424,8 +2424,8 @@ test("healWindowSize resets window-size to latest with a single call when the se
   const dir = mkdtempSync(path.join(tmpdir(), "agetor-heal-log-"));
   const logPath = path.join(dir, "log.txt");
   const bin = fakeHealTmuxBin(0, logPath); // has-session always "succeeds"
-  await withFakeTmuxBin(bin, () => {
-    healWindowSize("heal-live-task-id");
+  await withFakeTmuxBin(bin, async () => {
+    await healWindowSize("heal-live-task-id");
   });
   const lines = readFileSync(logPath, "utf8").trim().split("\n");
   expect(lines.length).toBe(2);

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -1416,20 +1416,32 @@ interface RunResult {
 /** Run a one-shot tmux command. Never throws — callers check `ok`. Always
  *  threads `tmuxSocketArgs()` in right after the binary — see
  *  `tmuxSocketName()` in tmux-resolution.ts for why every invocation (this is
- *  the single choke point all of them share) must carry the socket args. */
-function tmux(args: string[], opts: { stdinText?: string } = {}): RunResult {
+ *  the single choke point all of them share) must carry the socket args.
+ *
+ *  Async (`Bun.spawn` + `await proc.exited`) so a tmux round-trip never
+ *  blocks the event loop that also serves the HTTP API — this used to be
+ *  `Bun.spawnSync`, which stalled every concurrent request for the duration
+ *  of the fork+exec (see docs/plans/fix-task-details-load-delay.md). No
+ *  timeout: a wedged tmux client now hangs only the awaiting op, not the
+ *  whole process, and adding one was explicitly declined for this change. */
+async function tmux(args: string[], opts: { stdinText?: string } = {}): Promise<RunResult> {
   try {
-    const proc = Bun.spawnSync([resolveTmuxBin(), ...tmuxSocketArgs(), ...args], {
+    const proc = Bun.spawn([resolveTmuxBin(), ...tmuxSocketArgs(), ...args], {
       stdin: opts.stdinText !== undefined
         ? new TextEncoder().encode(opts.stdinText)
         : "ignore",
       stdout: "pipe",
       stderr: "pipe",
     });
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const exitCode = await proc.exited;
     return {
-      ok: proc.exitCode === 0,
-      stdout: new TextDecoder().decode(proc.stdout).trim(),
-      stderr: new TextDecoder().decode(proc.stderr).trim(),
+      ok: exitCode === 0,
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
     };
   } catch (e) {
     return { ok: false, stdout: "", stderr: (e as Error).message };
@@ -1440,8 +1452,8 @@ function tmux(args: string[], opts: { stdinText?: string } = {}): RunResult {
  *  an exact match — without it, a probe for an absent name PREFIX-MATCHES
  *  and can report a live, unrelated session as "exists" (empirically proven
  *  on this task's sibling `agetor-<id>` names). */
-export function sessionExists(taskId: string): boolean {
-  return tmux(["has-session", "-t", "=" + sessionNameFor(taskId)]).ok;
+export async function sessionExists(taskId: string): Promise<boolean> {
+  return (await tmux(["has-session", "-t", "=" + sessionNameFor(taskId)])).ok;
 }
 
 /**
@@ -1495,8 +1507,8 @@ export function getSessionLaunchEffort(taskId: string): string | null {
 /** Name-keyed variant for callers that hold a persisted session name (e.g.
  *  `runs.tmux_session`) and don't want to recompute it from a task id.
  *  Exact-match `=` prefix — see `sessionExists`. */
-export function sessionExistsByName(name: string): boolean {
-  return tmux(["has-session", "-t", "=" + name]).ok;
+export async function sessionExistsByName(name: string): Promise<boolean> {
+  return (await tmux(["has-session", "-t", "=" + name])).ok;
 }
 
 /**
@@ -1568,8 +1580,8 @@ export function parseSessionActivityLine(line: string): { attached: boolean; act
  * the caller treats that as "can't tell," not "definitely dead."
  */
 let probeFailureWarned = false;
-export function probeSessionActivity(taskId: string): { attached: boolean; activityAt: number } | null {
-  const r = tmux([
+export async function probeSessionActivity(taskId: string): Promise<{ attached: boolean; activityAt: number } | null> {
+  const r = await tmux([
     "list-sessions", "-F", "#{session_attached}:#{session_activity}",
     "-f", "#{==:#{session_name}," + sessionNameFor(taskId) + "}",
   ]);
@@ -1624,11 +1636,11 @@ export type SessionLiveness = "alive" | "gone" | "unreachable";
  * detecting a genuinely-dead session or server the moment tmux says so (instead
  * of waiting for boot `reconcileOrphans`).
  */
-export function sessionLiveness(name: string): SessionLiveness {
+export async function sessionLiveness(name: string): Promise<SessionLiveness> {
   // Exact-match `=` prefix — see `sessionExists`. tmux's error string becomes
   // e.g. "can't find session: =x", which still contains "find session" below,
   // so the classification is unaffected by the prefix.
-  const r = tmux(["has-session", "-t", "=" + name]);
+  const r = await tmux(["has-session", "-t", "=" + name]);
   if (r.ok) return "alive";
   const err = `${r.stderr} ${r.stdout}`.toLowerCase();
   // Only UNAMBIGUOUS death strings count as `gone`:
@@ -1679,8 +1691,8 @@ export function sessionLiveness(name: string): SessionLiveness {
  * `kill(pid, 0)` syscall per tick instead of forking a tmux client — see
  * `createDeathProbe` in session-liveness.ts.
  */
-export function panePidFor(name: string): number | null {
-  const r = tmux(["list-panes", "-a", "-F", "#{session_name}\t#{pane_pid}"]);
+export async function panePidFor(name: string): Promise<number | null> {
+  const r = await tmux(["list-panes", "-a", "-F", "#{session_name}\t#{pane_pid}"]);
   if (!r.ok) return null;
   for (const line of r.stdout.split("\n")) {
     const tab = line.indexOf("\t");
@@ -1735,14 +1747,14 @@ export function deathTickOutcome(
 /** Kill any tmux session for the given task. Idempotent / silent on miss.
  *  Exact-match `=` prefix — see `sessionExists`; without it a kill for an
  *  absent exact name can prefix-match and kill an unrelated live session. */
-export function killTaskSession(taskId: string): void {
-  tmux(["kill-session", "-t", "=" + sessionNameFor(taskId)]);
+export async function killTaskSession(taskId: string): Promise<void> {
+  await tmux(["kill-session", "-t", "=" + sessionNameFor(taskId)]);
 }
 
 /** Kill an arbitrary session name. Used by reconcileOrphans. Exact-match `=`
  *  prefix — see `sessionExists`. */
-export function killSessionByName(name: string): void {
-  tmux(["kill-session", "-t", "=" + name]);
+export async function killSessionByName(name: string): Promise<void> {
+  await tmux(["kill-session", "-t", "=" + name]);
 }
 
 /**
@@ -1876,7 +1888,7 @@ export async function dismissTmuxPrompt(
     } else {
       // y/n style: send the literal keystroke.
       bumpKeystroke(state);
-      if (!tmux(["send-keys", "-t", state.sessionName, key]).ok) return;
+      if (!(await tmux(["send-keys", "-t", state.sessionName, key])).ok) return;
       await Bun.sleep(50);
       if (!stillCurrent()) return;
     }
@@ -1892,7 +1904,7 @@ export async function dismissTmuxPrompt(
     // keystroke and always confirms with a plain Enter here.
     const finalKey = useArrowNav ? (ctx.confirmKey ?? "Enter") : "Enter";
     bumpKeystroke(state);
-    ok = tmux(["send-keys", "-t", state.sessionName, finalKey]).ok;
+    ok = (await tmux(["send-keys", "-t", state.sessionName, finalKey])).ok;
   }, state);
   return ok;
 }
@@ -1927,7 +1939,7 @@ async function walkCursor(
 ): Promise<boolean> {
   for (let i = 0; i < steps; i++) {
     bumpKeystroke(state);
-    if (!tmux(["send-keys", "-t", state.sessionName, arrow]).ok) return false;
+    if (!(await tmux(["send-keys", "-t", state.sessionName, arrow])).ok) return false;
     await Bun.sleep(30);
     if (!stillCurrent()) return false;
   }
@@ -1961,7 +1973,7 @@ export async function sendModalKeys(taskId: string, keys: NavKey[]): Promise<boo
   await queueTmuxOp(taskId, async (stillCurrent) => {
     for (const key of keys) {
       bumpKeystroke(state);
-      if (!tmux(["send-keys", "-t", state.sessionName, key]).ok) return;
+      if (!(await tmux(["send-keys", "-t", state.sessionName, key])).ok) return;
       // Inter-key gap mirrors dismissTmuxPrompt: a bursted pair can read as a
       // single Ink event, and the gap lets the dispose re-gate fire.
       await Bun.sleep(35);
@@ -2103,7 +2115,7 @@ export async function driveAskAnswers(
   await queueTmuxOp(taskId, async (stillCurrent) => {
     for (const key of body) {
       bumpKeystroke(state);
-      if (!tmux(["send-keys", "-t", state.sessionName, key]).ok) return;
+      if (!(await tmux(["send-keys", "-t", state.sessionName, key])).ok) return;
       // Inter-key gap mirrors sendModalKeys: a bursted pair can read as a
       // single Ink event, and the gap lets the dispose re-gate fire.
       await Bun.sleep(35);
@@ -2115,11 +2127,11 @@ export async function driveAskAnswers(
       for (let attempt = 0; attempt < ASK_REVIEW_POLL_ATTEMPTS && !confirmSent; attempt++) {
         await Bun.sleep(ASK_REVIEW_POLL_MS);
         if (!stillCurrent()) return;
-        const step = decideAskDriveStep(detectAskModal(captureTail(state)), confirmSent, 0);
+        const step = decideAskDriveStep(detectAskModal(await captureTail(state)), confirmSent, 0);
         if (step === "done") { ok = true; return; }
         if (step === "send-enter") {
           bumpKeystroke(state);
-          if (!tmux(["send-keys", "-t", state.sessionName, "Enter"]).ok) return;
+          if (!(await tmux(["send-keys", "-t", state.sessionName, "Enter"])).ok) return;
           confirmSent = true;
         }
         // "wait" — review screen not up yet; keep polling. ("fail" cannot
@@ -2134,12 +2146,12 @@ export async function driveAskAnswers(
     for (let attempt = 0; attempt < ASK_VERIFY_POLL_ATTEMPTS; attempt++) {
       await Bun.sleep(ASK_VERIFY_POLL_MS);
       if (!stillCurrent()) return;
-      const step = decideAskDriveStep(detectAskModal(captureTail(state)), confirmSent, resends);
+      const step = decideAskDriveStep(detectAskModal(await captureTail(state)), confirmSent, resends);
       if (step === "done") { ok = true; return; }
       if (step === "fail") return;
       if (step === "send-enter") {
         bumpKeystroke(state);
-        if (!tmux(["send-keys", "-t", state.sessionName, "Enter"]).ok) return;
+        if (!(await tmux(["send-keys", "-t", state.sessionName, "Enter"])).ok) return;
         confirmSent = true;
         resends++;
       }
@@ -2628,9 +2640,10 @@ const sessions = new Map<string, SessionState>(); // taskId → state
  * choice can't interleave its `"1"` + Enter keystrokes with an in-flight
  * paste from `queuePaste`. (The exact tmux payload is mode-dependent —
  * non-bracketed slash commands send `load-buffer + paste-buffer +
- * delete-buffer + send-keys Enter` synchronously, while bracketed user
- * pastes split the trailing Enter out with a small `bracketedEnterGapMs`
- * sleep in between. See `queuePaste`.)
+ * delete-buffer + send-keys Enter` back-to-back with no deliberate gap
+ * (each still its own awaited `tmux()` round-trip — see `pastePrompt`),
+ * while bracketed user pastes split the trailing Enter out with a small
+ * `bracketedEnterGapMs` sleep in between. See `queuePaste`.)
  *
  * The map's value is the tail promise of the in-flight chain; new ops
  * append via `queueTmuxOp`. Entries self-evict on completion when no
@@ -2754,7 +2767,7 @@ function bumpActivity(state: SessionState): void {
  *     calls `queueTmuxOp`, since queuing a paste on a long-idle session is
  *     already the intent to type, and the queued op can sit behind other work
  *     on the per-task chain for multiple scrape ticks before it actually
- *     runs), and again right before each `pastePromptSync` dispatch, before
+ *     runs), and again right before each `pastePrompt` dispatch, before
  *     the deferred bracketed Enter, and before the composer-clear keystrokes;
  *   - `walkCursor` (the shared arrow-nav loop behind `dismissTmuxPrompt` and
  *     `mirrorModelViaPicker`) and `dismissTmuxPrompt`'s own literal-key and
@@ -2954,8 +2967,8 @@ function firePendingEndTurn(state: SessionState): void {
  * tool_result. This prevents both the "run flips to succeeded mid-turn" bug
  * and the spurious "TURN COMPLETE" divider spam it caused. */
 /** Capture the trailing pane lines for this session (best-effort; "" on miss). */
-function captureTail(state: SessionState): string {
-  const cap = tmux(["capture-pane", "-p", "-t", state.sessionName]);
+async function captureTail(state: SessionState): Promise<string> {
+  const cap = await tmux(["capture-pane", "-p", "-t", state.sessionName]);
   if (!cap.ok) return "";
   const cl = cap.stdout.split("\n");
   return cl.slice(Math.max(0, cl.length - SCRAPE_TAIL_LINES)).join("\n");
@@ -3083,24 +3096,24 @@ const OPTION_NAV_MS = 160;         // settle after each Up/Down before capturing
  *  with a fake pane (the real one shells out to tmux). */
 interface PaneIo {
   /** Full pane capture (NOT the scrape tail). */
-  capture(): string;
+  capture(): Promise<string>;
   /** Send one nav key; false when tmux errored (session gone). */
-  send(key: NavKey): boolean;
+  send(key: NavKey): Promise<boolean>;
   /** Current `<w>x<h>`, or null. */
-  size(): { w: number; h: number } | null;
-  resize(w: number, h: number): void;
-  restore(w: number, h: number): void;
+  size(): Promise<{ w: number; h: number } | null>;
+  resize(w: number, h: number): Promise<void>;
+  restore(w: number, h: number): Promise<void>;
   sleep(ms: number): Promise<void>;
 }
 
 function tmuxPaneIo(state: SessionState): PaneIo {
   return {
     capture: () => captureFullPane(state),
-    send: (key) => {
+    send: async (key) => {
       // Ask-collector cursor navigation is still agetor typing into the live
       // pane — same idle-settle clock as every other keystroke path.
       bumpKeystroke(state);
-      return tmux(["send-keys", "-t", state.sessionName, key]).ok;
+      return (await tmux(["send-keys", "-t", state.sessionName, key])).ok;
     },
     size: () => paneSize(state),
     resize: (w, h) => resizePane(state, w, h),
@@ -3121,8 +3134,8 @@ function paneHasPreviewPanel(text: string): boolean {
 }
 
 /** Current `<w>x<h>` of the session's window, or null. */
-function paneSize(state: SessionState): { w: number; h: number } | null {
-  const r = tmux(["display-message", "-p", "-t", state.sessionName, "#{window_width}x#{window_height}"]);
+async function paneSize(state: SessionState): Promise<{ w: number; h: number } | null> {
+  const r = await tmux(["display-message", "-p", "-t", state.sessionName, "#{window_width}x#{window_height}"]);
   if (!r.ok) return null;
   const m = r.stdout.trim().match(/^(\d+)x(\d+)$/);
   return m ? { w: Number(m[1]), h: Number(m[2]) } : null;
@@ -3134,8 +3147,8 @@ function paneSize(state: SessionState): { w: number; h: number } | null {
  *  it's a literal semicolon, not a shell-escaped `\;`) so the two commands reach
  *  the tmux server atomically: if agetor dies mid-call there's no window where
  *  `window-size` is `manual` but the resize hasn't landed yet. */
-function resizePane(state: SessionState, w: number, h: number): void {
-  tmux([
+async function resizePane(state: SessionState, w: number, h: number): Promise<void> {
+  await tmux([
     "set-window-option", "-t", "=" + state.sessionName, "window-size", "manual", ";",
     "resize-window", "-t", "=" + state.sessionName, "-x", String(w), "-y", String(h),
   ]);
@@ -3160,8 +3173,8 @@ function resizePane(state: SessionState, w: number, h: number): void {
  *  inherited value rather than forcing `latest` — see the comment on
  *  `healWindowSize` for why that heal path, unlike this one, deliberately
  *  forces `latest` instead. */
-function restorePaneSize(state: SessionState, w: number, h: number): void {
-  const r = tmux([
+async function restorePaneSize(state: SessionState, w: number, h: number): Promise<void> {
+  const r = await tmux([
     "resize-window", "-t", "=" + state.sessionName, "-x", String(w), "-y", String(h), ";",
     "set-window-option", "-u", "-t", "=" + state.sessionName, "window-size",
   ]);
@@ -3170,7 +3183,7 @@ function restorePaneSize(state: SessionState, w: number, h: number): void {
       `[claude-tmux] restorePaneSize chain failed for session ${state.sessionName} — ` +
         `falling back to a standalone unpin: ${r.stderr}`,
     );
-    tmux(["set-window-option", "-u", "-t", "=" + state.sessionName, "window-size"]);
+    await tmux(["set-window-option", "-u", "-t", "=" + state.sessionName, "window-size"]);
   }
 }
 
@@ -3205,17 +3218,17 @@ function restorePaneSize(state: SessionState, w: number, h: number): void {
  * `reattachSession` only runs for sessions `reconcileOrphans` already
  * verified alive.
  */
-export function healWindowSize(taskId: string, opts: { assumeAlive?: boolean } = {}): void {
+export async function healWindowSize(taskId: string, opts: { assumeAlive?: boolean } = {}): Promise<void> {
   const state = sessions.get(taskId);
   if (state?.paneGrowInFlight) return;
-  if (!opts.assumeAlive && !sessionExists(taskId)) return;
-  tmux(["set-window-option", "-t", "=" + sessionNameFor(taskId), "window-size", "latest"]);
+  if (!opts.assumeAlive && !(await sessionExists(taskId))) return;
+  await tmux(["set-window-option", "-t", "=" + sessionNameFor(taskId), "window-size", "latest"]);
 }
 
 /** Full pane capture (NOT the 40-line tail) — a grown preview panel can be much
  *  taller than the scrape tail. Sliced to the modal region by the caller. */
-function captureFullPane(state: SessionState): string {
-  const cap = tmux(["capture-pane", "-p", "-t", state.sessionName]);
+async function captureFullPane(state: SessionState): Promise<string> {
+  const cap = await tmux(["capture-pane", "-p", "-t", state.sessionName]);
   return cap.ok ? cap.stdout : "";
 }
 
@@ -3251,11 +3264,11 @@ async function captureTabWithPreviews(
   const previews: Array<string | undefined> = base.options.map((o) => o.preview);
   let downs = 0;
   for (let j = 1; j < base.options.length; j++) {
-    if (!io.send("Down")) break;
+    if (!(await io.send("Down"))) break;
     downs++;
     await io.sleep(OPTION_NAV_MS);
     if (!stillCurrent()) break;
-    const p = parseModalPane(sliceModalRegion(io.capture()));
+    const p = parseModalPane(sliceModalRegion(await io.capture()));
     // Only trust a capture whose cursor AND option count match — a mid-repaint
     // frame can't then misassign a preview to the wrong option.
     if (p && p.cursorIndex === j && p.options.length === base.options.length) {
@@ -3265,7 +3278,7 @@ async function captureTabWithPreviews(
   // Restore the cursor to option 0 (exact Up count — no over-pressing, which
   // could wrap) so the later answer-drive starts where planAskAnswers expects.
   for (let k = 0; k < downs; k++) {
-    if (!io.send("Up")) break;
+    if (!(await io.send("Up"))) break;
     await io.sleep(OPTION_NAV_MS);
     if (!stillCurrent()) break;
   }
@@ -3331,7 +3344,7 @@ async function collectAskQuestionsFromPane(
   let sizeUnavailable = false;
   const collected: Array<ParsedQuestionPane | null> = [];
   await queueTmuxOp(state.taskId, async (stillCurrent) => {
-    const orig = io.size();
+    const orig = await io.size();
     if (orig) grew = true;
     else sizeUnavailable = true;
     // Brackets the ONLY window where `window-size manual` is expected on this
@@ -3343,24 +3356,24 @@ async function collectAskQuestionsFromPane(
     if (orig) state.paneGrowInFlight = true;
     try {
       if (orig) {
-        io.resize(Math.max(orig.w, PREVIEW_PANE_MIN_COLS), PREVIEW_PANE_ROWS);
+        await io.resize(Math.max(orig.w, PREVIEW_PANE_MIN_COLS), PREVIEW_PANE_ROWS);
         await io.sleep(PREVIEW_REFLOW_MS);
         if (!stillCurrent()) return; // finally below restores + clears
       }
       for (let t = 0; t < n; t++) {
         if (t > 0) {
-          if (!io.send("Right")) return; // entering a tab resets the cursor to option 0
+          if (!(await io.send("Right"))) return; // entering a tab resets the cursor to option 0
           await io.sleep(180);
           if (!stillCurrent()) return;
         }
-        const base = parseModalPane(sliceModalRegion(io.capture()));
+        const base = parseModalPane(sliceModalRegion(await io.capture()));
         if (!base) { collected.push(null); return; }
         if (t === 0 && orig) {
           // Guard the post-resize transient: a mid-reflow capture can drop an
           // option and mis-drive the answer. Require two consecutive captures to
           // agree on the option count before trusting this tab.
           await io.sleep(OPTION_NAV_MS);
-          const recheck = parseModalPane(sliceModalRegion(io.capture()));
+          const recheck = parseModalPane(sliceModalRegion(await io.capture()));
           if (!recheck || recheck.options.length !== base.options.length) { collected.push(null); return; }
         }
         // Walk options only when THIS tab's focused option actually has a panel
@@ -3373,14 +3386,14 @@ async function collectAskQuestionsFromPane(
       }
       // Back to the first tab so the answer-driving sequence starts known.
       for (let t = 1; t < n; t++) {
-        if (!io.send("Left")) break;
+        if (!(await io.send("Left"))) break;
         await io.sleep(90);
         if (!stillCurrent()) break;
       }
     } finally {
       if (orig) {
         try {
-          io.restore(orig.w, orig.h);
+          await io.restore(orig.w, orig.h);
         } finally {
           state.paneGrowInFlight = false;
         }
@@ -3470,7 +3483,7 @@ async function collectAndRegisterAskCard(state: SessionState, firstTail: string)
     const questions = fromJsonl ?? await collectAskQuestionsFromPane(state, firstTail);
     if (!questions) return;
     // The modal may have been answered out from under us mid-collect.
-    if (state.askCardId || detectAskModal(captureTail(state)) === null) return;
+    if (state.askCardId || detectAskModal(await captureTail(state)) === null) return;
     const card = registerScrapedAskQuestions({
       taskId: state.taskId,
       runId,
@@ -4020,6 +4033,31 @@ export function rebuildEventsFromJsonl(text: string, onChunk: ChunkHandler): voi
  * without yielding to the event loop. Used by `sendTurn` before pushing a
  * new turn slot — guarantees that any trailing end_turn from the current
  * turn lands on the *current* slot, not on the one we're about to queue.
+ *
+ * DELIBERATELY KEPT SYNC (docs/plans/fix-task-details-load-delay.md T1) — this
+ * is the one sync fs read this file's async conversion left in place, and it's
+ * a correctness requirement, not an oversight. `flush()`'s own race guard
+ * (`if (state.offset !== startOffset) return;`, see its comment) only works
+ * because a call to THIS function is atomic with respect to the event loop:
+ * it runs `fsStatSync`/`fsOpenSync`/`fsReadSync`/`fsCloseSync` back-to-back
+ * with no `await` in between, so no other flush of the same `state.offset`
+ * can interleave mid-read. Rewriting it on top of `fs/promises` (mirroring
+ * `readAppended`) would reopen exactly the double-dispatch race `flush`'s
+ * guard exists to close — two overlapping reads of the same byte range, each
+ * independently advancing `state.offset` and re-dispatching lines, with a
+ * trailing `end_turn` capable of popping the wrong turn slot. Closing that
+ * race for real needs a shared in-flight guard both `flush` and this function
+ * check *before* their first read (not just after, the way `flush` does now)
+ * — restructuring beyond a same-file, same-task conversion, so it's left for
+ * a follow-up rather than risked here.
+ *
+ * The blocking cost this leaves behind is bounded, not unbounded: unlike the
+ * tmux spawns this task converts (one full process fork+exec per call) or the
+ * SSE replay query (sorts a task's ENTIRE event history), `flushSync` only
+ * reads the bytes appended to the JSONL since `state.offset` — normally a
+ * single turn's worth of new lines, a few KB at most — via a plain sync
+ * stat+read, not a subprocess. That's exactly the class of "µs-scale syscall"
+ * the file's own `fileWrittenWithin` comment calls out as fine to leave sync.
  */
 function flushSync(state: SessionState): void {
   let st;
@@ -5063,11 +5101,11 @@ async function confirmStartupDialog(taskId: string, sessionName: string, m: Star
   const arrow = delta >= 0 ? "Down" : "Up";
   for (let i = 0; i < Math.abs(delta); i++) {
     bumpIfLive();
-    if (!tmux(["send-keys", "-t", sessionName, arrow]).ok) return false;
+    if (!(await tmux(["send-keys", "-t", sessionName, arrow])).ok) return false;
     await Bun.sleep(30);
   }
   bumpIfLive();
-  return tmux(["send-keys", "-t", sessionName, "Enter"]).ok;
+  return (await tmux(["send-keys", "-t", sessionName, "Enter"])).ok;
 }
 
 /** How often the boot-time consent poller re-checks the pane. Fast enough
@@ -5675,7 +5713,7 @@ function normalizePaneForActivity(tail: string): string {
 /** Run a single scrape tick. Idempotent: registers at most one new
  *  TmuxPromptRequest per call, auto-cancels any pending one whose
  *  fingerprint no longer matches the pane. */
-function scrapeOnce(state: SessionState): void {
+async function scrapeOnce(state: SessionState): Promise<void> {
   const now = Date.now();
   // Computed once and reused for every read below (`decideScrapeTick`'s
   // `activePromptCount`, the idle-settle gate, and the `__external__` sweep)
@@ -5700,7 +5738,7 @@ function scrapeOnce(state: SessionState): void {
   if (tick.stampIdle) state.lastIdleScrapeAt = now;
   if (!tick.run) return;
 
-  const cap = tmux(["capture-pane", "-p", "-t", state.sessionName]);
+  const cap = await tmux(["capture-pane", "-p", "-t", state.sessionName]);
   if (!cap.ok) {
     // Session vanished — let `disposeSessionState` clean us up the next
     // time the orchestrator notices. Don't churn here.
@@ -5991,7 +6029,7 @@ export function markTmuxPromptAnswered(taskId: string, fingerprint: string): voi
 function startScraper(state: SessionState): void {
   if (state.scrapeTimer) return;
   state.scrapeTimer = setInterval(() => {
-    try { scrapeOnce(state); } catch { /* swallow — never crash the timer */ }
+    void scrapeOnce(state).catch(() => { /* swallow — never crash the timer */ });
   }, SCRAPE_INTERVAL_MS);
 }
 
@@ -6350,24 +6388,41 @@ function startDeathWatch(state: SessionState): void {
     resolvePid: panePidFor,
   });
   let misses = 0;
+  // Guards a tick against overlapping the previous one now that the
+  // authoritative probe is awaited (no timeout — an owner decision, see
+  // docs/plans/fix-task-details-load-delay.md §8): without it, a stalled
+  // tmux round-trip could let a second 400ms tick start concurrently and
+  // double-count a `wait` outcome. Mirrors codex/cursor/gemini-tmux's own
+  // death watch, which converted to this same shape for the same reason.
+  // The decision logic itself is unchanged.
+  let tickInFlight = false;
   state.deathTimer = setInterval(() => {
+    if (tickInFlight) return;
     if (!turnInFlight(state) && !heldProbeSafe(state.taskId)) { misses = 0; return; } // idle & not held — skip the poll
-    // Compute the log-recency veto lazily — it only matters for a `gone` probe,
-    // and `gone` is the rare tick, so we skip a statSync on every `alive` poll.
-    const liveness = probe.probe();
-    const outcome = deathTickOutcome({
-      liveness,
-      logFresh: liveness === "gone" && fileWrittenWithin(state.jsonlPath, DEATH_JSONL_QUIET_MS),
-      misses,
-      threshold: DEATH_MISS_THRESHOLD,
-    });
-    if (outcome === "reset") { misses = 0; return; }
-    if (outcome === "wait") { misses++; return; }
-    if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
-    setTimeout(() => {
-      flushSync(state);
-      signalSessionDeath(state);
-    }, DEATH_GRACE_MS);
+    tickInFlight = true;
+    void (async () => {
+      try {
+        // Compute the log-recency veto lazily — it only matters for a `gone`
+        // probe, and `gone` is the rare tick, so we skip a statSync on every
+        // `alive` poll.
+        const liveness = await probe.probe();
+        const outcome = deathTickOutcome({
+          liveness,
+          logFresh: liveness === "gone" && fileWrittenWithin(state.jsonlPath, DEATH_JSONL_QUIET_MS),
+          misses,
+          threshold: DEATH_MISS_THRESHOLD,
+        });
+        if (outcome === "reset") { misses = 0; return; }
+        if (outcome === "wait") { misses++; return; }
+        if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
+        setTimeout(() => {
+          flushSync(state);
+          signalSessionDeath(state);
+        }, DEATH_GRACE_MS);
+      } finally {
+        tickInFlight = false;
+      }
+    })();
   }, DEATH_POLL_MS);
 }
 
@@ -6499,7 +6554,7 @@ const DEFERRED_PROMPT_TIMEOUT_MS = 30_000;
  * Assumes `sessionExists(taskId)` is false; the caller (orchestrator) is
  * responsible for routing follow-up turns through `sendTurn`.
  */
-export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
+export async function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): Promise<SpawnedAgent> {
   const sessionName = sessionNameFor(opts.taskId);
 
   // Defensively clear any stale same-named session before (re)creating it, so
@@ -6508,7 +6563,7 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
   // `reconcileOrphans`): an idle claude session survives a restart, so a fresh
   // run of the same task must reset it. Own-scoped (only this task's name) and
   // idempotent/silent on miss — mirrors codex's spawn pre-kill.
-  killTaskSession(opts.taskId);
+  await killTaskSession(opts.taskId);
 
   // Clean up any stale agetor settings before tmux starts so claude reads a
   // tidy `.claude/settings.local.json` on launch. agetor is non-invasive: it
@@ -6518,7 +6573,7 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
   // self-heals permission rules in owned worktrees. Owned worktrees get a
   // self-heal-safe pass; user-repo cwds (isolation=none) get a merge pass
   // that preserves all existing user config.
-  ensureInstalledForCwd(opts.cwd, opts.mode);
+  await ensureInstalledForCwd(opts.cwd, opts.mode);
 
   // Build the tmux command. `-e KEY=VAL` injects env vars into the new
   // session (so the spawned claude inherits them); `--` separates the tmux
@@ -6535,7 +6590,7 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
   for (const [k, v] of Object.entries(fullEnv)) tmuxArgs.push("-e", `${k}=${v}`);
   tmuxArgs.push("--", ...opts.argv);
 
-  const launch = tmux(tmuxArgs);
+  const launch = await tmux(tmuxArgs);
   if (!launch.ok) {
     const err = new Error(`tmux new-session failed: ${launch.stderr || launch.stdout}`);
     opts.onChunk("stderr", err.message);
@@ -6679,24 +6734,24 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
         windows: for (;;) {
           const deadline = Date.now() + DEFERRED_PROMPT_TIMEOUT_MS;
           while (Date.now() < deadline) {
-            if (!tmux(["has-session", "-t", "=" + sessionName]).ok) return; // session died — nothing to paste into
+            if (!(await tmux(["has-session", "-t", "=" + sessionName])).ok) return; // session died — nothing to paste into
             if (sessions.get(opts.taskId) !== state) return; // superseded by a newer spawn/reattach
             if (!slotLive()) return; // cancelled (or otherwise settled) — never paste over it
-            if (readPaneMode(state) !== null) { ready = true; break windows; }
+            if ((await readPaneMode(state)) !== null) { ready = true; break windows; }
             await Bun.sleep(DEFERRED_PROMPT_POLL_MS);
           }
           // Window timed out. Don't paste over an unanswered startup
           // question — re-arm a fresh window instead, as long as there's
           // still something to wait for.
           if (activeTmuxPromptsForTask(opts.taskId).length === 0) break;
-          if (!tmux(["has-session", "-t", "=" + sessionName]).ok) return;
+          if (!(await tmux(["has-session", "-t", "=" + sessionName])).ok) return;
           if (sessions.get(opts.taskId) !== state) return;
           if (!slotLive()) return;
         }
         // Re-check liveness/identity before the final attempt — the loop can
         // exit via the timeout with the session still alive, and a dropped
         // prompt is worse than a best-effort paste into whatever's on screen.
-        if (!tmux(["has-session", "-t", "=" + sessionName]).ok) return;
+        if (!(await tmux(["has-session", "-t", "=" + sessionName])).ok) return;
         if (sessions.get(opts.taskId) !== state) return;
         if (!slotLive()) return; // cancelled during the final liveness check
         if (!ready) {
@@ -6803,8 +6858,8 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
           // a re-shown consent dialog on resume is out of scope (bypass
           // acceptance is global + persistent once accepted).
           if (bootSettled || existsSync(jsonlPath)) return;
-          if (!tmux(["has-session", "-t", "=" + sessionName]).ok) return;
-          const pane = tmux(["capture-pane", "-p", "-t", sessionName]).stdout;
+          if (!(await tmux(["has-session", "-t", "=" + sessionName])).ok) return;
+          const pane = (await tmux(["capture-pane", "-p", "-t", sessionName])).stdout;
           // A startup prompt we already surfaced and is still awaiting the
           // user keeps the boot window from expiring under them.
           if (activeTmuxPromptsForTask(opts.taskId).length > 0) {
@@ -6913,17 +6968,17 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
       if (found) break;
       const blockedOnUser =
         sawStartupPromptThisWindow || activeTmuxPromptsForTask(opts.taskId).length > 0;
-      if (blockedOnUser && tmux(["has-session", "-t", "=" + sessionName]).ok) continue;
+      if (blockedOnUser && (await tmux(["has-session", "-t", "=" + sessionName])).ok) continue;
       break;
     }
     bootSettled = true;
     if (!found) {
-      const stillAlive = tmux(["has-session", "-t", "=" + sessionName]).ok;
+      const stillAlive = (await tmux(["has-session", "-t", "=" + sessionName])).ok;
       // Capture whatever claude actually printed inside the pane so the user
       // sees the real cause (unknown flag, MCP initialize hung, auth prompt
       // waiting, …) rather than just "no JSONL".
       const paneRaw = stillAlive
-        ? tmux(["capture-pane", "-p", "-t", sessionName, "-S", "-200"]).stdout
+        ? (await tmux(["capture-pane", "-p", "-t", sessionName, "-S", "-200"])).stdout
         : "";
       const pane = paneRaw.trim() || "(empty — claude has not drawn any TUI output yet)";
       const detail = stillAlive
@@ -6932,7 +6987,7 @@ export function spawnClaudeViaTmux(opts: ClaudeLaunchOptions): SpawnedAgent {
       opts.onChunk("stderr", `claude session JSONL never appeared: ${detail}`);
       opts.onChunk("stderr", `expected at: ${jsonlPath}`);
       opts.onChunk("stderr", `--- tmux pane ---\n${pane}\n--- end pane ---`);
-      killTaskSession(opts.taskId);
+      await killTaskSession(opts.taskId);
       sessions.delete(opts.taskId);
       // Reject every queued turn so all dependent promises settle. Drop any
       // staged end_turn — without claude's JSONL we can't confirm it, and
@@ -6989,7 +7044,7 @@ export interface ReattachOptions {
  * as orphaned and kill the tmux session — without the JSONL we'd have no
  * structured visibility into the session anyway).
  */
-export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
+export async function reattachSession(opts: ReattachOptions): Promise<SpawnedAgent | null> {
   const sessionName = sessionNameFor(opts.taskId);
   const jsonlPath = jsonlPathFor(opts.cwd, opts.sessionId, opts.configDir);
   if (!existsSync(jsonlPath)) return null;
@@ -7050,7 +7105,7 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
   // `assumeAlive`: `reattachSession` only runs for sessions `reconcileOrphans`
   // already verified alive, so the internal `sessionExists` probe would be a
   // duplicate round-trip.
-  healWindowSize(opts.taskId, { assumeAlive: true });
+  await healWindowSize(opts.taskId, { assumeAlive: true });
 
   return {
     kill: () => {
@@ -7062,7 +7117,10 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
       // Drop any staged end_turn so a late-arriving JSONL line can't fire it
       // post-cancel and emit a spurious "turn complete" banner.
       bumpKeystroke(s);
-      tmux(["send-keys", "-t", s.sessionName, "C-c"]);
+      // Fire-and-forget: `kill` is a sync SpawnedAgent method (shared contract
+      // across every driver) and tmux() never throws, so there's nothing to
+      // await here — mirrors `makeAgent`'s kill below.
+      void tmux(["send-keys", "-t", s.sessionName, "C-c"]);
       const err = new Error("cancelled");
       s.pendingEndTurn = null;
       for (const slot of s.turnQueue.splice(0)) slot.reject?.(err);
@@ -7101,12 +7159,12 @@ export function reattachSession(opts: ReattachOptions): SpawnedAgent | null {
  * `onPasteFailure` callback: same outcomes, plus the success case, and it
  * always settles even when the queued tmux op is dropped without running.
  */
-export function sendTurn(
+export async function sendTurn(
   taskId: string,
   prompt: string,
   onChunk: ChunkHandler,
   opts?: { onPasteFailure?: (outcome: Extract<PasteOutcome, { ok: false }>) => void },
-): SpawnedAgent {
+): Promise<SpawnedAgent> {
   const state = sessions.get(taskId);
   if (!state) {
     const err = new Error(`no live session for task ${taskId}`);
@@ -7241,11 +7299,11 @@ export function sendTurn(
  * The callback and `pasteOutcome` describe the same event — use whichever
  * shape fits the call site; both fire for every failure.
  */
-export function pasteFollowUp(
+export async function pasteFollowUp(
   taskId: string,
   prompt: string,
   opts?: { onPasteFailure?: (outcome: Extract<PasteOutcome, { ok: false }>) => void },
-): { delivered: true; pasteOutcome: Promise<PasteOutcome> } | false {
+): Promise<{ delivered: true; pasteOutcome: Promise<PasteOutcome> } | false> {
   const state = sessions.get(taskId);
   if (!state) return false;
   // A folded-in follow-up paste is a life signal — reset the idle clock and
@@ -7300,7 +7358,7 @@ const SLASH_CONFIRM_IDLE_BREAK_TICKS = 2;
  * for `cycleToMode`); the unit suite swaps in a synthetic pane so it can
  * drive the confirm-detection step without a real claude session.
  */
-let captureConfirmPane: (state: SessionState) => string = captureTail;
+let captureConfirmPane: (state: SessionState) => Promise<string> = captureTail;
 
 /**
  * Test seam: how `queuePaste`'s modal guard reads the live pane before
@@ -7309,7 +7367,7 @@ let captureConfirmPane: (state: SessionState) => string = captureTail;
  * Mirrors `captureConfirmPane` immediately above exactly — a SEPARATE seam,
  * deliberately: overriding one must never silently redirect the other.
  */
-let capturePastePane: (state: SessionState) => string = captureTail;
+let capturePastePane: (state: SessionState) => Promise<string> = captureTail;
 
 /**
  * How often `queuePaste`'s modal guard re-captures the pane while a
@@ -7358,9 +7416,9 @@ let PASTE_MODAL_GRACE_MS = 1_500;
  * the "am I about to act on this" moment.
  */
 async function stillBlocking(state: SessionState): Promise<boolean> {
-  if (!paneShowsBlockingPrompt(capturePastePane(state))) return false;
+  if (!paneShowsBlockingPrompt(await capturePastePane(state))) return false;
   await Bun.sleep(PASTE_MODAL_POLL_MS);
-  return paneShowsBlockingPrompt(capturePastePane(state));
+  return paneShowsBlockingPrompt(await capturePastePane(state));
 }
 
 /**
@@ -7438,14 +7496,14 @@ async function stillBlocking(state: SessionState): Promise<boolean> {
  * ticks (not one) guards against a single transient idle-looking frame
  * mid-repaint; Enter is still never sent on this path.
  */
-export function sendSlashCommand(
+export async function sendSlashCommand(
   taskId: string,
   line: string,
   opts?: {
     autoConfirm?: "model" | "effort";
     onPasteFailure?: (outcome: Extract<PasteOutcome, { ok: false }>) => void;
   },
-): boolean {
+): Promise<boolean> {
   const state = sessions.get(taskId);
   if (!state) return false;
   // Settle delay after slash commands: claude's TUI takes ~hundreds of ms
@@ -7499,12 +7557,12 @@ async function autoConfirmSlashModal(
   let idleStreak = 0;
   for (let i = 0; i < attempts; i++) {
     if (!stillCurrent()) return false;
-    const tail = captureConfirmPane(state);
+    const tail = await captureConfirmPane(state);
     const match = matchSlashConfirmModal(tail, kind);
     if (match) {
       if (!stillCurrent()) return false;
       bumpKeystroke(state);
-      if (!tmux(["send-keys", "-t", state.sessionName, "Enter"]).ok) return false;
+      if (!(await tmux(["send-keys", "-t", state.sessionName, "Enter"])).ok) return false;
       // Stamp answered only AFTER the Enter actually landed (finding #6):
       // a failed send-keys means the confirm is still genuinely on the
       // pane, so it must stay eligible for the scraper's own matcher
@@ -7726,7 +7784,7 @@ export async function mirrorModelViaPicker(
   // Never open the picker on a busy session (finding #2, wave-5 re-review) —
   // see this function's doc. Checked again as the first thing the driving op
   // does below.
-  if (turnInFlight(state) || paneShowsClaudeWorking(capturePastePane(state))) {
+  if (turnInFlight(state) || paneShowsClaudeWorking(await capturePastePane(state))) {
     return { ok: false, reason: "turn in flight" };
   }
 
@@ -7764,7 +7822,7 @@ export async function mirrorModelViaPicker(
     // busy — including one where the bare `/model` we just pasted got
     // swallowed into claude's queued-input buffer instead of opening the
     // picker immediately.
-    if (turnInFlight(state) || paneShowsClaudeWorking(capturePastePane(state))) {
+    if (turnInFlight(state) || paneShowsClaudeWorking(await capturePastePane(state))) {
       result = { ok: false, reason: "turn in flight" };
       return;
     }
@@ -7784,7 +7842,7 @@ export async function mirrorModelViaPicker(
       let picker: ScrapeMatch | null = null;
       for (let i = 0; i < attempts; i++) {
         if (!stillCurrent()) return;
-        const m = matchNumberedModal(captureConfirmPane(state));
+        const m = matchNumberedModal(await captureConfirmPane(state));
         if (m && m.confirmKey === "s" && typeof m.cursorIndex === "number") {
           picker = m;
           break;
@@ -7807,7 +7865,7 @@ export async function mirrorModelViaPicker(
           return;
         }
         bumpKeystroke(state);
-        const escape = tmux(["send-keys", "-t", state.sessionName, "Escape"]);
+        const escape = await tmux(["send-keys", "-t", state.sessionName, "Escape"]);
         // Stamp the fingerprint answered ONLY when the Escape actually
         // landed (finding #4, wave-5 re-review) — mirrors the symmetry
         // `autoConfirmSlashModal` already applies to its own Enter: a failed
@@ -7834,7 +7892,7 @@ export async function mirrorModelViaPicker(
       // the match rather than hardcoding, so a future footer wording change
       // flows through `SESSION_ONLY_CONFIRM_RE` in one place.
       bumpKeystroke(state);
-      if (!tmux(["send-keys", "-t", state.sessionName, picker.confirmKey!]).ok) {
+      if (!(await tmux(["send-keys", "-t", state.sessionName, picker.confirmKey!])).ok) {
         result = { ok: false, reason: "keystroke failed" };
         return;
       }
@@ -7939,7 +7997,7 @@ let modePollIntervalMs = 100;
  * drive the verifier without a real claude session (the `/bin/echo` tmux stub
  * the tests use can't paint a status bar).
  */
-let captureModePane: (state: SessionState) => string = captureTail;
+let captureModePane: (state: SessionState) => Promise<string> = captureTail;
 
 /**
  * Parse claude's current permission mode out of the tmux status bar. The bar
@@ -7964,8 +8022,8 @@ let captureModePane: (state: SessionState) => string = captureTail;
  * "auto mode on" sitting in assistant/user output above the bar would
  * otherwise be mis-read as the live mode.
  */
-function readPaneMode(state: SessionState): string | null {
-  const lines = captureModePane(state).split("\n");
+async function readPaneMode(state: SessionState): Promise<string | null> {
+  const lines = (await captureModePane(state)).split("\n");
   let bar = "";
   for (let i = lines.length - 1; i >= 0; i--) {
     if (lines[i]!.trim() !== "") { bar = lines[i]!; break; }
@@ -8003,7 +8061,7 @@ async function waitForPaneMode(state: SessionState, from: string, target: string
   const deadline = Date.now() + modeVerifyTimeoutMs;
   let prev: string | null = null;
   for (;;) {
-    const mode = readPaneMode(state);
+    const mode = await readPaneMode(state);
     if (mode === target) return mode;
     // Settled on a moved, non-target mode → that's the landing.
     if (mode !== null && mode !== from && mode === prev) return mode;
@@ -8136,7 +8194,7 @@ async function cycleToModeInner(taskId: string, targetAgetorMode: string): Promi
     // every "mode change" silently no-op'd).
     const keys = Array<string>(presses).fill("BTab");
     bumpKeystroke(state);
-    tmux(["send-keys", "-t", state.sessionName, ...keys]);
+    await tmux(["send-keys", "-t", state.sessionName, ...keys]);
 
     // Verify by scraping the status bar, NOT the JSONL: claude only journals
     // `permission-mode` at the next turn start, so an idle Shift+Tab emits no
@@ -8199,7 +8257,7 @@ export function cycleToMode(taskId: string, targetAgetorMode: string): Promise<C
  * Tear down per-task state for `taskId` and kill the tmux session. Used by
  * deleteTask and reconcileOrphans.
  */
-export function dropSession(taskId: string): void {
+export async function dropSession(taskId: string): Promise<void> {
   const state = sessions.get(taskId);
   if (state) {
     // `orphanSubagents: true` — this task's session is being torn down for
@@ -8215,7 +8273,7 @@ export function dropSession(taskId: string): void {
     detachWatcherFor(taskId);
     orphanRunningSubagents(taskId);
   }
-  killTaskSession(taskId);
+  await killTaskSession(taskId);
 }
 
 /**
@@ -8225,15 +8283,15 @@ export function dropSession(taskId: string): void {
  * no `active` run handle to route the interrupt through, and after a restart it
  * has no `SessionState` either. Returns false when the session is already gone.
  */
-export function interruptTaskSession(taskId: string): boolean {
+export async function interruptTaskSession(taskId: string): Promise<boolean> {
   const name = sessionNameFor(taskId);
-  if (!sessionExistsByName(name)) return false;
+  if (!(await sessionExistsByName(name))) return false;
   // Best-effort: this path deliberately works from the session NAME alone
   // (there may be no in-memory state after a restart), but when there IS a
   // live state, stamp the keystroke clock like every other send-keys site.
   const state = sessions.get(taskId);
   if (state) bumpKeystroke(state);
-  tmux(["send-keys", "-t", name, "C-c"]);
+  await tmux(["send-keys", "-t", name, "C-c"]);
   return true;
 }
 
@@ -8333,7 +8391,8 @@ function makeAgent(
       const state = sessions.get(taskId);
       if (!state) return;
       bumpKeystroke(state);
-      tmux(["send-keys", "-t", state.sessionName, "C-c"]);
+      // Fire-and-forget — see reattachSession's kill closure for why.
+      void tmux(["send-keys", "-t", state.sessionName, "C-c"]);
       const err = new Error("cancelled");
       state.pendingEndTurn = null;
       for (const slot of state.turnQueue.splice(0)) slot.reject?.(err);
@@ -8497,7 +8556,9 @@ export const __forTest = {
    *  tmux pane). Tests inject a synthetic status bar — pass a function that
    *  returns the pane text claude would show. Returns the previous reader so
    *  the test can restore it. */
-  setCaptureModePane(fn: (state: SessionState) => string): (state: SessionState) => string {
+  setCaptureModePane(
+    fn: (state: SessionState) => Promise<string>,
+  ): (state: SessionState) => Promise<string> {
     const prev = captureModePane;
     captureModePane = fn;
     return prev;
@@ -8508,7 +8569,9 @@ export const __forTest = {
    *  confirm-modal pane so the confirm-poll step can be driven without a
    *  real tmux session. Returns the previous reader so the test can restore
    *  it in `afterEach` (mirrors `setCaptureModePane`). */
-  setCaptureConfirmPane(fn: (state: SessionState) => string): (state: SessionState) => string {
+  setCaptureConfirmPane(
+    fn: (state: SessionState) => Promise<string>,
+  ): (state: SessionState) => Promise<string> {
     const prev = captureConfirmPane;
     captureConfirmPane = fn;
     return prev;
@@ -8662,7 +8725,9 @@ export const __forTest = {
    *  synthetic modal (or idle) pane so the guard can be driven without a
    *  real tmux session. Returns the previous reader so the test can restore
    *  it in `afterEach` (mirrors `setCaptureConfirmPane`). */
-  setCapturePastePane(fn: (state: SessionState) => string): (state: SessionState) => string {
+  setCapturePastePane(
+    fn: (state: SessionState) => Promise<string>,
+  ): (state: SessionState) => Promise<string> {
     const prev = capturePastePane;
     capturePastePane = fn;
     return prev;
@@ -8779,12 +8844,28 @@ const IMAGE_ATTACH_SETTLE_MAX_MS = 3_000;
  * newlines, dollar signs, quotes, …), paste it into the active window, then
  * press Enter to submit.
  *
- * Stays synchronous — the caller (`queuePaste`) is responsible for any
- * post-paste delays (the base bracketed gap or the longer image-attach
- * gap) and for re-gating the trailing Enter on session identity. Keeping
- * this function sync preserves the "no awaits between tmux calls"
- * invariant the `queueTmuxOp` chain depends on; the gap + Enter split for
- * the bracketed case happens in `queuePaste`.
+ * Async (renamed from `pastePromptSync` — docs/plans/fix-task-details-load-
+ * delay.md T1: `tmux()` itself moved off `Bun.spawnSync`, so nothing in this
+ * file is truly "Sync" anymore). Its four tmux calls (load-buffer,
+ * paste-buffer, delete-buffer, send-keys Enter) each now yield to the event
+ * loop across the `await`.
+ *
+ * The load-bearing invariant is no longer "no awaits between tmux calls"
+ * (that guarantee is gone by construction) — it's that this whole
+ * micro-sequence is only ever invoked from inside a `queueTmuxOp`/`queuePaste`
+ * body on the PER-TASK chain (`pasteChains`), so two calls for the *same*
+ * task can never interleave their four steps with each other. Cross-task
+ * interleaving is safe by construction too: each call targets a distinct
+ * tmux session (`-t sessionName`) and a distinct, session-scoped buffer name
+ * (`agetor-${sessionName}`), so even fully-concurrent awaits for different
+ * tasks can never step on each other's buffer or pane. A session dying
+ * mid-sequence (between, say, load-buffer and paste-buffer) is no longer
+ * structurally impossible the way a single synchronous call made it — but it
+ * doesn't need to be: the next tmux call in the sequence just comes back
+ * `ok: false` (session gone), which this function already turns into a
+ * `TmuxPasteFailure` the caller (`queuePaste`) already knows how to handle
+ * (re-stash to the backlog, surface a status line) exactly as it does for
+ * any other tmux failure.
  *
  * `skipEnter` defers the trailing Enter to the caller so it can insert a
  * gap before the `send-keys Enter`. See `queuePaste`'s bracketed branch
@@ -8799,14 +8880,14 @@ const IMAGE_ATTACH_SETTLE_MAX_MS = 3_000;
  * caller instead of silently swallowed — see `queuePaste`'s handling of a
  * non-`ok` result.
  */
-function pastePromptSync(
+async function pastePrompt(
   sessionName: string,
   text: string,
   opts: { bracketed?: boolean; skipEnter?: boolean } = {},
-): { ok: true } | TmuxPasteFailure {
+): Promise<{ ok: true } | TmuxPasteFailure> {
   // load-buffer reads from stdin; -b names a tmux buffer we can target.
   const buf = `agetor-${sessionName}`;
-  const load = tmux(["load-buffer", "-b", buf, "-"], { stdinText: text });
+  const load = await tmux(["load-buffer", "-b", buf, "-"], { stdinText: text });
   if (!load.ok) return { ok: false, op: "load-buffer", stderr: load.stderr };
   // `-p` wraps the paste in bracketed-paste codes (ESC[200~ … ESC[201~) when
   // the app has requested bracketed-paste mode (claude's Ink TUI does). Long
@@ -8818,8 +8899,8 @@ function pastePromptSync(
   // typically insert pasted text verbatim instead of dispatching it as a
   // command, which would silently break the mode/model switchers.
   const pasteFlags = opts.bracketed ? ["-p"] : [];
-  const paste = tmux(["paste-buffer", ...pasteFlags, "-b", buf, "-t", sessionName]);
-  tmux(["delete-buffer", "-b", buf]);
+  const paste = await tmux(["paste-buffer", ...pasteFlags, "-b", buf, "-t", sessionName]);
+  await tmux(["delete-buffer", "-b", buf]);
   if (!paste.ok) return { ok: false, op: "paste-buffer", stderr: paste.stderr };
   // `skipEnter` defers the trailing Enter to the caller so it can sleep
   // between the bracketed paste and the Enter — see `queuePaste`. Without
@@ -8828,19 +8909,19 @@ function pastePromptSync(
   // absorbed as part of the same paste event, so the queued bubble sits
   // unsubmitted until the user (or a later Enter) commits it.
   if (!opts.skipEnter) {
-    const enter = tmux(["send-keys", "-t", sessionName, "Enter"]);
+    const enter = await tmux(["send-keys", "-t", sessionName, "Enter"]);
     if (!enter.ok) return { ok: false, op: "send-keys", stderr: enter.stderr };
   }
   return { ok: true };
 }
 
-/** Result of `pastePromptSync` / the deferred bracketed-paste Enter in
+/** Result of `pastePrompt` / the deferred bracketed-paste Enter in
  *  `queuePaste`, PLUS the guard's own synthesized withhold. `ok: false` for
  *  `op: "load-buffer" | "paste-buffer" | "send-keys"` means the tmux
  *  subprocess for `op` exited non-zero — a real signal that the paste didn't
  *  land (dead server, socket gone, session vanished mid-op), not just
  *  "nothing happened yet". `op: "modal-guard"` is different in kind: it's
- *  synthesized by `queuePaste` itself (never by `pastePromptSync`, and never
+ *  synthesized by `queuePaste` itself (never by `pastePrompt`, and never
  *  the result of an actual tmux call) when the paste — or its deferred
  *  bracketed Enter — is withheld because a live claude modal is still on the
  *  pane after the guard's grace window; see the guard blocks in `queuePaste`.
@@ -8866,10 +8947,10 @@ export type PasteOutcome =
 
 /**
  * The subset of `PasteOutcome` failures that actually came from a tmux
- * subprocess call (`pastePromptSync`'s three failure ops, or the manually
+ * subprocess call (`pastePrompt`'s three failure ops, or the manually
  * constructed `"send-keys"` outcome for the deferred bracketed Enter) — i.e.
  * every `PasteOutcome` failure except the guard's own synthesized
- * `"modal-guard"`. Used as `pastePromptSync`'s return type, so its declared
+ * `"modal-guard"`. Used as `pastePrompt`'s return type, so its declared
  * type itself proves (no cast needed) that it can never produce
  * `modal-guard`, and to narrow `reportPasteFailure`'s parameter (finding
  * #11, docs/plans/model-effort-local-command-turns.md §10) so its
@@ -8892,7 +8973,7 @@ type TmuxPasteFailure = Exclude<Extract<PasteOutcome, { ok: false }>, { op: "mod
  * applied before the *next* operation — never before the slash itself.
  *
  * Important caveat about what this delay actually buys: the timer starts
- * when `pastePromptSync` returns (i.e. when tmux's `send-keys Enter`
+ * when `pastePrompt` returns (i.e. when tmux's `send-keys Enter`
  * exits), NOT when claude has finished processing the slash command. On
  * an idle REPL these are close enough that 700ms covers consumption +
  * repaint. When claude is mid-turn, the slash command queues inside
@@ -9045,7 +9126,7 @@ function queueTmuxOp(
  * of which is "deliver this as the next chat message." If the modal is
  * STILL there once the grace window elapses, `stillBlocking` (a double
  * sample — finding #3, §10 review) confirms it isn't just a mid-repaint
- * transient before the paste is WITHHELD (no `pastePromptSync` call at
+ * transient before the paste is WITHHELD (no `pastePrompt` call at
  * all): a `status` chunk + console log surface it, and `opts.onPasteFailure`
  * fires with `{ ok: false, op: "modal-guard", phase: "pre-paste" }` exactly
  * like any other paste failure, so a caller with a turn slot (`sendTurn`)
@@ -9195,9 +9276,12 @@ function queuePaste(
   // delayed well past this enqueue-time stamp.
   if (expectedState) bumpKeystroke(expectedState);
   // Non-bracketed path: load-buffer + paste-buffer + delete-buffer +
-  // send-keys Enter all happen synchronously inside pastePromptSync, so
-  // the only await is the optional settle — no tmux calls land after the
-  // sleep, and a dispose during the sleep can't leak keystrokes.
+  // send-keys Enter each now await their own tmux() round-trip inside
+  // `pastePrompt` (it stopped being truly "synchronous" the moment `tmux()`
+  // itself moved off `Bun.spawnSync` — see `pastePrompt`'s doc for how
+  // atomicity survives that: the per-task chain plus per-session buffer
+  // names, not an uninterruptible call). The settle sleep after it returns is
+  // just one more await in the same already-async op body.
   //
   // Bracketed path: we split the trailing Enter out and insert a gap so
   // claude's Ink TUI has time to consume `ESC[201~` and commit the paste
@@ -9254,7 +9338,8 @@ function queuePaste(
     if (expectedState && !opts.skipModalGuard) {
       const graceMs = opts.modalGuardGraceMs ?? PASTE_MODAL_GRACE_MS;
       const guardDeadline = Date.now() + graceMs;
-      while (paneShowsBlockingPrompt(capturePastePane(expectedState))) {
+      while (paneShowsBlockingPrompt(await capturePastePane(expectedState))) {
+        if (!stillCurrent()) return;
         if (Date.now() >= guardDeadline) {
           // Double-sample before withholding (finding #3, docs/plans/model-
           // effort-local-command-turns.md §10 review) — also what turns the
@@ -9295,7 +9380,8 @@ function queuePaste(
     // nothing to catch.
     let insertedComposerClearDelay = false;
     if (expectedState && !opts.skipModalGuard && expectedState.composerHoldsText) {
-      const tail = capturePastePane(expectedState);
+      const tail = await capturePastePane(expectedState);
+      if (!stillCurrent()) return;
       if (paneShowsClaudeWorking(tail)) {
         // No safe mid-turn clear — Escape/Ctrl-C would interrupt the live
         // turn (see COMPOSER_CLEAR_KEYS's doc) — so withhold until idle.
@@ -9315,7 +9401,12 @@ function queuePaste(
         // other tmux call — check `.ok` rather than assuming the clear
         // keystrokes landed just because a pane re-capture follows.
         bumpKeystroke(expectedState);
-        const clearResult = tmux(["send-keys", "-t", sessionName, ...COMPOSER_CLEAR_KEYS]);
+        // No `stillCurrent()` gate immediately after this await, for the same
+        // reason as the `pastePrompt` call below: a real send-keys failure
+        // here must still be reported (invariant #3), not swallowed behind a
+        // stale-session check. `stillCurrent()` gates the settle sleep right
+        // after instead, before any further action is taken on success.
+        const clearResult = await tmux(["send-keys", "-t", sessionName, ...COMPOSER_CLEAR_KEYS]);
         if (!clearResult.ok) {
           const outcome: Extract<PasteOutcome, { ok: false }> =
             { ok: false, op: "modal-guard", phase: "composer-dirty", stderr: clearResult.stderr || "composer-clear send-keys failed" };
@@ -9337,7 +9428,8 @@ function queuePaste(
         // since that predicate requires `!paneShowsClaudeWorking` and a
         // genuine `❯`-row, neither of which a modal provides). Require both
         // "no blocking prompt" AND a confirmed bare row before trusting it.
-        const after = capturePastePane(expectedState);
+        const after = await capturePastePane(expectedState);
+        if (!stillCurrent()) return;
         if (paneShowsBlockingPrompt(after) || !paneShowsIdleInputBox(after)) {
           const outcome: Extract<PasteOutcome, { ok: false }> =
             { ok: false, op: "modal-guard", phase: "composer-dirty", stderr: "composer clear did not take" };
@@ -9401,7 +9493,14 @@ function queuePaste(
     }
     if (opts.bracketed) {
       if (expectedState) bumpKeystroke(expectedState);
-      const result = pastePromptSync(sessionName, text, { bracketed: true, skipEnter: true });
+      // No `stillCurrent()` gate right after this await (unlike the pane-read
+      // awaits above): `pastePrompt` already ran its tmux calls against
+      // whatever session was live when they fired, and that outcome — success
+      // or a real tmux failure — is the truth to report either way (invariant
+      // #3: mid-sequence session death surfaces as a non-ok result, not a
+      // suppressed one). `stillCurrent()` still gates every action taken
+      // AFTER this point, below.
+      const result = await pastePrompt(sessionName, text, { bracketed: true, skipEnter: true });
       if (!result.ok) {
         reportPasteFailure(taskId, expectedState, result);
         report(result);
@@ -9447,7 +9546,7 @@ function queuePaste(
         }
       }
       if (expectedState) bumpKeystroke(expectedState);
-      const enter = tmux(["send-keys", "-t", sessionName, "Enter"]);
+      const enter = await tmux(["send-keys", "-t", sessionName, "Enter"]);
       if (!enter.ok) {
         const outcome: TmuxPasteFailure =
           { ok: false, op: "send-keys", stderr: enter.stderr };
@@ -9470,23 +9569,22 @@ function queuePaste(
       report({ ok: true });
     } else {
       if (expectedState) bumpKeystroke(expectedState);
-      const result = pastePromptSync(sessionName, text, { bracketed: opts.bracketed });
+      const result = await pastePrompt(sessionName, text, { bracketed: opts.bracketed });
       if (!result.ok) {
         reportPasteFailure(taskId, expectedState, result);
-        // (finding #7, §10 re-review) `pastePromptSync` without `skipEnter`
-        // runs load-buffer + paste-buffer + send-keys Enter all
-        // synchronously — an `op: "send-keys"` failure here means the paste
-        // itself already landed and only the Enter didn't, so the composer
-        // holds this text exactly like the bracketed path's Enter-failure
-        // branch above.
+        // (finding #7, §10 re-review) `pastePrompt` without `skipEnter`
+        // runs load-buffer + paste-buffer + send-keys Enter in sequence —
+        // an `op: "send-keys"` failure here means the paste itself already
+        // landed and only the Enter didn't, so the composer holds this text
+        // exactly like the bracketed path's Enter-failure branch above.
         if (expectedState && result.op === "send-keys") expectedState.composerHoldsText = true;
         report(result);
         return;
       }
       if (expectedState) expectedState.composerHoldsText = false;
-      // Terminal success for the non-bracketed path: `pastePromptSync`
-      // without `skipEnter` runs load-buffer + paste-buffer + Enter all
-      // synchronously, so an `ok` result means all three landed.
+      // Terminal success for the non-bracketed path: `pastePrompt`
+      // without `skipEnter` runs load-buffer + paste-buffer + Enter in
+      // sequence, so an `ok` result means all three landed.
       report({ ok: true });
     }
     if (settleMs > 0) await Bun.sleep(settleMs);

--- a/src/bun/claude-tmux.ts
+++ b/src/bun/claude-tmux.ts
@@ -6028,8 +6028,22 @@ export function markTmuxPromptAnswered(taskId: string, fingerprint: string): voi
  *  `attachTailer`; torn down by `disposeSessionState`. */
 function startScraper(state: SessionState): void {
   if (state.scrapeTimer) return;
+  // Guards a tick against overlapping the previous one now that `scrapeOnce`
+  // does a real awaited capture-pane: without it, a stalled tmux round-trip
+  // could let a second SCRAPE_INTERVAL_MS tick start concurrently and act on
+  // the same pane frame, defeating the two-tick stability gates
+  // (`scrapeLastFingerprint`, `scrapeUnparsableStreak`, `scrapeIdleSettleStreak`)
+  // that exist precisely to require a modal to persist across ticks before a
+  // card is registered off it — a card registered from a single sighting can
+  // drive wrong-option keystrokes. Mirrors the death watch's own
+  // `tickInFlight` guard (see `startDeathWatch`).
+  let tickInFlight = false;
   state.scrapeTimer = setInterval(() => {
-    void scrapeOnce(state).catch(() => { /* swallow — never crash the timer */ });
+    if (tickInFlight) return;
+    tickInFlight = true;
+    void scrapeOnce(state)
+      .catch(() => { /* swallow — never crash the timer */ })
+      .finally(() => { tickInFlight = false; });
   }, SCRAPE_INTERVAL_MS);
 }
 
@@ -6419,6 +6433,8 @@ function startDeathWatch(state: SessionState): void {
           flushSync(state);
           signalSessionDeath(state);
         }, DEATH_GRACE_MS);
+      } catch {
+        /* never crash the watch */
       } finally {
         tickInFlight = false;
       }
@@ -9106,8 +9122,10 @@ function queueTmuxOp(
  * the one this paste was scheduled against — see `queueTmuxOp` for the
  * race this closes.
  *
- * When `opts.bracketed` is true, the trailing `Enter` is split out of
- * the synchronous paste body and sent after a small internal gap
+ * When `opts.bracketed` is true, the trailing `Enter` is split out of the
+ * paste body — load-buffer + paste-buffer land back-to-back, each its own
+ * awaited `tmux()` round-trip, with no deliberate gap between them — and
+ * sent after a small internal gap
  * (`bracketedEnterGapMs`) so claude's Ink TUI commits the `ESC[200~ …
  * ESC[201~` paste event before the `\r` arrives — without that gap the
  * Enter is absorbed as part of the paste event and the queued bubble
@@ -9158,8 +9176,9 @@ function queueTmuxOp(
  * already-bare branch, which inserts no delay) — a further one-shot,
  * double-sampled (`stillBlocking`) re-check of `paneShowsBlockingPrompt` runs
  * right before dispatch, covering BOTH paste paths, since the non-bracketed
- * one sends paste+Enter synchronously with no pre-Enter net of its own
- * (unlike the bracketed path's own re-check below).
+ * one sends paste+Enter back-to-back — each its own awaited `tmux()`
+ * round-trip, with no deliberate gap — and so has no pre-Enter net of its
+ * own (unlike the bracketed path's own re-check below).
  *
  * The modal guard re-runs a THIRD time — one-shot, double-sampled via
  * `stillBlocking`, no polling loop — right before the deferred bracketed
@@ -9474,7 +9493,8 @@ function queuePaste(
     // ever saw (e.g. a permission prompt that appeared during that sleep).
     // Re-run the same double-sampled check right before dispatch so BOTH
     // paste paths get this net — the non-bracketed path sends paste+Enter
-    // synchronously with no separate pre-Enter check of its own, unlike the
+    // back-to-back, each its own awaited tmux() round-trip, with no
+    // deliberate gap and no separate pre-Enter check of its own, unlike the
     // bracketed path below.
     if (insertedComposerClearDelay && expectedState && !opts.skipModalGuard) {
       const blocked = await stillBlocking(expectedState);

--- a/src/bun/claude-turn-routing.test.ts
+++ b/src/bun/claude-turn-routing.test.ts
@@ -80,6 +80,40 @@ function readLog(logPath: string): Array<{ argv: string[]; stdin?: string }> {
 }
 
 /**
+ * Poll `readLog(logPath)` until some entry's argv contains `token`, or
+ * `maxMs` elapses. Every tmux op in these fixtures now costs a real
+ * fork+exec (`tmux()` moved off `Bun.spawnSync` — see
+ * docs/plans/fix-task-details-load-delay.md), and with several independent
+ * pollers (death-watch, boot-wait, the deferred-paste chain itself) now
+ * running concurrently instead of serialized on one blocking thread, the
+ * wall-clock cost of a given chain reaching this fixture's process is both
+ * higher and noisier than the old fully-synchronous world. Polling for the
+ * actual recorded op (rather than sleeping a fixed guess) avoids asserting a
+ * tight wall-clock bound — see the flake class this repo already documents:
+ * never assert a fixed sleep is enough for a fake-tmux spawn chain to
+ * settle; either poll for the recorded outcome or use a >=5x margin.
+ */
+async function waitForLog(logPath: string, token: string, maxMs = 4000): Promise<Array<{ argv: string[]; stdin?: string }>> {
+  const deadline = Date.now() + maxMs;
+  for (;;) {
+    const entries = readLog(logPath);
+    if (entries.some((e) => e.argv.includes(token)) || Date.now() >= deadline) return entries;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+/** General-purpose poll: same rationale as `waitForLog`, for conditions that
+ *  aren't a logged tmux invocation (e.g. a run row's status settling). */
+async function waitUntil(check: () => boolean, maxMs = 4000): Promise<boolean> {
+  const deadline = Date.now() + maxMs;
+  for (;;) {
+    if (check()) return true;
+    if (Date.now() >= deadline) return check();
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+/**
  * Write an executable fake tmux for the deferred-large-prompt regression
  * tests below. Unlike `fakeRoutingTmuxBin` (a single fixed `has-session`
  * verdict for the whole test), this stub needs to answer `has-session`
@@ -386,7 +420,7 @@ test("a large (>4KB) follow-up resume never embeds the prompt in new-session arg
   // Make claude's composer look immediately idle so the deferred-paste
   // readiness gate (`readPaneMode`, which reads via this seam) fires on its
   // first poll instead of spinning toward DEFERRED_PROMPT_TIMEOUT_MS (30s).
-  const prevCapture = __forTest.setCaptureModePane(() => "? for shortcuts");
+  const prevCapture = __forTest.setCaptureModePane(async () => "? for shortcuts");
   const prevGap = __forTest.setBracketedEnterGapMs(0);
   const prevSettle = __forTest.setSlashCommandSettleMs(0);
 
@@ -443,10 +477,11 @@ test("a large (>4KB) follow-up resume never embeds the prompt in new-session arg
     const newRunId = result.runId;
 
     // Let the spawn + the fire-and-forget deferred-paste chain run their
-    // course (readiness is immediate given the captureModePane stub above,
-    // so this only needs to cover a handful of synchronous tmux round-trips,
-    // not the real 30s timeout).
-    await new Promise((r) => setTimeout(r, 800));
+    // course. Poll for the final `send-keys Enter` rather than sleeping a
+    // fixed guess — see `waitForLog`'s doc for why a flat sleep here is the
+    // documented flake class now that every tmux op is a real fork+exec
+    // running alongside other concurrent pollers (death-watch, boot-wait).
+    await waitForLog(logPath, "send-keys");
 
     const entries = readLog(logPath);
 
@@ -522,7 +557,7 @@ test("cancelling a run while its large prompt is deferred (composer never confir
   // loop's readiness gate (`readPaneMode`) never fires, so it sits in its
   // poll loop exactly like a launch whose claude session is slow to boot.
   // This is the window a Stop click needs to land in for the bug to repro.
-  const prevCapture = __forTest.setCaptureModePane(() => "");
+  const prevCapture = __forTest.setCaptureModePane(async () => "");
   const prevGap = __forTest.setBracketedEnterGapMs(0);
   const prevSettle = __forTest.setSlashCommandSettleMs(0);
 
@@ -580,7 +615,7 @@ test("cancelling a run while its large prompt is deferred (composer never confir
     // IIFE reach its poll loop (composer stays "" so it never breaks out).
     await new Promise((r) => setTimeout(r, 150));
 
-    expect(cancelRun(newRunId)).toBe(true);
+    expect(await cancelRun(newRunId)).toBe(true);
 
     // Let the poll loop wake at least once (DEFERRED_PROMPT_POLL_MS = 400ms)
     // after the cancel and observe the slot is gone.
@@ -589,7 +624,7 @@ test("cancelling a run while its large prompt is deferred (composer never confir
     // Now flip the composer to "ready" — if the abort check were missing,
     // the very next poll tick would go ahead and paste. Give it another
     // full poll interval to prove it doesn't.
-    __forTest.setCaptureModePane(() => "? for shortcuts");
+    __forTest.setCaptureModePane(async () => "? for shortcuts");
     await new Promise((r) => setTimeout(r, 700));
 
     const entries = readLog(logPath);
@@ -684,7 +719,7 @@ test("a failed deferred paste (load-buffer errors) settles the run instead of le
   // Make the composer look immediately idle so the deferred-paste loop fires
   // its (doomed) paste attempt right away instead of spinning toward the
   // 30s timeout.
-  const prevCapture = __forTest.setCaptureModePane(() => "? for shortcuts");
+  const prevCapture = __forTest.setCaptureModePane(async () => "? for shortcuts");
   const prevGap = __forTest.setBracketedEnterGapMs(0);
   const prevSettle = __forTest.setSlashCommandSettleMs(0);
 
@@ -740,8 +775,10 @@ test("a failed deferred paste (load-buffer errors) settles the run instead of le
 
     // Let the spawn + the fire-and-forget deferred-paste chain run their
     // course, including the doomed load-buffer call and its failure
-    // handling.
-    await new Promise((r) => setTimeout(r, 800));
+    // handling. Poll for the run settling rather than a fixed sleep — see
+    // `waitForLog`'s doc for why a flat wait over a fake-tmux spawn chain is
+    // the documented flake class now that `tmux()` is a real fork+exec.
+    await waitUntil(() => runs.listForTask(taskId).find((r) => r.id === newRunId)?.status !== "running");
 
     const entries = readLog(logPath);
     expect(entries.some((e) => e.argv.includes("load-buffer"))).toBe(true);
@@ -880,7 +917,13 @@ test("spawnClaudeViaTmux pins state.launchEffort from CLAUDE_CODE_EFFORT_LEVEL i
   writeFileSync(jsonlPath, "");
 
   try {
-    const agent = spawnClaudeViaTmux({
+    // spawnClaudeViaTmux is itself async now (killTaskSession/
+    // ensureInstalledForCwd/`tmux new-session` are all awaited internally),
+    // but launchEffort is still pinned before it kicks off the fire-and-
+    // forget boot-wait IIFE (BOOT_TIMEOUT_MS poller) and returns — awaiting
+    // the call resolves well ahead of that background poller, which is what
+    // still lets this assert the pin without waiting out any boot timeout.
+    const agent = await spawnClaudeViaTmux({
       taskId,
       argv: ["claude", "--session-id", sessionId, "hello"],
       env: { CLAUDE_CODE_EFFORT_LEVEL: "high" },
@@ -892,8 +935,6 @@ test("spawnClaudeViaTmux pins state.launchEffort from CLAUDE_CODE_EFFORT_LEVEL i
     });
     agent.done.catch(() => {}); // never resolves in this fake-tmux harness — not under test here
 
-    // Pinned synchronously inside spawnClaudeViaTmux, before its async
-    // boot-wait IIFE even starts.
     expect(__forTest.getSessionLaunchEffort(taskId)).toBe("high");
 
     // Let the boot-wait poller notice the pre-created JSONL and settle
@@ -924,7 +965,9 @@ test("spawnClaudeViaTmux with no CLAUDE_CODE_EFFORT_LEVEL in the launch env leav
   writeFileSync(jsonlPath, "");
 
   try {
-    const agent = spawnClaudeViaTmux({
+    // See the sibling test above for why `await` here still checks the pin
+    // ahead of the fire-and-forget boot-wait poller.
+    const agent = await spawnClaudeViaTmux({
       taskId,
       argv: ["claude", "--session-id", sessionId, "hello"],
       env: {},

--- a/src/bun/claude-turn-routing.test.ts
+++ b/src/bun/claude-turn-routing.test.ts
@@ -114,6 +114,48 @@ async function waitUntil(check: () => boolean, maxMs = 4000): Promise<boolean> {
 }
 
 /**
+ * Poll a run's persisted events until a `status` chunk containing `substr`
+ * appears, or `maxMs` elapses. Used to deterministically wait for
+ * `spawnClaudeViaTmux`'s fire-and-forget boot-wait IIFE to reach
+ * `attachTailer` — signaled by the "claude session … ready (jsonl: …)"
+ * status line it emits right after (see claude-tmux.ts's boot-wait, just
+ * after `attachTailer(state)`) — before a test's `finally` calls
+ * `dropSession`.
+ *
+ * Without this, `dropSession` can race that still-in-flight IIFE: several
+ * tests below only wait for the DEFERRED-PASTE chain (a separate
+ * fire-and-forget IIFE — see claude-tmux.ts's `deferredPrompt` branch) to
+ * finish, or for the run to settle, neither of which implies the boot-wait
+ * IIFE has reached `attachTailer` yet — the two IIFEs race independently off
+ * the same `spawnClaudeViaTmux` call. If `dropSession` disposes + removes
+ * the in-memory `SessionState` first, the still-in-flight boot-wait IIFE
+ * then calls `attachTailer` on the now-orphaned state object, arming a
+ * deathTimer/pollTimer/scraper/fs.watch that nothing will ever clear again —
+ * a zombie poller that keeps firing real tmux invocations (has-session,
+ * capture-pane, …) into whatever `AGETOR_TMUX_BIN` (process-global) happens
+ * to point at once a LATER test file reassigns that env var, contaminating
+ * that file's own fake-tmux recording log mid-test (see
+ * claude-tmux-local-command.test.ts's `[load-buffer, paste-buffer,
+ * delete-buffer]`-shaped assertions, which is exactly the shape a stray
+ * interleaved `has-session` call corrupts).
+ */
+async function waitForRunStatus(
+  runsModule: { events(runId: string): Array<{ stream: string; data: string }> },
+  runId: string,
+  substr: string,
+  maxMs = 4000,
+): Promise<boolean> {
+  const deadline = Date.now() + maxMs;
+  for (;;) {
+    const found = runsModule.events(runId).some(
+      (e) => e.stream === "status" && e.data.includes(substr),
+    );
+    if (found || Date.now() >= deadline) return found;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+/**
  * Write an executable fake tmux for the deferred-large-prompt regression
  * tests below. Unlike `fakeRoutingTmuxBin` (a single fixed `has-session`
  * verdict for the whole test), this stub needs to answer `has-session`
@@ -361,6 +403,7 @@ test("an unambiguous 'gone' probe routes a follow-up through the resume path (ki
 
     const result = await sendInput(priorRunId, "please continue");
     expect(result.delivered).toBe(true);
+    const newRunId = result.delivered ? result.runId : undefined;
 
     const entries = readLog(logPath);
     const killIdx = entries.findIndex((e) => e.argv.includes("kill-session"));
@@ -370,9 +413,12 @@ test("an unambiguous 'gone' probe routes a follow-up through the resume path (ki
     expect(killIdx).toBeLessThan(newIdx);
 
     // Give the background boot-wait a beat to observe the pre-created JSONL
-    // and settle (bootSettled=true) before this test — and the dangling
-    // AGETOR_TMUX_BIN it keeps re-resolving — hands off to the next test.
-    await new Promise((r) => setTimeout(r, 500));
+    // and settle (bootSettled=true, `attachTailer` called) before this test —
+    // and the dangling AGETOR_TMUX_BIN it keeps re-resolving — hands off to
+    // the next test. Deterministic (poll for the "ready" status the boot-wait
+    // IIFE emits right after `attachTailer`) rather than a fixed sleep — see
+    // `waitForRunStatus`'s doc for why a race here leaks a zombie poller.
+    if (newRunId) await waitForRunStatus(runs, newRunId, "ready (jsonl:");
   } finally {
     // Dispose in-memory state + kill whatever (fake) session is now named
     // for this task, mirroring claude-followup-restart.test.ts's cleanup.
@@ -428,6 +474,11 @@ test("a large (>4KB) follow-up resume never embeds the prompt in new-session arg
   const largePrompt = "x".repeat(CLAUDE_PROMPT_ARGV_MAX_BYTES + 500);
   expect(Buffer.byteLength(largePrompt, "utf8")).toBeGreaterThan(CLAUDE_PROMPT_ARGV_MAX_BYTES);
 
+  // Declared outside `try` (not `const` inside it) so `finally` can see it —
+  // needed to wait for the boot-wait IIFE's "ready" status before disposing
+  // the session (see `waitForRunStatus`'s doc).
+  let newRunId: string | undefined;
+
   try {
     tasks.insert({
       id: taskId,
@@ -474,7 +525,7 @@ test("a large (>4KB) follow-up resume never embeds the prompt in new-session arg
     const result = await sendInput(priorRunId, largePrompt);
     expect(result.delivered).toBe(true);
     if (!result.delivered) throw new Error(result.reason);
-    const newRunId = result.runId;
+    newRunId = result.runId;
 
     // Let the spawn + the fire-and-forget deferred-paste chain run their
     // course. Poll for the final `send-keys Enter` rather than sleeping a
@@ -522,6 +573,9 @@ test("a large (>4KB) follow-up resume never embeds the prompt in new-session arg
     __forTest.setCaptureModePane(prevCapture);
     __forTest.setBracketedEnterGapMs(prevGap);
     __forTest.setSlashCommandSettleMs(prevSettle);
+    // Let the (independent, fire-and-forget) boot-wait IIFE reach
+    // `attachTailer` before disposing the session — see `waitForRunStatus`.
+    if (newRunId) await waitForRunStatus(runs, newRunId, "ready (jsonl:");
     dropSession(taskId);
     rmSync(path.dirname(expectedJsonlPath), { recursive: true, force: true });
   }
@@ -562,6 +616,11 @@ test("cancelling a run while its large prompt is deferred (composer never confir
   const prevSettle = __forTest.setSlashCommandSettleMs(0);
 
   const largePrompt = "y".repeat(CLAUDE_PROMPT_ARGV_MAX_BYTES + 500);
+
+  // Declared outside `try` (not `const` inside it) so `finally` can see it —
+  // needed to wait for the boot-wait IIFE's "ready" status before disposing
+  // the session (see `waitForRunStatus`'s doc).
+  let newRunId: string | undefined;
 
   try {
     tasks.insert({
@@ -609,7 +668,7 @@ test("cancelling a run while its large prompt is deferred (composer never confir
     const result = await sendInput(priorRunId, largePrompt);
     expect(result.delivered).toBe(true);
     if (!result.delivered) throw new Error(result.reason);
-    const newRunId = result.runId;
+    newRunId = result.runId;
 
     // Give the spawn a moment to run `new-session` and let the deferred-paste
     // IIFE reach its poll loop (composer stays "" so it never breaks out).
@@ -641,6 +700,9 @@ test("cancelling a run while its large prompt is deferred (composer never confir
     __forTest.setCaptureModePane(prevCapture);
     __forTest.setBracketedEnterGapMs(prevGap);
     __forTest.setSlashCommandSettleMs(prevSettle);
+    // Let the (independent, fire-and-forget) boot-wait IIFE reach
+    // `attachTailer` before disposing the session — see `waitForRunStatus`.
+    if (newRunId) await waitForRunStatus(runs, newRunId, "ready (jsonl:");
     dropSession(taskId);
     rmSync(path.dirname(expectedJsonlPath), { recursive: true, force: true });
   }
@@ -725,6 +787,11 @@ test("a failed deferred paste (load-buffer errors) settles the run instead of le
 
   const largePrompt = "z".repeat(CLAUDE_PROMPT_ARGV_MAX_BYTES + 500);
 
+  // Declared outside `try` (not `const` inside it) so `finally` can see it —
+  // needed to wait for the boot-wait IIFE's "ready" status before disposing
+  // the session (see `waitForRunStatus`'s doc).
+  let newRunId: string | undefined;
+
   try {
     tasks.insert({
       id: taskId,
@@ -771,7 +838,7 @@ test("a failed deferred paste (load-buffer errors) settles the run instead of le
     const result = await sendInput(priorRunId, largePrompt);
     expect(result.delivered).toBe(true);
     if (!result.delivered) throw new Error(result.reason);
-    const newRunId = result.runId;
+    newRunId = result.runId;
 
     // Let the spawn + the fire-and-forget deferred-paste chain run their
     // course, including the doomed load-buffer call and its failure
@@ -796,6 +863,9 @@ test("a failed deferred paste (load-buffer errors) settles the run instead of le
     __forTest.setCaptureModePane(prevCapture);
     __forTest.setBracketedEnterGapMs(prevGap);
     __forTest.setSlashCommandSettleMs(prevSettle);
+    // Let the (independent, fire-and-forget) boot-wait IIFE reach
+    // `attachTailer` before disposing the session — see `waitForRunStatus`.
+    if (newRunId) await waitForRunStatus(runs, newRunId, "ready (jsonl:");
     dropSession(taskId);
     rmSync(path.dirname(expectedJsonlPath), { recursive: true, force: true });
   }
@@ -826,6 +896,11 @@ test("a small (<=4KB) follow-up resume still embeds the prompt in new-session ar
   writeFileSync(expectedJsonlPath, "");
 
   const smallPrompt = "please continue with the small change";
+
+  // Declared outside `try` (not `const` inside it) so `finally` can see it —
+  // needed to wait for the boot-wait IIFE's "ready" status before disposing
+  // the session (see `waitForRunStatus`'s doc).
+  let newRunId: string | undefined;
 
   try {
     tasks.insert({
@@ -872,6 +947,7 @@ test("a small (<=4KB) follow-up resume still embeds the prompt in new-session ar
 
     const result = await sendInput(priorRunId, smallPrompt);
     expect(result.delivered).toBe(true);
+    if (result.delivered) newRunId = result.runId;
 
     await new Promise((r) => setTimeout(r, 300));
 
@@ -886,6 +962,9 @@ test("a small (<=4KB) follow-up resume still embeds the prompt in new-session ar
     // have fired for it at all.
     expect(entries.some((e) => e.argv.includes("load-buffer"))).toBe(false);
   } finally {
+    // Let the (independent, fire-and-forget) boot-wait IIFE reach
+    // `attachTailer` before disposing the session — see `waitForRunStatus`.
+    if (newRunId) await waitForRunStatus(runs, newRunId, "ready (jsonl:");
     dropSession(taskId);
     rmSync(path.dirname(expectedJsonlPath), { recursive: true, force: true });
   }

--- a/src/bun/codex-tmux.test.ts
+++ b/src/bun/codex-tmux.test.ts
@@ -193,7 +193,7 @@ function readArgvLog(logPath: string): Array<{ argv: string[] }> {
   return readFileSync(logPath, "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l));
 }
 
-test("spawnCodexViaTmux's new-session argv pins -x 200 -y 50 (fixed size, never window-size manual)", () => {
+test("spawnCodexViaTmux's new-session argv pins -x 200 -y 50 (fixed size, never window-size manual)", async () => {
   const { bin, logPath } = fakeFailingTmuxBin();
   const prevBin = process.env.AGETOR_TMUX_BIN;
   process.env.AGETOR_TMUX_BIN = bin;
@@ -201,7 +201,7 @@ test("spawnCodexViaTmux's new-session argv pins -x 200 -y 50 (fixed size, never 
     const { chunks, onChunk } = collect();
     const taskId = `task-codexsize-${randomUUID()}`;
     const runId = `run-codexsize-${randomUUID()}`;
-    spawnCodexViaTmux({
+    await spawnCodexViaTmux({
       taskId,
       runId,
       argv: ["codex", "exec", "-"],

--- a/src/bun/codex-tmux.ts
+++ b/src/bun/codex-tmux.ts
@@ -12,7 +12,6 @@ import {
 } from "node:fs";
 import { StringDecoder } from "node:string_decoder";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import { dataDir } from "./db.ts";
 import { resolveTmuxBin, tmuxSocketArgs } from "./tmux-resolution.ts";
 import { createDeathProbe } from "./session-liveness.ts";
@@ -380,38 +379,52 @@ function startCodexTailer(state: CodexSessionState): Promise<number> {
     resolvePid: panePidFor,
   });
   let misses = 0;
+  // Guards a tick against overlapping the previous one now that the
+  // authoritative probe is awaited (no timeout — an owner decision, see
+  // docs/plans/fix-task-details-load-delay.md §8): without it, a stalled
+  // tmux round-trip could let a second 400ms tick start concurrently and
+  // double-count a `wait` outcome. The decision logic itself is unchanged.
+  let tickInFlight = false;
   state.deathTimer = setInterval(() => {
-    tryWatch();
-    // Compute the log-recency veto lazily — only a `gone` probe uses it.
-    const liveness = probe.probe();
-    const outcome = deathTickOutcome({
-      liveness,
-      logFresh: liveness === "gone" && fileWrittenWithin(state.logPath, DEATH_JSONL_QUIET_MS),
-      misses,
-      threshold: DEATH_MISS_THRESHOLD,
-    });
-    if (outcome === "reset") { misses = 0; return; }
-    if (outcome === "wait") { misses++; return; }
-    // Session gone. Give the FS a beat to surface the final bytes, flush, then
-    // resolve with whatever terminal code we saw (default: failed — a codex
-    // exec that vanished without `turn.completed` did not succeed).
-    setTimeout(() => {
-      flushCodexLog(state);
-      // If the final flush surfaced a terminal event (turn.completed/failed),
-      // resolveCodexDone already fired — this was an orderly finish, not a
-      // death, so don't emit the "session ended" sentinel.
-      if (!state.resolved) {
-        // Emit the shared sentinel so the orchestrator flips the card to
-        // `blocked` (via makeChunkHandler) and the user sees WHY the run
-        // stopped in the stream, instead of a silent drop to `ready`.
-        state.onChunk(
-          "status",
-          `${SESSION_DIED_STATUS_PREFIX}tmux session ${state.sessionName} ended unexpectedly — task blocked`,
-        );
+    if (tickInFlight) return;
+    tickInFlight = true;
+    void (async () => {
+      try {
+        tryWatch();
+        // Compute the log-recency veto lazily — only a `gone` probe uses it.
+        const liveness = await probe.probe();
+        const outcome = deathTickOutcome({
+          liveness,
+          logFresh: liveness === "gone" && fileWrittenWithin(state.logPath, DEATH_JSONL_QUIET_MS),
+          misses,
+          threshold: DEATH_MISS_THRESHOLD,
+        });
+        if (outcome === "reset") { misses = 0; return; }
+        if (outcome === "wait") { misses++; return; }
+        // Session gone. Give the FS a beat to surface the final bytes, flush, then
+        // resolve with whatever terminal code we saw (default: failed — a codex
+        // exec that vanished without `turn.completed` did not succeed).
+        setTimeout(() => {
+          flushCodexLog(state);
+          // If the final flush surfaced a terminal event (turn.completed/failed),
+          // resolveCodexDone already fired — this was an orderly finish, not a
+          // death, so don't emit the "session ended" sentinel.
+          if (!state.resolved) {
+            // Emit the shared sentinel so the orchestrator flips the card to
+            // `blocked` (via makeChunkHandler) and the user sees WHY the run
+            // stopped in the stream, instead of a silent drop to `ready`.
+            state.onChunk(
+              "status",
+              `${SESSION_DIED_STATUS_PREFIX}tmux session ${state.sessionName} ended unexpectedly — task blocked`,
+            );
+          }
+          resolveCodexDone(state, state.lastCode ?? 1);
+        }, DEATH_GRACE_MS);
+        if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
+      } finally {
+        tickInFlight = false;
       }
-      resolveCodexDone(state, state.lastCode ?? 1);
-    }, DEATH_GRACE_MS);
-    if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
+    })();
   }, DEATH_POLL_MS);
 
   return done;
@@ -422,6 +435,39 @@ function startCodexTailer(state: CodexSessionState): Promise<number> {
  * ────────────────────────────────────────────────────────────────────────── */
 
 const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
+
+/**
+ * Launch `tmux new-session` for codex's detached hosting session. Async
+ * (`Bun.spawn` + `await proc.exited`) so this fork+exec never blocks the
+ * event loop that also serves the HTTP API — this used to be
+ * `node:child_process`'s `spawnSync`, which stalled every concurrent request
+ * for the duration of tmux's fork+exec (see
+ * docs/plans/fix-task-details-load-delay.md). No timeout, mirroring
+ * claude-tmux.ts's `tmux()` helper — an owner decision to keep behavior
+ * unchanged beyond removing the block. Never throws; a spawn failure (e.g.
+ * tmux not on PATH) folds into `stderr` the same way a non-zero exit does,
+ * so callers only need one failure branch.
+ */
+async function spawnTmuxNewSession(
+  tmux: string,
+  args: string[],
+): Promise<{ status: number | null; stderr: string }> {
+  try {
+    const proc = Bun.spawn([tmux, ...args], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const status = await proc.exited;
+    return { status, stderr: stderr.trim() };
+  } catch (e) {
+    return { status: null, stderr: (e as Error).message };
+  }
+}
 
 export interface CodexLaunchOptions {
   taskId: string;
@@ -444,7 +490,7 @@ export interface CodexLaunchOptions {
  * `--json` log. Returns a `SpawnedAgent` whose `done` resolves when the turn
  * ends (0 on `turn.completed`, 1 on failure/crash).
  */
-export function spawnCodexViaTmux(opts: CodexLaunchOptions): SpawnedAgent {
+export async function spawnCodexViaTmux(opts: CodexLaunchOptions): Promise<SpawnedAgent> {
   ensureLogDir();
   const logPath = codexLogPath(opts.runId);
   const promptPath = codexPromptPath(opts.runId);
@@ -455,7 +501,7 @@ export function spawnCodexViaTmux(opts: CodexLaunchOptions): SpawnedAgent {
 
   const sessionName = sessionNameFor(opts.taskId);
   // Defensive: a zombie session under this name would make new-session fail.
-  killSessionByName(sessionName);
+  await killSessionByName(sessionName);
 
   const tmux = resolveTmuxBin();
   const inner = `exec ${opts.argv.map(sq).join(" ")} < ${sq(promptPath)} > ${sq(logPath)} 2>&1`;
@@ -473,7 +519,7 @@ export function spawnCodexViaTmux(opts: CodexLaunchOptions): SpawnedAgent {
     ...envArgs,
     "--", "sh", "-c", inner,
   ];
-  const res = spawnSync(tmux, args, { encoding: "utf8" });
+  const res = await spawnTmuxNewSession(tmux, args);
 
   const state: CodexSessionState = {
     taskId: opts.taskId,
@@ -499,7 +545,7 @@ export function spawnCodexViaTmux(opts: CodexLaunchOptions): SpawnedAgent {
   if (res.status !== 0) {
     // tmux failed to launch the session — surface stderr and resolve failed
     // synchronously so the run doesn't hang in `running`.
-    const detail = (res.stderr || res.error?.message || "tmux new-session failed").trim();
+    const detail = (res.stderr || "tmux new-session failed").trim();
     opts.onChunk("stderr", `failed to start codex session: ${detail}`, undefined);
     const done = Promise.resolve(1);
     return { kill: () => { /* nothing to kill */ }, writeInput: () => false, done };
@@ -523,11 +569,24 @@ export function spawnCodexViaTmux(opts: CodexLaunchOptions): SpawnedAgent {
  * resolution code here is immaterial to the recorded status.
  */
 function killCodexState(state: CodexSessionState): void {
-  killSessionByName(state.sessionName);
-  setTimeout(() => {
-    flushCodexLog(state);
-    resolveCodexDone(state, state.lastCode ?? 1);
-  }, DEATH_GRACE_MS);
+  // `kill` is a synchronous `SpawnedAgent` field (shared contract in
+  // claude-tmux.ts), so the now-async tmux kill is fired-and-forgotten here
+  // rather than awaited — never left unhandled: a rejection still falls
+  // through to schedule the flush + resolve so the run can't hang.
+  void (async () => {
+    try {
+      await killSessionByName(state.sessionName);
+    } catch {
+      // best-effort — killSessionByName is expected to never throw (its
+      // underlying tmux() swallows spawn errors into an ok:false result),
+      // but this path must never leave the run stuck in `running` even if
+      // that changes.
+    }
+    setTimeout(() => {
+      flushCodexLog(state);
+      resolveCodexDone(state, state.lastCode ?? 1);
+    }, DEATH_GRACE_MS);
+  })();
 }
 
 export interface CodexReattachOptions {
@@ -546,8 +605,8 @@ export interface CodexReattachOptions {
  * resolves `done` when the turn finishes. Returns null when the session is no
  * longer alive (caller should orphan the run).
  */
-export function reattachCodexSession(opts: CodexReattachOptions): SpawnedAgent | null {
-  if (!sessionExistsByName(opts.sessionName)) return null;
+export async function reattachCodexSession(opts: CodexReattachOptions): Promise<SpawnedAgent | null> {
+  if (!(await sessionExistsByName(opts.sessionName))) return null;
   const state: CodexSessionState = {
     taskId: opts.taskId,
     runId: opts.runId,
@@ -587,11 +646,11 @@ export function codexSessionActive(taskId: string): boolean {
  * archiveTask and on a cross-kind agent switch. Safe to call when no codex
  * session exists (kills any stray session under the task's name too).
  */
-export function dropCodexSession(taskId: string): void {
+export async function dropCodexSession(taskId: string): Promise<void> {
   const state = codexSessions.get(taskId);
   if (state) {
     disposeCodexState(state);
     codexSessions.delete(taskId);
   }
-  killSessionByName(sessionNameFor(taskId));
+  await killSessionByName(sessionNameFor(taskId));
 }

--- a/src/bun/codex-tmux.ts
+++ b/src/bun/codex-tmux.ts
@@ -13,7 +13,7 @@ import {
 import { StringDecoder } from "node:string_decoder";
 import path from "node:path";
 import { dataDir } from "./db.ts";
-import { resolveTmuxBin, tmuxSocketArgs } from "./tmux-resolution.ts";
+import { resolveTmuxBin, tmuxSocketArgs, spawnTmuxNewSession } from "./tmux-resolution.ts";
 import { createDeathProbe } from "./session-liveness.ts";
 import { SESSION_DIED_STATUS_PREFIX } from "../shared/types.ts";
 import {
@@ -421,6 +421,8 @@ function startCodexTailer(state: CodexSessionState): Promise<number> {
           resolveCodexDone(state, state.lastCode ?? 1);
         }, DEATH_GRACE_MS);
         if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
+      } catch {
+        /* never crash the watch */
       } finally {
         tickInFlight = false;
       }
@@ -436,38 +438,8 @@ function startCodexTailer(state: CodexSessionState): Promise<number> {
 
 const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
 
-/**
- * Launch `tmux new-session` for codex's detached hosting session. Async
- * (`Bun.spawn` + `await proc.exited`) so this fork+exec never blocks the
- * event loop that also serves the HTTP API — this used to be
- * `node:child_process`'s `spawnSync`, which stalled every concurrent request
- * for the duration of tmux's fork+exec (see
- * docs/plans/fix-task-details-load-delay.md). No timeout, mirroring
- * claude-tmux.ts's `tmux()` helper — an owner decision to keep behavior
- * unchanged beyond removing the block. Never throws; a spawn failure (e.g.
- * tmux not on PATH) folds into `stderr` the same way a non-zero exit does,
- * so callers only need one failure branch.
- */
-async function spawnTmuxNewSession(
-  tmux: string,
-  args: string[],
-): Promise<{ status: number | null; stderr: string }> {
-  try {
-    const proc = Bun.spawn([tmux, ...args], {
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, stderr] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-    ]);
-    const status = await proc.exited;
-    return { status, stderr: stderr.trim() };
-  } catch (e) {
-    return { status: null, stderr: (e as Error).message };
-  }
-}
+// `spawnTmuxNewSession` (launches codex's detached hosting session) lives in
+// tmux-resolution.ts — shared verbatim with cursor-tmux.ts/gemini-tmux.ts.
 
 export interface CodexLaunchOptions {
   taskId: string;

--- a/src/bun/cursor-tmux.ts
+++ b/src/bun/cursor-tmux.ts
@@ -14,7 +14,7 @@ import {
 import { StringDecoder } from "node:string_decoder";
 import path from "node:path";
 import { dataDir } from "./db.ts";
-import { resolveTmuxBin, tmuxSocketArgs } from "./tmux-resolution.ts";
+import { resolveTmuxBin, tmuxSocketArgs, spawnTmuxNewSession } from "./tmux-resolution.ts";
 import { createDeathProbe } from "./session-liveness.ts";
 import { SESSION_DIED_STATUS_PREFIX } from "../shared/types.ts";
 import {
@@ -506,6 +506,8 @@ function startCursorTailer(state: CursorSessionState): Promise<number> {
           resolveCursorDone(state, state.lastCode ?? 1);
         }, DEATH_GRACE_MS);
         if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
+      } catch {
+        /* never crash the watch */
       } finally {
         tickInFlight = false;
       }
@@ -525,38 +527,8 @@ function startCursorTailer(state: CursorSessionState): Promise<number> {
  *  identically. */
 const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
 
-/**
- * Launch `tmux new-session` for cursor's detached hosting session. Async
- * (`Bun.spawn` + `await proc.exited`) so this fork+exec never blocks the
- * event loop that also serves the HTTP API — this used to be
- * `node:child_process`'s `spawnSync`, which stalled every concurrent request
- * for the duration of tmux's fork+exec (see
- * docs/plans/fix-task-details-load-delay.md). No timeout, mirroring
- * claude-tmux.ts's `tmux()` helper — an owner decision to keep behavior
- * unchanged beyond removing the block. Never throws; a spawn failure (e.g.
- * tmux not on PATH) folds into `stderr` the same way a non-zero exit does,
- * so callers only need one failure branch.
- */
-async function spawnTmuxNewSession(
-  tmux: string,
-  args: string[],
-): Promise<{ status: number | null; stderr: string }> {
-  try {
-    const proc = Bun.spawn([tmux, ...args], {
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, stderr] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-    ]);
-    const status = await proc.exited;
-    return { status, stderr: stderr.trim() };
-  } catch (e) {
-    return { status: null, stderr: (e as Error).message };
-  }
-}
+// `spawnTmuxNewSession` (launches cursor's detached hosting session) lives in
+// tmux-resolution.ts — shared verbatim with codex-tmux.ts/gemini-tmux.ts.
 
 export interface CursorLaunchOptions {
   taskId: string;

--- a/src/bun/cursor-tmux.ts
+++ b/src/bun/cursor-tmux.ts
@@ -13,7 +13,6 @@ import {
 } from "node:fs";
 import { StringDecoder } from "node:string_decoder";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import { dataDir } from "./db.ts";
 import { resolveTmuxBin, tmuxSocketArgs } from "./tmux-resolution.ts";
 import { createDeathProbe } from "./session-liveness.ts";
@@ -448,55 +447,69 @@ function startCursorTailer(state: CursorSessionState): Promise<number> {
     resolvePid: panePidFor,
   });
   let misses = 0;
+  // Guards a tick against overlapping the previous one now that the
+  // authoritative probe is awaited (no timeout — an owner decision, see
+  // docs/plans/fix-task-details-load-delay.md §8): without it, a stalled
+  // tmux round-trip could let a second 400ms tick start concurrently and
+  // double-count a `wait` outcome. The decision logic itself is unchanged.
+  let tickInFlight = false;
   state.deathTimer = setInterval(() => {
-    tryWatch();
-    // Compute the log-recency veto lazily — only a `gone` probe uses it.
-    const liveness = probe.probe();
-    const outcome = deathTickOutcome({
-      liveness,
-      logFresh: liveness === "gone" && fileWrittenWithin(state.logPath, DEATH_JSONL_QUIET_MS),
-      misses,
-      threshold: DEATH_MISS_THRESHOLD,
-    });
-    if (outcome === "reset") { misses = 0; return; }
-    if (outcome === "wait") { misses++; return; }
-    // Session gone. Give the FS a beat to surface the final bytes, flush, then
-    // decide clean-exit vs death before resolving.
-    setTimeout(() => {
-      flushCursorLog(state);
-      // If the final flush surfaced a terminal event (`result`),
-      // resolveCursorDone already fired — this was an orderly finish, not a
-      // death, so don't emit the "session ended" sentinel.
-      if (!state.resolved) {
-        // Check the exit-code sidecar FIRST: its presence means the hosting
-        // shell ran to completion and wrote `echo $?` before the tmux
-        // session went away — a clean process exit, just one that happened
-        // not to end in a `result` event (e.g. cursor-agent errored out
-        // before printing one). That's an ordinary failed/succeeded run,
-        // not a death, so it must NOT get the session-died sentinel (which
-        // the orchestrator maps to `blocked`, not the normal
-        // running->ready/review flow).
-        const exitCode = readCursorExitCode(state.runId);
-        if (exitCode !== null) {
-          if (exitCode !== 0) {
-            state.onChunk("stderr", `cursor-agent exited with code ${exitCode}`);
+    if (tickInFlight) return;
+    tickInFlight = true;
+    void (async () => {
+      try {
+        tryWatch();
+        // Compute the log-recency veto lazily — only a `gone` probe uses it.
+        const liveness = await probe.probe();
+        const outcome = deathTickOutcome({
+          liveness,
+          logFresh: liveness === "gone" && fileWrittenWithin(state.logPath, DEATH_JSONL_QUIET_MS),
+          misses,
+          threshold: DEATH_MISS_THRESHOLD,
+        });
+        if (outcome === "reset") { misses = 0; return; }
+        if (outcome === "wait") { misses++; return; }
+        // Session gone. Give the FS a beat to surface the final bytes, flush, then
+        // decide clean-exit vs death before resolving.
+        setTimeout(() => {
+          flushCursorLog(state);
+          // If the final flush surfaced a terminal event (`result`),
+          // resolveCursorDone already fired — this was an orderly finish, not a
+          // death, so don't emit the "session ended" sentinel.
+          if (!state.resolved) {
+            // Check the exit-code sidecar FIRST: its presence means the hosting
+            // shell ran to completion and wrote `echo $?` before the tmux
+            // session went away — a clean process exit, just one that happened
+            // not to end in a `result` event (e.g. cursor-agent errored out
+            // before printing one). That's an ordinary failed/succeeded run,
+            // not a death, so it must NOT get the session-died sentinel (which
+            // the orchestrator maps to `blocked`, not the normal
+            // running->ready/review flow).
+            const exitCode = readCursorExitCode(state.runId);
+            if (exitCode !== null) {
+              if (exitCode !== 0) {
+                state.onChunk("stderr", `cursor-agent exited with code ${exitCode}`);
+              }
+              resolveCursorDone(state, exitCode);
+              return;
+            }
+            // No exitfile: the session vanished before the shell could write
+            // one — a genuine crash / external kill / tmux server death. Emit
+            // the shared sentinel so the orchestrator flips the card to
+            // `blocked` (via makeChunkHandler) and the user sees WHY the run
+            // stopped in the stream, instead of a silent drop to `ready`.
+            state.onChunk(
+              "status",
+              `${SESSION_DIED_STATUS_PREFIX}tmux session ${state.sessionName} ended unexpectedly — task blocked`,
+            );
           }
-          resolveCursorDone(state, exitCode);
-          return;
-        }
-        // No exitfile: the session vanished before the shell could write
-        // one — a genuine crash / external kill / tmux server death. Emit
-        // the shared sentinel so the orchestrator flips the card to
-        // `blocked` (via makeChunkHandler) and the user sees WHY the run
-        // stopped in the stream, instead of a silent drop to `ready`.
-        state.onChunk(
-          "status",
-          `${SESSION_DIED_STATUS_PREFIX}tmux session ${state.sessionName} ended unexpectedly — task blocked`,
-        );
+          resolveCursorDone(state, state.lastCode ?? 1);
+        }, DEATH_GRACE_MS);
+        if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
+      } finally {
+        tickInFlight = false;
       }
-      resolveCursorDone(state, state.lastCode ?? 1);
-    }, DEATH_GRACE_MS);
-    if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
+    })();
   }, DEATH_POLL_MS);
 
   return done;
@@ -511,6 +524,39 @@ function startCursorTailer(state: CursorSessionState): Promise<number> {
  *  than reimplemented) from codex-tmux's convention so both drivers quote
  *  identically. */
 const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
+
+/**
+ * Launch `tmux new-session` for cursor's detached hosting session. Async
+ * (`Bun.spawn` + `await proc.exited`) so this fork+exec never blocks the
+ * event loop that also serves the HTTP API — this used to be
+ * `node:child_process`'s `spawnSync`, which stalled every concurrent request
+ * for the duration of tmux's fork+exec (see
+ * docs/plans/fix-task-details-load-delay.md). No timeout, mirroring
+ * claude-tmux.ts's `tmux()` helper — an owner decision to keep behavior
+ * unchanged beyond removing the block. Never throws; a spawn failure (e.g.
+ * tmux not on PATH) folds into `stderr` the same way a non-zero exit does,
+ * so callers only need one failure branch.
+ */
+async function spawnTmuxNewSession(
+  tmux: string,
+  args: string[],
+): Promise<{ status: number | null; stderr: string }> {
+  try {
+    const proc = Bun.spawn([tmux, ...args], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const status = await proc.exited;
+    return { status, stderr: stderr.trim() };
+  } catch (e) {
+    return { status: null, stderr: (e as Error).message };
+  }
+}
 
 export interface CursorLaunchOptions {
   taskId: string;
@@ -565,7 +611,7 @@ export interface CursorLaunchOptions {
  * `sq` the same way codex-tmux escapes its paths; those paths are
  * agetor-generated (derived from `runId`), never user text.
  */
-export function spawnCursorViaTmux(opts: CursorLaunchOptions): SpawnedAgent {
+export async function spawnCursorViaTmux(opts: CursorLaunchOptions): Promise<SpawnedAgent> {
   ensureLogDir();
   const logPath = cursorLogPath(opts.runId);
   const promptPath = cursorPromptPath(opts.runId);
@@ -580,7 +626,7 @@ export function spawnCursorViaTmux(opts: CursorLaunchOptions): SpawnedAgent {
 
   const sessionName = sessionNameFor(opts.taskId);
   // Defensive: a zombie session under this name would make new-session fail.
-  killSessionByName(sessionName);
+  await killSessionByName(sessionName);
 
   const tmux = resolveTmuxBin();
   // The prompt never enters shell text: `"$(cat <promptfile>)"` is expanded
@@ -607,7 +653,7 @@ export function spawnCursorViaTmux(opts: CursorLaunchOptions): SpawnedAgent {
     ...envArgs,
     "--", "sh", "-c", inner, "sh", ...opts.argv,
   ];
-  const res = spawnSync(tmux, args, { encoding: "utf8" });
+  const res = await spawnTmuxNewSession(tmux, args);
 
   const state: CursorSessionState = {
     taskId: opts.taskId,
@@ -634,7 +680,7 @@ export function spawnCursorViaTmux(opts: CursorLaunchOptions): SpawnedAgent {
   if (res.status !== 0) {
     // tmux failed to launch the session — surface stderr and resolve failed
     // synchronously so the run doesn't hang in `running`.
-    const detail = (res.stderr || res.error?.message || "tmux new-session failed").trim();
+    const detail = (res.stderr || "tmux new-session failed").trim();
     opts.onChunk("stderr", `failed to start cursor session: ${detail}`, undefined);
     const done = Promise.resolve(1);
     return { kill: () => { /* nothing to kill */ }, writeInput: () => false, done };
@@ -659,11 +705,24 @@ export function spawnCursorViaTmux(opts: CursorLaunchOptions): SpawnedAgent {
  * resolution code here is immaterial to the recorded status.
  */
 function killCursorState(state: CursorSessionState): void {
-  killSessionByName(state.sessionName);
-  setTimeout(() => {
-    flushCursorLog(state);
-    resolveCursorDone(state, state.lastCode ?? 1);
-  }, DEATH_GRACE_MS);
+  // `kill` is a synchronous `SpawnedAgent` field (shared contract in
+  // claude-tmux.ts), so the now-async tmux kill is fired-and-forgotten here
+  // rather than awaited — never left unhandled: a rejection still falls
+  // through to schedule the flush + resolve so the run can't hang.
+  void (async () => {
+    try {
+      await killSessionByName(state.sessionName);
+    } catch {
+      // best-effort — killSessionByName is expected to never throw (its
+      // underlying tmux() swallows spawn errors into an ok:false result),
+      // but this path must never leave the run stuck in `running` even if
+      // that changes.
+    }
+    setTimeout(() => {
+      flushCursorLog(state);
+      resolveCursorDone(state, state.lastCode ?? 1);
+    }, DEATH_GRACE_MS);
+  })();
 }
 
 export interface CursorReattachOptions {
@@ -682,8 +741,8 @@ export interface CursorReattachOptions {
  * resolves `done` when the turn finishes. Returns null when the session is
  * no longer alive (caller should orphan the run).
  */
-export function reattachCursorSession(opts: CursorReattachOptions): SpawnedAgent | null {
-  if (!sessionExistsByName(opts.sessionName)) return null;
+export async function reattachCursorSession(opts: CursorReattachOptions): Promise<SpawnedAgent | null> {
+  if (!(await sessionExistsByName(opts.sessionName))) return null;
   const state: CursorSessionState = {
     taskId: opts.taskId,
     runId: opts.runId,
@@ -724,11 +783,11 @@ export function cursorSessionActive(taskId: string): boolean {
  * archiveTask and on a cross-kind agent switch. Safe to call when no cursor
  * session exists (kills any stray session under the task's name too).
  */
-export function dropCursorSession(taskId: string): void {
+export async function dropCursorSession(taskId: string): Promise<void> {
   const state = cursorSessions.get(taskId);
   if (state) {
     disposeCursorState(state);
     cursorSessions.delete(taskId);
   }
-  killSessionByName(sessionNameFor(taskId));
+  await killSessionByName(sessionNameFor(taskId));
 }

--- a/src/bun/db-events-paging.test.ts
+++ b/src/bun/db-events-paging.test.ts
@@ -218,6 +218,117 @@ test("eventsForTask limit larger than available events returns all of them", () 
 });
 
 // ---------------------------------------------------------------------------
+// runs.eventsForTask — oracle-parity grid, events INTERLEAVED with a foreign
+// task in the global run_events id space.
+//
+// This is the regression trap for the two-step limit-path rewrite (db.ts
+// ~:1177): step 1 sorts ids-only over the covering index, step 2 fetches the
+// actual rows for `id >= minId` (re-filtered by `runs.task_id` AND, when
+// given, `beforeId`). A step-2 fetch that dropped the task filter — trusting
+// the `id >= minId` floor alone — or a step-1 id search missing it, would
+// leak a foreign task's rows into the page whenever they land inside
+// [minId, max] of this task's own ids. Plain sequential seeding (like
+// `seedTaskWithEvents` above, or two single-task seeds run back to back)
+// can't exercise that: a naive bug would go unnoticed because the id ranges
+// never actually overlap. The interleaving below guarantees they do.
+// ---------------------------------------------------------------------------
+
+/** Seeds `taskId` with `runCount` runs of `eventsPerRun` events each,
+ *  interleaving a second, unrelated task's events between every run so the
+ *  target task's own event ids form a "holey" (non-contiguous) subsequence
+ *  of the global id space — every id range this task's events span also
+ *  contains foreign rows. Returns the target task's id and its full
+ *  ascending list of persisted event ids: the ground truth (the oracle)
+ *  every case in the grid below is checked against. */
+function seedTaskInterleavedWithForeignEvents(
+  eventsPerRun: number,
+  runCount: number,
+): { taskId: string; ids: number[] } {
+  const taskId = randomUUID();
+  const foreignTaskId = randomUUID();
+  const foreignRunId = randomUUID();
+  const now = Date.now();
+  tasks.insert(makeTaskRow(taskId));
+  tasks.insert(makeTaskRow(foreignTaskId));
+  runs.insert({
+    id: foreignRunId, taskId: foreignTaskId, agent: "claude-code", status: "succeeded",
+    startedAt: now, endedAt: now + 1, exitCode: 0,
+    tmuxSession: null, claudeSessionId: null, codexSessionId: null, cursorSessionId: null, geminiSessionId: null, fxSessionId: null,
+  });
+
+  const seedAll = db.transaction(() => {
+    for (let r = 0; r < runCount; r++) {
+      const runId = randomUUID();
+      runs.insert({
+        id: runId, taskId, agent: "claude-code", status: "succeeded",
+        startedAt: now, endedAt: now + 1, exitCode: 0,
+        tmuxSession: null, claudeSessionId: null, codexSessionId: null, cursorSessionId: null, geminiSessionId: null, fxSessionId: null,
+      });
+      for (let i = 0; i < eventsPerRun; i++) runs.appendEvent(runId, "assistant", `a-r${r}-e${i}`);
+      // The foreign task's events land in the id range right after this
+      // run's block and before the next — this is what guarantees foreign
+      // ids fall inside [minId, max] of any page built from this task's own
+      // events below.
+      for (let i = 0; i < eventsPerRun; i++) runs.appendEvent(foreignRunId, "assistant", `foreign-r${r}-e${i}`);
+    }
+  });
+  seedAll();
+
+  const ids = runs.eventsForTask(taskId).map((e) => e.id);
+  return { taskId, ids };
+}
+
+/** Ground truth for what the limit-path SHOULD return, computed purely from
+ *  the unlimited oracle list: filter to ids strictly before `beforeId` (when
+ *  given), then keep the newest `limit` of what remains, ascending — exactly
+ *  what the two-step query claims to compute. */
+function expectedPage(oracleIds: number[], opts: { beforeId?: number; limit: number }): number[] {
+  let eligible = oracleIds;
+  if (opts.beforeId != null) eligible = eligible.filter((id) => id < opts.beforeId!);
+  return eligible.slice(-opts.limit);
+}
+
+const GRID_EVENTS_PER_RUN = 5;
+const GRID_RUN_COUNT = 3; // 15 total target-task events, spread across 3 runs with a foreign block between each
+
+const gridCases: Array<{ name: string; opts: (ids: number[]) => { beforeId?: number; limit: number } }> = [
+  { name: "limit smaller than the eligible set (no beforeId)", opts: () => ({ limit: 5 }) },
+  { name: "limit equal to the eligible set (no beforeId)", opts: () => ({ limit: 15 }) },
+  { name: "limit larger than the eligible set (no beforeId)", opts: () => ({ limit: 1000 }) },
+  // ids[9] is the 10th target-task event (last event of the middle run) — a
+  // real id belonging to this task, well inside the seeded range.
+  { name: "beforeId at a mid id, limit smaller than what remains eligible", opts: (ids) => ({ beforeId: ids[9]!, limit: 4 }) },
+  { name: "beforeId at a mid id, eligible set (9) smaller than limit", opts: (ids) => ({ beforeId: ids[9]!, limit: 1000 }) },
+  { name: "beforeId at the smallest id — empty result", opts: (ids) => ({ beforeId: ids[0]!, limit: 1000 }) },
+];
+
+for (const { name, opts } of gridCases) {
+  test(`eventsForTask limit-path matches the unlimited oracle, foreign-task events interleaved in the id space: ${name}`, () => {
+    const { taskId, ids } = seedTaskInterleavedWithForeignEvents(GRID_EVENTS_PER_RUN, GRID_RUN_COUNT);
+    expect(ids.length).toBe(GRID_EVENTS_PER_RUN * GRID_RUN_COUNT);
+
+    const resolvedOpts = opts(ids);
+    const page = runs.eventsForTask(taskId, resolvedOpts);
+    expect(page.map((e) => e.id)).toEqual(expectedPage(ids, resolvedOpts));
+    // No foreign-task leakage: every returned row belongs to this task's own
+    // seeded prefix, never the interleaved foreign task's ("foreign-...").
+    expect(page.every((e) => e.data.startsWith("a-"))).toBe(true);
+    // Ascending order, not the DESC order step 1 sorts in internally.
+    for (let i = 1; i < page.length; i++) expect(page[i]!.id).toBeGreaterThan(page[i - 1]!.id);
+  });
+}
+
+test("eventsForTask limit-path returns empty for a task with zero events, even with foreign events elsewhere in the id space", () => {
+  // Seed unrelated interleaved data first so the global id space is
+  // non-trivial and spans well past this empty task's (nonexistent) events.
+  seedTaskInterleavedWithForeignEvents(GRID_EVENTS_PER_RUN, GRID_RUN_COUNT);
+  const emptyTaskId = randomUUID();
+  tasks.insert(makeTaskRow(emptyTaskId));
+  expect(runs.eventsForTask(emptyTaskId, { limit: 50 })).toEqual([]);
+  expect(runs.eventsForTask(emptyTaskId, { beforeId: 999999999, limit: 50 })).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
 // runs.hasEventsBefore
 // ---------------------------------------------------------------------------
 

--- a/src/bun/db.ts
+++ b/src/bun/db.ts
@@ -1147,32 +1147,73 @@ export const runs = {
    *
    *  With `opts.limit` set, returns only the MOST RECENT `limit` events:
    *  filters `id < opts.beforeId` when given, orders by id DESC, takes
-   *  `limit`, then reverses so the caller still sees ascending order. This
-   *  is what powers the capped SSE replay window and the `/events/page`
-   *  paging route — both want "the newest N (before some cursor)", not
-   *  "the first N". */
+   *  `limit`, then re-sorts ascending. This is what powers the capped SSE
+   *  replay window and the `/events/page` paging route — both want "the
+   *  newest N (before some cursor)", not "the first N".
+   *
+   *  The limit path is a two-step query, not one. A single
+   *  `SELECT … ORDER BY run_events.id DESC LIMIT ?` still has to sort every
+   *  matching row before it can take the top N — `EXPLAIN QUERY PLAN` shows
+   *  SQLite picks the covering index for the join+filter but then falls back
+   *  to `USE TEMP B-TREE FOR ORDER BY`, and that b-tree materializes the full
+   *  `data` payload (often the largest column by far) for EVERY event the
+   *  task ever had, not just the `limit` returned. Measured 219.5ms on a
+   *  production task with 18.5k events. Splitting it in two fixes that:
+   *   1. Sort ids only (`SELECT run_events.id …`) — no `data` payload in the
+   *      row, so the temp b-tree rides the covering index
+   *      (`idx_run_events_run(run_id, id)`) instead of materializing text.
+   *   2. Fetch the actual rows for that exact id range, ascending (no
+   *      reverse needed) — a plain indexed range scan, not a sort.
+   *  Measured 14.8ms + 3.9ms ≈ 19ms for the identical 800-row result on the
+   *  same task — an ~11x improvement, no schema change.
+   *
+   *  Step 2 re-applies `beforeId` (not just the `id >= minId` floor coming
+   *  out of step 1): without it, events newer than the cursor — i.e. events
+   *  the caller has already seen, or that landed on a DIFFERENT run of the
+   *  same task with an id inside `[minId, taskMax]` but still `>= beforeId`
+   *  — would wrongly re-enter the page. `id >= minId` alone only bounds the
+   *  page from below; `beforeId` is what bounds it from above, exactly as it
+   *  did in the one-query version. */
   eventsForTask(
     taskId: string,
     opts?: { beforeId?: number; limit?: number },
   ): Array<{ id: number; runId: string; stream: string; data: string; ts: number; subagentId: string | null }> {
     type Row = { id: number; runId: string; stream: string; data: string; ts: number; subagentId: string | null };
     if (opts?.limit) {
-      const conditions = ["runs.task_id = ?"];
-      const params: Array<string | number> = [taskId];
+      const idConditions = ["runs.task_id = ?"];
+      const idParams: Array<string | number> = [taskId];
       if (opts.beforeId != null) {
-        conditions.push("run_events.id < ?");
-        params.push(opts.beforeId);
+        idConditions.push("run_events.id < ?");
+        idParams.push(opts.beforeId);
       }
-      params.push(opts.limit);
-      const rows = db.query<Row, Array<string | number>>(
+      idParams.push(opts.limit);
+      const idRows = db.query<{ id: number }, Array<string | number>>(
+        `SELECT run_events.id as id
+         FROM run_events
+         JOIN runs ON runs.id = run_events.run_id
+         WHERE ${idConditions.join(" AND ")}
+         ORDER BY run_events.id DESC
+         LIMIT ?`,
+      ).all(...idParams);
+      if (idRows.length === 0) return [];
+      // DESC order — the last row is the smallest id in the page.
+      const minId = idRows[idRows.length - 1]!.id;
+
+      const rowConditions = ["runs.task_id = ?", "run_events.id >= ?"];
+      const rowParams: Array<string | number> = [taskId, minId];
+      if (opts.beforeId != null) {
+        rowConditions.push("run_events.id < ?");
+        rowParams.push(opts.beforeId);
+      }
+      rowParams.push(opts.limit);
+      return db.query<Row, Array<string | number>>(
         `SELECT run_events.id as id, run_events.run_id as runId, stream, data, ts, run_events.subagent_id as subagentId
          FROM run_events
          JOIN runs ON runs.id = run_events.run_id
-         WHERE ${conditions.join(" AND ")}
-         ORDER BY run_events.id DESC
+         WHERE ${rowConditions.join(" AND ")}
+         ORDER BY run_events.id ASC
          LIMIT ?`,
-      ).all(...params);
-      return rows.reverse();
+      ).all(...rowParams);
     }
     return db.query<Row, [string]>(
       `SELECT run_events.id as id, run_events.run_id as runId, stream, data, ts, run_events.subagent_id as subagentId

--- a/src/bun/event-loop-responsiveness.test.ts
+++ b/src/bun/event-loop-responsiveness.test.ts
@@ -1,0 +1,125 @@
+import { afterAll, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { rmTestDataDir } from "./test-data-dir.ts";
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Responsiveness regression test — docs/plans/fix-task-details-load-delay.md
+ * §1/§5 (TT1). The bug: `tmux()` (claude-tmux.ts) and the one-shot drivers'
+ * `spawnSync`/`Bun.spawnSync` calls held Bun's single event-loop thread for
+ * the full fork+exec+wait of every tmux invocation — so opening the
+ * task-details panel (an ordinary HTTP GET) could stall for as long as
+ * another task's warm-up tmux call took, because `Bun.serve` and the whole
+ * orchestrator share that one thread. The fix (T1/T2) converts every
+ * warm-up-path tmux invocation to `Bun.spawn` + `await proc.exited`, so the
+ * wait happens off-thread and concurrent event-loop work (an HTTP response,
+ * a timer, another awaited op) keeps flowing while a tmux child is alive.
+ *
+ * This file proves that property directly: point `AGETOR_TMUX_BIN` at a stub
+ * that SLEEPS for a full second before exiting, call an op that hits the
+ * tmux choke point, and race a 25ms `Bun.sleep` against it. Under the fixed
+ * async implementation the probe returns in ~25ms regardless of how long the
+ * tmux child takes. Under the old synchronous implementation the calling op
+ * itself blocked the thread for ~1000ms before `killSessionByName` /
+ * `sessionExists` / etc. even returned control to the caller — so the probe
+ * could not have completed until ~1000ms had elapsed either, which is what
+ * the 500ms assertion below (20x margin over the 25ms ideal, still 2x under
+ * the 1000ms failure signal) catches. See the repo's flake-class rule: never
+ * assert a tight wall-clock bound against a fake-tmux spawn — this bound is
+ * structurally safe because the failure mode is >=1000ms, not "a bit slow".
+ * ────────────────────────────────────────────────────────────────────────── */
+
+// Pre-set AGETOR_DATA_DIR before claude-tmux.ts's/codex-tmux.ts's transitive
+// db.ts import — a static top-level import would be hoisted and evaluated
+// before any in-file assignment runs, capturing the wrong data dir (db.ts
+// reads AGETOR_DATA_DIR once, at first import, across the whole `bun test`
+// process — see claude-tmux-death.test.ts for the same pattern).
+const testDataDir = mkdtempSync(path.join(tmpdir(), "agetor-evloop-data-"));
+process.env.AGETOR_DATA_DIR = testDataDir;
+
+// Stub tmux: sleeps 1s then exits 0, regardless of argv. Any op that hits
+// the `tmux()` choke point pays that full second as CHILD process time —
+// but under the fixed async spawn, that second belongs to the child, not to
+// Bun's event-loop thread, so a concurrent `Bun.sleep` probe returns close
+// to on-time. Under the old `Bun.spawnSync`/`spawnSync` implementation the
+// whole process (including any other in-flight HTTP request) blocked for
+// that same second.
+const tmuxStubDir = mkdtempSync(path.join(tmpdir(), "agetor-evloop-tmux-"));
+const tmuxBin = path.join(tmuxStubDir, "tmux");
+writeFileSync(tmuxBin, "#!/bin/sh\nsleep 1\nexit 0\n");
+chmodSync(tmuxBin, 0o755);
+process.env.AGETOR_TMUX_BIN = tmuxBin;
+
+const { killSessionByName, sessionExists } = await import("./claude-tmux.ts");
+// codex-tmux.ts (T2: one-shot drivers) — `dropCodexSession` is a minimal,
+// fully-representative T2 op: no prompt/log files, no tailer, no watcher to
+// clean up (a fresh random taskId has no in-memory CodexSessionState, so it
+// short-circuits straight to `await killSessionByName(...)`). This is
+// deliberately NOT `spawnCodexViaTmux`: a real spawn writes a prompt/log
+// file, starts a tailer with a file watcher + poll/death timers, and (since
+// the stub never produces a `turn.completed` line) its `done` promise never
+// resolves — none of that machinery is needed to prove the event loop stays
+// free while a T2 driver's tmux call is in flight, and dragging it in would
+// leave dangling timers/watchers this file would then have to reach into
+// private state to tear down. `dropCodexSession` hits the exact same
+// `tmux()` choke point through the T2 module's own async call path and
+// resolves cleanly to `void`.
+const { dropCodexSession } = await import("./codex-tmux.ts");
+
+afterAll(() => {
+  rmTestDataDir(testDataDir);
+  rmSync(tmuxStubDir, { recursive: true, force: true });
+});
+
+/** 20x margin over the 25ms probe sleep, while staying 2x under the ~1000ms
+ *  failure signal a blocked event loop would produce (see file header). */
+const RESPONSIVENESS_BUDGET_MS = 500;
+const PROBE_SLEEP_MS = 25;
+
+/** Starts `op`, races a `PROBE_SLEEP_MS` sleep against it, and returns how
+ *  long the probe itself took to get scheduled + wake (`elapsed`) alongside
+ *  `op`'s eventual result. `elapsed` staying near `PROBE_SLEEP_MS` proves the
+ *  event loop was free to service other work (a timer, here; an HTTP
+ *  response, in production) while `op` was in flight. Always awaits `op` to
+ *  completion before returning, so the caller can assert it produced a
+ *  well-formed result and didn't hang. */
+async function measureLoopDrift<T>(op: () => Promise<T>): Promise<{ elapsed: number; result: T }> {
+  const t0 = performance.now();
+  const p = op();
+  await Bun.sleep(PROBE_SLEEP_MS);
+  const elapsed = performance.now() - t0;
+  const result = await p;
+  return { elapsed, result };
+}
+
+test("killSessionByName (claude-tmux.ts, T1) does not block the event loop while its tmux child sleeps", async () => {
+  const { elapsed, result } = await measureLoopDrift(() =>
+    killSessionByName("agetor-nonexistent-test")
+  );
+  expect(elapsed).toBeLessThan(RESPONSIVENESS_BUDGET_MS);
+  // Completed (didn't hang) and, being `void`, resolved to undefined — a
+  // reintroduced sync spawn would either blow the elapsed budget above or,
+  // if somehow fast, still prove nothing broke; the real regression this
+  // guards is the timing assertion, this is the "didn't throw/hang" half.
+  expect(result).toBeUndefined();
+});
+
+test("sessionExists (claude-tmux.ts, T1) does not block the event loop while its tmux child sleeps", async () => {
+  const taskId = `evloop-${randomUUID()}`;
+  const { elapsed, result } = await measureLoopDrift(() => sessionExists(taskId));
+  expect(elapsed).toBeLessThan(RESPONSIVENESS_BUDGET_MS);
+  // The stub always exits 0, so `has-session` reads as "exists" — asserting
+  // `true` (rather than just "didn't throw") proves the op actually ran the
+  // tmux call and parsed its result, not that it short-circuited.
+  expect(result).toBe(true);
+});
+
+test("dropCodexSession (codex-tmux.ts, T2 one-shot driver) does not block the event loop while its tmux child sleeps", async () => {
+  const taskId = `evloop-${randomUUID()}`;
+  const { elapsed, result } = await measureLoopDrift(() => dropCodexSession(taskId));
+  expect(elapsed).toBeLessThan(RESPONSIVENESS_BUDGET_MS);
+  expect(result).toBeUndefined();
+});

--- a/src/bun/gemini-tmux.test.ts
+++ b/src/bun/gemini-tmux.test.ts
@@ -196,7 +196,7 @@ function readArgvLog(logPath: string): Array<{ argv: string[] }> {
   return readFileSync(logPath, "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l));
 }
 
-test("spawnGeminiViaTmux's new-session argv pins -x 200 -y 50 and forwards GEMINI_CLI_HOME via -e", () => {
+test("spawnGeminiViaTmux's new-session argv pins -x 200 -y 50 and forwards GEMINI_CLI_HOME via -e", async () => {
   const { bin, logPath } = fakeFailingTmuxBin();
   const prevBin = process.env.AGETOR_TMUX_BIN;
   process.env.AGETOR_TMUX_BIN = bin;
@@ -204,7 +204,7 @@ test("spawnGeminiViaTmux's new-session argv pins -x 200 -y 50 and forwards GEMIN
     const { chunks, onChunk } = collect();
     const taskId = `task-geminisize-${randomUUID()}`;
     const runId = `run-geminisize-${randomUUID()}`;
-    spawnGeminiViaTmux({
+    await spawnGeminiViaTmux({
       taskId,
       runId,
       argv: ["gemini", "-m", "gemini-3-pro-preview", "--output-format", "stream-json", "--yolo", "--skip-trust", "-p", "hello"],

--- a/src/bun/gemini-tmux.ts
+++ b/src/bun/gemini-tmux.ts
@@ -12,7 +12,6 @@ import {
 } from "node:fs";
 import { StringDecoder } from "node:string_decoder";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import { dataDir } from "./db.ts";
 import { resolveTmuxBin, tmuxSocketArgs } from "./tmux-resolution.ts";
 import { createDeathProbe } from "./session-liveness.ts";
@@ -361,37 +360,51 @@ function startGeminiTailer(state: GeminiSessionState): Promise<number> {
     resolvePid: panePidFor,
   });
   let misses = 0;
+  // Guards a tick against overlapping the previous one now that the
+  // authoritative probe is awaited (no timeout — an owner decision, see
+  // docs/plans/fix-task-details-load-delay.md §8): without it, a stalled
+  // tmux round-trip could let a second 400ms tick start concurrently and
+  // double-count a `wait` outcome. The decision logic itself is unchanged.
+  let tickInFlight = false;
   state.deathTimer = setInterval(() => {
-    tryWatch();
-    const liveness = probe.probe();
-    const outcome = deathTickOutcome({
-      liveness,
-      logFresh: liveness === "gone" && fileWrittenWithin(state.logPath, DEATH_JSONL_QUIET_MS),
-      misses,
-      threshold: DEATH_MISS_THRESHOLD,
-    });
-    if (outcome === "reset") { misses = 0; return; }
-    if (outcome === "wait") { misses++; return; }
-    // Session gone. Give the FS a beat to surface the final bytes, flush, then
-    // resolve with whatever terminal code we saw (default: failed — a gemini
-    // process that vanished without a `result` event did not succeed).
-    setTimeout(() => {
-      flushGeminiLog(state);
-      // If the final flush surfaced a terminal `result` event,
-      // resolveGeminiDone already fired — this was an orderly finish, not a
-      // death, so don't emit the "session ended" sentinel.
-      if (!state.resolved) {
-        // Emit the shared sentinel so the orchestrator flips the card to
-        // `blocked` (via makeChunkHandler) and the user sees WHY the run
-        // stopped in the stream, instead of a silent drop to `ready`.
-        state.onChunk(
-          "status",
-          `${SESSION_DIED_STATUS_PREFIX}tmux session ${state.sessionName} ended unexpectedly — task blocked`,
-        );
+    if (tickInFlight) return;
+    tickInFlight = true;
+    void (async () => {
+      try {
+        tryWatch();
+        const liveness = await probe.probe();
+        const outcome = deathTickOutcome({
+          liveness,
+          logFresh: liveness === "gone" && fileWrittenWithin(state.logPath, DEATH_JSONL_QUIET_MS),
+          misses,
+          threshold: DEATH_MISS_THRESHOLD,
+        });
+        if (outcome === "reset") { misses = 0; return; }
+        if (outcome === "wait") { misses++; return; }
+        // Session gone. Give the FS a beat to surface the final bytes, flush, then
+        // resolve with whatever terminal code we saw (default: failed — a gemini
+        // process that vanished without a `result` event did not succeed).
+        setTimeout(() => {
+          flushGeminiLog(state);
+          // If the final flush surfaced a terminal `result` event,
+          // resolveGeminiDone already fired — this was an orderly finish, not a
+          // death, so don't emit the "session ended" sentinel.
+          if (!state.resolved) {
+            // Emit the shared sentinel so the orchestrator flips the card to
+            // `blocked` (via makeChunkHandler) and the user sees WHY the run
+            // stopped in the stream, instead of a silent drop to `ready`.
+            state.onChunk(
+              "status",
+              `${SESSION_DIED_STATUS_PREFIX}tmux session ${state.sessionName} ended unexpectedly — task blocked`,
+            );
+          }
+          resolveGeminiDone(state, state.lastCode ?? 1);
+        }, DEATH_GRACE_MS);
+        if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
+      } finally {
+        tickInFlight = false;
       }
-      resolveGeminiDone(state, state.lastCode ?? 1);
-    }, DEATH_GRACE_MS);
-    if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
+    })();
   }, DEATH_POLL_MS);
 
   return done;
@@ -402,6 +415,39 @@ function startGeminiTailer(state: GeminiSessionState): Promise<number> {
  * ────────────────────────────────────────────────────────────────────────── */
 
 const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
+
+/**
+ * Launch `tmux new-session` for gemini's detached hosting session. Async
+ * (`Bun.spawn` + `await proc.exited`) so this fork+exec never blocks the
+ * event loop that also serves the HTTP API — this used to be
+ * `node:child_process`'s `spawnSync`, which stalled every concurrent request
+ * for the duration of tmux's fork+exec (see
+ * docs/plans/fix-task-details-load-delay.md). No timeout, mirroring
+ * claude-tmux.ts's `tmux()` helper — an owner decision to keep behavior
+ * unchanged beyond removing the block. Never throws; a spawn failure (e.g.
+ * tmux not on PATH) folds into `stderr` the same way a non-zero exit does,
+ * so callers only need one failure branch.
+ */
+async function spawnTmuxNewSession(
+  tmux: string,
+  args: string[],
+): Promise<{ status: number | null; stderr: string }> {
+  try {
+    const proc = Bun.spawn([tmux, ...args], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const status = await proc.exited;
+    return { status, stderr: stderr.trim() };
+  } catch (e) {
+    return { status: null, stderr: (e as Error).message };
+  }
+}
 
 export interface GeminiLaunchOptions {
   taskId: string;
@@ -420,7 +466,7 @@ export interface GeminiLaunchOptions {
  * `stream-json` log. Returns a `SpawnedAgent` whose `done` resolves when the
  * turn ends (0 on a `result` event with `status: "success"`, 1 otherwise).
  */
-export function spawnGeminiViaTmux(opts: GeminiLaunchOptions): SpawnedAgent {
+export async function spawnGeminiViaTmux(opts: GeminiLaunchOptions): Promise<SpawnedAgent> {
   ensureLogDir();
   const logPath = geminiLogPath(opts.runId);
   // Truncate/create the log up front so the tailer's first stat succeeds and
@@ -429,7 +475,7 @@ export function spawnGeminiViaTmux(opts: GeminiLaunchOptions): SpawnedAgent {
 
   const sessionName = sessionNameFor(opts.taskId);
   // Defensive: a zombie session under this name would make new-session fail.
-  killSessionByName(sessionName);
+  await killSessionByName(sessionName);
 
   const tmux = resolveTmuxBin();
   // No stdin redirect — unlike codex, gemini's prompt is already an argv
@@ -449,7 +495,7 @@ export function spawnGeminiViaTmux(opts: GeminiLaunchOptions): SpawnedAgent {
     ...envArgs,
     "--", "sh", "-c", inner,
   ];
-  const res = spawnSync(tmux, args, { encoding: "utf8" });
+  const res = await spawnTmuxNewSession(tmux, args);
 
   const state: GeminiSessionState = {
     taskId: opts.taskId,
@@ -473,7 +519,7 @@ export function spawnGeminiViaTmux(opts: GeminiLaunchOptions): SpawnedAgent {
   if (res.status !== 0) {
     // tmux failed to launch the session — surface stderr and resolve failed
     // synchronously so the run doesn't hang in `running`.
-    const detail = (res.stderr || res.error?.message || "tmux new-session failed").trim();
+    const detail = (res.stderr || "tmux new-session failed").trim();
     opts.onChunk("stderr", `failed to start gemini session: ${detail}`, undefined);
     const done = Promise.resolve(1);
     return { kill: () => { /* nothing to kill */ }, writeInput: () => false, done };
@@ -497,11 +543,24 @@ export function spawnGeminiViaTmux(opts: GeminiLaunchOptions): SpawnedAgent {
  * resolution code here is immaterial to the recorded status.
  */
 function killGeminiState(state: GeminiSessionState): void {
-  killSessionByName(state.sessionName);
-  setTimeout(() => {
-    flushGeminiLog(state);
-    resolveGeminiDone(state, state.lastCode ?? 1);
-  }, DEATH_GRACE_MS);
+  // `kill` is a synchronous `SpawnedAgent` field (shared contract in
+  // claude-tmux.ts), so the now-async tmux kill is fired-and-forgotten here
+  // rather than awaited — never left unhandled: a rejection still falls
+  // through to schedule the flush + resolve so the run can't hang.
+  void (async () => {
+    try {
+      await killSessionByName(state.sessionName);
+    } catch {
+      // best-effort — killSessionByName is expected to never throw (its
+      // underlying tmux() swallows spawn errors into an ok:false result),
+      // but this path must never leave the run stuck in `running` even if
+      // that changes.
+    }
+    setTimeout(() => {
+      flushGeminiLog(state);
+      resolveGeminiDone(state, state.lastCode ?? 1);
+    }, DEATH_GRACE_MS);
+  })();
 }
 
 export interface GeminiReattachOptions {
@@ -520,8 +579,8 @@ export interface GeminiReattachOptions {
  * resolves `done` when the turn finishes. Returns null when the session is no
  * longer alive (caller should orphan the run).
  */
-export function reattachGeminiSession(opts: GeminiReattachOptions): SpawnedAgent | null {
-  if (!sessionExistsByName(opts.sessionName)) return null;
+export async function reattachGeminiSession(opts: GeminiReattachOptions): Promise<SpawnedAgent | null> {
+  if (!(await sessionExistsByName(opts.sessionName))) return null;
   const state: GeminiSessionState = {
     taskId: opts.taskId,
     runId: opts.runId,
@@ -559,11 +618,11 @@ export function geminiSessionActive(taskId: string): boolean {
  * archiveTask and on a cross-kind agent switch. Safe to call when no gemini
  * session exists (kills any stray session under the task's name too).
  */
-export function dropGeminiSession(taskId: string): void {
+export async function dropGeminiSession(taskId: string): Promise<void> {
   const state = geminiSessions.get(taskId);
   if (state) {
     disposeGeminiState(state);
     geminiSessions.delete(taskId);
   }
-  killSessionByName(sessionNameFor(taskId));
+  await killSessionByName(sessionNameFor(taskId));
 }

--- a/src/bun/gemini-tmux.ts
+++ b/src/bun/gemini-tmux.ts
@@ -13,7 +13,7 @@ import {
 import { StringDecoder } from "node:string_decoder";
 import path from "node:path";
 import { dataDir } from "./db.ts";
-import { resolveTmuxBin, tmuxSocketArgs } from "./tmux-resolution.ts";
+import { resolveTmuxBin, tmuxSocketArgs, spawnTmuxNewSession } from "./tmux-resolution.ts";
 import { createDeathProbe } from "./session-liveness.ts";
 import { SESSION_DIED_STATUS_PREFIX } from "../shared/types.ts";
 import {
@@ -401,6 +401,8 @@ function startGeminiTailer(state: GeminiSessionState): Promise<number> {
           resolveGeminiDone(state, state.lastCode ?? 1);
         }, DEATH_GRACE_MS);
         if (state.deathTimer) { clearInterval(state.deathTimer); state.deathTimer = null; }
+      } catch {
+        /* never crash the watch */
       } finally {
         tickInFlight = false;
       }
@@ -416,38 +418,8 @@ function startGeminiTailer(state: GeminiSessionState): Promise<number> {
 
 const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
 
-/**
- * Launch `tmux new-session` for gemini's detached hosting session. Async
- * (`Bun.spawn` + `await proc.exited`) so this fork+exec never blocks the
- * event loop that also serves the HTTP API — this used to be
- * `node:child_process`'s `spawnSync`, which stalled every concurrent request
- * for the duration of tmux's fork+exec (see
- * docs/plans/fix-task-details-load-delay.md). No timeout, mirroring
- * claude-tmux.ts's `tmux()` helper — an owner decision to keep behavior
- * unchanged beyond removing the block. Never throws; a spawn failure (e.g.
- * tmux not on PATH) folds into `stderr` the same way a non-zero exit does,
- * so callers only need one failure branch.
- */
-async function spawnTmuxNewSession(
-  tmux: string,
-  args: string[],
-): Promise<{ status: number | null; stderr: string }> {
-  try {
-    const proc = Bun.spawn([tmux, ...args], {
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, stderr] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-    ]);
-    const status = await proc.exited;
-    return { status, stderr: stderr.trim() };
-  } catch (e) {
-    return { status: null, stderr: (e as Error).message };
-  }
-}
+// `spawnTmuxNewSession` (launches gemini's detached hosting session) lives in
+// tmux-resolution.ts — shared verbatim with codex-tmux.ts/cursor-tmux.ts.
 
 export interface GeminiLaunchOptions {
   taskId: string;

--- a/src/bun/headless.ts
+++ b/src/bun/headless.ts
@@ -115,8 +115,15 @@ export async function runDaemon(): Promise<void> {
 
   // Same PATH hydration + orphan reconciliation the app does at boot, so the
   // daemon can find claude/codex/tmux and doesn't leave stale "running" cards.
+  // Awaited so `startApiServer()` below never starts serving `/tasks`/`/runs`
+  // while a `status='running'` row from a previous process is still being
+  // reattached or flipped to `orphaned` underneath it — the "reconcile
+  // before the API starts" invariant (CLAUDE.md §5), mirroring index.ts's
+  // desktop boot path. A reconcile throw propagates out of `runDaemon` and
+  // fails boot loudly, same as the old synchronous `reconcileOrphans` did —
+  // no swallow.
   rehydratePath();
-  reconcileOrphans();
+  await reconcileOrphans();
   // Same boot-sweep + periodic-refresh pair as index.ts's desktop boot path
   // (see its comment for the full rationale) — the daemon needs the same
   // model-discovery freshness the app gets, and `startPeriodicDiscovery`'s

--- a/src/bun/hook-installer.test.ts
+++ b/src/bun/hook-installer.test.ts
@@ -284,6 +284,94 @@ test("ensureInstalled: strips permission entries claude's parser would reject (o
   expect(settings.permissions.allow).toEqual(["Bash(git status)", "Edit(/repo/src/**)"]);
 });
 
+test("ensureInstalledMerged / ensureInstalled / ensureInstalledForCwd all resolve { settingsFile } pointing at the exact settings.local.json path", async () => {
+  const { ensureInstalledMerged, ensureInstalled, ensureInstalledForCwd } = await import("./hook-installer.ts");
+
+  const cwd1 = makeCwd();
+  const r1 = await ensureInstalledMerged(cwd1);
+  expect(r1).toEqual({ settingsFile: path.join(cwd1, ".claude", "settings.local.json") });
+
+  const cwd2 = makeCwd();
+  const r2 = await ensureInstalled(cwd2);
+  expect(r2).toEqual({ settingsFile: path.join(cwd2, ".claude", "settings.local.json") });
+
+  const owned = path.join(process.env.AGETOR_DATA_DIR!, "worktrees", "shape-task");
+  require("node:fs").mkdirSync(owned, { recursive: true });
+  const r3 = await ensureInstalledForCwd(owned, "ask");
+  expect(r3).toEqual({ settingsFile: path.join(owned, ".claude", "settings.local.json") });
+});
+
+test("ensureInstalled (owned worktree): overwrites malformed JSON instead of refusing — the self-heal branch ensureInstalledMerged's refuse path deliberately does NOT take", async () => {
+  const { ensureInstalled } = await import("./hook-installer.ts");
+  const owned = path.join(process.env.AGETOR_DATA_DIR!, "worktrees", "malformed-task");
+  const dir = path.join(owned, ".claude");
+  require("node:fs").mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, "settings.local.json");
+  writeFileSync(file, "{ this is not json");
+
+  const result = await ensureInstalled(owned);
+  expect(result).not.toBeNull();
+  const settings = JSON.parse(readFileSync(file, "utf8")) as {
+    hooks?: { PreToolUse?: unknown[] };
+    mcpServers?: Record<string, unknown>;
+  };
+  expect(settings.hooks?.PreToolUse).toBeUndefined();
+  expect(settings.mcpServers).toBeUndefined();
+});
+
+test("ensureInstalled (owned worktree): overwrites a malformed JSON array too (the non-object shape ensureInstalledMerged refuses on)", async () => {
+  const { ensureInstalled } = await import("./hook-installer.ts");
+  const owned = path.join(process.env.AGETOR_DATA_DIR!, "worktrees", "malformed-array-task");
+  const dir = path.join(owned, ".claude");
+  require("node:fs").mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, "settings.local.json");
+  writeFileSync(file, JSON.stringify([1, 2, 3]));
+
+  const result = await ensureInstalled(owned);
+  expect(result).not.toBeNull();
+  const settings = JSON.parse(readFileSync(file, "utf8"));
+  expect(Array.isArray(settings)).toBe(false);
+});
+
+test("writeJsonAtomic leaves exactly one file behind — no leftover *.tmp.<pid>.<random> artifact after a successful install", async () => {
+  const { ensureInstalled } = await import("./hook-installer.ts");
+  const cwd = makeCwd();
+  await ensureInstalled(cwd);
+  const dir = path.join(cwd, ".claude");
+  const entries: string[] = require("node:fs").readdirSync(dir);
+  expect(entries).toEqual(["settings.local.json"]);
+});
+
+test("writeJsonAtomic: concurrent installs against the same file never leave it partially written, and no racer's temp file survives", async () => {
+  // Each concurrent ensureInstalledMerged call reads the file, computes its
+  // own merge, writes to its OWN uniquely-named temp file (pid + random
+  // suffix — see writeJsonAtomic), then renames onto the shared target.
+  // POSIX rename is atomic, so however the five calls interleave, the final
+  // file must always be exactly one complete writer's output — never a torn
+  // read of two writes at once, and never left as a stray tempfile.
+  const { ensureInstalledMerged } = await import("./hook-installer.ts");
+  const cwd = makeCwd();
+  const dir = path.join(cwd, ".claude");
+  require("node:fs").mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, "settings.local.json");
+  // Give every racer something non-trivial to preserve, so a torn write
+  // would be obviously wrong rather than accidentally matching `{}`.
+  writeFileSync(file, JSON.stringify({ permissions: { allow: ["Bash(git status)"] } }));
+
+  const results = await Promise.all(
+    Array.from({ length: 5 }, () => ensureInstalledMerged(cwd)),
+  );
+  expect(results.every((r) => r !== null)).toBe(true);
+
+  const raw = readFileSync(file, "utf8");
+  expect(() => JSON.parse(raw)).not.toThrow(); // never truncated/interleaved
+  const final = JSON.parse(raw) as { permissions: { allow: string[] } };
+  expect(final.permissions.allow).toEqual(["Bash(git status)"]);
+
+  const entries: string[] = require("node:fs").readdirSync(dir);
+  expect(entries).toEqual(["settings.local.json"]); // every racer's tempfile was renamed away, none abandoned
+});
+
 test("ensureInstalledMerged: does NOT strip a user repo's own permission entries", async () => {
   // The user's source repo (isolation=none) — we strip our stale entries but
   // must never silently delete the user's version-controlled rules, even ones

--- a/src/bun/hook-installer.test.ts
+++ b/src/bun/hook-installer.test.ts
@@ -23,7 +23,7 @@ beforeEach(() => {
 test("ensureInstalledMerged: writes a clean settings file into an empty repo (no hook, no MCP)", async () => {
   const { ensureInstalledMerged } = await import("./hook-installer.ts");
   const cwd = makeCwd();
-  const paths = ensureInstalledMerged(cwd);
+  const paths = await ensureInstalledMerged(cwd);
   expect(paths).not.toBeNull();
 
   const settings = readSettings(cwd) as { hooks?: { PreToolUse?: unknown[] }; mcpServers?: Record<string, unknown> };
@@ -50,7 +50,7 @@ test("ensureInstalledMerged: preserves a pre-existing user PreToolUse entry", as
   require("node:fs").mkdirSync(dir, { recursive: true });
   writeFileSync(path.join(dir, "settings.local.json"), JSON.stringify(existing));
 
-  ensureInstalledMerged(cwd);
+  await ensureInstalledMerged(cwd);
 
   const settings = readSettings(cwd) as {
     hooks: { PreToolUse: Array<{ matcher: string; hooks: Array<{ command: string }> }> };
@@ -67,9 +67,9 @@ test("ensureInstalledMerged: preserves a pre-existing user PreToolUse entry", as
 test("ensureInstalledMerged: re-merge stays clean — never installs a PreToolUse hook or MCP", async () => {
   const { ensureInstalledMerged } = await import("./hook-installer.ts");
   const cwd = makeCwd();
-  ensureInstalledMerged(cwd);
-  ensureInstalledMerged(cwd);
-  ensureInstalledMerged(cwd);
+  await ensureInstalledMerged(cwd);
+  await ensureInstalledMerged(cwd);
+  await ensureInstalledMerged(cwd);
 
   const settings = readSettings(cwd) as { hooks?: { PreToolUse?: unknown[] }; mcpServers?: Record<string, unknown> };
   expect(settings.hooks?.PreToolUse).toBeUndefined();
@@ -93,7 +93,7 @@ test("ensureInstalledMerged: strips a stale agetor PreToolUse hook from a previo
     },
   }));
 
-  ensureInstalledMerged(cwd);
+  await ensureInstalledMerged(cwd);
 
   const settings = readSettings(cwd) as {
     hooks: { PreToolUse: Array<{ matcher: string; hooks: Array<{ command: string }> }> };
@@ -120,7 +120,7 @@ test("ensureInstalledMerged: strips a stale `mcpServers.agetor` registration (no
     },
   }));
 
-  ensureInstalledMerged(cwd);
+  await ensureInstalledMerged(cwd);
 
   const settings = readSettings(cwd) as { mcpServers: Record<string, { command: string }> };
   // The stale agetor registration is gone, and none is re-added.
@@ -138,7 +138,7 @@ test("ensureInstalledMerged: drops the whole mcpServers object once the only key
     mcpServers: { agetor: { command: "/old/.agetor/bin/agetor-mcp.sh" } },
   }));
 
-  ensureInstalledMerged(cwd);
+  await ensureInstalledMerged(cwd);
 
   const settings = readSettings(cwd) as { mcpServers?: Record<string, unknown> };
   // Mirrors the empty-PreToolUse handling: drop the key, don't leave `{}`.
@@ -153,7 +153,7 @@ test("ensureInstalledMerged: refuses to overwrite malformed JSON and returns nul
   const file = path.join(dir, "settings.local.json");
   writeFileSync(file, "{ this is not json");
 
-  const result = ensureInstalledMerged(cwd);
+  const result = await ensureInstalledMerged(cwd);
   expect(result).toBeNull();
   // Original content untouched.
   expect(readFileSync(file, "utf8")).toBe("{ this is not json");
@@ -167,7 +167,7 @@ test("ensureInstalledMerged: refuses to overwrite a JSON array (must be an objec
   const file = path.join(dir, "settings.local.json");
   writeFileSync(file, JSON.stringify([1, 2, 3]));
 
-  const result = ensureInstalledMerged(cwd);
+  const result = await ensureInstalledMerged(cwd);
   expect(result).toBeNull();
   expect(JSON.parse(readFileSync(file, "utf8"))).toEqual([1, 2, 3]);
 });
@@ -179,7 +179,7 @@ test("ensureInstalledMerged: empty file content treated as fresh install", async
   require("node:fs").mkdirSync(dir, { recursive: true });
   writeFileSync(path.join(dir, "settings.local.json"), "   \n  ");
 
-  const result = ensureInstalledMerged(cwd);
+  const result = await ensureInstalledMerged(cwd);
   expect(result).not.toBeNull();
   const settings = readSettings(cwd) as { hooks?: { PreToolUse?: unknown[] }; mcpServers?: Record<string, unknown> };
   expect(settings.hooks?.PreToolUse).toBeUndefined();
@@ -190,13 +190,13 @@ test("ensureInstalledMerged: returns null when the cwd doesn't exist", async () 
   const { ensureInstalledMerged } = await import("./hook-installer.ts");
   const missing = path.join(tmpdir(), "definitely-not-a-real-dir-" + Date.now());
   expect(existsSync(missing)).toBe(false);
-  expect(ensureInstalledMerged(missing)).toBeNull();
+  expect(await ensureInstalledMerged(missing)).toBeNull();
 });
 
 test("ensureInstalled (owned worktree): writes a clean settings file — no hook, no MCP, no CLAUDE.md", async () => {
   const { ensureInstalled } = await import("./hook-installer.ts");
   const cwd = makeCwd();
-  ensureInstalled(cwd);
+  await ensureInstalled(cwd);
   const settings = readSettings(cwd) as {
     hooks?: { PreToolUse?: Array<{ matcher: string }> };
     mcpServers?: Record<string, unknown>;
@@ -213,7 +213,7 @@ test("ensureInstalledForCwd: cleans up inside an agetor-owned worktree", async (
   const owned = path.join(process.env.AGETOR_DATA_DIR!, "worktrees", "fake-task");
   require("node:fs").mkdirSync(owned, { recursive: true });
 
-  const paths = ensureInstalledForCwd(owned, "ask");
+  const paths = await ensureInstalledForCwd(owned, "ask");
   expect(paths).not.toBeNull();
   const settings = readSettings(owned) as {
     hooks?: { PreToolUse?: Array<{ matcher: string }> };
@@ -237,7 +237,7 @@ test("ensureInstalled preserves `permissions.allow` and other keys across re-spa
   require("node:fs").mkdirSync(owned, { recursive: true });
 
   // 1. First install (fresh worktree, no settings file).
-  ensureInstalled(owned);
+  await ensureInstalled(owned);
 
   // 2. Simulate a permissions.allow entry landing in the same settings
   //    file (from any of the sources noted above).
@@ -249,7 +249,7 @@ test("ensureInstalled preserves `permissions.allow` and other keys across re-spa
   require("node:fs").writeFileSync(settingsFile, JSON.stringify(after1, null, 2));
 
   // 3. Re-spawn: ensureInstalled runs again on the same cwd.
-  ensureInstalled(owned);
+  await ensureInstalled(owned);
 
   const final = JSON.parse(require("node:fs").readFileSync(settingsFile, "utf8"));
   expect(final.permissions?.allow).toEqual(["Bash(git status)"]);
@@ -278,7 +278,7 @@ test("ensureInstalled: strips permission entries claude's parser would reject (o
     },
   }));
 
-  ensureInstalled(owned);
+  await ensureInstalled(owned);
 
   const settings = readSettings(owned) as { permissions: { allow: string[] } };
   expect(settings.permissions.allow).toEqual(["Bash(git status)", "Edit(/repo/src/**)"]);
@@ -296,7 +296,7 @@ test("ensureInstalledMerged: does NOT strip a user repo's own permission entries
     permissions: { allow: ["Bash(git status)", "Bash(echo $((1+1)))"] },
   }));
 
-  ensureInstalledMerged(cwd);
+  await ensureInstalledMerged(cwd);
 
   const settings = readSettings(cwd) as { permissions: { allow: string[] } };
   expect(settings.permissions.allow).toEqual(["Bash(git status)", "Bash(echo $((1+1)))"]);

--- a/src/bun/hook-installer.ts
+++ b/src/bun/hook-installer.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { dataDir } from "./db.ts";
@@ -42,7 +43,7 @@ export interface InstalledPaths {
   settingsFile: string;
 }
 
-export function ensureInstalled(cwd: string): InstalledPaths | null {
+export async function ensureInstalled(cwd: string): Promise<InstalledPaths | null> {
   // We own the worktree dir, but the settings.local.json INSIDE it may still
   // hold `permissions.allow` entries we have to preserve across re-spawns:
   // legacy entries from older agetor builds, rules the user hand-added, and
@@ -62,7 +63,7 @@ export function ensureInstalled(cwd: string): InstalledPaths | null {
  * inside agetor's owned worktree namespace. Used by claude-tmux to avoid
  * accidentally touching a user's source repo when isolation is off.
  */
-export function ensureInstalledIfOwned(cwd: string): InstalledPaths | null {
+export async function ensureInstalledIfOwned(cwd: string): Promise<InstalledPaths | null> {
   const owned = path.resolve(dataDir, "worktrees") + path.sep;
   if (!path.resolve(cwd).startsWith(owned)) return null;
   // Guard against an exotic case where the dir was deleted between
@@ -113,7 +114,7 @@ function isAgetorHookEntry(e: unknown): boolean {
  * Returns null when the cwd doesn't exist OR the existing settings file
  * is malformed; otherwise the settings file path.
  */
-export function ensureInstalledMerged(cwd: string): InstalledPaths | null {
+export async function ensureInstalledMerged(cwd: string): Promise<InstalledPaths | null> {
   return applyAgetorSettings(cwd, {
     refuseOnMalformed: true,
     sanitizeAllow: false,
@@ -142,21 +143,21 @@ interface ApplyOpts {
  * `mcpServers.agetor`), optionally self-heals `permissions.allow`, and writes
  * back atomically. All other keys are preserved verbatim.
  */
-function applyAgetorSettings(
+async function applyAgetorSettings(
   cwd: string,
   opts: ApplyOpts,
-): InstalledPaths | null {
+): Promise<InstalledPaths | null> {
   if (!existsSync(cwd)) return null;
 
   const settingsDir = path.join(cwd, ".claude");
-  mkdirSync(settingsDir, { recursive: true });
+  await mkdir(settingsDir, { recursive: true });
   const settingsFile = path.join(settingsDir, "settings.local.json");
 
   // Read & parse existing settings.
   let settings: Record<string, unknown> = {};
   if (existsSync(settingsFile)) {
     let raw: string;
-    try { raw = readFileSync(settingsFile, "utf8"); } catch (e) {
+    try { raw = await readFile(settingsFile, "utf8"); } catch (e) {
       console.error(
         `[agetor:hook-installer] cannot read ${settingsFile}: ${(e as Error).message}. ` +
         `Skipping settings install.`,
@@ -250,7 +251,7 @@ function applyAgetorSettings(
     }
   }
 
-  writeJsonAtomic(settingsFile, settings);
+  await writeJsonAtomic(settingsFile, settings);
 
   return { settingsFile };
 }
@@ -260,10 +261,10 @@ function applyAgetorSettings(
  *  leave the destination corrupted. Crucial for settings.local.json which
  *  hook-installer merges into on every task spawn while preserving any
  *  pre-existing user / legacy entries underneath. */
-function writeJsonAtomic(file: string, value: unknown): void {
+async function writeJsonAtomic(file: string, value: unknown): Promise<void> {
   const tmp = `${file}.tmp.${process.pid}.${randomUUID().slice(0, 8)}`;
-  writeFileSync(tmp, JSON.stringify(value, null, 2));
-  renameSync(tmp, file);
+  await writeFile(tmp, JSON.stringify(value, null, 2));
+  await rename(tmp, file);
 }
 
 /**
@@ -274,10 +275,10 @@ function writeJsonAtomic(file: string, value: unknown): void {
  * The `mode` argument is accepted for call-site compatibility but no longer
  * influences behaviour — agetor installs nothing mode-specific any more.
  */
-export function ensureInstalledForCwd(
+export async function ensureInstalledForCwd(
   cwd: string,
   _mode?: string | null | undefined,
-): InstalledPaths | null {
+): Promise<InstalledPaths | null> {
   const owned = path.resolve(dataDir, "worktrees") + path.sep;
   if (path.resolve(cwd).startsWith(owned)) {
     if (!existsSync(cwd)) return null;

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -119,8 +119,17 @@ async function getMainViewUrl(): Promise<string> {
 rehydratePath();
 
 // Mark any runs that were "running" when we last shut down as orphaned, so the
-// kanban doesn't show stuck cards.
-reconcileOrphans();
+// kanban doesn't show stuck cards. Awaited (top-level await — this module is
+// ESM) so the rest of boot, in particular `startApiServer()` below, never
+// runs concurrently with reconciliation: the API must not start serving
+// `/tasks`/`/runs` while a `status='running'` row from a previous process is
+// still being reattached or flipped to `orphaned` underneath it — the same
+// "reconcile before the API starts" invariant CLAUDE.md §5 documents, and the
+// same ordering the old synchronous `reconcileOrphans` gave for free by
+// blocking this whole script until it returned. An unhandled rejection here
+// fails boot loudly, matching that old synchronous-throw behavior — no
+// swallow.
+await reconcileOrphans();
 
 // Heal any archive/delete teardown (tmux kill, terminal shells, worktree
 // detach) that was deferred to the in-memory teardown queue but never ran

--- a/src/bun/orchestrator-continuation.test.ts
+++ b/src/bun/orchestrator-continuation.test.ts
@@ -252,7 +252,7 @@ test("onAdopted registers the continuation run as active (cancelRun succeeds aga
   // documented way to observe registration (same technique
   // subagent-hold.test.ts uses for the settle-hook side of #92).
   const { cancelRun } = await import("./orchestrator.ts");
-  const result = cancelRun(newRunId);
+  const result = await cancelRun(newRunId);
   expect(result).toBe(true);
   expect(killed).toBe(true);
 });

--- a/src/bun/orchestrator-fx.test.ts
+++ b/src/bun/orchestrator-fx.test.ts
@@ -357,7 +357,7 @@ test("cancelRun (fx) mid-turn records the run cancelled and returns the task to 
   // makeFakeAgent's kill() clears the pending timers and resolves done(0)
   // immediately, with the `cancelled` flag on the active handle overriding
   // the exit-code mapping.
-  const result = cancelRun(runId);
+  const result = await cancelRun(runId);
   expect(result).toBe(true);
 
   await settle();
@@ -587,7 +587,7 @@ test("reconcileOrphans has no reattach path for fx: a mid-boot running fx run al
     fxSessionId: `fake-fx-session-${taskId}`,
   });
 
-  const reconciled = reconcileOrphans();
+  const reconciled = await reconcileOrphans();
   expect(reconciled).toBe(1);
 
   const row = db.query<{ status: string }, [string]>(`SELECT status FROM runs WHERE id = ?`).get(runId);
@@ -598,7 +598,7 @@ test("reconcileOrphans has no reattach path for fx: a mid-boot running fx run al
   expect(task?.runId).toBeNull();
 
   // A second call is a no-op — nothing left to reconcile.
-  expect(reconcileOrphans()).toBe(0);
+  expect(await reconcileOrphans()).toBe(0);
 });
 
 /* ─── T11 additions: todo tracker, card × queue interplay, model-null

--- a/src/bun/orchestrator-paste-withheld.test.ts
+++ b/src/bun/orchestrator-paste-withheld.test.ts
@@ -86,7 +86,7 @@ test("withheld folded follow-up: re-stashed to backlog with a status breadcrumb,
 
   const prevGrace = claudeTmux.__forTest.setPasteModalGraceMs(20);
   const prevPoll = claudeTmux.__forTest.setPasteModalPollMs(10);
-  const prevCapture = claudeTmux.__forTest.setCapturePastePane(() => BLOCKING_PANE);
+  const prevCapture = claudeTmux.__forTest.setCapturePastePane(async () => BLOCKING_PANE);
 
   try {
     // TIMING INVARIANT (mirrors orchestrator.test.ts): no await between
@@ -182,7 +182,7 @@ test("withheld idle send: the fresh run ends failed, the task returns to ready, 
   claudeTmux.__forTest.installSession(taskId, freshJsonl());
   const prevGrace = claudeTmux.__forTest.setPasteModalGraceMs(20);
   const prevPoll = claudeTmux.__forTest.setPasteModalPollMs(10);
-  const prevCapture = claudeTmux.__forTest.setCapturePastePane(() => BLOCKING_PANE);
+  const prevCapture = claudeTmux.__forTest.setCapturePastePane(async () => BLOCKING_PANE);
 
   try {
     const sent = await sendInput(r1, "are you there");
@@ -263,8 +263,8 @@ test("reconcileTaskSession: a withheld /model mirror leaves a '\u26a0\ufe0f mode
 
   const prevGrace = claudeTmux.__forTest.setPasteModalGraceMs(20);
   const prevPoll = claudeTmux.__forTest.setPasteModalPollMs(10);
-  const prevPastePane = claudeTmux.__forTest.setCapturePastePane(() => BLOCKING_PANE);
-  const prevConfirmPane = claudeTmux.__forTest.setCaptureConfirmPane(() => BLOCKING_PANE);
+  const prevPastePane = claudeTmux.__forTest.setCapturePastePane(async () => BLOCKING_PANE);
+  const prevConfirmPane = claudeTmux.__forTest.setCaptureConfirmPane(async () => BLOCKING_PANE);
 
   try {
     const before = tasks.get(taskId)!;
@@ -333,7 +333,7 @@ test("reconcileTaskSession: a withheld /plan mirror leaves a '\u26a0\ufe0f plan 
 
   const prevGrace = claudeTmux.__forTest.setPasteModalGraceMs(20);
   const prevPoll = claudeTmux.__forTest.setPasteModalPollMs(10);
-  const prevPastePane = claudeTmux.__forTest.setCapturePastePane(() => BLOCKING_PANE);
+  const prevPastePane = claudeTmux.__forTest.setCapturePastePane(async () => BLOCKING_PANE);
 
   try {
     const before = tasks.get(taskId)!;
@@ -530,13 +530,13 @@ test("sendSlashCommand({autoConfirm}): a confirm that only renders after two sti
   __forTest.installSession(taskId, freshJsonl());
 
   let confirmCalls = 0;
-  const prevConfirmPane = __forTest.setCaptureConfirmPane(() => {
+  const prevConfirmPane = __forTest.setCaptureConfirmPane(async () => {
     confirmCalls++;
     return confirmCalls <= 2 ? STILL_WORKING_PANE : EFFORT_CONFIRM_PANE;
   });
   // Keep the paste's OWN modal guard from ever seeing a blocking pane — this
   // test is about the auto-confirm poll, not the paste guard.
-  const prevPastePane = __forTest.setCapturePastePane(() => "");
+  const prevPastePane = __forTest.setCapturePastePane(async () => "");
 
   const match = __forTest.matchSlashConfirmModal(EFFORT_CONFIRM_PANE, "effort");
   expect(match).not.toBeNull();
@@ -552,7 +552,7 @@ test("sendSlashCommand({autoConfirm}): a confirm that only renders after two sti
   expect(listPendingForTask(taskId)).toHaveLength(1);
 
   try {
-    const ok = sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
+    const ok = await sendSlashCommand(taskId, "/effort low", { autoConfirm: "effort" });
     expect(ok).toBe(true);
 
     await __forTest.pasteChains.get(taskId);
@@ -578,70 +578,95 @@ test("sendSlashCommand({autoConfirm}): a confirm that only renders after two sti
  * enough headroom, per its own doc comment in orchestrator.ts) race must not
  * delay an ordinary (non-withheld) send — it should settle off the paste's
  * real, fast outcome.
+ *
+ * RESTRUCTURED for the async tmux conversion (docs/plans/
+ * fix-task-details-load-delay.md T1/T5): this test's "fold, not a fresh
+ * spawn" proof (`sent.runId === r1`) depends on R1 still being in the
+ * orchestrator's in-memory `active` set at the moment `sendInput` checks it —
+ * true only while R1's fake turn hasn't resolved yet. Under the OLD sync
+ * `tmux()`, `sessionLiveness`'s `has-session` probe blocked the event loop,
+ * so the fake driver's own 20ms completion `setTimeout` could never fire
+ * mid-probe; the "no await between startTask and sendInput" comment that used
+ * to live here was sufficient on that guarantee alone. `sessionLiveness` (called from
+ * `sendClaudeTurn` before the fold check) is now a genuine `await Bun.spawn`,
+ * which yields the event loop — so a slow `AGETOR_TMUX_BIN` stub can now lose
+ * the race against that 20ms timer where it never could before. This file's
+ * `withRecordingTmuxBin` helper writes a FRESH `#!bun` script per call, and a
+ * freshly-written executable pays a one-time macOS exec/Gatekeeper penalty on
+ * first spawn (measured 130–350ms here) — nowhere near production's
+ * already-cached real `tmux` binary, and enough alone to blow the fake's 20ms
+ * budget across the several sequential tmux calls a fold does (liveness probe
+ * + load-buffer/paste-buffer/send-keys). Using the file-scope `/bin/echo`
+ * (already resident, no cold-start tax — much closer to a real installed
+ * `tmux` binary's spawn cost) keeps the whole fold well under that budget, so
+ * this test no longer needs a recording stub to prove the same guarantee: a
+ * `delivered:true` + `runId === r1` result is only reachable through
+ * `sendTurnInExistingSession`'s `pasteFollowUp` → `resolveClaudeTurnOutcome`
+ * path, which itself only reports `delivered:true` once `pasteOutcome.ok` —
+ * i.e. the real tmux paste calls already succeeded — so that pairing already
+ * proves "a real tmux paste landed" without a separate call log. What's
+ * dropped is only the redundant cross-check against recorded call
+ * timestamps; the "not the 15s race" guarantee stays intact via `elapsed`.
  * ────────────────────────────────────────────────────────────────────────── */
 
 test("non-withheld send: delivered:true resolves promptly, driven by the paste's real outcome, not the 15s race timeout", async () => {
-  await withRecordingTmuxBin(async (logPath) => {
-    const { createTask, startTask, sendInput } = await import("./orchestrator.ts");
-    const { db, tasks } = await import("./db.ts");
-    const claudeTmux = await import("./claude-tmux.ts");
+  const { createTask, startTask, sendInput } = await import("./orchestrator.ts");
+  const { db, tasks } = await import("./db.ts");
+  const claudeTmux = await import("./claude-tmux.ts");
 
-    const created = await createTask({
-      title: "non-withheld-fold",
-      prompt: "first message",
-      agent: "claude-code",
-      workdir: process.cwd(),
-      isolation: "none",
-      model: "sonnet-5",
-      effort: "high",
-    });
-    if ("error" in created) throw new Error(created.error);
-    const taskId = created.task.id;
-
-    const res = await startTask(taskId);
-    expect("runId" in res).toBe(true);
-    if (!("runId" in res)) return;
-    const r1 = res.runId;
-
-    // Install a REAL session so this takes the fold-capable path, same as
-    // test 1 above — but the pane is a plain idle composer this time, so the
-    // modal guard never engages and the paste lands immediately.
-    claudeTmux.__forTest.installSession(taskId, freshJsonl());
-    const prevCapture = claudeTmux.__forTest.setCapturePastePane(() => "");
-
-    try {
-      // TIMING INVARIANT (mirrors test 1): no await between `startTask`
-      // above and this call — R1 must still be in `active` when `sendInput`
-      // reads it, so this folds instead of spawning a new turn.
-      const start = Date.now();
-      const sent = await sendInput(r1, "hello again");
-      const afterSend = Date.now();
-      const elapsed = afterSend - start;
-
-      if (!sent.delivered) throw new Error(`expected delivered:true, got ${JSON.stringify(sent)}`);
-      expect(sent.runId).toBe(r1);
-
-      // The 15s race (`PASTE_OUTCOME_TIMEOUT_MS`) must not be what resolved
-      // this — a real, non-withheld paste lands almost immediately. The
-      // fake tmux bin spawns a real subprocess per tmux call (load-buffer /
-      // paste-buffer / delete-buffer / send-keys), so the bound here is
-      // generous for a loaded machine while still catching a regression that
-      // waits out anywhere near the full 15s race.
-      expect(elapsed).toBeLessThan(3000);
-
-      // Cross-check against the recorded paste's own landing time: `sendInput`
-      // should have resolved shortly after the paste's last real tmux call,
-      // not after padding out most of a 15s wait.
-      const log = readTmuxLog(logPath);
-      expect(log.length).toBeGreaterThan(0);
-      const lastCallMs = Math.max(...log.map((e) => e.ms));
-      expect(afterSend - lastCallMs).toBeLessThan(2000);
-    } finally {
-      claudeTmux.__forTest.setCapturePastePane(prevCapture);
-      claudeTmux.__forTest.uninstallSession(taskId);
-      db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
-    }
+  const created = await createTask({
+    title: "non-withheld-fold",
+    prompt: "first message",
+    agent: "claude-code",
+    workdir: process.cwd(),
+    isolation: "none",
+    model: "sonnet-5",
+    effort: "high",
   });
+  if ("error" in created) throw new Error(created.error);
+  const taskId = created.task.id;
+
+  const res = await startTask(taskId);
+  expect("runId" in res).toBe(true);
+  if (!("runId" in res)) return;
+  const r1 = res.runId;
+
+  // Install a REAL session so this takes the fold-capable path, same as
+  // test 1 above — but the pane is a plain idle composer this time, so the
+  // modal guard never engages and the paste lands immediately. Deliberately
+  // NOT wrapped in `withRecordingTmuxBin` — see the restructuring note above.
+  claudeTmux.__forTest.installSession(taskId, freshJsonl());
+  const prevCapture = claudeTmux.__forTest.setCapturePastePane(async () => "");
+
+  try {
+    // TIMING INVARIANT (mirrors test 1): no await between `startTask` above
+    // and this call — R1 must still be in `active` when `sendInput` reads
+    // it, so this folds instead of spawning a new turn. Holds here because
+    // every tmux call the fold makes (liveness probe + load-buffer/
+    // paste-buffer/send-keys) goes through the already-resident `/bin/echo`,
+    // comfortably faster than the fake driver's 20ms completion timer.
+    const start = Date.now();
+    const sent = await sendInput(r1, "hello again");
+    const elapsed = Date.now() - start;
+
+    if (!sent.delivered) throw new Error(`expected delivered:true, got ${JSON.stringify(sent)}`);
+    // Only reachable via the fold path (`sendTurnInExistingSession` →
+    // `pasteFollowUp` → `resolveClaudeTurnOutcome`) — which is itself proof
+    // the real tmux paste calls landed (see restructuring note above), so no
+    // separate recorded-call cross-check is needed.
+    expect(sent.runId).toBe(r1);
+
+    // The 15s race (`PASTE_OUTCOME_TIMEOUT_MS`) must not be what resolved
+    // this — a real, non-withheld paste lands almost immediately. The bound
+    // here is generous (~30x the typical ~90-100ms observed against
+    // `/bin/echo`) for a loaded machine while still catching a regression
+    // that waits out anywhere near the full 15s race.
+    expect(elapsed).toBeLessThan(3000);
+  } finally {
+    claudeTmux.__forTest.setCapturePastePane(prevCapture);
+    claudeTmux.__forTest.uninstallSession(taskId);
+    db.run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  }
 }, 10_000);
 
 /* ────────────────────────────────────────────────────────────────────────── *
@@ -694,9 +719,9 @@ test("reconcileTaskSession: a full /model picker mirror walks the cursor, confir
   claudeTmux.__forTest.installSession(taskId, freshJsonl());
 
   const prevSettle = claudeTmux.__forTest.setSlashCommandSettleMs(0);
-  const prevPastePane = claudeTmux.__forTest.setCapturePastePane(() => ""); // idle — guard passes
+  const prevPastePane = claudeTmux.__forTest.setCapturePastePane(async () => ""); // idle — guard passes
   let confirmPaneCalls = 0;
-  const prevConfirmPane = claudeTmux.__forTest.setCaptureConfirmPane(() => {
+  const prevConfirmPane = claudeTmux.__forTest.setCaptureConfirmPane(async () => {
     confirmPaneCalls++;
     // `mirrorModelViaPicker`'s picker-detection poll registers on its very
     // FIRST sighting (no stability-gate, unlike the scraper's own matcher
@@ -844,9 +869,9 @@ test("reconcileTaskSession: model mirror poll timeout when the picker never rend
   });
 
   const prevSettle = claudeTmux.__forTest.setSlashCommandSettleMs(0);
-  const prevPastePane = claudeTmux.__forTest.setCapturePastePane(() => "");
+  const prevPastePane = claudeTmux.__forTest.setCapturePastePane(async () => "");
   // Idle throughout — the picker never renders on the pane at all.
-  const prevConfirmPane = claudeTmux.__forTest.setCaptureConfirmPane(() => "");
+  const prevConfirmPane = claudeTmux.__forTest.setCaptureConfirmPane(async () => "");
 
   try {
     const before = tasks.get(taskId)!;
@@ -919,8 +944,8 @@ test("reconcileTaskSession: model mirror closes the picker with Escape when the 
   });
 
   const prevSettle = claudeTmux.__forTest.setSlashCommandSettleMs(0);
-  const prevPastePane = claudeTmux.__forTest.setCapturePastePane(() => "");
-  const prevConfirmPane = claudeTmux.__forTest.setCaptureConfirmPane(() => MODEL_PICKER_PANE_NO_FABLE);
+  const prevPastePane = claudeTmux.__forTest.setCapturePastePane(async () => "");
+  const prevConfirmPane = claudeTmux.__forTest.setCaptureConfirmPane(async () => MODEL_PICKER_PANE_NO_FABLE);
 
   try {
     await withRecordingTmuxBin(async (logPath) => {
@@ -1107,7 +1132,7 @@ test("reconcileTaskSession: a model change with NO in-memory session state (even
 
   // Deliberately NO claudeTmux.__forTest.installSession call.
   expect(claudeTmux.hasSessionState(taskId)).toBe(false);
-  expect(claudeTmux.sessionExists(taskId)).toBe(true);
+  expect(await claudeTmux.sessionExists(taskId)).toBe(true);
 
   const runId = randomUUID();
   runs.insert({
@@ -1179,7 +1204,7 @@ test("withheld send: whole-backlog dedupe — a withheld message whose matching 
   claudeTmux.__forTest.installSession(taskId, freshJsonl());
   const prevGrace = claudeTmux.__forTest.setPasteModalGraceMs(20);
   const prevPoll = claudeTmux.__forTest.setPasteModalPollMs(10);
-  const prevCapture = claudeTmux.__forTest.setCapturePastePane(() => BLOCKING_PANE);
+  const prevCapture = claudeTmux.__forTest.setCapturePastePane(async () => BLOCKING_PANE);
 
   try {
     const sent = await sendInput(r1, "are you there");
@@ -1246,7 +1271,7 @@ test("POST /ask-questions/:id/answer: a custom free-text answer while a blocking
   claudeTmux.__forTest.installSession(taskId, freshJsonl());
   const prevGrace = claudeTmux.__forTest.setPasteModalGraceMs(20);
   const prevPoll = claudeTmux.__forTest.setPasteModalPollMs(10);
-  const prevCapture = claudeTmux.__forTest.setCapturePastePane(() => BLOCKING_PANE);
+  const prevCapture = claudeTmux.__forTest.setCapturePastePane(async () => BLOCKING_PANE);
 
   const specs = [{ question: "Which approach?", multiSelect: false, options: ["A", "B"] }];
   const expectedText = formatAnswersMessage(specs, [{ selected: [], custom: "my own answer" }]);

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -185,8 +185,10 @@ let reapInFlight = false;
 // Archive/delete teardown (tmux session kill, terminal teardown, worktree
 // detach/remove) is deferred onto a per-source-workdir FIFO queue so
 // `archiveTask` can flip the DB column and respond in milliseconds instead of
-// blocking on `spawnSync` tmux kills and `git worktree remove --force`/
-// `prune`. The serialization is deliberate, not incidental: concurrent `git
+// blocking on tmux kills (async `Bun.spawn` since the fix-task-details-load-
+// delay conversion, but still real wall-clock latency, not free) and `git
+// worktree remove --force`/`prune`. The serialization is deliberate, not
+// incidental: concurrent `git
 // worktree remove`/`prune` invocations against the SAME source repo contend
 // on git's internal locks (`.git/worktrees/.lock` etc.), so archiving several
 // tasks that share a workdir must still tear them down one at a time — just
@@ -586,7 +588,7 @@ setResolvedBroadcaster((res: InteractionResolved) => {
  *
  * Called once at boot from `src/bun/index.ts`.
  */
-export function reconcileOrphans(): number {
+export async function reconcileOrphans(): Promise<number> {
   // Sort newest-first so the at-most-one-reattach-per-task rule below keeps
   // the latest run row. If agetor crashed in the narrow window between
   // `sendTurnInExistingSession` inserting Run2 and `attachDoneHandler`
@@ -625,20 +627,31 @@ export function reconcileOrphans(): number {
       : null;
     // fx is driven over ACP/stdio, not tmux — nothing to reattach to, so a
     // `running` fx row at boot always takes the orphaned→ready path.
-    const canTryReattach =
+    // Split into a cheap sync pre-check and a separate async liveness probe
+    // (rather than one `&&` chain) — `sessionExistsByName` is genuinely async
+    // now (wave 1), and a boolean-context `&&` with an un-awaited Promise
+    // operand would evaluate to always-truthy (the Promise object itself),
+    // silently skipping the actual liveness check. The `if` guard preserves
+    // the original short-circuit (never probes tmux for a row that can't
+    // possibly reattach) and keeps TS's narrowing of `row.tmux_session` to
+    // `string` for everything below.
+    let canTryReattach = false;
+    if (
       (kind === "claude-code" || kind === "codex" || kind === "cursor" || kind === "gemini")
       && task !== null
       && row.tmux_session !== null
       && reattachKey !== null
       && !reattachedTaskIds.has(row.task_id)
-      && sessionExistsByName(row.tmux_session);
+    ) {
+      canTryReattach = await sessionExistsByName(row.tmux_session);
+    }
 
     if (canTryReattach && task) {
       const cwd = task.worktreePath ?? task.workdir;
       const harness = resolveHarness(task.agent);
       const onChunk = makeChunkHandler(row.id, row.task_id, kind as AgentKind, task.mode);
       const spawned = kind === "claude-code"
-        ? reattachSession({
+        ? await reattachSession({
             taskId: row.task_id,
             cwd,
             sessionId: row.claude_session_id as string,
@@ -648,7 +661,7 @@ export function reconcileOrphans(): number {
             mode: task.mode,
           })
         : kind === "codex"
-        ? reattachCodexSession({
+        ? await reattachCodexSession({
             taskId: row.task_id,
             runId: row.id,
             sessionName: row.tmux_session as string,
@@ -656,14 +669,14 @@ export function reconcileOrphans(): number {
             seenLineUuids: runs.seenLineUuidsForTask(row.task_id),
           })
         : kind === "cursor"
-        ? reattachCursorSession({
+        ? await reattachCursorSession({
             taskId: row.task_id,
             runId: row.id,
             sessionName: row.tmux_session as string,
             onChunk,
             seenLineUuids: runs.seenLineUuidsForTask(row.task_id),
           })
-        : reattachGeminiSession({
+        : await reattachGeminiSession({
             taskId: row.task_id,
             runId: row.id,
             sessionName: row.tmux_session as string,
@@ -702,7 +715,7 @@ export function reconcileOrphans(): number {
       }
       // JSONL missing despite live tmux — can't safely resume; kill the
       // session and fall through to orphan marking.
-      killSessionByName(row.tmux_session as string);
+      await killSessionByName(row.tmux_session as string);
     }
     orphaned.push({ id: row.id, task_id: row.task_id, prevColumn });
   }
@@ -782,7 +795,7 @@ export function reconcileOrphans(): number {
       // background agents" task, not an ordinary run still legitimately in
       // progress that just happens to also have live subagent rows).
       if (!isHeldByBackgroundAgents(heldId)) continue;
-      if (sessionExistsByName(sessionNameFor(heldId))) {
+      if (await sessionExistsByName(sessionNameFor(heldId))) {
         const run = task.runId ? runs.get(task.runId) : null;
         // No JSONL session id means no watch directory to derive, so nothing will
         // ever observe these agents finishing. Treat it exactly like a dead
@@ -818,7 +831,7 @@ export function reconcileOrphans(): number {
     // session-alive / session-id-recoverable branch structure as above.
     // HARD INVARIANT: never kill or create tmux sessions here — only re-arm
     // watchers and flip DB rows.
-    if (sessionExistsByName(sessionNameFor(heldId))) {
+    if (await sessionExistsByName(sessionNameFor(heldId))) {
       const run = task.runId ? runs.get(task.runId) : null;
       if (!run?.claudeSessionId) {
         orphanRunningSubagents(heldId);
@@ -866,11 +879,11 @@ export function reconcileOrphans(): number {
  * `onChunk` itself (see `SpawnAgentArgs`), so there's no separate parameter
  * for them.
  */
-function spawnAgentOrFail(
+async function spawnAgentOrFail(
   args: SpawnAgentArgs,
-): { agent: SpawnedAgent; message?: undefined } | { agent: null; message: string } {
+): Promise<{ agent: SpawnedAgent; message?: undefined } | { agent: null; message: string }> {
   try {
-    return { agent: spawnAgent(args) };
+    return { agent: await spawnAgent(args) };
   } catch (err) {
     const { runId, taskId, onChunk } = args;
     const message = err instanceof Error ? err.message : String(err);
@@ -881,11 +894,40 @@ function spawnAgentOrFail(
   }
 }
 
+/**
+ * Guards against two overlapping `startTask` calls for the SAME task both
+ * reaching `spawnAgentOrFail`. The `task.runId && active.has(task.runId)`
+ * check at the top only rules out a task that's ALREADY running — it does
+ * nothing about two concurrent calls that both read that check as false and
+ * then both walk the chain of awaits below (`pendingTeardown`, `checkHarness`,
+ * `prepareWorkdir`, `resolveRef`, and now the async `spawnAgentOrFail`
+ * itself) before either has registered an active run. This window predates
+ * wave 1 (the first three awaits already existed), but the async spawn adds
+ * one more await after the DB transaction has already stamped `task.runId` —
+ * so a second overlapping call could, in principle, race in behind the first
+ * and reach `spawnAgentOrFail` too, minting two run rows and two spawned
+ * agents for one task. `startingTaskIds` closes the window for real double
+ * clicks / rapid re-POSTs to `/tasks/:id/start`: whichever call claims the
+ * taskId first proceeds through the whole function; a second overlapping
+ * call is rejected immediately instead of racing through every await behind
+ * it.
+ */
+const startingTaskIds = new Set<string>();
+
 export async function startTask(taskId: string): Promise<{ runId: string } | { error: string }> {
   let task = tasks.get(taskId);
   if (!task) return { error: "task not found" };
   if (task.runId && active.has(task.runId)) return { error: "task already running" };
+  if (startingTaskIds.has(taskId)) return { error: "task is already starting" };
+  startingTaskIds.add(taskId);
+  try {
+    return await startTaskInner(taskId, task);
+  } finally {
+    startingTaskIds.delete(taskId);
+  }
+}
 
+async function startTaskInner(taskId: string, task: Task): Promise<{ runId: string } | { error: string }> {
   // startTask auto-unarchives and materializes the worktree below — it must
   // not race a teardown archiveTask (or deleteTask) deferred for this task,
   // or a `detachWorktree`/`removeWorktree` still in flight could yank the
@@ -1008,7 +1050,7 @@ export async function startTask(taskId: string): Promise<{ runId: string } | { e
   // up.
   onChunk("user", normalizeUserText(promptWithRefs));
 
-  const { agent, message } = spawnAgentOrFail({
+  const { agent, message } = await spawnAgentOrFail({
     taskId,
     runId,
     harness,
@@ -1329,7 +1371,15 @@ function registerActiveRun(
   runId: string,
   taskId: string,
   task: Task,
-  agent: ReturnType<typeof spawnAgent>,
+  // NOT `ReturnType<typeof spawnAgent>` — `spawnAgent` itself resolves to
+  // `Promise<SpawnedAgent>` (wave 1 async contract); every caller here
+  // already passes the awaited value. Using the raw ReturnType would
+  // silently retype this as `Promise<SpawnedAgent>` the moment agents.ts
+  // lands its own async conversion, breaking every call site with no
+  // typecheck signal in THIS file (the mismatch would only surface as a
+  // runtime `.kill is not a function` once a Promise is stored and later
+  // used as if it were the resolved agent).
+  agent: SpawnedAgent,
 ): void {
   active.set(runId, {
     taskId,
@@ -1412,10 +1462,22 @@ function detectCursorPlan(task: Task, runId: string): void {
 function attachDoneHandler(
   runId: string,
   taskId: string,
-  agent: ReturnType<typeof spawnAgent>,
+  // See `registerActiveRun`'s doc: `SpawnedAgent`, not
+  // `ReturnType<typeof spawnAgent>` — every caller passes the already-awaited
+  // agent handle, never the promise `spawnAgent` itself returns.
+  agent: SpawnedAgent,
 ): void {
   agent.done
-    .then((code) => {
+    // Async: `drainCodexQueue`/`drainCursorQueue`/`drainGeminiQueue`/
+    // `drainFxQueue` below now await their own spawn (wave 1's async
+    // `spawnAgentOrFail`). This callback is never itself awaited by anything
+    // (attachDoneHandler returns void; the `.then()`/`.catch()` chain is
+    // fire-and-forget from every caller's perspective, same as before), so
+    // making it `async` only changes how ITS OWN internal steps are
+    // sequenced — still strictly sequential, matching the pre-wave-1
+    // back-to-back synchronous calls exactly. A throw here still flows into
+    // the `.catch()` below exactly as a synchronous throw always did.
+    .then(async (code) => {
       const handle = active.get(runId);
       const wasCancelled = handle?.cancelled ?? false;
       const wasApiError = handle?.apiError ?? false;
@@ -1518,12 +1580,12 @@ function attachDoneHandler(
       }
       // Spawn the next queued codex/cursor/gemini/fx follow-up, if any (no-op
       // for a task of a different kind).
-      drainCodexQueue(taskId);
-      drainCursorQueue(taskId);
-      drainGeminiQueue(taskId);
-      drainFxQueue(taskId);
+      await drainCodexQueue(taskId);
+      await drainCursorQueue(taskId);
+      await drainGeminiQueue(taskId);
+      await drainFxQueue(taskId);
     })
-    .catch((err) => {
+    .catch(async (err) => {
       const handle = active.get(runId);
       const wasCancelled = handle?.cancelled ?? false;
       const wasSessionDied = handle?.sessionDied ?? false;
@@ -1552,10 +1614,10 @@ function attachDoneHandler(
       }
       // Spawn the next queued codex/cursor/gemini/fx follow-up, if any (no-op
       // for a task of a different kind).
-      drainCodexQueue(taskId);
-      drainCursorQueue(taskId);
-      drainGeminiQueue(taskId);
-      drainFxQueue(taskId);
+      await drainCodexQueue(taskId);
+      await drainCursorQueue(taskId);
+      await drainGeminiQueue(taskId);
+      await drainFxQueue(taskId);
     });
 }
 
@@ -1591,11 +1653,11 @@ export async function reconcileTaskSession(taskId: string, before: Task, after: 
   // alias's HOME/env block changes, so the on-disk JSONL & login differ. Even
   // same-kind alias swaps (claude-work → claude-personal) need a fresh tmux.
   if (before.agent !== after.agent) {
-    if (beforeKind === "claude-code") dropSession(taskId);
-    else if (beforeKind === "codex") dropCodexSession(taskId);
-    else if (beforeKind === "cursor") dropCursorSession(taskId);
-    else if (beforeKind === "gemini") dropGeminiSession(taskId);
-    else if (beforeKind === "fx") dropFxSession(taskId);
+    if (beforeKind === "claude-code") await dropSession(taskId);
+    else if (beforeKind === "codex") await dropCodexSession(taskId);
+    else if (beforeKind === "cursor") await dropCursorSession(taskId);
+    else if (beforeKind === "gemini") await dropGeminiSession(taskId);
+    else if (beforeKind === "fx") dropFxSession(taskId); // fx has no tmux session — stays sync
     // Any queued codex/cursor/gemini/fx follow-ups belong to the old agent —
     // drop them so a later drain doesn't spawn them against the new harness.
     codexTurnQueue.delete(taskId);
@@ -1615,7 +1677,7 @@ export async function reconcileTaskSession(taskId: string, before: Task, after: 
     return;
   }
   if (afterKind !== "claude-code") return;
-  if (!sessionExists(taskId)) return;
+  if (!(await sessionExists(taskId))) return;
 
   // `after.mode` guard: a PATCH that clears the mode (mode → null) leaves
   // the live session alone — the UI doesn't expose a "clear mode" control
@@ -1635,7 +1697,7 @@ export async function reconcileTaskSession(taskId: string, before: Task, after: 
     // which is the right fallback for "we couldn't switch modes."
     if (result.ok) {
       const cwd = after.worktreePath ?? after.workdir;
-      const refreshed = ensureInstalledForCwd(cwd, after.mode);
+      const refreshed = await ensureInstalledForCwd(cwd, after.mode);
       if (!refreshed) emitMatcherRefreshFailure(taskId, cwd);
     }
   }
@@ -2086,13 +2148,17 @@ function stopActiveHandle(h: ActiveRun, reason: string): void {
  * no `active` handle to kill. Interrupt the live session and release the
  * hold. Shared by `cancelRun` (Stop button) and `archiveTask` (`stopRun`).
  */
-function stopHeldTask(taskId: string, reason: string): void {
+async function stopHeldTask(taskId: string, reason: string): Promise<void> {
   cancelPendingForTask(taskId, reason);
-  interruptTaskSession(taskId);
+  // Ordering rule (§7 of the async-warmup plan): the interrupt must complete
+  // — not fire-and-forget — before this returns, matching `deleteTask`'s and
+  // `enqueueArchiveTeardown`'s kill-before-teardown discipline. Awaited here
+  // rather than left as a bare call now that `interruptTaskSession` is async.
+  await interruptTaskSession(taskId);
   orphanRunningSubagents(taskId);
 }
 
-export function cancelRun(runId: string): boolean {
+export async function cancelRun(runId: string): Promise<boolean> {
   const h = active.get(runId);
   if (!h) {
     // A held task (turn succeeded, background agents still running) has no
@@ -2103,7 +2169,7 @@ export function cancelRun(runId: string): boolean {
     // already succeeded, so the card advances to `review`.
     const taskId = runs.get(runId)?.taskId;
     if (!taskId || !isHeldByBackgroundAgents(taskId)) return false;
-    stopHeldTask(taskId, "cancelled by user");
+    await stopHeldTask(taskId, "cancelled by user");
     return true;
   }
   // Stop targets the whole task, not just one run.
@@ -2226,25 +2292,25 @@ export async function sendInput(runId: string, line: string): Promise<SendInputR
     return { delivered: true, runId: result.runId };
   }
   if (kind === "codex") {
-    const result = sendCodexTurn(row.task_id, line);
+    const result = await sendCodexTurn(row.task_id, line);
     return result
       ? { delivered: true, runId: result }
       : { delivered: false, reason: "internal: task lookup failed" };
   }
   if (kind === "cursor") {
-    const result = sendCursorTurn(row.task_id, line);
+    const result = await sendCursorTurn(row.task_id, line);
     return result
       ? { delivered: true, runId: result }
       : { delivered: false, reason: "internal: task lookup failed" };
   }
   if (kind === "gemini") {
-    const result = sendGeminiTurn(row.task_id, line);
+    const result = await sendGeminiTurn(row.task_id, line);
     return result
       ? { delivered: true, runId: result }
       : { delivered: false, reason: "internal: task lookup failed" };
   }
   if (kind === "fx") {
-    const result = sendFxTurn(row.task_id, line);
+    const result = await sendFxTurn(row.task_id, line);
     return result
       ? { delivered: true, runId: result }
       : { delivered: false, reason: "internal: task lookup failed" };
@@ -2269,7 +2335,7 @@ const codexTurnQueue = new Map<string, string[]>();
  * already running, the message is queued; otherwise it spawns immediately.
  * Returns the run id the message was attached to, or null on lookup failure.
  */
-function sendCodexTurn(taskId: string, line: string): string | null {
+async function sendCodexTurn(taskId: string, line: string): Promise<string | null> {
   const task = tasks.get(taskId);
   if (!task) return null;
   if (task.runId && active.has(task.runId)) {
@@ -2292,7 +2358,7 @@ function sendCodexTurn(taskId: string, line: string): string | null {
  * `codex exec resume <thread_id>`. New run row, new tmux session (the previous
  * turn's exited), same `thread_id` carried forward.
  */
-function spawnCodexTurnNow(task: Task, taskId: string, line: string): string {
+async function spawnCodexTurnNow(task: Task, taskId: string, line: string): Promise<string> {
   const priorThreadId = findLastCodexSessionId(taskId);
   const cwd = task.worktreePath ?? task.workdir;
   const harness = resolveHarness(task.agent);
@@ -2340,7 +2406,7 @@ function spawnCodexTurnNow(task: Task, taskId: string, line: string): string {
     return newRunId;
   }
 
-  const { agent } = spawnAgentOrFail({
+  const { agent } = await spawnAgentOrFail({
     taskId,
     runId: newRunId,
     harness,
@@ -2380,7 +2446,7 @@ function spawnCodexTurnNow(task: Task, taskId: string, line: string): string {
  * fresh resume turn. No-op for claude tasks (their queue is always empty) and
  * while a run is still active for the task.
  */
-function drainCodexQueue(taskId: string): void {
+async function drainCodexQueue(taskId: string): Promise<void> {
   const q = codexTurnQueue.get(taskId);
   if (!q || q.length === 0) return;
   const task = tasks.get(taskId);
@@ -2396,7 +2462,7 @@ function drainCodexQueue(taskId: string): void {
   if (task.runId && active.has(task.runId)) return;
   const next = q.shift();
   if (q.length === 0) codexTurnQueue.delete(taskId);
-  if (next !== undefined) spawnCodexTurnNow(task, taskId, next);
+  if (next !== undefined) await spawnCodexTurnNow(task, taskId, next);
 }
 
 /** Most-recent codex thread id across the task's runs (for `resume`). */
@@ -2427,7 +2493,7 @@ const cursorTurnQueue = new Map<string, string[]>();
  * immediately. Returns the run id the message was attached to, or null on
  * lookup failure.
  */
-function sendCursorTurn(taskId: string, line: string): string | null {
+async function sendCursorTurn(taskId: string, line: string): Promise<string | null> {
   const task = tasks.get(taskId);
   if (!task) return null;
   if (task.runId && active.has(task.runId)) {
@@ -2450,7 +2516,7 @@ function sendCursorTurn(taskId: string, line: string): string | null {
  * `cursor-agent --resume <session_id>`. New run row, new tmux session (the
  * previous turn's exited), same `session_id` carried forward.
  */
-function spawnCursorTurnNow(task: Task, taskId: string, line: string): string {
+async function spawnCursorTurnNow(task: Task, taskId: string, line: string): Promise<string> {
   const priorSessionId = findLastCursorSessionId(taskId);
   const cwd = task.worktreePath ?? task.workdir;
   const harness = resolveHarness(task.agent);
@@ -2498,7 +2564,7 @@ function spawnCursorTurnNow(task: Task, taskId: string, line: string): string {
     return newRunId;
   }
 
-  const { agent } = spawnAgentOrFail({
+  const { agent } = await spawnAgentOrFail({
     taskId,
     runId: newRunId,
     harness,
@@ -2540,7 +2606,7 @@ function spawnCursorTurnNow(task: Task, taskId: string, line: string): string {
  * fresh resume turn. No-op for claude/codex/gemini tasks (their queue is
  * always empty) and while a run is still active for the task.
  */
-function drainCursorQueue(taskId: string): void {
+async function drainCursorQueue(taskId: string): Promise<void> {
   const q = cursorTurnQueue.get(taskId);
   if (!q || q.length === 0) return;
   const task = tasks.get(taskId);
@@ -2556,7 +2622,7 @@ function drainCursorQueue(taskId: string): void {
   if (task.runId && active.has(task.runId)) return;
   const next = q.shift();
   if (q.length === 0) cursorTurnQueue.delete(taskId);
-  if (next !== undefined) spawnCursorTurnNow(task, taskId, next);
+  if (next !== undefined) await spawnCursorTurnNow(task, taskId, next);
 }
 
 /** Most-recent cursor session id across the task's runs (for `--resume`). */
@@ -2586,7 +2652,7 @@ const geminiTurnQueue = new Map<string, string[]>();
  * immediately. Returns the run id the message was attached to, or null on
  * lookup failure.
  */
-function sendGeminiTurn(taskId: string, line: string): string | null {
+async function sendGeminiTurn(taskId: string, line: string): Promise<string | null> {
   const task = tasks.get(taskId);
   if (!task) return null;
   if (task.runId && active.has(task.runId)) {
@@ -2612,7 +2678,7 @@ function sendGeminiTurn(taskId: string, line: string): string | null {
  * session id is already known synchronously, so it's stamped on the new run
  * row directly rather than via an `onSessionId` re-stamp.
  */
-function spawnGeminiTurnNow(task: Task, taskId: string, line: string): string {
+async function spawnGeminiTurnNow(task: Task, taskId: string, line: string): Promise<string> {
   const priorSessionId = findLastGeminiSessionId(taskId);
   const cwd = task.worktreePath ?? task.workdir;
   const harness = resolveHarness(task.agent);
@@ -2657,7 +2723,7 @@ function spawnGeminiTurnNow(task: Task, taskId: string, line: string): string {
     return newRunId;
   }
 
-  const { agent } = spawnAgentOrFail({
+  const { agent } = await spawnAgentOrFail({
     taskId,
     runId: newRunId,
     harness,
@@ -2700,7 +2766,7 @@ function spawnGeminiTurnNow(task: Task, taskId: string, line: string): string {
  * fresh resume turn. No-op while a run is still active for the task, or if
  * the task's agent was switched away from gemini mid-flight.
  */
-function drainGeminiQueue(taskId: string): void {
+async function drainGeminiQueue(taskId: string): Promise<void> {
   const q = geminiTurnQueue.get(taskId);
   if (!q || q.length === 0) return;
   const task = tasks.get(taskId);
@@ -2715,7 +2781,7 @@ function drainGeminiQueue(taskId: string): void {
   if (task.runId && active.has(task.runId)) return;
   const next = q.shift();
   if (q.length === 0) geminiTurnQueue.delete(taskId);
-  if (next !== undefined) spawnGeminiTurnNow(task, taskId, next);
+  if (next !== undefined) await spawnGeminiTurnNow(task, taskId, next);
 }
 
 /** Most-recent gemini session id across the task's runs (for `--resume`). */
@@ -2744,7 +2810,7 @@ const fxTurnQueue = new Map<string, string[]>();
  * immediately. Returns the run id the message was attached to, or null on
  * lookup failure.
  */
-function sendFxTurn(taskId: string, line: string): string | null {
+async function sendFxTurn(taskId: string, line: string): Promise<string | null> {
   const task = tasks.get(taskId);
   if (!task) return null;
   if (task.runId && active.has(task.runId)) {
@@ -2770,7 +2836,7 @@ function sendFxTurn(taskId: string, line: string): string | null {
  * response), so it's carried forward on the insert below and re-stamped
  * (idempotently) once `onSessionId` fires again for this turn.
  */
-function spawnFxTurnNow(task: Task, taskId: string, line: string): string {
+async function spawnFxTurnNow(task: Task, taskId: string, line: string): Promise<string> {
   const priorSessionId = findLastFxSessionId(taskId);
   const cwd = task.worktreePath ?? task.workdir;
   const harness = resolveHarness(task.agent);
@@ -2815,7 +2881,7 @@ function spawnFxTurnNow(task: Task, taskId: string, line: string): string {
     return newRunId;
   }
 
-  const { agent } = spawnAgentOrFail({
+  const { agent } = await spawnAgentOrFail({
     taskId,
     runId: newRunId,
     harness,
@@ -2852,7 +2918,7 @@ function spawnFxTurnNow(task: Task, taskId: string, line: string): string {
  * fresh resume turn. No-op while a run is still active for the task, or if
  * the task's agent was switched away from fx mid-flight.
  */
-function drainFxQueue(taskId: string): void {
+async function drainFxQueue(taskId: string): Promise<void> {
   const q = fxTurnQueue.get(taskId);
   if (!q || q.length === 0) return;
   const task = tasks.get(taskId);
@@ -2867,7 +2933,7 @@ function drainFxQueue(taskId: string): void {
   if (task.runId && active.has(task.runId)) return;
   const next = q.shift();
   if (q.length === 0) fxTurnQueue.delete(taskId);
-  if (next !== undefined) spawnFxTurnNow(task, taskId, next);
+  if (next !== undefined) await spawnFxTurnNow(task, taskId, next);
 }
 
 /** Most-recent fx session id across the task's runs (for resume). */
@@ -2937,6 +3003,33 @@ type ClaudeTurnResult =
  * `{ ok: true }`.
  */
 const PASTE_OUTCOME_TIMEOUT_MS = 15_000;
+
+/**
+ * Guards the claude "this task is idle (or its session is dead) → mint a
+ * brand-new run" critical section, shared by `sendClaudeTurn`'s fresh-spawn
+ * branch (`spawnResumedSession`) and `sendTurnInExistingSession`'s idle
+ * branch. Before wave 1, `sendClaudeTurn` read `sessionLiveness` (and
+ * `sessionExists`) SYNCHRONOUSLY, so the whole stretch from that read through
+ * the new run row's `tasks.update` executed as one uninterrupted tick of JS —
+ * two overlapping `sendInput` calls for the same task could never both
+ * observe "idle": whichever one's continuation resumed first ran that entire
+ * stretch to completion (including stamping `task.runId`) before the other's
+ * continuation got a turn. `sessionLiveness` becoming genuinely async (a real
+ * tmux probe) opened a real event-loop gap between that read and everything
+ * after it. Two sends arriving close together can now both read "idle" (or
+ * "session dead") from their own independently-fetched `task` snapshot and
+ * both try to mint a run: the second `tasks.update` clobbers the first's
+ * `runId` stamp while BOTH runs still end up registered in `active`,
+ * violating the "at most one in-flight run per task" invariant the rest of
+ * this file depends on. This closes that window the same way `startingTaskIds`
+ * protects `startTask` below: whichever call claims the taskId first
+ * proceeds; a second overlapping call is told to retry rather than silently
+ * mint a sibling run. Scoped to ONLY the idle/dead-session paths — the
+ * fold-while-busy path (`pasteFollowUp`, above the idle branch in
+ * `sendTurnInExistingSession`) is unaffected and still allows any number of
+ * concurrent follow-ups to fold onto the one active run.
+ */
+const startingClaudeIdleTurns = new Set<string>();
 
 /**
  * Await a paste's `pasteOutcome` (from `sendTurn`/`pasteFollowUp`, §10
@@ -3012,12 +3105,28 @@ async function sendClaudeTurn(taskId: string, line: string): Promise<ClaudeTurnR
   // pre-kill (`spawnClaudeViaTmux`) tearing down a live, possibly mid-turn
   // session over a transient probe failure. Only an unambiguous `gone` (or no
   // in-memory state at all) reaches the destructive respawn path.
-  if (hasSessionState(taskId) && sessionLiveness(sessionNameFor(taskId)) !== "gone") {
+  if (hasSessionState(taskId) && (await sessionLiveness(sessionNameFor(taskId))) !== "gone") {
     return sendTurnInExistingSession(task, taskId, line);
   }
-  // A fresh spawn has no live modal to withhold a keystroke against, so
-  // there's no `pasteOutcome` to await here — always delivered.
-  return { runId: spawnResumedSession(task, taskId, line), delivered: true };
+  // Dead/no session: about to mint a brand-new run. Claim the per-task
+  // "starting" slot first — see `startingClaudeIdleTurns`'s doc for why this
+  // is needed now that `sessionLiveness` above is a genuine await.
+  if (startingClaudeIdleTurns.has(taskId)) {
+    return {
+      runId: task.runId ?? "",
+      delivered: false,
+      withheld: false,
+      reason: "another message is already starting a new turn for this task — try again in a moment",
+    };
+  }
+  startingClaudeIdleTurns.add(taskId);
+  try {
+    // A fresh spawn has no live modal to withhold a keystroke against, so
+    // there's no `pasteOutcome` to await here — always delivered.
+    return { runId: await spawnResumedSession(task, taskId, line), delivered: true };
+  } finally {
+    startingClaudeIdleTurns.delete(taskId);
+  }
 }
 
 async function sendTurnInExistingSession(task: Task, taskId: string, line: string): Promise<ClaudeTurnResult> {
@@ -3040,7 +3149,7 @@ async function sendTurnInExistingSession(task: Task, taskId: string, line: strin
     // the task's backlog tray (rather than lose it outright) and say so on
     // the run, since the "user" bubble below is appended optimistically
     // before the paste's real outcome is known.
-    const pasted = pasteFollowUp(taskId, line, {
+    const pasted = await pasteFollowUp(taskId, line, {
       onPasteFailure: (outcome) => handlePasteWithheld(taskId, activeRunId, line, outcome),
     });
     // `pasteFollowUp` returns `false` only when no live session exists (falls
@@ -3062,47 +3171,66 @@ async function sendTurnInExistingSession(task: Task, taskId: string, line: strin
     }
   }
 
-  // Idle (or the paste raced a vanishing session): one run row per user turn —
-  // the runs list mirrors the conversation history at turn granularity. The
-  // race that used to make a fast claude reply land the new row as "succeeded"
-  // before the UI ever observed the "running" transition no longer matters:
-  // the unified task-level event stream surfaces the new user/assistant
-  // messages live regardless of which run row they belong to.
-  const newRunId = randomUUID();
-  const now = Date.now();
-  const inheritedSessionId = findLastClaudeSessionId(taskId);
-  runs.insert({
-    id: newRunId,
-    taskId,
-    agent: task.agent,
-    status: "running",
-    startedAt: now,
-    endedAt: null,
-    exitCode: null,
-    tmuxSession: sessionNameFor(taskId),
-    claudeSessionId: inheritedSessionId,
-    codexSessionId: null,
-    cursorSessionId: null,
-    geminiSessionId: null,
-    fxSessionId: null,
-  });
-  const prevColumn: ColumnId = task.column;
-  tasks.update(taskId, { column: "running", runId: newRunId });
-  if (prevColumn !== "running") {
-    emitGlobal({ kind: "column", taskId, runId: newRunId, column: "running", prev: prevColumn, ts: now });
+  // Idle (or the paste raced a vanishing session): about to mint a brand-new
+  // run row. Claim the per-task "starting" slot first — see
+  // `startingClaudeIdleTurns`'s doc for why this is needed now that
+  // `sendClaudeTurn`'s `sessionLiveness` read is a genuine await: two
+  // overlapping sends can both arrive here having each independently
+  // observed "idle" from their own stale snapshot.
+  if (startingClaudeIdleTurns.has(taskId)) {
+    return {
+      runId: task.runId ?? "",
+      delivered: false,
+      withheld: false,
+      reason: "another message is already starting a new turn for this task — try again in a moment",
+    };
   }
+  startingClaudeIdleTurns.add(taskId);
+  try {
+    // One run row per user turn — the runs list mirrors the conversation
+    // history at turn granularity. The race that used to make a fast claude
+    // reply land the new row as "succeeded" before the UI ever observed the
+    // "running" transition no longer matters: the unified task-level event
+    // stream surfaces the new user/assistant messages live regardless of
+    // which run row they belong to.
+    const newRunId = randomUUID();
+    const now = Date.now();
+    const inheritedSessionId = findLastClaudeSessionId(taskId);
+    runs.insert({
+      id: newRunId,
+      taskId,
+      agent: task.agent,
+      status: "running",
+      startedAt: now,
+      endedAt: null,
+      exitCode: null,
+      tmuxSession: sessionNameFor(taskId),
+      claudeSessionId: inheritedSessionId,
+      codexSessionId: null,
+      cursorSessionId: null,
+      geminiSessionId: null,
+      fxSessionId: null,
+    });
+    const prevColumn: ColumnId = task.column;
+    tasks.update(taskId, { column: "running", runId: newRunId });
+    if (prevColumn !== "running") {
+      emitGlobal({ kind: "column", taskId, runId: newRunId, column: "running", prev: prevColumn, ts: now });
+    }
 
-  const harness = resolveHarness(task.agent);
-  const kind: AgentKind = harness?.kind ?? "claude-code";
-  const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
-  onChunk("user", normalizeUserText(line));
+    const harness = resolveHarness(task.agent);
+    const kind: AgentKind = harness?.kind ?? "claude-code";
+    const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
+    onChunk("user", normalizeUserText(line));
 
-  const agent = sendTurn(taskId, line, onChunk, {
-    onPasteFailure: (outcome) => handlePasteWithheld(taskId, newRunId, line, outcome),
-  });
-  registerActiveRun(newRunId, taskId, task, agent);
-  attachDoneHandler(newRunId, taskId, agent);
-  return resolveClaudeTurnOutcome(newRunId, agent.pasteOutcome);
+    const agent = await sendTurn(taskId, line, onChunk, {
+      onPasteFailure: (outcome) => handlePasteWithheld(taskId, newRunId, line, outcome),
+    });
+    registerActiveRun(newRunId, taskId, task, agent);
+    attachDoneHandler(newRunId, taskId, agent);
+    return resolveClaudeTurnOutcome(newRunId, agent.pasteOutcome);
+  } finally {
+    startingClaudeIdleTurns.delete(taskId);
+  }
 }
 
 /**
@@ -3333,7 +3461,7 @@ function startContinuationRun(taskId: string): ContinuationHooks | null {
  * Reuses the existing worktree (`task.worktreePath`) so the agent operates
  * on the same checkout as before.
  */
-function spawnResumedSession(task: Task, taskId: string, line: string): string {
+async function spawnResumedSession(task: Task, taskId: string, line: string): Promise<string> {
   const priorSessionId = findLastClaudeSessionId(taskId);
   const cwd = task.worktreePath ?? task.workdir;
 
@@ -3377,7 +3505,7 @@ function spawnResumedSession(task: Task, taskId: string, line: string): string {
     tasks.update(taskId, { column: "ready", runId: null });
     return newRunId;
   }
-  const { agent } = spawnAgentOrFail({
+  const { agent } = await spawnAgentOrFail({
     taskId,
     runId: newRunId,
     harness,
@@ -3757,12 +3885,17 @@ function enqueueArchiveTeardown(
     }
     // Same contract as deleteTask: dropSession is non-throwing (it
     // best-efforts tmux teardown internally). Don't wrap — a silent catch
-    // would hide a regression in claude-tmux from the next reviewer.
-    if (kind === "claude-code") dropSession(cur.id);
-    else if (kind === "codex") dropCodexSession(cur.id);
-    else if (kind === "cursor") dropCursorSession(cur.id);
-    else if (kind === "gemini") dropGeminiSession(cur.id);
-    else if (kind === "fx") dropFxSession(cur.id);
+    // would hide a regression in claude-tmux from the next reviewer. Awaited
+    // (wave 1 made every drop* async) so the session kill genuinely completes
+    // BEFORE killTerminalsForTask/detachWorktree below — ordering rule from
+    // docs/plans/fix-archive-teardown-queue.md, still load-bearing now that
+    // "complete" means "the awaited promise settled" rather than "the
+    // synchronous call returned".
+    if (kind === "claude-code") await dropSession(cur.id);
+    else if (kind === "codex") await dropCodexSession(cur.id);
+    else if (kind === "cursor") await dropCursorSession(cur.id);
+    else if (kind === "gemini") await dropGeminiSession(cur.id);
+    else if (kind === "fx") dropFxSession(cur.id); // fx has no tmux session — stays sync
     await killTerminalsForTask(cur.id);
     result = await detachWorktree(cur, { force: opts?.force });
   });
@@ -3828,7 +3961,7 @@ export async function archiveTask(
     }
     stopActiveHandle(active.get(task.runId)!, "task archived");
   } else if (opts?.stopRun && isHeldByBackgroundAgents(taskId)) {
-    stopHeldTask(taskId, "task archived");
+    await stopHeldTask(taskId, "task archived");
   }
   if (task.archivedAt != null) {
     // Already archived is normally a cheap no-op — repeat-archives (e.g. a
@@ -3880,8 +4013,9 @@ export async function archiveTask(
   // detach) is pushed onto this task's source-workdir teardown queue rather
   // than awaited here, so `archiveTask` can flip the DB column and return in
   // milliseconds. Archiving several tasks against the same workdir back-to-
-  // back no longer blocks each POST on `spawnSync` tmux kills or `git
-  // worktree remove --force`/`prune` — those still run (serialized per
+  // back no longer blocks each POST on tmux kills (async `Bun.spawn` now,
+  // but still real wall-clock latency) or `git worktree remove --force`/
+  // `prune` — those still run (serialized per
   // workdir, see `enqueueTeardown`), just off the request's critical path;
   // tasks in a different workdir proceed independently. Callers that must
   // not race a deferred teardown (unarchive, start, delete, the boot sweep)
@@ -3959,11 +4093,15 @@ export async function deleteTask(taskId: string): Promise<void> {
   // remove`/`prune` calls against the same repo never contend on git's locks
   // at the same time. A delete against an unrelated workdir is unaffected.
   await enqueueTeardown(taskId, task.workdir, async () => {
-    if (deleteKind === "claude-code") dropSession(taskId);
-    else if (deleteKind === "codex") dropCodexSession(taskId);
-    else if (deleteKind === "cursor") dropCursorSession(taskId);
-    else if (deleteKind === "gemini") dropGeminiSession(taskId);
-    else if (deleteKind === "fx") dropFxSession(taskId);
+    // Awaited (wave 1 made every drop* async) — the session kill must
+    // genuinely complete before killTerminalsForTask/removeWorktree below,
+    // not just be kicked off. Same ordering discipline as
+    // enqueueArchiveTeardown above.
+    if (deleteKind === "claude-code") await dropSession(taskId);
+    else if (deleteKind === "codex") await dropCodexSession(taskId);
+    else if (deleteKind === "cursor") await dropCursorSession(taskId);
+    else if (deleteKind === "gemini") await dropGeminiSession(taskId);
+    else if (deleteKind === "fx") dropFxSession(taskId); // fx has no tmux session — stays sync
     // Kill any open terminal tabs before removing the worktree — a live shell
     // sitting in the worktree dir would block `git worktree remove`. Awaited
     // so the shells are actually gone before we tear the directory down.
@@ -4141,7 +4279,7 @@ export async function reapIdleSessions(): Promise<{ reaped: string[] }> {
         // called out in the review: a session could be driven by something
         // other than agetor (a human at the tmux client) bumping tmux's
         // activity clock without ever updating our DB row, or vice versa.
-        const activity = probeSessionActivity(taskId);
+        const activity = await probeSessionActivity(taskId);
         if (!activity) continue;
         if (activity.attached) continue;
         idleLongEnough =
@@ -4156,7 +4294,7 @@ export async function reapIdleSessions(): Promise<{ reaped: string[] }> {
       const fresh = tasks.get(taskId);
       if (!fresh || !isReapable(fresh)) continue;
 
-      dropSession(taskId);
+      await dropSession(taskId);
       reaped.push(taskId);
 
       const recent = runs.listForTask(taskId)[0];

--- a/src/bun/orchestrator.ts
+++ b/src/bun/orchestrator.ts
@@ -863,11 +863,16 @@ export async function reconcileOrphans(): Promise<number> {
 }
 
 /**
- * Wraps `spawnAgent` so a synchronous throw inside it — `buildCommand` can
- * throw before a process is ever spawned (gemini's argv-size cap, "model is
- * required", …) — can't strand the run row it was called for. Every call
- * site below has already inserted the run row and flipped the task to
- * `running` by the time it calls this, so on a throw there's persisted state
+ * Wraps `spawnAgent` so a failure inside it — either a *synchronous* throw
+ * before a process is ever spawned (`buildCommand` can throw on gemini's
+ * argv-size cap, "model is required", …) or an *async rejection* partway
+ * through spawning (e.g. a `git` failure inside `buildCodexCommand`'s
+ * external-git escalation check, or any other awaited step of `spawnAgent`
+ * that rejects) — can't strand the run row it was called for. `await
+ * spawnAgent(args)` inside the `try` catches both shapes identically; the
+ * catch block below doesn't need to know which one fired. Every call site
+ * below has already inserted the run row and flipped the task to `running`
+ * by the time it calls this, so on a throw/rejection there's persisted state
  * to unwind: emit the error as a stderr chunk, fail the run, and bounce the
  * task back to `ready` — the same recovery each call site already does for a
  * missing harness (see the neighboring `if (!harness)` branches). Returns
@@ -895,22 +900,46 @@ async function spawnAgentOrFail(
 }
 
 /**
- * Guards against two overlapping `startTask` calls for the SAME task both
- * reaching `spawnAgentOrFail`. The `task.runId && active.has(task.runId)`
- * check at the top only rules out a task that's ALREADY running — it does
- * nothing about two concurrent calls that both read that check as false and
- * then both walk the chain of awaits below (`pendingTeardown`, `checkHarness`,
- * `prepareWorkdir`, `resolveRef`, and now the async `spawnAgentOrFail`
- * itself) before either has registered an active run. This window predates
- * wave 1 (the first three awaits already existed), but the async spawn adds
- * one more await after the DB transaction has already stamped `task.runId` —
- * so a second overlapping call could, in principle, race in behind the first
- * and reach `spawnAgentOrFail` too, minting two run rows and two spawned
- * agents for one task. `startingTaskIds` closes the window for real double
- * clicks / rapid re-POSTs to `/tasks/:id/start`: whichever call claims the
- * taskId first proceeds through the whole function; a second overlapping
- * call is rejected immediately instead of racing through every await behind
- * it.
+ * Guards against two overlapping "mint a fresh run for this task" calls
+ * racing each other. The same failure shape shows up at every entry point
+ * that (a) reads `task.runId && active.has(task.runId)` (or, for claude,
+ * the `sessionLiveness`/`hasSessionState` equivalent) as "nothing in flight
+ * for this task", then (b) walks a chain of awaits — `pendingTeardown`,
+ * `checkHarness`, `prepareWorkdir`, `resolveRef`, `sessionLiveness`, the
+ * async `spawnAgentOrFail` itself — before it has registered the new run in
+ * `active` or (for codex/cursor/gemini/fx) even written `task.runId` via
+ * `tasks.update`. A second overlapping call can read that same stale "idle"
+ * snapshot before the first call's DB write lands, race in behind it, and
+ * reach its own mint path too: two run rows, two spawned agents — or worse,
+ * the second spawn's unconditional tmux pre-kill (`spawnClaudeViaTmux` et
+ * al.) tearing down the first turn's session mid-spawn — for one task.
+ *
+ * ONE module-level set closes this window for every caller that mints a
+ * fresh run without an existing one to fold into:
+ *   - `startTask`'s wrapper directly below (double clicks / rapid re-POSTs
+ *     to `/tasks/:id/start`);
+ *   - claude's idle/dead-session mint paths (`sendClaudeTurn`'s fresh-spawn
+ *     branch and `sendTurnInExistingSession`'s idle branch) — these used to
+ *     share a separate `startingClaudeIdleTurns` set; unified here so a
+ *     `startTask` and a claude idle-send can't each claim their own
+ *     disjoint keyspace and both mint against the same task;
+ *   - the four one-shot `spawn{Codex,Cursor,Gemini,Fx}TurnNow` functions,
+ *     which claim at entry (before `runs.insert`) and release in `finally`.
+ *
+ * Deliberately NOT claimed by claude's fold-while-busy path (`pasteFollowUp`,
+ * inside `sendTurnInExistingSession`, above its idle branch) — folding a
+ * message into an already-active run is safe under any amount of
+ * concurrency by design, and serializing it here would only add latency
+ * with no correctness benefit.
+ *
+ * Whichever call claims a taskId first proceeds through its whole function;
+ * every other overlapping call for the same taskId is rejected immediately
+ * with a friendly "try again" result instead of racing through the awaits
+ * behind it. Trade-off, accepted: a permanently wedged tmux op (its owner
+ * declined to add a timeout) leaves the claim held and that task un-startable
+ * / un-sendable for the remaining lifetime of the process — strictly better
+ * than the old app-wide synchronous hang this replaced, and scoped to one
+ * task rather than the whole app. Revisit if/when that op grows a timeout.
  */
 const startingTaskIds = new Set<string>();
 
@@ -2291,29 +2320,50 @@ export async function sendInput(runId: string, line: string): Promise<SendInputR
     }
     return { delivered: true, runId: result.runId };
   }
+  // The four `send*Turn` helpers below return `null` in two cases: the task
+  // vanished between `sendInput`'s own lookup above and their internal
+  // re-fetch (a genuine, rare lookup race), or their `spawn*TurnNow` call
+  // found `startingTaskIds` already claimed for this task and declined to
+  // mint a second run rather than risk the double-mint race `startingTaskIds`
+  // exists to close (see that set's doc, near `startTask`). The second case
+  // is overwhelmingly the common one in practice, so the message leads with
+  // it — matching the wording claude's own idle-mint guard already uses —
+  // while still being accurate ("try again") for the rare lookup race too.
   if (kind === "codex") {
     const result = await sendCodexTurn(row.task_id, line);
     return result
       ? { delivered: true, runId: result }
-      : { delivered: false, reason: "internal: task lookup failed" };
+      : {
+          delivered: false,
+          reason: "another message is already starting a new turn for this task — try again in a moment",
+        };
   }
   if (kind === "cursor") {
     const result = await sendCursorTurn(row.task_id, line);
     return result
       ? { delivered: true, runId: result }
-      : { delivered: false, reason: "internal: task lookup failed" };
+      : {
+          delivered: false,
+          reason: "another message is already starting a new turn for this task — try again in a moment",
+        };
   }
   if (kind === "gemini") {
     const result = await sendGeminiTurn(row.task_id, line);
     return result
       ? { delivered: true, runId: result }
-      : { delivered: false, reason: "internal: task lookup failed" };
+      : {
+          delivered: false,
+          reason: "another message is already starting a new turn for this task — try again in a moment",
+        };
   }
   if (kind === "fx") {
     const result = await sendFxTurn(row.task_id, line);
     return result
       ? { delivered: true, runId: result }
-      : { delivered: false, reason: "internal: task lookup failed" };
+      : {
+          delivered: false,
+          reason: "another message is already starting a new turn for this task — try again in a moment",
+        };
   }
   return { delivered: false, reason: `unknown agent kind for "${row.agent}"` };
 }
@@ -2333,7 +2383,9 @@ const codexTurnQueue = new Map<string, string[]>();
  * Send a follow-up to a codex task. Each follow-up is its own run row + its own
  * `codex exec resume <thread_id>` turn (sequential-turn model). When a turn is
  * already running, the message is queued; otherwise it spawns immediately.
- * Returns the run id the message was attached to, or null on lookup failure.
+ * Returns the run id the message was attached to, or null on lookup failure —
+ * or when `spawnCodexTurnNow` declined to mint a run because `startingTaskIds`
+ * was already claimed for this task (see that set's doc, near `startTask`).
  */
 async function sendCodexTurn(taskId: string, line: string): Promise<string | null> {
   const task = tasks.get(taskId);
@@ -2358,87 +2410,101 @@ async function sendCodexTurn(taskId: string, line: string): Promise<string | nul
  * `codex exec resume <thread_id>`. New run row, new tmux session (the previous
  * turn's exited), same `thread_id` carried forward.
  */
-async function spawnCodexTurnNow(task: Task, taskId: string, line: string): Promise<string> {
-  const priorThreadId = findLastCodexSessionId(taskId);
-  const cwd = task.worktreePath ?? task.workdir;
-  const harness = resolveHarness(task.agent);
+async function spawnCodexTurnNow(task: Task, taskId: string, line: string): Promise<string | null> {
+  // Claim the unified "starting" slot before touching the DB — see
+  // `startingTaskIds`'s doc (near `startTask`) for the double-mint race this
+  // closes: a second overlapping call could otherwise race in behind
+  // `tasks.update` below and reach `spawnAgentOrFail` too, minting a second
+  // run row and (via the driver's own session pre-kill) tearing down this
+  // turn's tmux session mid-spawn. `null` is unambiguous here — every other
+  // return path below yields `newRunId`, so a caller seeing `null` knows
+  // this call never touched the DB and should treat it as "try again".
+  if (startingTaskIds.has(taskId)) return null;
+  startingTaskIds.add(taskId);
+  try {
+    const priorThreadId = findLastCodexSessionId(taskId);
+    const cwd = task.worktreePath ?? task.workdir;
+    const harness = resolveHarness(task.agent);
 
-  const newRunId = randomUUID();
-  const now = Date.now();
-  runs.insert({
-    id: newRunId,
-    taskId,
-    agent: task.agent,
-    status: "running",
-    startedAt: now,
-    endedAt: null,
-    exitCode: null,
-    tmuxSession: sessionNameFor(taskId),
-    claudeSessionId: null,
-    // Carry the thread id forward up front so a reattach mid-turn finds it even
-    // before this run's own `thread.started` re-emits it. onSessionId below
-    // re-stamps the same value (idempotent).
-    codexSessionId: priorThreadId,
-    cursorSessionId: null,
-    geminiSessionId: null,
-    fxSessionId: null,
-  });
-  const prevColumn: ColumnId = task.column;
-  tasks.update(taskId, { column: "running", runId: newRunId });
-  if (prevColumn !== "running") {
-    emitGlobal({ kind: "column", taskId, runId: newRunId, column: "running", prev: prevColumn, ts: now });
-  }
+    const newRunId = randomUUID();
+    const now = Date.now();
+    runs.insert({
+      id: newRunId,
+      taskId,
+      agent: task.agent,
+      status: "running",
+      startedAt: now,
+      endedAt: null,
+      exitCode: null,
+      tmuxSession: sessionNameFor(taskId),
+      claudeSessionId: null,
+      // Carry the thread id forward up front so a reattach mid-turn finds it even
+      // before this run's own `thread.started` re-emits it. onSessionId below
+      // re-stamps the same value (idempotent).
+      codexSessionId: priorThreadId,
+      cursorSessionId: null,
+      geminiSessionId: null,
+      fxSessionId: null,
+    });
+    const prevColumn: ColumnId = task.column;
+    tasks.update(taskId, { column: "running", runId: newRunId });
+    if (prevColumn !== "running") {
+      emitGlobal({ kind: "column", taskId, runId: newRunId, column: "running", prev: prevColumn, ts: now });
+    }
 
-  const kind: AgentKind = harness?.kind ?? "codex";
-  const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
-  onChunk("user", normalizeUserText(line));
-  onChunk(
-    "status",
-    priorThreadId
-      ? `resuming codex thread ${priorThreadId.slice(0, 8)}…`
-      : "no prior codex thread — starting fresh",
-  );
+    const kind: AgentKind = harness?.kind ?? "codex";
+    const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
+    onChunk("user", normalizeUserText(line));
+    onChunk(
+      "status",
+      priorThreadId
+        ? `resuming codex thread ${priorThreadId.slice(0, 8)}…`
+        : "no prior codex thread — starting fresh",
+    );
 
-  if (!harness) {
-    onChunk("stderr", `harness "${task.agent}" not found — cannot resume`);
-    runs.update(newRunId, { status: "failed", endedAt: Date.now(), exitCode: -1 });
-    tasks.update(taskId, { column: "ready", runId: null });
+    if (!harness) {
+      onChunk("stderr", `harness "${task.agent}" not found — cannot resume`);
+      runs.update(newRunId, { status: "failed", endedAt: Date.now(), exitCode: -1 });
+      tasks.update(taskId, { column: "ready", runId: null });
+      return newRunId;
+    }
+
+    const { agent } = await spawnAgentOrFail({
+      taskId,
+      runId: newRunId,
+      harness,
+      prompt: line,
+      cwd,
+      onChunk,
+      onSessionId: (sessionId) => {
+        runs.update(newRunId, { codexSessionId: sessionId });
+      },
+      opts: {
+        mode: task.mode,
+        model: task.model ?? DEFAULT_MODEL[harness.kind],
+        effort: task.effort,
+        fast: task.fast,
+        maxMode: task.maxMode,
+        resumeSessionId: priorThreadId,
+      },
+    });
+    if (!agent) {
+      // spawnAgentOrFail already failed this run row and bounced the task to
+      // `ready` — attachDoneHandler (the only caller of drainCodexQueue) never
+      // runs, so any follow-ups queued behind this one would otherwise be
+      // stranded and resurface out of order on a later, unrelated turn. The
+      // dropped messages were already recorded as `user` events on their
+      // originating run, so dropping the queue here is more honest than
+      // re-delivering them later.
+      codexTurnQueue.delete(taskId);
+      return newRunId;
+    }
+    registerActiveRun(newRunId, taskId, task, agent);
+    attachDoneHandler(newRunId, taskId, agent);
     return newRunId;
+  } finally {
+    startingTaskIds.delete(taskId);
   }
-
-  const { agent } = await spawnAgentOrFail({
-    taskId,
-    runId: newRunId,
-    harness,
-    prompt: line,
-    cwd,
-    onChunk,
-    onSessionId: (sessionId) => {
-      runs.update(newRunId, { codexSessionId: sessionId });
-    },
-    opts: {
-      mode: task.mode,
-      model: task.model ?? DEFAULT_MODEL[harness.kind],
-      effort: task.effort,
-      fast: task.fast,
-      maxMode: task.maxMode,
-      resumeSessionId: priorThreadId,
-    },
-  });
-  if (!agent) {
-    // spawnAgentOrFail already failed this run row and bounced the task to
-    // `ready` — attachDoneHandler (the only caller of drainCodexQueue) never
-    // runs, so any follow-ups queued behind this one would otherwise be
-    // stranded and resurface out of order on a later, unrelated turn. The
-    // dropped messages were already recorded as `user` events on their
-    // originating run, so dropping the queue here is more honest than
-    // re-delivering them later.
-    codexTurnQueue.delete(taskId);
-    return newRunId;
-  }
-  registerActiveRun(newRunId, taskId, task, agent);
-  attachDoneHandler(newRunId, taskId, agent);
-  return newRunId;
 }
 
 /**
@@ -2491,7 +2557,9 @@ const cursorTurnQueue = new Map<string, string[]>();
  * own `cursor-agent --resume <session_id>` turn (sequential-turn model). When
  * a turn is already running, the message is queued; otherwise it spawns
  * immediately. Returns the run id the message was attached to, or null on
- * lookup failure.
+ * lookup failure — or when `spawnCursorTurnNow` declined to mint a run
+ * because `startingTaskIds` was already claimed for this task (see that
+ * set's doc, near `startTask`).
  */
 async function sendCursorTurn(taskId: string, line: string): Promise<string | null> {
   const task = tasks.get(taskId);
@@ -2516,89 +2584,99 @@ async function sendCursorTurn(taskId: string, line: string): Promise<string | nu
  * `cursor-agent --resume <session_id>`. New run row, new tmux session (the
  * previous turn's exited), same `session_id` carried forward.
  */
-async function spawnCursorTurnNow(task: Task, taskId: string, line: string): Promise<string> {
-  const priorSessionId = findLastCursorSessionId(taskId);
-  const cwd = task.worktreePath ?? task.workdir;
-  const harness = resolveHarness(task.agent);
+async function spawnCursorTurnNow(task: Task, taskId: string, line: string): Promise<string | null> {
+  // Claim the unified "starting" slot before touching the DB — see
+  // `startingTaskIds`'s doc (near `startTask`) and the matching comment in
+  // `spawnCodexTurnNow` for the double-mint race this closes. `null` is
+  // unambiguous: every other return path below yields `newRunId`.
+  if (startingTaskIds.has(taskId)) return null;
+  startingTaskIds.add(taskId);
+  try {
+    const priorSessionId = findLastCursorSessionId(taskId);
+    const cwd = task.worktreePath ?? task.workdir;
+    const harness = resolveHarness(task.agent);
 
-  const newRunId = randomUUID();
-  const now = Date.now();
-  runs.insert({
-    id: newRunId,
-    taskId,
-    agent: task.agent,
-    status: "running",
-    startedAt: now,
-    endedAt: null,
-    exitCode: null,
-    tmuxSession: sessionNameFor(taskId),
-    claudeSessionId: null,
-    codexSessionId: null,
-    // Carry the session id forward up front so a reattach mid-turn finds it
-    // even before this run's own first event re-emits it. onSessionId below
-    // re-stamps the same value (idempotent).
-    cursorSessionId: priorSessionId,
-    geminiSessionId: null,
-    fxSessionId: null,
-  });
-  const prevColumn: ColumnId = task.column;
-  tasks.update(taskId, { column: "running", runId: newRunId });
-  if (prevColumn !== "running") {
-    emitGlobal({ kind: "column", taskId, runId: newRunId, column: "running", prev: prevColumn, ts: now });
-  }
+    const newRunId = randomUUID();
+    const now = Date.now();
+    runs.insert({
+      id: newRunId,
+      taskId,
+      agent: task.agent,
+      status: "running",
+      startedAt: now,
+      endedAt: null,
+      exitCode: null,
+      tmuxSession: sessionNameFor(taskId),
+      claudeSessionId: null,
+      codexSessionId: null,
+      // Carry the session id forward up front so a reattach mid-turn finds it
+      // even before this run's own first event re-emits it. onSessionId below
+      // re-stamps the same value (idempotent).
+      cursorSessionId: priorSessionId,
+      geminiSessionId: null,
+      fxSessionId: null,
+    });
+    const prevColumn: ColumnId = task.column;
+    tasks.update(taskId, { column: "running", runId: newRunId });
+    if (prevColumn !== "running") {
+      emitGlobal({ kind: "column", taskId, runId: newRunId, column: "running", prev: prevColumn, ts: now });
+    }
 
-  const kind: AgentKind = harness?.kind ?? "cursor";
-  const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
-  onChunk("user", normalizeUserText(line));
-  onChunk(
-    "status",
-    priorSessionId
-      ? `resuming cursor session ${priorSessionId.slice(0, 8)}…`
-      : "no prior cursor session — starting fresh",
-  );
+    const kind: AgentKind = harness?.kind ?? "cursor";
+    const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
+    onChunk("user", normalizeUserText(line));
+    onChunk(
+      "status",
+      priorSessionId
+        ? `resuming cursor session ${priorSessionId.slice(0, 8)}…`
+        : "no prior cursor session — starting fresh",
+    );
 
-  if (!harness) {
-    onChunk("stderr", `harness "${task.agent}" not found — cannot resume`);
-    runs.update(newRunId, { status: "failed", endedAt: Date.now(), exitCode: -1 });
-    tasks.update(taskId, { column: "ready", runId: null });
+    if (!harness) {
+      onChunk("stderr", `harness "${task.agent}" not found — cannot resume`);
+      runs.update(newRunId, { status: "failed", endedAt: Date.now(), exitCode: -1 });
+      tasks.update(taskId, { column: "ready", runId: null });
+      return newRunId;
+    }
+
+    const { agent } = await spawnAgentOrFail({
+      taskId,
+      runId: newRunId,
+      harness,
+      prompt: line,
+      cwd,
+      onChunk,
+      onSessionId: (sessionId) => {
+        runs.update(newRunId, { cursorSessionId: sessionId });
+      },
+      opts: {
+        mode: task.mode,
+        model: task.model ?? DEFAULT_MODEL[harness.kind],
+        effort: task.effort,
+        fast: task.fast,
+        maxMode: task.maxMode,
+        // Same generic resume-session field claude-code and codex already
+        // thread through `spawnAgent` → `buildCommand` — cursor's `session_id`
+        // rides the same `AgentRunOptions.resumeSessionId` contract rather than
+        // a cursor-specific field name (see this function's file-level header
+        // note on the resume option-field contract).
+        resumeSessionId: priorSessionId,
+      },
+    });
+    if (!agent) {
+      // See the matching comment in spawnCodexTurnNow: spawnAgentOrFail already
+      // failed this run and attachDoneHandler (the only caller of
+      // drainCursorQueue) never runs, so drop the queue rather than let queued
+      // follow-ups resurface out of order on a later turn.
+      cursorTurnQueue.delete(taskId);
+      return newRunId;
+    }
+    registerActiveRun(newRunId, taskId, task, agent);
+    attachDoneHandler(newRunId, taskId, agent);
     return newRunId;
+  } finally {
+    startingTaskIds.delete(taskId);
   }
-
-  const { agent } = await spawnAgentOrFail({
-    taskId,
-    runId: newRunId,
-    harness,
-    prompt: line,
-    cwd,
-    onChunk,
-    onSessionId: (sessionId) => {
-      runs.update(newRunId, { cursorSessionId: sessionId });
-    },
-    opts: {
-      mode: task.mode,
-      model: task.model ?? DEFAULT_MODEL[harness.kind],
-      effort: task.effort,
-      fast: task.fast,
-      maxMode: task.maxMode,
-      // Same generic resume-session field claude-code and codex already
-      // thread through `spawnAgent` → `buildCommand` — cursor's `session_id`
-      // rides the same `AgentRunOptions.resumeSessionId` contract rather than
-      // a cursor-specific field name (see this function's file-level header
-      // note on the resume option-field contract).
-      resumeSessionId: priorSessionId,
-    },
-  });
-  if (!agent) {
-    // See the matching comment in spawnCodexTurnNow: spawnAgentOrFail already
-    // failed this run and attachDoneHandler (the only caller of
-    // drainCursorQueue) never runs, so drop the queue rather than let queued
-    // follow-ups resurface out of order on a later turn.
-    cursorTurnQueue.delete(taskId);
-    return newRunId;
-  }
-  registerActiveRun(newRunId, taskId, task, agent);
-  attachDoneHandler(newRunId, taskId, agent);
-  return newRunId;
 }
 
 /**
@@ -2650,7 +2728,9 @@ const geminiTurnQueue = new Map<string, string[]>();
  * own `gemini --resume <uuid>` turn (sequential-turn model, same as codex).
  * When a turn is already running, the message is queued; otherwise it spawns
  * immediately. Returns the run id the message was attached to, or null on
- * lookup failure.
+ * lookup failure — or when `spawnGeminiTurnNow` declined to mint a run
+ * because `startingTaskIds` was already claimed for this task (see that
+ * set's doc, near `startTask`).
  */
 async function sendGeminiTurn(taskId: string, line: string): Promise<string | null> {
   const task = tasks.get(taskId);
@@ -2678,87 +2758,97 @@ async function sendGeminiTurn(taskId: string, line: string): Promise<string | nu
  * session id is already known synchronously, so it's stamped on the new run
  * row directly rather than via an `onSessionId` re-stamp.
  */
-async function spawnGeminiTurnNow(task: Task, taskId: string, line: string): Promise<string> {
-  const priorSessionId = findLastGeminiSessionId(taskId);
-  const cwd = task.worktreePath ?? task.workdir;
-  const harness = resolveHarness(task.agent);
+async function spawnGeminiTurnNow(task: Task, taskId: string, line: string): Promise<string | null> {
+  // Claim the unified "starting" slot before touching the DB — see
+  // `startingTaskIds`'s doc (near `startTask`) and the matching comment in
+  // `spawnCodexTurnNow` for the double-mint race this closes. `null` is
+  // unambiguous: every other return path below yields `newRunId`.
+  if (startingTaskIds.has(taskId)) return null;
+  startingTaskIds.add(taskId);
+  try {
+    const priorSessionId = findLastGeminiSessionId(taskId);
+    const cwd = task.worktreePath ?? task.workdir;
+    const harness = resolveHarness(task.agent);
 
-  const newRunId = randomUUID();
-  const now = Date.now();
-  runs.insert({
-    id: newRunId,
-    taskId,
-    agent: task.agent,
-    status: "running",
-    startedAt: now,
-    endedAt: null,
-    exitCode: null,
-    tmuxSession: sessionNameFor(taskId),
-    claudeSessionId: null,
-    codexSessionId: null,
-    cursorSessionId: null,
-    geminiSessionId: priorSessionId,
-    fxSessionId: null,
-  });
-  const prevColumn: ColumnId = task.column;
-  tasks.update(taskId, { column: "running", runId: newRunId });
-  if (prevColumn !== "running") {
-    emitGlobal({ kind: "column", taskId, runId: newRunId, column: "running", prev: prevColumn, ts: now });
-  }
+    const newRunId = randomUUID();
+    const now = Date.now();
+    runs.insert({
+      id: newRunId,
+      taskId,
+      agent: task.agent,
+      status: "running",
+      startedAt: now,
+      endedAt: null,
+      exitCode: null,
+      tmuxSession: sessionNameFor(taskId),
+      claudeSessionId: null,
+      codexSessionId: null,
+      cursorSessionId: null,
+      geminiSessionId: priorSessionId,
+      fxSessionId: null,
+    });
+    const prevColumn: ColumnId = task.column;
+    tasks.update(taskId, { column: "running", runId: newRunId });
+    if (prevColumn !== "running") {
+      emitGlobal({ kind: "column", taskId, runId: newRunId, column: "running", prev: prevColumn, ts: now });
+    }
 
-  const kind: AgentKind = harness?.kind ?? "gemini";
-  const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
-  onChunk("user", normalizeUserText(line));
-  onChunk(
-    "status",
-    priorSessionId
-      ? `resuming gemini session ${priorSessionId.slice(0, 8)}…`
-      : "no prior gemini session — starting fresh",
-  );
+    const kind: AgentKind = harness?.kind ?? "gemini";
+    const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
+    onChunk("user", normalizeUserText(line));
+    onChunk(
+      "status",
+      priorSessionId
+        ? `resuming gemini session ${priorSessionId.slice(0, 8)}…`
+        : "no prior gemini session — starting fresh",
+    );
 
-  if (!harness) {
-    onChunk("stderr", `harness "${task.agent}" not found — cannot resume`);
-    runs.update(newRunId, { status: "failed", endedAt: Date.now(), exitCode: -1 });
-    tasks.update(taskId, { column: "ready", runId: null });
+    if (!harness) {
+      onChunk("stderr", `harness "${task.agent}" not found — cannot resume`);
+      runs.update(newRunId, { status: "failed", endedAt: Date.now(), exitCode: -1 });
+      tasks.update(taskId, { column: "ready", runId: null });
+      return newRunId;
+    }
+
+    const { agent } = await spawnAgentOrFail({
+      taskId,
+      runId: newRunId,
+      harness,
+      prompt: line,
+      cwd,
+      onChunk,
+      // Normally re-stamps the same `priorSessionId` already written above
+      // (idempotent) — kept for the edge case where a task somehow has no
+      // prior session id yet (spawnAgent mints a fresh uuid via
+      // crypto.randomUUID() when resumeSessionId is absent, and this is the
+      // only way that freshly-minted id gets persisted).
+      onSessionId: (sessionId) => {
+        runs.update(newRunId, { geminiSessionId: sessionId });
+      },
+      opts: {
+        mode: task.mode,
+        model: task.model ?? DEFAULT_MODEL[harness.kind],
+        effort: task.effort,
+        fast: task.fast,
+        maxMode: task.maxMode,
+        resumeSessionId: priorSessionId,
+      },
+    });
+    if (!agent) {
+      // See the matching comment in spawnCodexTurnNow: spawnAgentOrFail already
+      // failed this run and attachDoneHandler (the only caller of
+      // drainGeminiQueue) never runs, so drop the queue rather than let queued
+      // follow-ups resurface out of order on a later turn. Reachable in
+      // practice via GEMINI_PROMPT_ARGV_MAX_BYTES on a long follow-up.
+      geminiTurnQueue.delete(taskId);
+      return newRunId;
+    }
+    registerActiveRun(newRunId, taskId, task, agent);
+    attachDoneHandler(newRunId, taskId, agent);
     return newRunId;
+  } finally {
+    startingTaskIds.delete(taskId);
   }
-
-  const { agent } = await spawnAgentOrFail({
-    taskId,
-    runId: newRunId,
-    harness,
-    prompt: line,
-    cwd,
-    onChunk,
-    // Normally re-stamps the same `priorSessionId` already written above
-    // (idempotent) — kept for the edge case where a task somehow has no
-    // prior session id yet (spawnAgent mints a fresh uuid via
-    // crypto.randomUUID() when resumeSessionId is absent, and this is the
-    // only way that freshly-minted id gets persisted).
-    onSessionId: (sessionId) => {
-      runs.update(newRunId, { geminiSessionId: sessionId });
-    },
-    opts: {
-      mode: task.mode,
-      model: task.model ?? DEFAULT_MODEL[harness.kind],
-      effort: task.effort,
-      fast: task.fast,
-      maxMode: task.maxMode,
-      resumeSessionId: priorSessionId,
-    },
-  });
-  if (!agent) {
-    // See the matching comment in spawnCodexTurnNow: spawnAgentOrFail already
-    // failed this run and attachDoneHandler (the only caller of
-    // drainGeminiQueue) never runs, so drop the queue rather than let queued
-    // follow-ups resurface out of order on a later turn. Reachable in
-    // practice via GEMINI_PROMPT_ARGV_MAX_BYTES on a long follow-up.
-    geminiTurnQueue.delete(taskId);
-    return newRunId;
-  }
-  registerActiveRun(newRunId, taskId, task, agent);
-  attachDoneHandler(newRunId, taskId, agent);
-  return newRunId;
 }
 
 /**
@@ -2808,7 +2898,9 @@ const fxTurnQueue = new Map<string, string[]>();
  * resumed ACP turn (sequential-turn model, same as codex/cursor/gemini). When
  * a turn is already running, the message is queued; otherwise it spawns
  * immediately. Returns the run id the message was attached to, or null on
- * lookup failure.
+ * lookup failure — or when `spawnFxTurnNow` declined to mint a run because
+ * `startingTaskIds` was already claimed for this task (see that set's doc,
+ * near `startTask`).
  */
 async function sendFxTurn(taskId: string, line: string): Promise<string | null> {
   const task = tasks.get(taskId);
@@ -2836,81 +2928,91 @@ async function sendFxTurn(taskId: string, line: string): Promise<string | null> 
  * response), so it's carried forward on the insert below and re-stamped
  * (idempotently) once `onSessionId` fires again for this turn.
  */
-async function spawnFxTurnNow(task: Task, taskId: string, line: string): Promise<string> {
-  const priorSessionId = findLastFxSessionId(taskId);
-  const cwd = task.worktreePath ?? task.workdir;
-  const harness = resolveHarness(task.agent);
+async function spawnFxTurnNow(task: Task, taskId: string, line: string): Promise<string | null> {
+  // Claim the unified "starting" slot before touching the DB — see
+  // `startingTaskIds`'s doc (near `startTask`) and the matching comment in
+  // `spawnCodexTurnNow` for the double-mint race this closes. `null` is
+  // unambiguous: every other return path below yields `newRunId`.
+  if (startingTaskIds.has(taskId)) return null;
+  startingTaskIds.add(taskId);
+  try {
+    const priorSessionId = findLastFxSessionId(taskId);
+    const cwd = task.worktreePath ?? task.workdir;
+    const harness = resolveHarness(task.agent);
 
-  const newRunId = randomUUID();
-  const now = Date.now();
-  runs.insert({
-    id: newRunId,
-    taskId,
-    agent: task.agent,
-    status: "running",
-    startedAt: now,
-    endedAt: null,
-    exitCode: null,
-    tmuxSession: sessionNameFor(taskId),
-    claudeSessionId: null,
-    codexSessionId: null,
-    cursorSessionId: null,
-    geminiSessionId: null,
-    fxSessionId: priorSessionId,
-  });
-  const prevColumn: ColumnId = task.column;
-  tasks.update(taskId, { column: "running", runId: newRunId });
-  if (prevColumn !== "running") {
-    emitGlobal({ kind: "column", taskId, runId: newRunId, column: "running", prev: prevColumn, ts: now });
-  }
+    const newRunId = randomUUID();
+    const now = Date.now();
+    runs.insert({
+      id: newRunId,
+      taskId,
+      agent: task.agent,
+      status: "running",
+      startedAt: now,
+      endedAt: null,
+      exitCode: null,
+      tmuxSession: sessionNameFor(taskId),
+      claudeSessionId: null,
+      codexSessionId: null,
+      cursorSessionId: null,
+      geminiSessionId: null,
+      fxSessionId: priorSessionId,
+    });
+    const prevColumn: ColumnId = task.column;
+    tasks.update(taskId, { column: "running", runId: newRunId });
+    if (prevColumn !== "running") {
+      emitGlobal({ kind: "column", taskId, runId: newRunId, column: "running", prev: prevColumn, ts: now });
+    }
 
-  const kind: AgentKind = harness?.kind ?? "fx";
-  const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
-  onChunk("user", normalizeUserText(line));
-  onChunk(
-    "status",
-    priorSessionId
-      ? `resuming fx session ${priorSessionId.slice(0, 8)}…`
-      : "no prior fx session — starting fresh",
-  );
+    const kind: AgentKind = harness?.kind ?? "fx";
+    const onChunk = makeChunkHandler(newRunId, taskId, kind, task.mode);
+    onChunk("user", normalizeUserText(line));
+    onChunk(
+      "status",
+      priorSessionId
+        ? `resuming fx session ${priorSessionId.slice(0, 8)}…`
+        : "no prior fx session — starting fresh",
+    );
 
-  if (!harness) {
-    onChunk("stderr", `harness "${task.agent}" not found — cannot resume`);
-    runs.update(newRunId, { status: "failed", endedAt: Date.now(), exitCode: -1 });
-    tasks.update(taskId, { column: "ready", runId: null });
+    if (!harness) {
+      onChunk("stderr", `harness "${task.agent}" not found — cannot resume`);
+      runs.update(newRunId, { status: "failed", endedAt: Date.now(), exitCode: -1 });
+      tasks.update(taskId, { column: "ready", runId: null });
+      return newRunId;
+    }
+
+    const { agent } = await spawnAgentOrFail({
+      taskId,
+      runId: newRunId,
+      harness,
+      prompt: line,
+      cwd,
+      onChunk,
+      onSessionId: (sessionId) => {
+        runs.update(newRunId, { fxSessionId: sessionId });
+      },
+      opts: {
+        mode: task.mode,
+        model: task.model ?? DEFAULT_MODEL[harness.kind],
+        effort: task.effort,
+        fast: task.fast,
+        maxMode: task.maxMode,
+        resumeSessionId: priorSessionId,
+      },
+    });
+    if (!agent) {
+      // See the matching comment in spawnCodexTurnNow: spawnAgentOrFail already
+      // failed this run and attachDoneHandler (the only caller of
+      // drainFxQueue) never runs, so drop the queue rather than let queued
+      // follow-ups resurface out of order on a later turn.
+      fxTurnQueue.delete(taskId);
+      return newRunId;
+    }
+    registerActiveRun(newRunId, taskId, task, agent);
+    attachDoneHandler(newRunId, taskId, agent);
     return newRunId;
+  } finally {
+    startingTaskIds.delete(taskId);
   }
-
-  const { agent } = await spawnAgentOrFail({
-    taskId,
-    runId: newRunId,
-    harness,
-    prompt: line,
-    cwd,
-    onChunk,
-    onSessionId: (sessionId) => {
-      runs.update(newRunId, { fxSessionId: sessionId });
-    },
-    opts: {
-      mode: task.mode,
-      model: task.model ?? DEFAULT_MODEL[harness.kind],
-      effort: task.effort,
-      fast: task.fast,
-      maxMode: task.maxMode,
-      resumeSessionId: priorSessionId,
-    },
-  });
-  if (!agent) {
-    // See the matching comment in spawnCodexTurnNow: spawnAgentOrFail already
-    // failed this run and attachDoneHandler (the only caller of
-    // drainFxQueue) never runs, so drop the queue rather than let queued
-    // follow-ups resurface out of order on a later turn.
-    fxTurnQueue.delete(taskId);
-    return newRunId;
-  }
-  registerActiveRun(newRunId, taskId, task, agent);
-  attachDoneHandler(newRunId, taskId, agent);
-  return newRunId;
 }
 
 /**
@@ -3005,31 +3107,22 @@ type ClaudeTurnResult =
 const PASTE_OUTCOME_TIMEOUT_MS = 15_000;
 
 /**
- * Guards the claude "this task is idle (or its session is dead) → mint a
- * brand-new run" critical section, shared by `sendClaudeTurn`'s fresh-spawn
- * branch (`spawnResumedSession`) and `sendTurnInExistingSession`'s idle
- * branch. Before wave 1, `sendClaudeTurn` read `sessionLiveness` (and
+ * Claude's idle/dead-session mint paths (`sendClaudeTurn`'s fresh-spawn
+ * branch, via `spawnResumedSession`, and `sendTurnInExistingSession`'s idle
+ * branch) claim the unified `startingTaskIds` set declared near `startTask`
+ * above — see that doc comment for the full double-mint race this closes.
+ * Before wave 1, `sendClaudeTurn` read `sessionLiveness` (and
  * `sessionExists`) SYNCHRONOUSLY, so the whole stretch from that read through
- * the new run row's `tasks.update` executed as one uninterrupted tick of JS —
- * two overlapping `sendInput` calls for the same task could never both
- * observe "idle": whichever one's continuation resumed first ran that entire
- * stretch to completion (including stamping `task.runId`) before the other's
- * continuation got a turn. `sessionLiveness` becoming genuinely async (a real
- * tmux probe) opened a real event-loop gap between that read and everything
- * after it. Two sends arriving close together can now both read "idle" (or
- * "session dead") from their own independently-fetched `task` snapshot and
- * both try to mint a run: the second `tasks.update` clobbers the first's
- * `runId` stamp while BOTH runs still end up registered in `active`,
- * violating the "at most one in-flight run per task" invariant the rest of
- * this file depends on. This closes that window the same way `startingTaskIds`
- * protects `startTask` below: whichever call claims the taskId first
- * proceeds; a second overlapping call is told to retry rather than silently
- * mint a sibling run. Scoped to ONLY the idle/dead-session paths — the
- * fold-while-busy path (`pasteFollowUp`, above the idle branch in
- * `sendTurnInExistingSession`) is unaffected and still allows any number of
- * concurrent follow-ups to fold onto the one active run.
+ * the new run row's `tasks.update` executed as one uninterrupted tick of JS;
+ * `sessionLiveness` becoming genuinely async (a real tmux probe) opened a
+ * real event-loop gap that made this claim necessary. Scoped to ONLY the
+ * idle/dead-session paths — the fold-while-busy path (`pasteFollowUp`, above
+ * the idle branch in `sendTurnInExistingSession`) is unaffected and still
+ * allows any number of concurrent follow-ups to fold onto the one active
+ * run. (This used to be a claude-only `startingClaudeIdleTurns` set; it was
+ * folded into `startingTaskIds` so a `startTask` and a claude idle-send can't
+ * each claim their own disjoint keyspace and both mint.)
  */
-const startingClaudeIdleTurns = new Set<string>();
 
 /**
  * Await a paste's `pasteOutcome` (from `sendTurn`/`pasteFollowUp`, §10
@@ -3108,10 +3201,11 @@ async function sendClaudeTurn(taskId: string, line: string): Promise<ClaudeTurnR
   if (hasSessionState(taskId) && (await sessionLiveness(sessionNameFor(taskId))) !== "gone") {
     return sendTurnInExistingSession(task, taskId, line);
   }
-  // Dead/no session: about to mint a brand-new run. Claim the per-task
-  // "starting" slot first — see `startingClaudeIdleTurns`'s doc for why this
-  // is needed now that `sessionLiveness` above is a genuine await.
-  if (startingClaudeIdleTurns.has(taskId)) {
+  // Dead/no session: about to mint a brand-new run. Claim the unified
+  // per-task "starting" slot first — see `startingTaskIds`'s doc (near
+  // `startTask`) for why this is needed now that `sessionLiveness` above is
+  // a genuine await.
+  if (startingTaskIds.has(taskId)) {
     return {
       runId: task.runId ?? "",
       delivered: false,
@@ -3119,13 +3213,13 @@ async function sendClaudeTurn(taskId: string, line: string): Promise<ClaudeTurnR
       reason: "another message is already starting a new turn for this task — try again in a moment",
     };
   }
-  startingClaudeIdleTurns.add(taskId);
+  startingTaskIds.add(taskId);
   try {
     // A fresh spawn has no live modal to withhold a keystroke against, so
     // there's no `pasteOutcome` to await here — always delivered.
     return { runId: await spawnResumedSession(task, taskId, line), delivered: true };
   } finally {
-    startingClaudeIdleTurns.delete(taskId);
+    startingTaskIds.delete(taskId);
   }
 }
 
@@ -3172,12 +3266,12 @@ async function sendTurnInExistingSession(task: Task, taskId: string, line: strin
   }
 
   // Idle (or the paste raced a vanishing session): about to mint a brand-new
-  // run row. Claim the per-task "starting" slot first — see
-  // `startingClaudeIdleTurns`'s doc for why this is needed now that
-  // `sendClaudeTurn`'s `sessionLiveness` read is a genuine await: two
+  // run row. Claim the unified per-task "starting" slot first — see
+  // `startingTaskIds`'s doc (near `startTask`) for why this is needed now
+  // that `sendClaudeTurn`'s `sessionLiveness` read is a genuine await: two
   // overlapping sends can both arrive here having each independently
   // observed "idle" from their own stale snapshot.
-  if (startingClaudeIdleTurns.has(taskId)) {
+  if (startingTaskIds.has(taskId)) {
     return {
       runId: task.runId ?? "",
       delivered: false,
@@ -3185,7 +3279,7 @@ async function sendTurnInExistingSession(task: Task, taskId: string, line: strin
       reason: "another message is already starting a new turn for this task — try again in a moment",
     };
   }
-  startingClaudeIdleTurns.add(taskId);
+  startingTaskIds.add(taskId);
   try {
     // One run row per user turn — the runs list mirrors the conversation
     // history at turn granularity. The race that used to make a fast claude
@@ -3229,7 +3323,7 @@ async function sendTurnInExistingSession(task: Task, taskId: string, line: strin
     attachDoneHandler(newRunId, taskId, agent);
     return resolveClaudeTurnOutcome(newRunId, agent.pasteOutcome);
   } finally {
-    startingClaudeIdleTurns.delete(taskId);
+    startingTaskIds.delete(taskId);
   }
 }
 
@@ -3883,11 +3977,19 @@ function enqueueArchiveTeardown(
       result = { removed: false, reason: "failed" };
       return;
     }
+    // Terminals → sessions → worktree. Terminal tabs hold only PTYs rooted
+    // in the worktree dir, not a tmux session, so they can die independently
+    // of (and, under the scheduler, sooner than) the drop*Session awaits
+    // below — killing them first is what keeps `killTerminalsForTask`'s own
+    // completion honest relative to the drop*Session ordering guarantee the
+    // next paragraph documents, and both must still land before the
+    // worktree is detached/removed.
+    await killTerminalsForTask(cur.id);
     // Same contract as deleteTask: dropSession is non-throwing (it
     // best-efforts tmux teardown internally). Don't wrap — a silent catch
     // would hide a regression in claude-tmux from the next reviewer. Awaited
     // (wave 1 made every drop* async) so the session kill genuinely completes
-    // BEFORE killTerminalsForTask/detachWorktree below — ordering rule from
+    // BEFORE detachWorktree below — ordering rule from
     // docs/plans/fix-archive-teardown-queue.md, still load-bearing now that
     // "complete" means "the awaited promise settled" rather than "the
     // synchronous call returned".
@@ -3896,7 +3998,6 @@ function enqueueArchiveTeardown(
     else if (kind === "cursor") await dropCursorSession(cur.id);
     else if (kind === "gemini") await dropGeminiSession(cur.id);
     else if (kind === "fx") dropFxSession(cur.id); // fx has no tmux session — stays sync
-    await killTerminalsForTask(cur.id);
     result = await detachWorktree(cur, { force: opts?.force });
   });
   return { promise, result: () => result };
@@ -4093,19 +4194,20 @@ export async function deleteTask(taskId: string): Promise<void> {
   // remove`/`prune` calls against the same repo never contend on git's locks
   // at the same time. A delete against an unrelated workdir is unaffected.
   await enqueueTeardown(taskId, task.workdir, async () => {
-    // Awaited (wave 1 made every drop* async) — the session kill must
-    // genuinely complete before killTerminalsForTask/removeWorktree below,
-    // not just be kicked off. Same ordering discipline as
-    // enqueueArchiveTeardown above.
+    // Terminals → sessions → worktree. Terminal tabs hold only PTYs rooted
+    // in the worktree dir, not a tmux session, so they can die independently
+    // of (and sooner than) the drop*Session awaits below — kill them first,
+    // then the drop*Session calls (awaited — wave 1 made every drop* async —
+    // so the session kill genuinely completes, not just gets kicked off,
+    // same ordering discipline as enqueueArchiveTeardown above), then remove
+    // the worktree. A live shell still sitting in the worktree dir would
+    // block `git worktree remove`, so both kills must land before it.
+    await killTerminalsForTask(taskId);
     if (deleteKind === "claude-code") await dropSession(taskId);
     else if (deleteKind === "codex") await dropCodexSession(taskId);
     else if (deleteKind === "cursor") await dropCursorSession(taskId);
     else if (deleteKind === "gemini") await dropGeminiSession(taskId);
     else if (deleteKind === "fx") dropFxSession(taskId); // fx has no tmux session — stays sync
-    // Kill any open terminal tabs before removing the worktree — a live shell
-    // sitting in the worktree dir would block `git worktree remove`. Awaited
-    // so the shells are actually gone before we tear the directory down.
-    await killTerminalsForTask(taskId);
     await removeWorktree(task);
   });
   // Refs are otherwise path-only — agetor never copies anything to disk for

--- a/src/bun/pane-pid.test.ts
+++ b/src/bun/pane-pid.test.ts
@@ -33,33 +33,33 @@ function fakeTmux(stdout: string, code = 0) {
   };
 }
 
-test("panePidFor: exact session-name match on the list-panes listing", () => {
+test("panePidFor: exact session-name match on the list-panes listing", async () => {
   const restore = fakeTmux("agetor-other\t111\nagetor-x\t4242\nagetor-x2\t9\n");
   try {
-    expect(panePidFor("agetor-x")).toBe(4242);
-    expect(panePidFor("agetor-x2")).toBe(9);
-    expect(panePidFor("agetor-other")).toBe(111);
+    expect(await panePidFor("agetor-x")).toBe(4242);
+    expect(await panePidFor("agetor-x2")).toBe(9);
+    expect(await panePidFor("agetor-other")).toBe(111);
   } finally { restore(); }
 });
 
-test("panePidFor: a name prefix never matches (agetor-x must not read agetor-x2's pid)", () => {
+test("panePidFor: a name prefix never matches (agetor-x must not read agetor-x2's pid)", async () => {
   const restore = fakeTmux("agetor-x2\t9\n");
-  try { expect(panePidFor("agetor-x")).toBeNull(); } finally { restore(); }
+  try { expect(await panePidFor("agetor-x")).toBeNull(); } finally { restore(); }
 });
 
-test("panePidFor: the first listed pane wins when the user split the window", () => {
+test("panePidFor: the first listed pane wins when the user split the window", async () => {
   const restore = fakeTmux("agetor-x\t4242\nagetor-x\t5151\n");
-  try { expect(panePidFor("agetor-x")).toBe(4242); } finally { restore(); }
+  try { expect(await panePidFor("agetor-x")).toBe(4242); } finally { restore(); }
 });
 
-test("panePidFor: an empty/unparseable pid field is null, never 0 (tmux 3.6a empty-format trap)", () => {
+test("panePidFor: an empty/unparseable pid field is null, never 0 (tmux 3.6a empty-format trap)", async () => {
   for (const out of ["agetor-x\t\n", "agetor-x\tabc\n", "agetor-x\t0\n", "agetor-x\n", ""]) {
     const restore = fakeTmux(out);
-    try { expect(panePidFor("agetor-x")).toBeNull(); } finally { restore(); }
+    try { expect(await panePidFor("agetor-x")).toBeNull(); } finally { restore(); }
   }
 });
 
-test("panePidFor: a failing tmux is null", () => {
+test("panePidFor: a failing tmux is null", async () => {
   const restore = fakeTmux("agetor-x\t4242\n", 1);
-  try { expect(panePidFor("agetor-x")).toBeNull(); } finally { restore(); }
+  try { expect(await panePidFor("agetor-x")).toBeNull(); } finally { restore(); }
 });

--- a/src/bun/reconcile-session.test.ts
+++ b/src/bun/reconcile-session.test.ts
@@ -267,7 +267,14 @@ test("reconcileTaskSession does NOT refresh the matcher when cycleToMode fails (
   state.permissionMode = "default";
 
   const after: Task = { ...before, mode: "bypass" };
-  reconcileTaskSession("task-matcher-skip", before, after);
+  // Await the reconcile (mirrors the two sibling tests above) so its
+  // internal async work — `sessionExists`'s real tmux probe plus whatever
+  // `cycleToMode` does before bailing on the unreachable target — can't
+  // keep running as an unawaited background chain past this test's own
+  // teardown and leak stray `tmux` calls into a later test file's fake-tmux
+  // recording log (see the identical comment on the narrow/full tests
+  // above).
+  await reconcileTaskSession("task-matcher-skip", before, after);
 
   // No agetor entry was written, so readMatcher returns undefined.
   expect(readMatcher(cwd)).toBeUndefined();

--- a/src/bun/reconcile-session.test.ts
+++ b/src/bun/reconcile-session.test.ts
@@ -176,7 +176,7 @@ test("reconcileTaskSession refreshes the hook matcher to narrow on ask → auto"
   // polling a real pane for the full timeout. Await the reconcile so its
   // (otherwise fire-and-forget) background poll can't leak `tmux` calls into
   // a later test's recording bin.
-  const prevPane = __forTest.setCaptureModePane(() => "⏵⏵ auto mode on (shift+tab to cycle)");
+  const prevPane = __forTest.setCaptureModePane(async () => "⏵⏵ auto mode on (shift+tab to cycle)");
   const prevPoll = __forTest.setModePollIntervalMs(1);
   const after: Task = { ...before, mode: "auto" };
   await reconcileTaskSession("task-matcher-narrow", before, after);
@@ -220,7 +220,7 @@ test("reconcileTaskSession refreshes the hook matcher to full on auto → ask", 
   // Target `ask` → claude's `default` mode, whose status bar shows the
   // "? for shortcuts" hint (no mode banner). Feed that so the switch resolves
   // promptly, and await so the background poll can't leak `tmux` calls.
-  const prevPane = __forTest.setCaptureModePane(() => "? for shortcuts · ← for agents");
+  const prevPane = __forTest.setCaptureModePane(async () => "? for shortcuts · ← for agents");
   const prevPoll = __forTest.setModePollIntervalMs(1);
   const after: Task = { ...before, mode: "ask" };
   await reconcileTaskSession("task-matcher-full", before, after);

--- a/src/bun/reconcile.test.ts
+++ b/src/bun/reconcile.test.ts
@@ -206,7 +206,7 @@ test("reconcileOrphans marks running rows as orphaned and returns tasks to ready
     claudeSessionId: null, codexSessionId: null, cursorSessionId: null, geminiSessionId: null, fxSessionId: null,
   });
 
-  const reconciled = reconcileOrphans();
+  const reconciled = await reconcileOrphans();
   expect(reconciled).toBe(1);
 
   const row = db.query<{ status: string }, [string]>(`SELECT status FROM runs WHERE id = ?`).get(runId);
@@ -217,7 +217,7 @@ test("reconcileOrphans marks running rows as orphaned and returns tasks to ready
   expect(task?.runId).toBeNull();
 
   // A second call is a no-op.
-  expect(reconcileOrphans()).toBe(0);
+  expect(await reconcileOrphans()).toBe(0);
 });
 
 test("reattach pre-seed SQL: detects a prior api-error status row scoped to the run", async () => {
@@ -338,7 +338,7 @@ test("startTask honors cancel — exit handler records status 'cancelled'", asyn
 
   // Give the tmux session a moment to come up, then cancel.
   await new Promise((r) => setTimeout(r, 250));
-  expect(cancelRun(started.runId)).toBe(true);
+  expect(await cancelRun(started.runId)).toBe(true);
 
   // Wait past the driver's kill grace + the exit handler's status flip.
   await new Promise((r) => setTimeout(r, 700));
@@ -383,8 +383,7 @@ test("held-task boot pass: dead tmux session → subagent orphaned, task release
     runs.insert(succeededRun(runId, taskId));
     subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
 
-    reconcileOrphans();
-
+    await reconcileOrphans();
     const sub = subagents.get(subId);
     expect(sub?.status).toBe("orphaned");
     expect(sub?.endedAt).not.toBeNull();
@@ -436,8 +435,7 @@ test("held-task boot pass: a task whose terminal run is still 'running' has its 
     }));
     subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
 
-    reconcileOrphans();
-
+    await reconcileOrphans();
     // Unchanged: the first pass still owns the run and the column drop.
     const run = runs.get(runId);
     expect(run?.status).toBe("orphaned");
@@ -483,8 +481,7 @@ test("held-task boot pass: succeeded run with no running subagents is left untou
   runs.insert(succeededRun(runId, taskId));
   subagents.insertIfAbsent(subagentRow(subId, taskId, runId, { status: "completed", endedAt: Date.now() }));
 
-  reconcileOrphans();
-
+  await reconcileOrphans();
   const task = tasks.get(taskId);
   expect(task?.column).toBe("running");
 
@@ -515,8 +512,7 @@ test("held-task boot pass: a codex task can never be held — the kind !== 'clau
   }));
   subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
 
-  reconcileOrphans();
-
+  await reconcileOrphans();
   const task = tasks.get(taskId);
   expect(task?.column).toBe("running");
 
@@ -546,8 +542,7 @@ test("held-task boot pass: null claudeSessionId with a live tmux session is rele
     runs.insert(succeededRun(runId, taskId, { claudeSessionId: null }));
     subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
 
-    reconcileOrphans();
-
+    await reconcileOrphans();
     const task = tasks.get(taskId);
     expect(task?.column).toBe("review");
 
@@ -592,7 +587,7 @@ test("boot pass (blind spot): review-column task with a dead-session subagent ro
       if (e.kind === "column" && e.taskId === taskId) columnEvents.push(e);
     });
 
-    reconcileOrphans();
+    await reconcileOrphans();
     unsub();
 
     const sub = subagents.get(subId);
@@ -629,8 +624,7 @@ test("boot pass (blind spot): review-column task with a live session + recoverab
     runs.insert(succeededRun(runId, taskId)); // seeds a non-null claudeSessionId
     subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
 
-    reconcileOrphans();
-
+    await reconcileOrphans();
     const sub = subagents.get(subId);
     expect(sub?.status).toBe("running");
 
@@ -660,8 +654,7 @@ test("boot pass (blind spot): review-column task with a live session but no clau
     runs.insert(succeededRun(runId, taskId, { claudeSessionId: null }));
     subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
 
-    reconcileOrphans();
-
+    await reconcileOrphans();
     const sub = subagents.get(subId);
     expect(sub?.status).toBe("orphaned");
 
@@ -695,8 +688,7 @@ test("boot pass (blind spot): a codex task's stray running subagent row is skipp
     }));
     subagents.insertIfAbsent(subagentRow(subId, taskId, runId));
 
-    reconcileOrphans();
-
+    await reconcileOrphans();
     const task = tasks.get(taskId);
     expect(task?.column).toBe("review");
 
@@ -731,7 +723,7 @@ test("boot pass: never issues a tmux kill — dead and live review-column cases 
 
   let restoreTmux = fakeTmux(1, "can't find session", logPath);
   try {
-    reconcileOrphans();
+    await reconcileOrphans();
   } finally {
     restoreTmux();
   }
@@ -747,7 +739,7 @@ test("boot pass: never issues a tmux kill — dead and live review-column cases 
 
   restoreTmux = fakeTmux(0, "", logPath);
   try {
-    reconcileOrphans();
+    await reconcileOrphans();
   } finally {
     detachWatcherFor(liveTaskId);
     restoreTmux();

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -3914,8 +3914,8 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       },
 
       "/runs/:id/cancel": {
-        POST: authed((req) =>
-          json({ cancelled: cancelRun(req.params.id) }, { headers: corsHeaders(req) })),
+        POST: authed(async (req) =>
+          json({ cancelled: await cancelRun(req.params.id) }, { headers: corsHeaders(req) })),
       },
 
       // Forward a line of user input to the running agent's stdin. Returns

--- a/src/bun/server.ts
+++ b/src/bun/server.ts
@@ -3756,7 +3756,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
       // for each failure mode instead of an empty Terminal that immediately
       // errors with "can't find session".
       "/tasks/:id/open-tmux": {
-        POST: authed((req) => {
+        POST: authed(async (req) => {
           const task = tasks.get(req.params.id);
           if (!task) {
             return json({ error: "task not found" }, { status: 404, headers: corsHeaders(req) });
@@ -3788,7 +3788,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
               { status: 503, headers: corsHeaders(req) },
             );
           }
-          if (!sessionExists(task.id)) {
+          if (!(await sessionExists(task.id))) {
             return json(
               {
                 error: `no live tmux session "${sessionName}" — start (or send a message to) the task first`,
@@ -3801,10 +3801,13 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           // Heal a stuck `window-size manual` pin (a prior crash mid pane-grow)
           // before attaching, so the client's own size wins instead of being
           // confined to whatever the pin left behind — see `healWindowSize`.
-          // Best-effort: must not block or delay the attach below.
+          // Best-effort: intentionally not awaited — must not block or delay
+          // the attach below. `healWindowSize` never throws (it only awaits
+          // `tmux()`, which itself never throws — see its doc comment), so
+          // this fire-and-forget can't produce an unhandled rejection.
           // `assumeAlive`: `sessionExists(task.id)` was just checked above, so
           // skip the internal probe's duplicate round-trip.
-          healWindowSize(task.id, { assumeAlive: true });
+          void healWindowSize(task.id, { assumeAlive: true });
           // AppleScript `do script` runs the string through `/bin/bash`, so
           // we escape anything bash would interpret inside double-quotes:
           // backslash, dollar, backtick, and the double-quote itself. Without
@@ -4347,7 +4350,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           // in-flight Esc-then-send interrupt (which is what corrupts the run
           // accounting). The modal having been Esc'd, the message reaches claude.
           if (body.reject === true) {
-            if (!sessionExists(pending.taskId)) {
+            if (!(await sessionExists(pending.taskId))) {
               return json(
                 { ok: false, error: "tmux session is gone — cancel the run and start a new one" },
                 { status: 410, headers: corsHeaders(req) },
@@ -4380,7 +4383,7 @@ export function startApiServer(deps: { native?: ApiNative } = {}) {
           // the modal. The user clicks "Yes", the card vanishes, and
           // nothing actually happens. Surface the failure so the UI
           // can leave the card up for retry.
-          if (!sessionExists(pending.taskId)) {
+          if (!(await sessionExists(pending.taskId))) {
             return json(
               { ok: false, error: "tmux session is gone — cancel the run and start a new one" },
               { status: 410, headers: corsHeaders(req) },

--- a/src/bun/session-liveness.test.ts
+++ b/src/bun/session-liveness.test.ts
@@ -23,91 +23,91 @@ function harness(opts: {
   return { probe, calls, advance: (ms: number) => { t += ms; } };
 }
 
-test("first tick is authoritative and learns the pid; steady-state ticks fork nothing", () => {
+test("first tick is authoritative and learns the pid; steady-state ticks fork nothing", async () => {
   const h = harness({});
-  expect(h.probe.probe()).toBe("alive");
+  expect(await h.probe.probe()).toBe("alive");
   expect(h.calls).toEqual({ authoritative: 1, resolve: 1, alive: 0 });
   expect(h.probe.pid()).toBe(4242);
   // 20 more ticks at 400ms — inside the 10s window — cost zero forks.
-  for (let i = 0; i < 20; i++) { h.advance(400); expect(h.probe.probe()).toBe("alive"); }
+  for (let i = 0; i < 20; i++) { h.advance(400); expect(await h.probe.probe()).toBe("alive"); }
   expect(h.calls.authoritative).toBe(1);
   expect(h.calls.resolve).toBe(1);
   expect(h.calls.alive).toBe(20);
 });
 
-test("re-validates with the real probe once per window even while the pid answers", () => {
+test("re-validates with the real probe once per window even while the pid answers", async () => {
   const h = harness({ every: 10_000 });
-  h.probe.probe();
-  h.advance(9_999); h.probe.probe();
+  await h.probe.probe();
+  h.advance(9_999); await h.probe.probe();
   expect(h.calls.authoritative).toBe(1);
-  h.advance(1); h.probe.probe();
+  h.advance(1); await h.probe.probe();
   expect(h.calls.authoritative).toBe(2);
   // Pid still alive → no re-resolve on a scheduled re-validation.
   expect(h.calls.resolve).toBe(1);
 });
 
-test("a vanished pid is confirmed by tmux before being reported gone — never invented", () => {
+test("a vanished pid is confirmed by tmux before being reported gone — never invented", async () => {
   let alive = true;
   let live: SessionLiveness = "alive";
   const h = harness({ alive: () => alive, liveness: () => live });
-  h.probe.probe();
+  await h.probe.probe();
   // Pid dies but tmux (still reachable) says the session is up — e.g. the
   // agent re-exec'd into a new pid. Reported alive; pid re-resolution is
   // throttled to the window so this can't double the fork rate.
   alive = false;
   h.advance(400);
-  expect(h.probe.probe()).toBe("alive");
+  expect(await h.probe.probe()).toBe("alive");
   expect(h.calls.authoritative).toBe(2);
   expect(h.calls.resolve).toBe(1); // throttled — still inside the window
   // Now tmux agrees it's gone: `gone` is passed through and the pid dropped.
   live = "gone";
   h.advance(400);
-  expect(h.probe.probe()).toBe("gone");
+  expect(await h.probe.probe()).toBe("gone");
   expect(h.probe.pid()).toBeNull();
   // Every subsequent tick is authoritative (no pid to fast-path on), so the
   // watch's consecutive-miss counter can reach its threshold.
-  h.advance(400); expect(h.probe.probe()).toBe("gone");
-  h.advance(400); expect(h.probe.probe()).toBe("gone");
+  h.advance(400); expect(await h.probe.probe()).toBe("gone");
+  h.advance(400); expect(await h.probe.probe()).toBe("gone");
   expect(h.calls.authoritative).toBe(5);
 });
 
-test("pid reuse: a scheduled re-validation reporting gone drops the recycled pid", () => {
+test("pid reuse: a scheduled re-validation reporting gone drops the recycled pid", async () => {
   let live: SessionLiveness = "alive";
   const h = harness({ liveness: () => live, every: 10_000 });
-  h.probe.probe();
+  await h.probe.probe();
   // The session dies but its pid is recycled by an unrelated process, so
   // `kill(pid, 0)` keeps succeeding. Inside the window we (wrongly but
   // boundedly) report alive without forking…
   live = "gone";
   h.advance(5_000);
-  expect(h.probe.probe()).toBe("alive");
+  expect(await h.probe.probe()).toBe("alive");
   expect(h.calls.authoritative).toBe(1);
   // …until the window elapses: the real probe says gone, the pid is dropped,
   // and from here on every tick is authoritative.
   h.advance(5_000);
-  expect(h.probe.probe()).toBe("gone");
+  expect(await h.probe.probe()).toBe("gone");
   expect(h.probe.pid()).toBeNull();
   h.advance(400);
-  expect(h.probe.probe()).toBe("gone");
+  expect(await h.probe.probe()).toBe("gone");
   expect(h.calls.authoritative).toBe(3);
 });
 
-test("unreachable keeps the pid: the next tick vouches for the pane without the server", () => {
+test("unreachable keeps the pid: the next tick vouches for the pane without the server", async () => {
   let live: SessionLiveness = "alive";
   const h = harness({ liveness: () => live, every: 10_000 });
-  h.probe.probe();
+  await h.probe.probe();
   live = "unreachable";
   h.advance(10_000);
-  expect(h.probe.probe()).toBe("unreachable");
+  expect(await h.probe.probe()).toBe("unreachable");
   expect(h.probe.pid()).toBe(4242);
   h.advance(400);
-  expect(h.probe.probe()).toBe("alive"); // fast path, no fork
+  expect(await h.probe.probe()).toBe("alive"); // fast path, no fork
   expect(h.calls.authoritative).toBe(2);
 });
 
-test("an unresolvable pid degrades to the old one-fork-per-tick behaviour, plus one resolve per window", () => {
+test("an unresolvable pid degrades to the old one-fork-per-tick behaviour, plus one resolve per window", async () => {
   const h = harness({ pid: null, every: 10_000 });
-  for (let i = 0; i < 26; i++) { h.advance(400); expect(h.probe.probe()).toBe("alive"); }
+  for (let i = 0; i < 26; i++) { h.advance(400); expect(await h.probe.probe()).toBe("alive"); }
   expect(h.calls.authoritative).toBe(26);
   // First resolve on the first tick (t=400ms); the throttle allows the next
   // one 10s later, i.e. on tick 26 (t=10,400ms) — exactly two in 26 ticks.

--- a/src/bun/session-liveness.ts
+++ b/src/bun/session-liveness.ts
@@ -58,20 +58,30 @@ export function pidAlive(pid: number): boolean {
 export interface DeathProbeOptions {
   sessionName: string;
   /** The real tmux probe (`sessionLiveness`). Called only when the fast path
-   *  can't vouch for the session, or when re-validation is due. */
-  authoritative: (sessionName: string) => SessionLiveness;
+   *  can't vouch for the session, or when re-validation is due. Async since
+   *  docs/plans/fix-task-details-load-delay.md (claude-tmux.ts's `tmux()`
+   *  choke point moved off `Bun.spawnSync`) — a plain sync return still works
+   *  (every caller `await`s the result either way). */
+  authoritative: (sessionName: string) => SessionLiveness | Promise<SessionLiveness>;
   /** Maps a session name to its pane's pid (`panePidFor`); `null` when it
-   *  can't. Called at most once per `authoritativeEveryMs`. */
-  resolvePid: (sessionName: string) => number | null;
-  /** Injectable for tests; defaults to the real `kill(pid, 0)`. */
+   *  can't. Called at most once per `authoritativeEveryMs`. Async for the same
+   *  reason as `authoritative`. */
+  resolvePid: (sessionName: string) => number | null | Promise<number | null>;
+  /** Injectable for tests; defaults to the real `kill(pid, 0)`. Deliberately
+   *  stays synchronous — it's a bare `kill(pid, 0)` syscall, not a subprocess,
+   *  and is the whole point of the fast path this module exists to provide. */
   pidAlive?: (pid: number) => boolean;
   authoritativeEveryMs?: number;
   now?: () => number;
 }
 
 export interface DeathProbe {
-  /** One death-watch tick's liveness verdict — drop-in for `sessionLiveness`. */
-  probe(): SessionLiveness;
+  /** One death-watch tick's liveness verdict — drop-in for `sessionLiveness`.
+   *  Async because the slow path awaits `authoritative`/`resolvePid`, which
+   *  (as of the sync→async tmux conversion) fork a real `tmux` client; the
+   *  fast `kill(pid, 0)` path still returns effectively immediately, just
+   *  wrapped in the same Promise so callers don't need to branch. */
+  probe(): Promise<SessionLiveness>;
   /** The pane pid currently trusted for the fast path, or null. Diagnostic /
    *  test surface only. */
   pid(): number | null;
@@ -86,14 +96,14 @@ export function createDeathProbe(opts: DeathProbeOptions): DeathProbe {
   let lastResolveAt = -Infinity;
   return {
     pid: () => pid,
-    probe(): SessionLiveness {
+    async probe(): Promise<SessionLiveness> {
       const t = now();
       const due = t - lastAuthoritativeAt >= every;
       // Fast path: a known pid that still answers, inside the validation
       // window. No fork, no tmux round-trip.
       if (pid !== null && !due && isAlive(pid)) return "alive";
       // Slow path: the pid is unknown, has vanished, or re-validation is due.
-      const liveness = opts.authoritative(opts.sessionName);
+      const liveness = await opts.authoritative(opts.sessionName);
       lastAuthoritativeAt = t;
       if (liveness === "gone") {
         // Whatever pid we held is stale (dead, or recycled by an unrelated
@@ -106,7 +116,7 @@ export function createDeathProbe(opts: DeathProbeOptions): DeathProbe {
         // pane pid, throttled so an unparseable `list-panes` can't turn every
         // tick into two forks.
         lastResolveAt = t;
-        pid = opts.resolvePid(opts.sessionName);
+        pid = await opts.resolvePid(opts.sessionName);
       }
       // `unreachable` keeps whatever pid we had: a busy tmux server says
       // nothing about the pane process, and the next tick's `kill(pid, 0)`

--- a/src/bun/subagent-hold.test.ts
+++ b/src/bun/subagent-hold.test.ts
@@ -315,7 +315,7 @@ test("cancelled wins over a hold: task goes to ready, not running", async () => 
 
   // Cancel immediately — the fake driver's success path doesn't resolve
   // `done()` until ~20ms, so this races ahead of it deterministically.
-  const cancelled = cancelRun(runId);
+  const cancelled = await cancelRun(runId);
   expect(cancelled).toBe(true);
 
   await wait(250);
@@ -495,7 +495,7 @@ test("Stop on a held task releases it: cancelRun orphans subagents and moves the
   // side effect (best-effort Ctrl+C) — it never reads the return value, so
   // whatever `/bin/echo` makes the underlying tmux probe report doesn't
   // change the outcome here; the assertion is on cancelRun's own return.
-  const cancelled = cancelRun(runId);
+  const cancelled = await cancelRun(runId);
   expect(cancelled).toBe(true);
 
   const task = tasks.get(taskId);
@@ -619,7 +619,7 @@ test("cancelled wins over a monitor hold: task goes to ready, not running", asyn
 
   // Cancel immediately — the fake driver's success path doesn't resolve
   // `done()` until ~20ms, so this races ahead of it deterministically.
-  const cancelled = cancelRun(runId);
+  const cancelled = await cancelRun(runId);
   expect(cancelled).toBe(true);
 
   await wait(250);

--- a/src/bun/tmux-resolution.ts
+++ b/src/bun/tmux-resolution.ts
@@ -109,3 +109,42 @@ export function tmuxSocketArgs(): string[] {
   const name = tmuxSocketName();
   return name ? ["-L", name] : [];
 }
+
+/**
+ * Launch `tmux new-session` for a driver's detached hosting session. Async
+ * (`Bun.spawn` + `await proc.exited`) so this fork+exec never blocks the
+ * event loop that also serves the HTTP API — this used to be
+ * `node:child_process`'s `spawnSync`, which stalled every concurrent request
+ * for the duration of tmux's fork+exec (see
+ * docs/plans/fix-task-details-load-delay.md). No timeout, mirroring
+ * claude-tmux.ts's `tmux()` helper — an owner decision to keep behavior
+ * unchanged beyond removing the block. Never throws; a spawn failure (e.g.
+ * tmux not on PATH) folds into `stderr` the same way a non-zero exit does,
+ * so callers only need one failure branch.
+ *
+ * Shared by codex-tmux.ts, cursor-tmux.ts, and gemini-tmux.ts — the
+ * one-shot-per-turn drivers that each host a turn in a detached tmux
+ * session. Hoisted here per docs/plans/tmux-sessions-killed-unexpectedly.md
+ * ("every tmux invocation flows through the single choke point... no
+ * parallel spawn logic") so the three drivers can't drift.
+ */
+export async function spawnTmuxNewSession(
+  tmux: string,
+  args: string[],
+): Promise<{ status: number | null; stderr: string }> {
+  try {
+    const proc = Bun.spawn([tmux, ...args], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const status = await proc.exited;
+    return { status, stderr: stderr.trim() };
+  } catch (e) {
+    return { status: null, stderr: (e as Error).message };
+  }
+}

--- a/src/bun/window-size-heal.test.ts
+++ b/src/bun/window-size-heal.test.ts
@@ -124,7 +124,7 @@ test.skipIf(!HAVE_TMUX)(
       // outlived the process, or a fresh boot before reattach rebuilds
       // state): `paneGrowInFlight` is only checked on a state that exists,
       // so healing must still proceed via the plain sessionExists() path.
-      healWindowSize(taskId);
+      await healWindowSize(taskId);
 
       const after = Bun.spawnSync([
         tmuxBin, ...sockArgs, "show-window-options", "-t", sessionName, "window-size",

--- a/src/bun/worktree.test.ts
+++ b/src/bun/worktree.test.ts
@@ -311,6 +311,31 @@ test("gitWritableRoots returns [] for a non-git directory", async () => {
   expect(await gitWritableRoots(dir)).toEqual([]);
 });
 
+// Async-conversion regression guard (gitWritableRootsSync -> gitWritableRoots):
+// prove several calls can genuinely be in flight together and each still
+// resolves with its own correct, independent result — rather than requiring
+// a caller to serialize them one at a time the way a sync spawn effectively
+// would. Deliberately no wall-clock assertion (documented flake class for
+// fake-tmux/subprocess timing in this repo) — Promise.all + result equality
+// is the whole check.
+test("gitWritableRoots resolves correctly when several calls are in flight concurrently (no serialization required)", async () => {
+  const { prepareWorkdir, gitWritableRoots } = await import("./worktree.ts");
+  const repo = await makeRepo();
+  const wt = await prepareWorkdir(fakeTask({ workdir: repo }));
+  if ("error" in wt) throw new Error(wt.error);
+  const nonGit = mkdtempSync(path.join(tmpdir(), "agetor-wt-nongit3-"));
+
+  const [linkedRoots, plainRoots, nonGitRoots] = await Promise.all([
+    gitWritableRoots(wt.cwd),
+    gitWritableRoots(repo),
+    gitWritableRoots(nonGit),
+  ]);
+  expect(linkedRoots).toHaveLength(1);
+  expect(path.basename(linkedRoots[0]!)).toBe(".git");
+  expect(plainRoots).toEqual([]);
+  expect(nonGitRoots).toEqual([]);
+});
+
 // End-to-end wiring of the codex spawn path: buildCodexCommand resolves the
 // cwd's external git dirs and feeds them to buildCommand's sandbox decision.
 // This is the seam spawnAgent uses; covering it here (where real worktrees

--- a/src/bun/worktree.test.ts
+++ b/src/bun/worktree.test.ts
@@ -279,14 +279,14 @@ test("prepareWorkdir on branchSource=existing uses the local branch when it alre
   expect(headBranch).toBe("pr-head");
 });
 
-test("gitWritableRootsSync returns the source repo's .git for a linked worktree", async () => {
-  const { prepareWorkdir, gitWritableRootsSync } = await import("./worktree.ts");
+test("gitWritableRoots returns the source repo's .git for a linked worktree", async () => {
+  const { prepareWorkdir, gitWritableRoots } = await import("./worktree.ts");
   const repo = await makeRepo();
   const task = fakeTask({ workdir: repo });
   const r = await prepareWorkdir(task);
   if ("error" in r) throw new Error(r.error);
 
-  const roots = gitWritableRootsSync(r.cwd);
+  const roots = await gitWritableRoots(r.cwd);
   expect(roots).toHaveLength(1);
   const common = roots[0]!;
   // It's the shared common dir (objects/refs + worktree registrations live here)…
@@ -298,17 +298,17 @@ test("gitWritableRootsSync returns the source repo's .git for a linked worktree"
   expect(common.startsWith(r.cwd + path.sep)).toBe(false);
 });
 
-test("gitWritableRootsSync returns [] for an ordinary in-repo checkout", async () => {
-  const { gitWritableRootsSync } = await import("./worktree.ts");
+test("gitWritableRoots returns [] for an ordinary in-repo checkout", async () => {
+  const { gitWritableRoots } = await import("./worktree.ts");
   const repo = await makeRepo();
   // `.git` sits inside the cwd, already covered by codex's writable workspace.
-  expect(gitWritableRootsSync(repo)).toEqual([]);
+  expect(await gitWritableRoots(repo)).toEqual([]);
 });
 
-test("gitWritableRootsSync returns [] for a non-git directory", async () => {
-  const { gitWritableRootsSync } = await import("./worktree.ts");
+test("gitWritableRoots returns [] for a non-git directory", async () => {
+  const { gitWritableRoots } = await import("./worktree.ts");
   const dir = mkdtempSync(path.join(tmpdir(), "agetor-wt-nongit2-"));
-  expect(gitWritableRootsSync(dir)).toEqual([]);
+  expect(await gitWritableRoots(dir)).toEqual([]);
 });
 
 // End-to-end wiring of the codex spawn path: buildCodexCommand resolves the
@@ -328,7 +328,7 @@ test("buildCodexCommand escalates to danger-full-access in a linked worktree", a
   const r = await prepareWorkdir(fakeTask({ workdir: repo }));
   if ("error" in r) throw new Error(r.error);
 
-  const { cmd } = buildCodexCommand(codexHarness, "hi", { ...codexOpts }, r.cwd);
+  const { cmd } = await buildCodexCommand(codexHarness, "hi", { ...codexOpts }, r.cwd);
   expect(cmd).toContain("danger-full-access");
   expect(cmd).not.toContain("workspace-write");
   expect(cmd).toContain("approval_policy=never");
@@ -338,7 +338,7 @@ test("buildCodexCommand keeps workspace-write for an ordinary in-repo checkout",
   const { buildCodexCommand } = await import("./agents.ts");
   const repo = await makeRepo();
 
-  const { cmd } = buildCodexCommand(codexHarness, "hi", { ...codexOpts }, repo);
+  const { cmd } = await buildCodexCommand(codexHarness, "hi", { ...codexOpts }, repo);
   expect(cmd).toContain("workspace-write");
   expect(cmd).not.toContain("danger-full-access");
 });

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -22,7 +22,11 @@ interface GitResult {
 const GIT_TIMEOUT_MS = 30_000;
 
 /**
- * Run `git` against a working directory. Never throws — callers inspect `ok`.
+ * Run `git` against a working directory. Resolves with `ok` reflecting exit
+ * status for a normal invocation — but CAN throw synchronously, since it's a
+ * thin wrapper over `Bun.spawn`, which throws when the `git` binary isn't on
+ * `PATH` or `cwd` doesn't exist. Callers that need a true non-throwing
+ * contract (e.g. `gitWritableRoots`) must wrap their own call in try/catch.
  * Using Bun.spawn directly (not Bun.$) so we don't pay shell-parsing cost or
  * worry about argument quoting on user-supplied paths/branch names.
  *
@@ -355,7 +359,17 @@ export async function repoRoot(dir: string): Promise<string | null> {
  * ordinary `.git`-inside-cwd checkout as "outside" and add a redundant root.
  */
 export async function gitWritableRoots(cwd: string): Promise<string[]> {
-  const res = await git(["rev-parse", "--path-format=absolute", "--git-common-dir"], cwd, 5_000);
+  let res: GitResult;
+  try {
+    res = await git(["rev-parse", "--path-format=absolute", "--git-common-dir"], cwd, 5_000);
+  } catch {
+    // `git()` itself can throw synchronously (`Bun.spawn` throws on a
+    // missing `git` binary or a `cwd` that no longer exists) even though
+    // THIS function's own contract, documented above, is non-throwing — a
+    // codex spawn on a host without git must proceed unescalated, not
+    // hard-fail. Same outcome as every other "can't tell" branch below.
+    return [];
+  }
   if (!res.ok) return [];
   const out = res.stdout;
   if (!out) return [];

--- a/src/bun/worktree.ts
+++ b/src/bun/worktree.ts
@@ -1,6 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { rm } from "node:fs/promises";
-import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { dataDir } from "./db.ts";
@@ -341,29 +340,24 @@ export async function repoRoot(dir: string): Promise<string | null> {
  * writable cwd, or when `cwd` isn't a git repo / git is unavailable
  * (non-throwing — callers just get no extra roots).
  *
- * Synchronous on purpose: the codex spawn paths (`spawnCodexTurnNow`,
- * `spawnAgent`) are synchronous, and a local `git rev-parse` is sub-20ms.
- * `--path-format=absolute` (git ≥ 2.31) yields an absolute path directly; the
- * `path.resolve` is belt-and-suspenders for any git that ignores the flag.
+ * Async, via the file's shared `git()` helper (`Bun.spawn` + its own 5s
+ * timeout here) rather than a sync `child_process.spawnSync` — the codex
+ * spawn paths this feeds (`buildCodexCommand` → `spawnAgent`) run on the same
+ * thread that serves `Bun.serve` + the whole orchestrator, so a sync fork
+ * would stall every concurrent HTTP/SSE connection for the life of the git
+ * call. `--path-format=absolute` (git ≥ 2.31) yields an absolute path
+ * directly; the `path.resolve` is belt-and-suspenders for any git that
+ * ignores the flag.
  *
  * Containment is checked against the realpath'd cwd: git canonicalizes symlinks
  * in the path it reports (e.g. `/tmp` → `/private/tmp` on macOS), so comparing
  * the reported common dir against a non-canonical `cwd` would otherwise flag an
  * ordinary `.git`-inside-cwd checkout as "outside" and add a redundant root.
  */
-export function gitWritableRootsSync(cwd: string): string[] {
-  let out: string;
-  try {
-    const res = spawnSync(
-      "git",
-      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-      { cwd, encoding: "utf8", timeout: 5_000 },
-    );
-    if (res.status !== 0 || typeof res.stdout !== "string") return [];
-    out = res.stdout.trim();
-  } catch {
-    return [];
-  }
+export async function gitWritableRoots(cwd: string): Promise<string[]> {
+  const res = await git(["rev-parse", "--path-format=absolute", "--git-common-dir"], cwd, 5_000);
+  if (!res.ok) return [];
+  const out = res.stdout;
   if (!out) return [];
   const commonDir = path.resolve(cwd, out);
   let realCwd = cwd;
@@ -984,7 +978,7 @@ export async function getTaskDiff(task: Task): Promise<TaskDiff> {
     // filename char, so it must never be rewritten).
     //
     // `repoRoot` reports git's canonicalized path (symlinks resolved, e.g.
-    // `/tmp` → `/private/tmp` on macOS — see `gitWritableRootsSync`'s doc
+    // `/tmp` → `/private/tmp` on macOS — see `gitWritableRoots`'s doc
     // comment for the same gotcha), so diffing it against a non-canonical
     // `cwd` would spuriously produce a non-empty prefix even when cwd IS the
     // root. Realpath `cwd` first to compare like-for-like. Skipped entirely


### PR DESCRIPTION
## Problem

Opening a task's details panel lagged noticeably whenever agetor was "warming up" another task (spawning its agent or delivering a just-sent message). One Bun thread serves both the HTTP API and the orchestrator, and the warm-up path ran genuinely synchronous work that stalled every in-flight request:

- The `tmux()` helper in `claude-tmux.ts` was `Bun.spawnSync` behind all 46 tmux call sites: start = sync `kill-session` + `new-session` back-to-back; every send = 3–4 sync paste calls; claude's boot polls fired sync `capture-pane`/`has-session` every ~250–400ms for up to 30s — a drumbeat of small event-loop stalls.
- The codex/cursor/gemini one-shot spawns, `gitWritableRootsSync` (5s worst case), and the hook-installer settings write were sync too.
- Separately measured on a production-sized DB: the SSE replay query (`eventsForTask` with limit) cost **219.5ms of synchronous sqlite** per details-panel connect on an 18.5k-event task — the temp b-tree materializes full `data` payloads for all of a task's events just to keep 800.

This conversion was already scoped and deferred to "its own branch" twice (`docs/plans/fix-cannot-reach-api-toasts.md`, `docs/plans/fix-archive-teardown-queue.md`); this is that branch.

## What changed

**Async conversion (no behavior change intended):**
- `tmux()` → async `Bun.spawn` (choke-point argv preserved per `docs/plans/tmux-sessions-killed-unexpectedly.md`; still never throws; deliberately still no timeout — see follow-ups). All exports that fork now return Promises; paste atomicity moves from "sync code can't be preempted" to the per-task `queueTmuxOp` chain + `stillCurrent()` re-checks, with per-session buffer names preventing cross-task collisions.
- codex/cursor/gemini `new-session`/kill/reattach paths converted the same way; the shared spawn helper is deduped into `tmux-resolution.ts`.
- `gitWritableRootsSync` → async `gitWritableRoots` (non-throwing contract preserved); hook-installer → async fs with the atomic temp-file+rename kept; session-liveness death-probe types Promise-returning.
- Consumers (`agents.ts`, `orchestrator.ts`, `server.ts`, both boot paths) audited call-site-by-call-site — typecheck alone misses Promise-in-boolean and fire-and-forget uses. The audit caught real latent bugs: `sessionLiveness(...) !== "gone"` was always true, `!(sessionExists(...))` never early-returned, `/runs/:id/cancel` briefly serialized a pending Promise.
- New awaits widen windows a sync stretch used to make atomic, so start/send double-mint is now guarded by a single `startingTaskIds` keyspace across all five agent kinds; teardown order is terminals → sessions → worktree; boot awaits `reconcileOrphans` before the API starts; the scraper and death watches got reentrancy guards + catches.

**Query rewrite (no migration):** `eventsForTask`'s limit path is now a two-step — ids-only sort over the covering `idx_run_events_run` index, then row fetch by id range (`beforeId` applied in **both** steps; step 2 keeps the task filter so interleaved foreign ids can't leak in). Measured **219.5ms → ~19ms** on the same worst-case task, byte-identical results.

## Testing

- New `event-loop-responsiveness.test.ts`: against a stub tmux that sleeps 1s, concurrent event-loop work measures ~27ms drift (vs ~1030ms with a simulated sync block, which fails the assertion) — this is the regression guard against reintroducing a sync spawn.
- New oracle-parity tests for the query rewrite (limit/beforeId grid, empty case, cross-task id interleaving) and atomic-write/concurrency tests for the installer.
- 18 existing test files adapted to the async contract; poller-leak teardown races fixed at the source.
- Full suite: **3994 pass / 1 skip / 0 fail** (203 files); `bun run typecheck` clean. E2e not applicable — the Playwright harness runs `AGETOR_CLAUDE_DRIVER=fake`, which bypasses tmux entirely.

## Notes / follow-ups

- `flushSync` deliberately stays sync: it reads only the bytes since the tailer's last flush (µs-scale, no fork), and its offset race guard depends on event-loop atomicity — rationale documented in-code.
- tmux ops remain untimed (owner decision): a wedged tmux now hangs only its own op/task instead of freezing the whole app; a timeout remains a tracked follow-up.
- Full plan, measurements, and decisions: `docs/plans/fix-task-details-load-delay.md`.