### PR TITLE
fix: stop macOS autocorrect from rewriting identifier inputs and search boxes

### DIFF
--- a/docs/plans/remove-autocorrect-from-pickers.md
+++ b/docs/plans/remove-autocorrect-from-pickers.md
@@ -186,3 +186,85 @@ at a time.
 | Free-text filter boxes (`Search title, prompt, workdir, branch…`) in KanbanFilters / WorktreesDialog | **out of scope** | they search prose (titles, prompts) as well as identifiers; not asked for, and not a "remainder" of this change |
 | Docs / CLAUDE.md | **out of scope** — nothing describes the old behaviour | — |
 | Owner-deferred | none | — |
+
+## 10. Wave 3 addendum — post-review sweep (2026-09-03)
+
+The wave-1 review (opus, `code-review` skill; 0 must-fix, 4 should-fix, 2 nits)
+found identifier inputs the §2 survey missed because they are raw `<input>`s
+or live in surfaces outside the New Task flow. The owner was asked once more
+and chose the **full identifier sweep**. Commit `63a8889`.
+
+**Review fixes applied**
+
+- Spread-first convention: `{...IDENTIFIER_INPUT_PROPS}` is the first prop at
+  every site (after `ref` / `data-testid` / `id` when present) so an explicit
+  local prop always wins; the duplicated inline comments in the two `ui/*-select`
+  primitives were removed (the constant's doc comment carries the rationale).
+- Datalist rule (documented in `identifier-input.ts`): an input with `list="…"`
+  spreads the constant then sets `autoComplete={undefined}` — `autocomplete="off"`
+  can suppress `<datalist>` suggestions in some engines, and React omits
+  undefined props. Applied to the Settings host input and the GitHub dialog's
+  Labels and Tag-name inputs.
+- Doc-comment site count removed (it was already wrong and would rot).
+
+**Ledger additions (all *in this run*, owner-approved at the review gate)**
+
+| Surface | Sites |
+| --- | --- |
+| `kanban/ExtensionPicker.tsx` search box (MCP / skills / plugins / prompts names) | 1 |
+| `settings/SettingsDialog.tsx` additional-harness editor: Id/slug, HOME path, Bin override (not the display Label) | 3 |
+| `kanban/GitHubDialog.tsx` — every input that must match a remote identifier exactly: labels, assignees, milestone number (×2 composers), item search query, assignee, head/base branch, reviewers (×2), teams, label name + hex (create + edit), tag name, ref, workflow-dispatch input name, `#number` (×2), transfer owner/repo | 24 |
+
+Still **out of scope** (prose): every Title / Description / Release-title
+input, the workflow-dispatch "Value" input, date inputs, textareas, prompt
+names, and the free-text "Search title, prompt, …" filter boxes. Password
+inputs never autocorrect.
+
+**Tests (wave 4)**: `e2e/identifier-inputs.spec.ts` extended to the Extensions
+search box and the Settings host input (asserting autocorrect/autocapitalize/
+spellcheck present and `autocomplete` absent — the datalist rule), plus the
+harness editor and GitHub-dialog inputs where reachable with existing fixtures.
+
+**Phase 7 first pass** (before wave 3): typecheck 0, bun suite all green,
+Playwright 48 passed / 3 failed / 12 skipped. `font-size.spec.ts` failed at the
+worker fixture's port pre-flight (a leaked worker backend on :4600 from an
+earlier single-spec run; the 12 skips are that worker's remaining tests) —
+environmental. `fx-interactions.spec.ts` and `resolve-conflicts.spec.ts` each
+had one failure whose artifacts were lost to a retry; both are re-triaged in
+the Phase 8 re-run.
+
+## 11. Wave 4 addendum — search/filter rule + wave-3 review (2026-09-03)
+
+The wave-3 review (opus, `code-review` skill; 0 must-fix, 2 should-fix, 1 nit)
+pointed out that the GitHub item-search box had opted out while its two
+structurally identical siblings (the Kanban and Worktrees free-text filter
+boxes) had not, with no recorded rule separating them. Resolution — the rule
+is now written into `identifier-input.ts`: **identifier inputs AND
+search/filter boxes opt out** (a box whose text is matched against existing
+content never wants correction; a corrected query just finds nothing);
+**composition fields keep autocorrect** (titles, descriptions, notes, prompts,
+prompt names). Consequently three more sites were swept in:
+
+| Surface | Sites |
+| --- | --- |
+| `kanban/KanbanFilters.tsx` free-text filter ("Search title, prompt, workdir, branch…") | 1 |
+| `worktrees/WorktreesDialog.tsx` free-text filter ("Search title, branch, project, path…") | 1 |
+| `kanban/RunPanel.tsx` transcript search ("Search messages") | 1 |
+
+This flips the §9 row "Free-text filter boxes — out of scope" to *in this
+run*, by the orchestrator under the completeness contract (the owner chose the
+widest scope at all three gates); it's a one-line revert per site if unwanted.
+
+**Datalist carve-out kept, honestly labelled.** The review noted the HTML
+spec says `autocomplete` shouldn't gate `<datalist>` suggestions and asked for
+an empirical check in the packaged app. That check can't be automated here,
+so the three `autoComplete={undefined}` overrides stay as the conservative
+choice (the datalist behaves exactly as it did before this change) and the
+doc comment now says so and names the removal condition. **Manual check for
+the owner:** in the packaged app, Settings → Git host tokens → does the
+detected-hosts dropdown still appear? If yes, the overrides can go.
+
+The three inline datalist comments were unified to the one-line
+cross-reference. Tests: the unit-test docstring lists the search/filter boxes;
+`e2e/identifier-inputs.spec.ts` gains an assertion on the Kanban free-text
+box (six e2e tests in the file now). Total spread sites: 36.

--- a/docs/plans/remove-autocorrect-from-pickers.md
+++ b/docs/plans/remove-autocorrect-from-pickers.md
@@ -1,0 +1,188 @@
+# Plan — Remove macOS autocorrect from the identifier search boxes (Project / Branch pickers)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-09-03 |
+| Source | `/implement remove the autocorrector from the project and branch pickers in the new task panel` |
+| Config | AGENTS_CONFIG.yml (balanced preset, schema v1) |
+| Flags | none |
+| Gates | grilled + approved by owner |
+| Branch | `fix/remove-auto-corrector-from-project-and-b` (agetor-created task branch, not the default branch) |
+| Base SHA | `3a771b3f94988af1a1dfb9a6bf2dcff74a093cb2` (tree clean apart from this untracked plan file) |
+
+## 1. Objective & success criteria
+
+Typing a project name or a branch name into the New Task panel's pickers is
+currently mangled by macOS text services: WebKit applies the system's
+"Correct spelling automatically" / "Capitalize words automatically" behaviour
+to any editable field that doesn't opt out, so `agetor` becomes `actor`,
+`feat` becomes `feet`, and the first letter gets capitalized. The search boxes
+hold identifiers, never prose, so autocorrect is always wrong there.
+
+Done means:
+
+- Every identifier search box (`SearchSelect` and `MultiSearchSelect`) and the
+  New Task panel's branch-name input render with `autocorrect="off"`,
+  `autocapitalize="off"`, `spellcheck="false"`, and `autocomplete="off"`.
+- The opt-out lives in one place, so a future identifier input can adopt it
+  in one line instead of re-deriving the attribute set.
+- `bun run typecheck` and `bun test` are green; a new Playwright spec asserts
+  the attributes on each affected surface; the existing e2e suite still passes.
+
+## 2. Context & constraints (Phase 1 findings)
+
+- **Both pickers are one primitive.** `ProjectPicker`
+  (`src/mainview/components/kanban/ProjectPicker.tsx:101`) and `BranchPicker`
+  (`src/mainview/components/kanban/BranchPicker.tsx:281`) render `SearchSelect`.
+  Its search box, `src/mainview/components/ui/search-select.tsx:152-158`, is a
+  bare `<Input>` (`ui/input.tsx`, a `forwardRef` that spreads every prop onto
+  the native `<input>`) with no autocorrect / autocapitalize / spellcheck /
+  autocomplete attributes.
+- **Reach.** `ProjectPicker` is used only by `NewTaskForm.tsx:583`.
+  `BranchPicker` is used only by `WorktreeOptions.tsx:277`, which is rendered
+  by `NewTaskForm`, `CreateTaskFromIssueDialog` (live variant) and
+  `ResolveConflictsDialog` (locked variant — read-only `<Input readOnly>`, no
+  picker, unaffected). Fixing `SearchSelect` therefore fixes every instance.
+- **Sibling with the identical defect.** `MultiSearchSelect`
+  (`src/mainview/components/ui/multi-search-select.tsx:145-151`) has the same
+  bare search `<Input>`; consumers are `KanbanFilters.tsx` (harness / project /
+  status / type filters) and `WorktreesDialog.tsx` (project / status filters).
+- **The Mode dropdown is unaffected**: `NewTaskForm.tsx:669` passes
+  `searchable={false}`, so no input is rendered.
+- **Branch-name input** (`WorktreeOptions.tsx:308-322`, test id
+  `branch-name-input`, shown while Isolate is on — the default) already sets
+  `spellCheck={false}` but not autocorrect / autocapitalize / autocomplete.
+  Same for `BranchNamingDialog.tsx:151` (the naming-pattern input reached from
+  the branch-name field's settings button).
+- **Repo precedent.** `spellCheck={false}` on identifier inputs
+  (`WorktreeOptions`, `BranchNamingDialog`, `GitHubTokensSection`) and
+  `autoComplete="off"` on the token input (`GitHubTokensSection.tsx:224`).
+  Nothing in the codebase sets `autoCorrect` yet.
+- **Platform facts (web research).** The HTML `autocorrect` global attribute
+  applies to `<input>` / `<textarea>` / contenteditable; `"off"` disables
+  correction. Safari on macOS has honoured it since 14.1 (caniuse,
+  `mdn-html_global_attributes_autocorrect`), Chrome since 152, Firefox since
+  136. The app ships in the system WKWebView (macOS 26), so support is a given.
+  `@types/react` 19.2 declares `autoCorrect?: string`, `autoCapitalize`,
+  `spellCheck?: Booleanish`, `autoComplete` on input attributes.
+- **Testing surface.** `bun test` (root `src/`) has no component harness —
+  existing webview tests are pure `lib/` modules. Playwright (Chromium, one
+  headless backend per worker via `e2e/fixtures.ts`) already drives the
+  branch search box: click the trigger via
+  `getByTitle(BRANCH_PICKER_TITLE)`, then `getByPlaceholder("Search
+  branches…")` (`e2e/issue-task.spec.ts:589-593`). Note the Kanban filter bar
+  also uses the placeholder `Search projects…`, so a spec must scope the New
+  Task panel's picker to its container. Run with
+  `bun node_modules/@playwright/test/cli.js test <spec>`; only one Playwright
+  run at a time (shared Vite :5173 / HMR).
+
+## 3. Approach & key decisions
+
+1. **One shared attribute set, spread at each site.** Add
+   `src/mainview/lib/identifier-input.ts` exporting
+   `IDENTIFIER_INPUT_PROPS = { autoCorrect: "off", autoCapitalize: "off",
+   spellCheck: false, autoComplete: "off" } as const` with a doc comment
+   explaining the WebKit/macOS behaviour it defeats. Each identifier input
+   spreads it (`{...IDENTIFIER_INPUT_PROPS}`). *Alternative considered:*
+   inline the four attributes at each site — rejected because four sites
+   already drifted (three had `spellCheck`, one also had `autoComplete`, none
+   had `autoCorrect`), and a constant is the cheapest way to stop that drift
+   and give the unit layer something real to assert. Rests on reasoning, not
+   spike evidence.
+2. **Fix the primitives, not the pickers.** The opt-out goes on
+   `SearchSelect`'s and `MultiSearchSelect`'s search `<Input>` rather than on
+   a new prop set from `ProjectPicker` / `BranchPicker`. There is no consumer
+   of either primitive where autocorrecting a filter query is desirable, and
+   the owner chose the all-search-boxes scope at the grill.
+3. **All four attributes, not just `autocorrect`.** `spellcheck=false` removes
+   the red-underline markers and (on WebKit) the correction pass that rides on
+   spell checking; `autocorrect=off` is the explicit switch; `autocapitalize=off`
+   defeats the separate "Capitalize words" service; `autocomplete=off` stops
+   form-autofill suggestions over the popover. Belt and braces is cheap here and
+   matches the existing token-input precedent.
+4. **Prose fields keep autocorrect.** Title and Prompt are natural-language
+   inputs; the owner confirmed they stay as they are.
+5. **Unverified assumption, stated.** Whether the WKWebView in Electrobun
+   honours these attributes exactly like Safari cannot be automated (it needs
+   the packaged app plus the OS setting). The e2e layer asserts the DOM
+   attributes are present; behaviour in the real app is a manual check.
+
+## 4. Work breakdown — implementation tasks
+
+Single-agent wave — the whole change is ~15 lines across five files, so one
+`implementation` runner does T0–T3 sequentially (no fan-out; see §6).
+
+| ID | Goal | Owns (exact files) | Depends on | Acceptance |
+| --- | --- | --- | --- | --- |
+| T0 | Add the shared opt-out constant | `src/mainview/lib/identifier-input.ts` (new) | — | Exports `IDENTIFIER_INPUT_PROPS` (`as const`, typed to satisfy `React.InputHTMLAttributes`) with a doc comment naming the macOS/WebKit behaviour and pointing at the consumers. |
+| T1 | Opt `SearchSelect`'s search box out | `src/mainview/components/ui/search-select.tsx` | T0 | The `<Input ref={searchRef} …>` at ~L152 spreads `IDENTIFIER_INPUT_PROPS`; a one-line comment says why. No other change. |
+| T2 | Opt `MultiSearchSelect`'s search box out | `src/mainview/components/ui/multi-search-select.tsx` | T0 | Same as T1 for the `<Input>` at ~L145. |
+| T3 | Opt the branch-name, naming-pattern, and Settings host inputs out | `src/mainview/components/kanban/WorktreeOptions.tsx`, `src/mainview/components/settings/BranchNamingDialog.tsx`, `src/mainview/components/settings/GitHubTokensSection.tsx` | T0 | `branch-name-input` (~L308), the pattern input (~L151), and the GitHub host input (~L200, the `spellCheck`-only one — NOT the `type="password"` token input) replace their bare `spellCheck={false}` with the spread; every other prop untouched. |
+
+Conventions for the agent: match surrounding style (2-space, double quotes,
+trailing commas), keep comments in the repo's "why, not what" voice, no new
+dependencies, no `TODO`s, don't touch `input.tsx`, the pickers, or any test.
+`bun run typecheck` must be green after the wave.
+
+## 5. Work breakdown — test tasks
+
+| ID | Layer | Covers | Owns | Notes |
+| --- | --- | --- | --- | --- |
+| TT1 | unit (`bun test`) | T0 | `src/mainview/lib/identifier-input.test.ts` (new) | Asserts the exact attribute set (`autoCorrect === "off"`, `autoCapitalize === "off"`, `spellCheck === false`, `autoComplete === "off"`) and that it has no extra keys, so a future edit can't silently widen or narrow it. |
+| TT2 | e2e (Playwright) | T1, T2, T3 | `e2e/identifier-inputs.spec.ts` (new) | One spec file, modelled on `e2e/font-size.spec.ts` / `issue-task.spec.ts`: (a) New Task panel → click the Project picker trigger (by its title "Pick the working directory the agent runs in…") → assert the `Search projects…` box **inside the New Task panel** carries `autocorrect="off"`, `autocapitalize="off"`, `spellcheck="false"`, `autocomplete="off"`; press Escape. (b) Click the Branch picker trigger (`getByTitle` with the isolated-mode title, as in `issue-task.spec.ts:95`) → same assertions on `Search branches…`. (c) `getByTestId("branch-name-input")` → same assertions (Isolate defaults on). (d) Kanban filter bar → click the "All harnesses" trigger → same assertions on `Search harnesses…` (covers `MultiSearchSelect`). Use `toHaveAttribute`, no sleeps, no screenshots. |
+
+**E2E applies** — the change is user-visible DOM in a real webview flow and
+the repo has a working Playwright harness. Run recipe (from Phase 1):
+`export PATH="$HOME/.bun/bin:$PATH"`; `bun install` already done; the
+Playwright `webServer` block starts `bun run hmr` (Vite :5173) itself and the
+`backend` fixture spawns a headless Bun API per worker — no manual services,
+no credentials. Command: `bun node_modules/@playwright/test/cli.js test
+e2e/identifier-inputs.spec.ts` (then the full `e2e/` run). One Playwright run
+at a time.
+
+## 6. Execution waves
+
+- **Wave 1 (Phase 4):** one `implementation` agent (sonnet) does T0 → T1 → T2 → T3 in order. No parallel agents — the files are tiny and a fan-out would cost more than it saves.
+- **Barrier:** typecheck green, wave committed.
+- **Wave 2 (Phase 6):** one `tests_creation` agent (sonnet) writes TT1 + TT2 (disjoint from every wave-1 file).
+- **Phase 5** (opus reviewer) runs between the waves on the wave-1 diff; **Phase 7** (haiku) runs `bun run typecheck`, `bun test`, the new spec, then the full e2e suite.
+
+## 7. Blast radius & risks
+
+- **Every `SearchSelect` / `MultiSearchSelect` search box** changes — Project,
+  Branch (New Task + issue dialog), Kanban filters, Worktrees dialog. The only
+  observable change is the four attributes; filtering, focus-on-open, Escape,
+  and the `data-popover-open` marker are untouched.
+- **Chromium (e2e) ignores `autocorrect` below v152** — irrelevant to the
+  assertions, which check attribute presence, not behaviour.
+- **No server, DB, API, CLI, or shared-types impact.** Nothing to migrate,
+  nothing to roll back beyond reverting the commit.
+- **Risk:** the WKWebView could in theory ignore the attributes (see §3.5).
+  Mitigation: the attribute set is the documented, standard remedy with
+  Safari 14.1+ support; manual verification in the packaged app is the
+  residual check.
+
+## 8. Open questions / assumptions
+
+- Owner confirmed at the grill: "autocorrector" = macOS text autocorrect (not
+  the pickers' auto-selection); scope = all identifier search boxes + the
+  branch-name input, prose fields untouched; acceptance = e2e attribute
+  assertions.
+- Assumption A1 (unverified, no spike possible): Electrobun's WKWebView
+  honours `autocorrect="off"` / `autocapitalize="off"` / `spellcheck="false"`
+  like Safari does. Blast radius if wrong: the fix is inert, nothing breaks.
+
+## 9. Completeness ledger
+
+| Candidate remainder | Disposition | Owner / reason |
+| --- | --- | --- |
+| `SearchSelect` search box (Project + Branch pickers, issue-dialog branch picker) | **in this run** — T1 | the request itself |
+| `MultiSearchSelect` search box (Kanban filters ×4, Worktrees dialog ×2) | **in this run** — T2 | owner chose "all identifier search boxes" at the grill |
+| Branch-name input (`WorktreeOptions`) | **in this run** — T3 | owner chose it explicitly at the grill |
+| Branch naming-pattern input (`BranchNamingDialog`) | **in this run** — T3 | reached from the branch-name field's settings button; same identifier semantics, already had a partial (`spellCheck`-only) opt-out — leaving it would be the drift the constant exists to end |
+| Existing `spellCheck={false}` / `autoComplete="off"` on the above sites | **in this run** — T3 replaces them with the spread (no duplicate attributes) | consistency |
+| GitHub tokens section host input (`GitHubTokensSection`, `spellCheck`-only today) | **in this run** — T3 | owner swept it in at the approval gate. The `type="password"` token input stays as-is: autocorrect is inherently off on password fields |
+| Title input and Prompt textarea in the New Task panel | **out of scope** | prose fields; owner confirmed autocorrect stays on |
+| Free-text filter boxes (`Search title, prompt, workdir, branch…`) in KanbanFilters / WorktreesDialog | **out of scope** | they search prose (titles, prompts) as well as identifiers; not asked for, and not a "remainder" of this change |
+| Docs / CLAUDE.md | **out of scope** — nothing describes the old behaviour | — |
+| Owner-deferred | none | — |

--- a/docs/plans/remove-autocorrect-from-pickers.md
+++ b/docs/plans/remove-autocorrect-from-pickers.md
@@ -268,3 +268,26 @@ The three inline datalist comments were unified to the one-line
 cross-reference. Tests: the unit-test docstring lists the search/filter boxes;
 `e2e/identifier-inputs.spec.ts` gains an assertion on the Kanban free-text
 box (six e2e tests in the file now). Total spread sites: 36.
+
+## 12. Final verification (Phase 8, after wave 4 — 2026-09-03)
+
+| Layer | Command | Result |
+| --- | --- | --- |
+| Typecheck | `bun run typecheck` | exit 0 |
+| Unit / integration | `bun test` | 4003 passed, 3 skipped, 0 failed (203 files) |
+| E2E | `bun node_modules/@playwright/test/cli.js test` | 66 passed, 1 failed, 0 skipped |
+| New spec | `… test e2e/identifier-inputs.spec.ts` | 6 / 6 passed |
+
+The single e2e failure — `unread-indicator.spec.ts` "board dot appears … stays
+clear on close" — passed on a same-file retry. Its assertion targets
+`locator("aside").last()` right after Close and expects `translate-x-full`;
+when the RunPanel unmounts before the assertion samples, `.last()` resolves to
+the New Task `<aside>` (`w-80` class string in the error). A close-animation
+race unrelated to input attributes. The three failures from the first pass
+(font-size port pre-flight, fx-interactions, resolve-conflicts) all passed in
+this run — environmental / flaky, not caused by the change.
+
+Residual manual checks (not automatable in Chromium): in the packaged app,
+type a project or branch name into the pickers and confirm no correction /
+capitalization; open Settings → Git host tokens and confirm the detected-hosts
+dropdown still appears (then the datalist carve-out can be removed).

--- a/e2e/identifier-inputs.spec.ts
+++ b/e2e/identifier-inputs.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, type Locator } from "./fixtures";
+import { gotoApp } from "./helpers";
+
+/**
+ * E2E coverage for `IDENTIFIER_INPUT_PROPS` (docs/plans/remove-autocorrect-
+ * from-pickers.md §5, TT2) — the shared `autocorrect="off"` /
+ * `autocapitalize="off"` / `spellcheck="false"` / `autocomplete="off"` set
+ * spread onto every identifier input so macOS/WebKit's text-correction
+ * services stop mangling typed identifiers (project names, branch names,
+ * harness ids).
+ *
+ * These assertions check DOM **attributes**, not autocorrect **behaviour**:
+ * Chromium (this harness) doesn't apply macOS's system text-correction
+ * services the way the packaged app's WKWebView does, so there's nothing to
+ * observe behaviourally here — confirming the opt-out attribute is present
+ * is the correct and complete e2e check; a manual pass in the packaged app
+ * is the residual verification for the behaviour itself (see the plan's
+ * §3.5 assumption).
+ *
+ * Modeled on e2e/font-size.spec.ts's harness (real Chromium + the real
+ * per-worker headless Bun backend via the `backend` fixture, no mocked
+ * fetches) and on how e2e/issue-task.spec.ts drives the Branch picker
+ * (`BRANCH_PICKER_TITLE` trigger tooltip + `getByPlaceholder` on the
+ * search box, ~L80-110 and ~L575-600 there).
+ *
+ * Covers, all inside the New Task left panel (`<aside>`, expanded by
+ * default in a fresh browser context) unless noted:
+ *  1. Project picker search box (`SearchSelect`, via `ProjectPicker`).
+ *  2. Branch picker search box (`SearchSelect`, via `BranchPicker` inside
+ *     `WorktreeOptions`).
+ *  3. The branch-name input (`branch-name-input`, visible because Isolate
+ *     defaults on).
+ *  4. The Kanban filter bar's harness filter search box (`MultiSearchSelect`)
+ *     — a sibling primitive to `SearchSelect`, and the one surface this
+ *     change reaches outside the New Task panel.
+ *  5. Negative check: the Title input (a prose field) must NOT carry
+ *     `autocorrect="off"` — pins the deliberate prose-vs-identifier split so
+ *     a future "apply everywhere" change trips this test.
+ *
+ * No sleeps/screenshots; `toBeVisible()` with `CONVERGE_TIMEOUT` is used
+ * wherever a popover needs to render before assertions run.
+ */
+
+// Tooltip WorktreeOptions puts on the Branch picker trigger while isolated
+// (the default state) — see WorktreeOptions.tsx. Mirrors
+// e2e/issue-task.spec.ts's identical constant.
+const BRANCH_PICKER_TITLE =
+  "Base ref the worktree branches from. Pick the current branch row to use what's checked out at task start.";
+
+// Tooltip ProjectPicker's trigger carries, set by NewTaskForm.tsx.
+const PROJECT_PICKER_TITLE =
+  "Pick the working directory the agent runs in. Add new ones with the folder picker at the bottom of the list.";
+
+// Generous but bounded convergence timeout for popovers to render — mirrors
+// issue-task.spec.ts's identical constant.
+const CONVERGE_TIMEOUT = 20_000;
+
+/** Asserts the full `IDENTIFIER_INPUT_PROPS` set is present on `locator`.
+ *  React renders `spellCheck={false}` as the DOM string `"false"` (not the
+ *  attribute's absence), so all four are checked as string values via
+ *  `toHaveAttribute`. */
+async function expectIdentifierInput(locator: Locator): Promise<void> {
+  await expect(locator).toHaveAttribute("autocorrect", "off");
+  await expect(locator).toHaveAttribute("autocapitalize", "off");
+  await expect(locator).toHaveAttribute("spellcheck", "false");
+  await expect(locator).toHaveAttribute("autocomplete", "off");
+}
+
+test.describe("identifier inputs opt out of autocorrect", () => {
+  test("New Task panel: Project picker, Branch picker, and branch-name input all carry the opt-out set", async ({
+    page,
+    backend,
+  }) => {
+    await gotoApp(page, backend.bootBase);
+
+    // The New Task panel is the left <aside> — it has no test id, so scope
+    // by its own "New task" header text (there's exactly one <aside> with
+    // that text; the other <aside> in the app, RunPanel's slide-over, only
+    // mounts once a task is opened, which this spec never does).
+    const newTaskPanel = page.locator("aside").filter({ hasText: "New task" });
+    await expect(newTaskPanel).toBeVisible();
+
+    // 1. Project picker search box.
+    const projectTrigger = newTaskPanel.getByTitle(PROJECT_PICKER_TITLE);
+    await projectTrigger.click();
+    const projectSearch = newTaskPanel.getByPlaceholder("Search projects…");
+    await expect(projectSearch).toBeVisible({ timeout: CONVERGE_TIMEOUT });
+    await expectIdentifierInput(projectSearch);
+    await page.keyboard.press("Escape");
+    await expect(projectSearch).toBeHidden();
+
+    // 2. Branch picker search box, inside worktree-options.
+    const worktreeOptions = newTaskPanel.getByTestId("worktree-options");
+    await expect(worktreeOptions).toBeVisible();
+    const branchTrigger = worktreeOptions.getByTitle(BRANCH_PICKER_TITLE);
+    await branchTrigger.click();
+    const branchSearch = worktreeOptions.getByPlaceholder("Search branches…");
+    await expect(branchSearch).toBeVisible({ timeout: CONVERGE_TIMEOUT });
+    await expectIdentifierInput(branchSearch);
+    await page.keyboard.press("Escape");
+    await expect(branchSearch).toBeHidden();
+
+    // 3. Branch-name input — visible because Isolate defaults on.
+    const branchNameInput = worktreeOptions.getByTestId("branch-name-input");
+    await expect(branchNameInput).toBeVisible();
+    await expectIdentifierInput(branchNameInput);
+
+    // 5 (negative check). The Title input is prose, not an identifier — it
+    // must NOT have picked up the opt-out.
+    const titleInput = newTaskPanel.getByPlaceholder("Short description");
+    await expect(titleInput).toBeVisible();
+    await expect(titleInput).not.toHaveAttribute("autocorrect", "off");
+  });
+
+  test("Kanban filter bar: harness filter search box carries the opt-out set", async ({ page, backend }) => {
+    await gotoApp(page, backend.bootBase);
+
+    // "All harnesses" is the MultiSearchSelect trigger's empty-state label
+    // (KanbanFilters.tsx) — a plain <button>, not inside the New Task panel,
+    // so no extra scoping is needed. The New Task panel's own placeholder
+    // "Search projects…" collides with the filter bar's repo filter, which
+    // is why this spec never asserts on that placeholder unscoped.
+    const harnessTrigger = page.getByRole("button", { name: "All harnesses", exact: true });
+    await harnessTrigger.click();
+    const harnessSearch = page.getByPlaceholder("Search harnesses…");
+    await expect(harnessSearch).toBeVisible({ timeout: CONVERGE_TIMEOUT });
+    await expectIdentifierInput(harnessSearch);
+    await page.keyboard.press("Escape");
+    await expect(harnessSearch).toBeHidden();
+  });
+});

--- a/e2e/identifier-inputs.spec.ts
+++ b/e2e/identifier-inputs.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Locator } from "./fixtures";
-import { gotoApp } from "./helpers";
+import { gotoApp, openSettingsGeneral } from "./helpers";
 
 /**
  * E2E coverage for `IDENTIFIER_INPUT_PROPS` (docs/plans/remove-autocorrect-
@@ -31,11 +31,19 @@ import { gotoApp } from "./helpers";
  *  3. The branch-name input (`branch-name-input`, visible because Isolate
  *     defaults on).
  *  4. The Kanban filter bar's harness filter search box (`MultiSearchSelect`)
- *     — a sibling primitive to `SearchSelect`, and the one surface this
- *     change reaches outside the New Task panel.
+ *     — a sibling primitive to `SearchSelect`.
  *  5. Negative check: the Title input (a prose field) must NOT carry
  *     `autocorrect="off"` — pins the deliberate prose-vs-identifier split so
  *     a future "apply everywhere" change trips this test.
+ *  6. Wave 3 — the New Task composer's Extensions picker search box
+ *     (`ExtensionPicker.tsx`, `extension-picker-search`).
+ *  7. Wave 3 — Settings → Git Integration's host input
+ *     (`GitHubTokensSection.tsx`): carries the three correction attributes
+ *     but deliberately NOT `autocomplete`, since it's paired with a
+ *     `<datalist>` (`autoComplete={undefined}` after the spread — see
+ *     identifier-input.ts's "one exception" paragraph).
+ *  8. Wave 3 — the Settings additional-harness editor's Id/slug and Bin
+ *     override inputs (`SettingsDialog.tsx`'s `Editor`).
  *
  * No sleeps/screenshots; `toBeVisible()` with `CONVERGE_TIMEOUT` is used
  * wherever a popover needs to render before assertions run.
@@ -65,6 +73,28 @@ async function expectIdentifierInput(locator: Locator): Promise<void> {
   await expect(locator).toHaveAttribute("spellcheck", "false");
   await expect(locator).toHaveAttribute("autocomplete", "off");
 }
+
+/** Variant of `expectIdentifierInput` for the one documented exception in
+ *  identifier-input.ts: an input paired with a `<datalist>` spreads
+ *  `IDENTIFIER_INPUT_PROPS` and then sets `autoComplete={undefined}` right
+ *  after it (React omits an `undefined` prop entirely, rather than
+ *  rendering `autocomplete="off"`) so the datalist keeps suggesting. The
+ *  three correction attributes still apply; `autocomplete` must be absent,
+ *  not merely a different value. */
+async function expectIdentifierInputNoAutocomplete(locator: Locator): Promise<void> {
+  await expect(locator).toHaveAttribute("autocorrect", "off");
+  await expect(locator).toHaveAttribute("autocapitalize", "off");
+  await expect(locator).toHaveAttribute("spellcheck", "false");
+  await expect(locator).not.toHaveAttribute("autocomplete");
+}
+
+// Distinctive, worker-unique project name for the Extensions-picker test
+// below — searched for and clicked explicitly rather than relying on
+// ProjectPicker's `autoSelectFirst`, since the `backend` fixture is
+// worker-scoped and other spec files sharing this worker may have already
+// registered their own projects (see e2e/issue-task.spec.ts's file header
+// for the identical concern around `openGitDialog`).
+const EXTENSIONS_TEST_PROJECT_NAME = "e2e-identifier-inputs-project";
 
 test.describe("identifier inputs opt out of autocorrect", () => {
   test("New Task panel: Project picker, Branch picker, and branch-name input all carry the opt-out set", async ({
@@ -127,5 +157,113 @@ test.describe("identifier inputs opt out of autocorrect", () => {
     await expectIdentifierInput(harnessSearch);
     await page.keyboard.press("Escape");
     await expect(harnessSearch).toBeHidden();
+  });
+
+  test("New Task panel: Extensions picker search box carries the opt-out set", async ({ page, backend }) => {
+    // The Extensions trigger is disabled until the New Task panel has a
+    // non-empty workdir (PromptComposer: `disabled={disabled ||
+    // !workdir.trim()}`), so a project must be registered and selected
+    // first. The worker's own `dataDir` is already guaranteed to exist and
+    // is unrelated to this repo checkout, so pointing a project at it can't
+    // touch a real git worktree — this test never starts a task.
+    const projectRes = await page.request.post(`${backend.apiBase}/projects`, {
+      headers: { authorization: `Bearer ${backend.apiToken}` },
+      data: { path: backend.dataDir, name: EXTENSIONS_TEST_PROJECT_NAME },
+    });
+    expect(projectRes.ok()).toBeTruthy();
+
+    await gotoApp(page, backend.bootBase);
+
+    const newTaskPanel = page.locator("aside").filter({ hasText: "New task" });
+    await expect(newTaskPanel).toBeVisible();
+
+    // Pick this test's project explicitly rather than relying on
+    // ProjectPicker's `autoSelectFirst` (most-recently-used project) — see
+    // EXTENSIONS_TEST_PROJECT_NAME's doc comment above.
+    const projectTrigger = newTaskPanel.getByTitle(PROJECT_PICKER_TITLE);
+    await projectTrigger.click();
+    const projectSearch = newTaskPanel.getByPlaceholder("Search projects…");
+    await expect(projectSearch).toBeVisible({ timeout: CONVERGE_TIMEOUT });
+    await projectSearch.fill(EXTENSIONS_TEST_PROJECT_NAME);
+    const projectRow = newTaskPanel.locator("button").filter({ hasText: EXTENSIONS_TEST_PROJECT_NAME });
+    await expect(projectRow).toBeVisible({ timeout: CONVERGE_TIMEOUT });
+    await projectRow.click();
+    await expect(projectSearch).toBeHidden();
+
+    // 6. Extensions picker search box. Its trigger label is "MCP · Skills ·
+    // Plugins · Prompts" (ExtensionPicker.tsx) — the test id is more
+    // robust than the label text, and is already used the same way by
+    // e2e/issue-task.spec.ts and e2e/resolve-conflicts.spec.ts.
+    const extTrigger = newTaskPanel.getByTestId("extension-picker-trigger");
+    await expect(extTrigger).toBeEnabled({ timeout: CONVERGE_TIMEOUT });
+    await extTrigger.click();
+    const extSearch = newTaskPanel.getByTestId("extension-picker-search");
+    await expect(extSearch).toBeVisible({ timeout: CONVERGE_TIMEOUT });
+    await expectIdentifierInput(extSearch);
+
+    // The Extensions popover is a `data-popover-open` carrier that closes
+    // itself on Escape (see ExtensionPicker.tsx and CLAUDE.md's carrier
+    // list) — regression guard mirroring the Project/Branch pickers above.
+    await page.keyboard.press("Escape");
+    await expect(extSearch).toBeHidden();
+  });
+
+  test("Settings → Git Integration: host input carries the identifier set but not autocomplete", async ({
+    page,
+    backend,
+  }) => {
+    await gotoApp(page, backend.bootBase);
+    const dialog = await openSettingsGeneral(page);
+
+    // 7. GitHubTokensSection stays mounted across sections (kept alive so an
+    // in-progress edit survives switching tabs) but is hidden until "Git
+    // Integration" is the active section — see SETTINGS_SECTIONS in
+    // src/mainview/lib/settings-dialog-view.ts.
+    await dialog.getByRole("button", { name: "Git Integration", exact: true }).click();
+    const hostInput = dialog.getByPlaceholder("github.com / gitlab.com / bitbucket.org");
+    await expect(hostInput).toBeVisible({ timeout: CONVERGE_TIMEOUT });
+    await expectIdentifierInputNoAutocomplete(hostInput);
+  });
+
+  test("Settings harness editor: Id/slug and Bin override inputs carry the opt-out set", async ({
+    page,
+    backend,
+  }) => {
+    await gotoApp(page, backend.bootBase);
+    const dialog = await openSettingsGeneral(page);
+
+    await dialog.getByRole("button", { name: "Harnesses", exact: true }).click();
+    const addButton = dialog.getByRole("button", { name: "Add harness", exact: true });
+    await expect(addButton).toBeEnabled({ timeout: CONVERGE_TIMEOUT });
+    await addButton.click();
+
+    // Any template works for this assertion — its `kind` only changes the
+    // (untested-here) HOME-override field's label text, not the Id/Bin
+    // fields. The button's accessible name also includes the template's
+    // description text, so match on the label via `hasText` rather than an
+    // exact role-name match.
+    const templateButton = dialog.getByRole("button").filter({ hasText: "Additional Claude Code" });
+    await expect(templateButton).toBeVisible({ timeout: CONVERGE_TIMEOUT });
+    await templateButton.click();
+
+    // 8. Id/slug and Bin override inputs (SettingsDialog.tsx's `Editor`).
+    const idInput = dialog.getByPlaceholder("claude-work");
+    await expect(idInput).toBeVisible({ timeout: CONVERGE_TIMEOUT });
+    await expectIdentifierInput(idInput);
+
+    const binInput = dialog.getByPlaceholder("/opt/homebrew/bin/claude");
+    await expect(binInput).toBeVisible();
+    await expectIdentifierInput(binInput);
+  });
+});
+
+// Wave 4 — the rule widened from "identifier inputs" to "identifier inputs
+// AND search/filter boxes" (a corrected query just finds nothing), so the
+// Kanban bar's free-text box opts out too. It's always mounted on the board,
+// so no popover to open.
+test.describe("search/filter boxes opt out of autocorrect", () => {
+  test("Kanban free-text filter box carries the opt-out set", async ({ page, backend }) => {
+    await gotoApp(page, backend.bootBase);
+    await expectIdentifierInput(page.getByPlaceholder("Search title, prompt, workdir, branch…"));
   });
 });

--- a/src/mainview/components/kanban/ExtensionPicker.tsx
+++ b/src/mainview/components/kanban/ExtensionPicker.tsx
@@ -3,6 +3,7 @@ import { Blocks, BookText, ChevronDown, Plug, Puzzle, Sparkles } from "lucide-re
 import type { AvailableExtension } from "@/lib/api";
 import type { SavedPrompt } from "../../../shared/types.ts";
 import { filterPromptsForPicker } from "@/lib/prompt-picker";
+import { IDENTIFIER_INPUT_PROPS } from "@/lib/identifier-input";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -209,6 +210,7 @@ export function ExtensionPicker({
             <input
               ref={searchRef}
               data-testid="extension-picker-search"
+              {...IDENTIFIER_INPUT_PROPS}
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={(e) => {

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -3686,7 +3686,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
         {caps.labels && (
           <Input
             {...IDENTIFIER_INPUT_PROPS}
-            // datalist suggestions can be suppressed by autocomplete="off" in some engines; the correction attributes still apply.
+            // Keeps the <datalist> working — see identifier-input.ts.
             autoComplete={undefined}
             value={labels}
             onChange={(e) => setLabels(e.target.value)}
@@ -5101,7 +5101,7 @@ function ReleasesManager({
       <div className="mb-2 grid gap-2 md:grid-cols-[minmax(0,0.8fr)_minmax(0,1fr)]">
         <Input
           {...IDENTIFIER_INPUT_PROPS}
-          // datalist suggestions can be suppressed by autocomplete="off" in some engines; the correction attributes still apply.
+          // Keeps the <datalist> working — see identifier-input.ts.
           autoComplete={undefined}
           value={tagName}
           onChange={(e) => setTagName(e.target.value)}

--- a/src/mainview/components/kanban/GitHubDialog.tsx
+++ b/src/mainview/components/kanban/GitHubDialog.tsx
@@ -71,6 +71,7 @@ import { toRows, type DiffRow } from "@/lib/diff-rows";
 import { mergeabilityView, type MergeTone } from "@/lib/mergeability";
 import { isMergedPull, mergedPullReplacement } from "@/lib/pull-merged";
 import { isCredentialError } from "@/lib/credential-error";
+import { IDENTIFIER_INPUT_PROPS } from "@/lib/identifier-input";
 import { BinaryFilePreview, binaryFileBasename, binaryPreviewSides } from "./BinaryFilePreview";
 import { binaryPreviewKind } from "../../../shared/attachments.ts";
 import { sameIssueUrl } from "../../../shared/issue-task.ts";
@@ -403,6 +404,7 @@ function LabelAssigneeMilestoneFields({
         </div>
       ) : (
         <Input
+          {...IDENTIFIER_INPUT_PROPS}
           value={labelDraft}
           onChange={(e) => onLabelDraftChange(e.target.value)}
           placeholder="Labels, comma separated"
@@ -429,6 +431,7 @@ function LabelAssigneeMilestoneFields({
         </div>
       ) : (
         <Input
+          {...IDENTIFIER_INPUT_PROPS}
           value={assigneeDraft}
           onChange={(e) => onAssigneeDraftChange(e.target.value)}
           placeholder="Assignees, comma separated"
@@ -453,6 +456,7 @@ function LabelAssigneeMilestoneFields({
         </Select>
       ) : (
         <Input
+          {...IDENTIFIER_INPUT_PROPS}
           value={milestoneDraft}
           onChange={(e) => onMilestoneDraftChange(e.target.value)}
           placeholder="Milestone number"
@@ -3646,6 +3650,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
         <div className="relative md:col-span-2">
           <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={(e) => {
@@ -3680,6 +3685,9 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
         </div>
         {caps.labels && (
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
+            // datalist suggestions can be suppressed by autocomplete="off" in some engines; the correction attributes still apply.
+            autoComplete={undefined}
             value={labels}
             onChange={(e) => setLabels(e.target.value)}
             placeholder="Labels, comma separated"
@@ -3688,6 +3696,7 @@ export function GitHubDialog({ open, projects, initialProjectPath, pullPrefill, 
           />
         )}
         <Input
+          {...IDENTIFIER_INPUT_PROPS}
           value={assignee}
           onChange={(e) => setAssignee(e.target.value)}
           placeholder="Assignee"
@@ -4345,6 +4354,7 @@ function PullComposer({
         />
         <div className="grid gap-2 md:grid-cols-2">
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
             value={head}
             onChange={(e) => onHeadChange(e.target.value)}
             placeholder="Head branch"
@@ -4352,6 +4362,7 @@ function PullComposer({
             disabled={submitting}
           />
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
             value={base}
             onChange={(e) => onBaseChange(e.target.value)}
             placeholder="Base branch"
@@ -4367,6 +4378,7 @@ function PullComposer({
           disabled={submitting}
         />
         <Input
+          {...IDENTIFIER_INPUT_PROPS}
           value={reviewers}
           onChange={(e) => onReviewersChange(e.target.value)}
           placeholder="Reviewers, comma separated"
@@ -4493,6 +4505,7 @@ function IssueComposer({
         />
         {caps.labels && (
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
             value={labels}
             onChange={(e) => onLabelsChange(e.target.value)}
             placeholder="Labels, comma separated"
@@ -4502,6 +4515,7 @@ function IssueComposer({
         )}
         <div className="grid gap-2 md:grid-cols-2">
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
             value={assignees}
             onChange={(e) => onAssigneesChange(e.target.value)}
             placeholder="Assignees, comma separated"
@@ -4510,6 +4524,7 @@ function IssueComposer({
           />
           {caps.milestones && (
             <Input
+              {...IDENTIFIER_INPUT_PROPS}
               value={milestone}
               onChange={(e) => onMilestoneChange(e.target.value)}
               placeholder="Milestone number"
@@ -4596,10 +4611,10 @@ function LabelManager({
         </div>
       </div>
       <div className="mb-2 grid gap-2 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1.4fr)_auto]">
-        <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" className="h-8 text-xs" disabled={creating || !authenticated} />
+        <Input {...IDENTIFIER_INPUT_PROPS} value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" className="h-8 text-xs" disabled={creating || !authenticated} />
         <div className="flex items-center gap-1">
           <span className="size-4 shrink-0 rounded-full border border-border/60" style={{ backgroundColor: labelSwatch(color) }} />
-          <Input value={color} onChange={(e) => setColor(e.target.value)} placeholder="hex" className="h-8 w-20 text-xs" disabled={creating || !authenticated} />
+          <Input {...IDENTIFIER_INPUT_PROPS} value={color} onChange={(e) => setColor(e.target.value)} placeholder="hex" className="h-8 w-20 text-xs" disabled={creating || !authenticated} />
         </div>
         <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Description (optional)" className="h-8 text-xs" disabled={creating || !authenticated} />
         <Button
@@ -4681,10 +4696,10 @@ function LabelRow({
     return (
       <div className="rounded border border-border/60 p-2">
         <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1.4fr)]">
-          <Input value={name} onChange={(e) => setName(e.target.value)} className="h-7 text-xs" disabled={busy === "save"} />
+          <Input {...IDENTIFIER_INPUT_PROPS} value={name} onChange={(e) => setName(e.target.value)} className="h-7 text-xs" disabled={busy === "save"} />
           <div className="flex items-center gap-1">
             <span className="size-4 shrink-0 rounded-full border border-border/60" style={{ backgroundColor: labelSwatch(color) }} />
-            <Input value={color} onChange={(e) => setColor(e.target.value)} placeholder="hex" className="h-7 w-20 text-xs" disabled={busy === "save"} />
+            <Input {...IDENTIFIER_INPUT_PROPS} value={color} onChange={(e) => setColor(e.target.value)} placeholder="hex" className="h-7 w-20 text-xs" disabled={busy === "save"} />
           </div>
           <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Description" className="h-7 text-xs" disabled={busy === "save"} />
         </div>
@@ -5085,6 +5100,9 @@ function ReleasesManager({
       </div>
       <div className="mb-2 grid gap-2 md:grid-cols-[minmax(0,0.8fr)_minmax(0,1fr)]">
         <Input
+          {...IDENTIFIER_INPUT_PROPS}
+          // datalist suggestions can be suppressed by autocomplete="off" in some engines; the correction attributes still apply.
+          autoComplete={undefined}
           value={tagName}
           onChange={(e) => setTagName(e.target.value)}
           placeholder="Tag name"
@@ -5630,6 +5648,7 @@ function ActionsPanel({
             ))}
           </Select>
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
             value={dispatchRef}
             onChange={(e) => onDispatchRefChange(e.target.value)}
             placeholder="Ref (branch, tag, or sha) — e.g. main"
@@ -5641,6 +5660,7 @@ function ActionsPanel({
           {dispatchInputs.map((row, i) => (
             <div key={i} className="flex items-center gap-1.5">
               <Input
+                {...IDENTIFIER_INPUT_PROPS}
                 value={row.key}
                 onChange={(e) => onUpdateDispatchInputRow(i, { key: e.target.value })}
                 placeholder="Input name"
@@ -5966,6 +5986,7 @@ function ProjectsPanel({
                 <option value="pr">PR</option>
               </Select>
               <Input
+                {...IDENTIFIER_INPUT_PROPS}
                 value={addNumber}
                 onChange={(e) => onAddNumberChange(e.target.value.replace(/[^0-9]/g, ""))}
                 placeholder="#number"
@@ -7327,6 +7348,7 @@ function IssueActions({
       {caps.issueTransfer && (
         <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
             value={transferDraft}
             onChange={(e) => onTransferDraftChange(e.target.value)}
             placeholder="Transfer to owner/repo"
@@ -7551,6 +7573,7 @@ function SubIssues({ path, issueNumber, canPush }: { path: string; issueNumber: 
           )}
           <div className="mt-2 flex items-center gap-2">
             <Input
+              {...IDENTIFIER_INPUT_PROPS}
               value={addDraft}
               onChange={(e) => setAddDraft(e.target.value)}
               placeholder="Add by #number"
@@ -7733,6 +7756,7 @@ function PullTriage({
       {provider === "github" && (
         <div className="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
             value={reviewerDraft}
             onChange={(e) => onReviewerDraftChange(e.target.value)}
             placeholder={prOpen ? "Reviewers, comma separated" : "Reviewers can only be requested on open PRs"}
@@ -7740,6 +7764,7 @@ function PullTriage({
             disabled={isBusy || !prOpen || !canPush}
           />
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
             value={teamReviewerDraft}
             onChange={(e) => onTeamReviewerDraftChange(e.target.value)}
             placeholder={prOpen ? "Teams, comma separated (org slugs)" : "Teams can only be requested on open PRs"}

--- a/src/mainview/components/kanban/KanbanFilters.tsx
+++ b/src/mainview/components/kanban/KanbanFilters.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { MultiSearchSelect } from "@/components/ui/multi-search-select";
 import { Select } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import { IDENTIFIER_INPUT_PROPS } from "@/lib/identifier-input";
 import { taskTypeIcon } from "@/lib/task-type-icon";
 import { COLUMNS, TASK_TYPES, type ColumnId, type Harness, type Project, type TaskType } from "../../../shared/types.ts";
 
@@ -110,6 +111,7 @@ export function KanbanFilters({
       <div className="relative flex-1 max-w-md">
         <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden />
         <Input
+          {...IDENTIFIER_INPUT_PROPS}
           value={textQuery}
           onChange={(e) => onTextQueryChange(e.target.value)}
           placeholder="Search title, prompt, workdir, branch…"

--- a/src/mainview/components/kanban/RunPanel.tsx
+++ b/src/mainview/components/kanban/RunPanel.tsx
@@ -9,6 +9,7 @@ import {
 import { api, commitPushPrompt, type AgentModelMap, type PendingInteraction } from "@/lib/api";
 import { shouldShowSubagentTabs, resolveActiveStream, splitTabsForOverflow, sortSubagentTabs, anySubagentRunning } from "@/lib/subagent-tabs";
 import { prHeadBranch, shouldOfferCommitPush, shouldOfferOpenPr, type TaskGitStatus } from "@/lib/commit-push";
+import { IDENTIFIER_INPUT_PROPS } from "@/lib/identifier-input";
 import { findMatchingEventIds, resolveActiveMatchIndex, stepMatchIndex } from "@/lib/event-search";
 import { EXPAND_EVENT, isExpandTargetFor } from "@/lib/expand-on-jump";
 import { latestPrProposal } from "@/lib/pr-proposal";
@@ -2737,6 +2738,7 @@ function RunPanelBody({
             <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden />
             <Input
               ref={searchInputRef}
+              {...IDENTIFIER_INPUT_PROPS}
               aria-label="Search messages"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}

--- a/src/mainview/components/kanban/WorktreeOptions.tsx
+++ b/src/mainview/components/kanban/WorktreeOptions.tsx
@@ -3,6 +3,7 @@ import { GitBranch, SlidersHorizontal } from "lucide-react";
 import { api, type BranchNamingConfig } from "@/lib/api";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { IDENTIFIER_INPUT_PROPS } from "@/lib/identifier-input";
 import { branchFieldState, type BranchFieldState } from "@/lib/branch-field";
 import { worktreePayload, type WorktreePayload } from "@/lib/worktree-payload";
 import {
@@ -309,7 +310,7 @@ export function WorktreeOptions(props: Props) {
               data-testid="branch-name-input"
               value={branchField.displayValue}
               onChange={(e) => { setBranchOverride(e.target.value); setBranchDirty(true); }}
-              spellCheck={false}
+              {...IDENTIFIER_INPUT_PROPS}
               placeholder="feature/my-task"
               className={cn(
                 "pr-9 font-mono text-[11px]",

--- a/src/mainview/components/kanban/WorktreeOptions.tsx
+++ b/src/mainview/components/kanban/WorktreeOptions.tsx
@@ -308,9 +308,9 @@ export function WorktreeOptions(props: Props) {
           <div className="relative">
             <Input
               data-testid="branch-name-input"
+              {...IDENTIFIER_INPUT_PROPS}
               value={branchField.displayValue}
               onChange={(e) => { setBranchOverride(e.target.value); setBranchDirty(true); }}
-              {...IDENTIFIER_INPUT_PROPS}
               placeholder="feature/my-task"
               className={cn(
                 "pr-9 font-mono text-[11px]",

--- a/src/mainview/components/settings/BranchNamingDialog.tsx
+++ b/src/mainview/components/settings/BranchNamingDialog.tsx
@@ -7,6 +7,7 @@ import { Dialog } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
+import { IDENTIFIER_INPUT_PROPS } from "@/lib/identifier-input";
 import {
   BRANCH_TEMPLATE_TAGS,
   DEFAULT_BRANCH_CONFIG,
@@ -148,7 +149,7 @@ export function BranchNamingDialog({ open, onClose, projectPath, projectName, ac
                     value={prefix}
                     onChange={(e) => setPrefix(t.id, e.target.value)}
                     placeholder="feature/"
-                    spellCheck={false}
+                    {...IDENTIFIER_INPUT_PROPS}
                     className="h-8 font-mono text-xs"
                   />
                   <p className="text-[10px] text-muted-foreground">

--- a/src/mainview/components/settings/BranchNamingDialog.tsx
+++ b/src/mainview/components/settings/BranchNamingDialog.tsx
@@ -146,10 +146,10 @@ export function BranchNamingDialog({ open, onClose, projectPath, projectName, ac
                   <Input
                     id={`prefix-${t.id}`}
                     ref={i === 0 ? firstFieldRef : undefined}
+                    {...IDENTIFIER_INPUT_PROPS}
                     value={prefix}
                     onChange={(e) => setPrefix(t.id, e.target.value)}
                     placeholder="feature/"
-                    {...IDENTIFIER_INPUT_PROPS}
                     className="h-8 font-mono text-xs"
                   />
                   <p className="text-[10px] text-muted-foreground">

--- a/src/mainview/components/settings/GitHubTokensSection.tsx
+++ b/src/mainview/components/settings/GitHubTokensSection.tsx
@@ -194,11 +194,13 @@ export function GitHubTokensSection() {
         <div className="space-y-1">
           <label className="text-xs text-muted-foreground">Host</label>
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
+            // Keeps the detected-hosts <datalist> working — see identifier-input.ts.
+            autoComplete={undefined}
             value={host}
             onChange={(e) => setHost(e.target.value)}
             placeholder="github.com / gitlab.com / bitbucket.org"
             list={DATALIST_ID}
-            {...IDENTIFIER_INPUT_PROPS}
           />
           <datalist id={DATALIST_ID}>
             {data.detectedHosts.map((h) => (

--- a/src/mainview/components/settings/GitHubTokensSection.tsx
+++ b/src/mainview/components/settings/GitHubTokensSection.tsx
@@ -3,6 +3,7 @@ import { BookOpen, Trash2 } from "lucide-react";
 import { api, type GitHubTokensResult } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { IDENTIFIER_INPUT_PROPS } from "@/lib/identifier-input";
 import { GitHubSetupDialog } from "@/components/settings/GitHubSetupDialog";
 import { GIT_HOST_TOKENS_SECTION } from "../../../shared/types.ts";
 
@@ -197,7 +198,7 @@ export function GitHubTokensSection() {
             onChange={(e) => setHost(e.target.value)}
             placeholder="github.com / gitlab.com / bitbucket.org"
             list={DATALIST_ID}
-            spellCheck={false}
+            {...IDENTIFIER_INPUT_PROPS}
           />
           <datalist id={DATALIST_ID}>
             {data.detectedHosts.map((h) => (

--- a/src/mainview/components/settings/SettingsDialog.tsx
+++ b/src/mainview/components/settings/SettingsDialog.tsx
@@ -15,6 +15,7 @@ import { SavedPromptsSection } from "@/components/settings/SavedPromptsSection";
 import { useFontSize } from "@/components/font-size-provider";
 import { useTheme } from "@/components/theme-provider";
 import { isMacPlatform } from "@/lib/font-size";
+import { IDENTIFIER_INPUT_PROPS } from "@/lib/identifier-input";
 import { ONBOARDING_DISMISSED_PREF } from "@/lib/onboarding";
 import { abbreviateHome, cn } from "@/lib/utils";
 import {
@@ -1040,6 +1041,7 @@ function Editor({
         <div className="space-y-1">
           <label className="text-xs text-muted-foreground">Id (slug)</label>
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
             value={id}
             onChange={(e) => setId(e.target.value)}
             disabled={isEdit}
@@ -1086,6 +1088,7 @@ function Editor({
           {HARNESS_HOME_COPY[kind].label}
         </label>
         <Input
+          {...IDENTIFIER_INPUT_PROPS}
           value={home}
           onChange={(e) => setHome(e.target.value)}
           placeholder={
@@ -1102,6 +1105,7 @@ function Editor({
       <div className="space-y-1">
         <label className="text-xs text-muted-foreground">Bin override (absolute path; optional)</label>
         <Input
+          {...IDENTIFIER_INPUT_PROPS}
           value={bin}
           onChange={(e) => setBin(e.target.value)}
           placeholder="/opt/homebrew/bin/claude"

--- a/src/mainview/components/ui/multi-search-select.tsx
+++ b/src/mainview/components/ui/multi-search-select.tsx
@@ -145,13 +145,11 @@ export function MultiSearchSelect<T extends string>({
             <Search className="size-3.5 shrink-0 opacity-60" aria-hidden />
             <Input
               ref={searchRef}
+              {...IDENTIFIER_INPUT_PROPS}
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder={placeholder}
               className="h-7 border-0 px-0 shadow-none focus-visible:ring-0"
-              // This box filters identifiers (paths, branch names, harness
-              // ids) — never let the OS autocorrect them.
-              {...IDENTIFIER_INPUT_PROPS}
             />
           </div>
           <div className="max-h-64 overflow-y-auto py-1">

--- a/src/mainview/components/ui/multi-search-select.tsx
+++ b/src/mainview/components/ui/multi-search-select.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Check, ChevronDown, Search } from "lucide-react";
 import { Input } from "./input";
 import { cn } from "@/lib/utils";
+import { IDENTIFIER_INPUT_PROPS } from "@/lib/identifier-input";
 
 export interface MultiSearchSelectItem<T extends string = string> {
   value: T;
@@ -148,6 +149,9 @@ export function MultiSearchSelect<T extends string>({
               onChange={(e) => setQuery(e.target.value)}
               placeholder={placeholder}
               className="h-7 border-0 px-0 shadow-none focus-visible:ring-0"
+              // This box filters identifiers (paths, branch names, harness
+              // ids) — never let the OS autocorrect them.
+              {...IDENTIFIER_INPUT_PROPS}
             />
           </div>
           <div className="max-h-64 overflow-y-auto py-1">

--- a/src/mainview/components/ui/search-select.tsx
+++ b/src/mainview/components/ui/search-select.tsx
@@ -152,13 +152,11 @@ export function SearchSelect({
               <Search className="size-3.5 shrink-0 opacity-60" aria-hidden />
               <Input
                 ref={searchRef}
+                {...IDENTIFIER_INPUT_PROPS}
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder={placeholder}
                 className="h-7 border-0 px-0 shadow-none focus-visible:ring-0"
-                // This box filters identifiers (paths, branch names, harness
-                // ids) — never let the OS autocorrect them.
-                {...IDENTIFIER_INPUT_PROPS}
               />
             </div>
           )}

--- a/src/mainview/components/ui/search-select.tsx
+++ b/src/mainview/components/ui/search-select.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Check, ChevronDown, Search } from "lucide-react";
 import { Input } from "./input";
 import { cn } from "@/lib/utils";
+import { IDENTIFIER_INPUT_PROPS } from "@/lib/identifier-input";
 
 export interface SearchSelectItem {
   value: string;
@@ -155,6 +156,9 @@ export function SearchSelect({
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder={placeholder}
                 className="h-7 border-0 px-0 shadow-none focus-visible:ring-0"
+                // This box filters identifiers (paths, branch names, harness
+                // ids) — never let the OS autocorrect them.
+                {...IDENTIFIER_INPUT_PROPS}
               />
             </div>
           )}

--- a/src/mainview/components/worktrees/WorktreesDialog.tsx
+++ b/src/mainview/components/worktrees/WorktreesDialog.tsx
@@ -10,6 +10,7 @@ import { MultiSearchSelect } from "@/components/ui/multi-search-select";
 import { Select } from "@/components/ui/select";
 import { useConfirm } from "@/components/ui/confirm";
 import { abbreviateHome } from "@/lib/utils";
+import { IDENTIFIER_INPUT_PROPS } from "@/lib/identifier-input";
 import {
   COLUMNS,
   type ColumnId,
@@ -399,6 +400,7 @@ export function WorktreesDialog({ open, onClose, tasks, projects, onOpenTask, ho
         <div className="relative min-w-[200px] flex-1">
           <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden />
           <Input
+            {...IDENTIFIER_INPUT_PROPS}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search title, branch, project, path…"

--- a/src/mainview/lib/identifier-input.test.ts
+++ b/src/mainview/lib/identifier-input.test.ts
@@ -4,11 +4,16 @@ import { IDENTIFIER_INPUT_PROPS } from "./identifier-input.ts";
 /**
  * `IDENTIFIER_INPUT_PROPS` (docs/plans/remove-autocorrect-from-pickers.md §5,
  * TT1) is spread onto every identifier input (Project/Branch picker search
- * boxes, the Kanban filter search box, the branch-name field, the branch-
- * naming pattern field, and the GitHub host field) so macOS/WebKit's
- * autocorrect/autocapitalize/spellcheck/autofill services never rewrite a
- * typed identifier. Prose fields (Title, Prompt) deliberately do NOT spread
- * it — see identifier-input.ts's doc comment.
+ * boxes, the Kanban filter dropdowns' search boxes (MultiSearchSelect), the
+ * branch-name field, the branch-naming pattern field, the GitHub host field,
+ * the Extensions picker search box, the Settings additional-harness editor's
+ * Id/slug + HOME override + Bin override fields, and the GitHub-dialog
+ * identifier fields (head/base branch, tag, ref, logins, labels, …)) and
+ * onto every search/filter box (the Kanban and Worktrees free-text filters,
+ * the GitHub item search, the transcript search) so
+ * macOS/WebKit's autocorrect/autocapitalize/spellcheck/autofill services
+ * never rewrite a typed identifier. Prose fields (Title, Prompt)
+ * deliberately do NOT spread it — see identifier-input.ts's doc comment.
  *
  * The exact-set assertions below (both the deep-equal AND the sorted key
  * list) exist so a future edit can't silently widen the constant (e.g. adding

--- a/src/mainview/lib/identifier-input.test.ts
+++ b/src/mainview/lib/identifier-input.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { IDENTIFIER_INPUT_PROPS } from "./identifier-input.ts";
+
+/**
+ * `IDENTIFIER_INPUT_PROPS` (docs/plans/remove-autocorrect-from-pickers.md §5,
+ * TT1) is spread onto every identifier input (Project/Branch picker search
+ * boxes, the Kanban filter search box, the branch-name field, the branch-
+ * naming pattern field, and the GitHub host field) so macOS/WebKit's
+ * autocorrect/autocapitalize/spellcheck/autofill services never rewrite a
+ * typed identifier. Prose fields (Title, Prompt) deliberately do NOT spread
+ * it — see identifier-input.ts's doc comment.
+ *
+ * The exact-set assertions below (both the deep-equal AND the sorted key
+ * list) exist so a future edit can't silently widen the constant (e.g. adding
+ * an attribute that fights some other input) or narrow it (dropping one of
+ * the four WebKit services it's meant to defeat) without a visible test
+ * failure — a plain `toEqual` alone wouldn't catch an added key.
+ */
+describe("IDENTIFIER_INPUT_PROPS", () => {
+  test("is exactly the four autocorrect-defeating attributes", () => {
+    expect(IDENTIFIER_INPUT_PROPS).toEqual({
+      autoCorrect: "off",
+      autoCapitalize: "off",
+      spellCheck: false,
+      autoComplete: "off",
+    });
+  });
+
+  test("has exactly these four keys — no more, no fewer", () => {
+    expect(Object.keys(IDENTIFIER_INPUT_PROPS).sort()).toEqual([
+      "autoCapitalize",
+      "autoComplete",
+      "autoCorrect",
+      "spellCheck",
+    ]);
+  });
+});

--- a/src/mainview/lib/identifier-input.ts
+++ b/src/mainview/lib/identifier-input.ts
@@ -3,13 +3,24 @@ import type { InputHTMLAttributes } from "react";
 /**
  * The app ships inside the system WKWebView, which applies macOS's "Correct
  * spelling automatically" / "Capitalize words automatically" text services to
- * any editable field that doesn't explicitly opt out — same as Safari. The
- * fields this constant targets (project/branch search boxes, branch names,
- * naming patterns, host names) hold identifiers, never prose, so a
- * correction pass is never wanted there: `agetor` silently becomes `actor`,
- * `feat/` gets capitalized to `Feat/`, and so on. Prose fields (task Title,
- * Prompt) deliberately do NOT spread this — the user is typing sentences
- * there and autocorrect is helpful, not hostile.
+ * any editable field that doesn't explicitly opt out — same as Safari. Two
+ * kinds of field never want that pass, and both spread this constant:
+ *
+ *  - **Identifier inputs** — project paths, branch/tag/ref names, naming
+ *    patterns, host names, harness slugs and binary paths, GitHub logins,
+ *    label names, team slugs, issue numbers, hex colours. The value has to
+ *    match something exactly: `agetor` silently becoming `actor`, or `feat/`
+ *    getting capitalized to `Feat/`, breaks the lookup or the remote call.
+ *  - **Search / filter boxes** — every box whose text is *matched against*
+ *    existing content rather than composed: the picker popovers, the Kanban
+ *    and Worktrees filter bars (including their free-text boxes), the
+ *    Extensions picker, the GitHub item search, the transcript search. A
+ *    "corrected" query just finds nothing; there is no prose to improve.
+ *
+ * Composition fields deliberately do NOT spread it — the task Title and
+ * Prompt, GitHub titles / descriptions / release notes, prompt names — the
+ * user is writing sentences there and autocorrect is helpful, not hostile.
+ * `type="password"` inputs never autocorrect, so they don't need it either.
  *
  * Each attribute defeats a distinct WebKit service, so all four are needed
  * together rather than any one alone: `autocorrect="off"` is the explicit
@@ -20,17 +31,23 @@ import type { InputHTMLAttributes } from "react";
  * `autocomplete="off"` keeps form autofill from popping a suggestion list
  * over what's usually a popover.
  *
- * One shared constant, spread (`{...IDENTIFIER_INPUT_PROPS}`) at each site,
- * exists so a future identifier input adopts the full set in one line
- * instead of re-deriving it — several call sites had already drifted to a
- * partial (`spellCheck`-only) opt-out before this constant existed.
+ * One shared constant, spread (`{...IDENTIFIER_INPUT_PROPS}`) as the FIRST
+ * prop at each site so an explicit local prop always wins, exists so a
+ * future input adopts the full set in one line instead of re-deriving it —
+ * several call sites had already drifted to a partial (`spellCheck`-only)
+ * opt-out before this constant existed.
  *
- * One exception to the "just spread it" pattern: an input that also carries
- * `list="…"` (backed by a `<datalist>`) spreads this constant and then sets
- * `autoComplete={undefined}` right after it, because `autocomplete="off"`
- * can suppress datalist suggestions in some engines — React omits
- * `undefined` props entirely, so the datalist keeps working while the other
- * three correction attributes still apply.
+ * One exception to "just spread it": an input that also carries `list="…"`
+ * (backed by a `<datalist>`) spreads this constant and then sets
+ * `autoComplete={undefined}` right after it. Per the HTML spec `autocomplete`
+ * shouldn't gate datalist suggestions, but engines have differed (Firefox
+ * historically hid them under `autocomplete="off"`), and the behaviour in
+ * the app's WKWebView hasn't been verified either way — so the override
+ * keeps the datalist exactly as it behaved before this constant existed
+ * (React omits `undefined` props), at the cost of autofill staying on for
+ * those three inputs. Once someone confirms the datalist still drops down
+ * with `autocomplete="off"` in the packaged app, delete the overrides and
+ * this paragraph.
  */
 export const IDENTIFIER_INPUT_PROPS = {
   autoCorrect: "off",

--- a/src/mainview/lib/identifier-input.ts
+++ b/src/mainview/lib/identifier-input.ts
@@ -22,9 +22,15 @@ import type { InputHTMLAttributes } from "react";
  *
  * One shared constant, spread (`{...IDENTIFIER_INPUT_PROPS}`) at each site,
  * exists so a future identifier input adopts the full set in one line
- * instead of re-deriving it — three of today's four call sites had already
- * drifted to a partial (`spellCheck`-only, or `spellCheck` + `autoComplete`)
- * opt-out before this constant existed.
+ * instead of re-deriving it — several call sites had already drifted to a
+ * partial (`spellCheck`-only) opt-out before this constant existed.
+ *
+ * One exception to the "just spread it" pattern: an input that also carries
+ * `list="…"` (backed by a `<datalist>`) spreads this constant and then sets
+ * `autoComplete={undefined}` right after it, because `autocomplete="off"`
+ * can suppress datalist suggestions in some engines — React omits
+ * `undefined` props entirely, so the datalist keeps working while the other
+ * three correction attributes still apply.
  */
 export const IDENTIFIER_INPUT_PROPS = {
   autoCorrect: "off",

--- a/src/mainview/lib/identifier-input.ts
+++ b/src/mainview/lib/identifier-input.ts
@@ -1,0 +1,34 @@
+import type { InputHTMLAttributes } from "react";
+
+/**
+ * The app ships inside the system WKWebView, which applies macOS's "Correct
+ * spelling automatically" / "Capitalize words automatically" text services to
+ * any editable field that doesn't explicitly opt out — same as Safari. The
+ * fields this constant targets (project/branch search boxes, branch names,
+ * naming patterns, host names) hold identifiers, never prose, so a
+ * correction pass is never wanted there: `agetor` silently becomes `actor`,
+ * `feat/` gets capitalized to `Feat/`, and so on. Prose fields (task Title,
+ * Prompt) deliberately do NOT spread this — the user is typing sentences
+ * there and autocorrect is helpful, not hostile.
+ *
+ * Each attribute defeats a distinct WebKit service, so all four are needed
+ * together rather than any one alone: `autocorrect="off"` is the explicit
+ * switch (Safari on macOS has honoured it since 14.1); `spellcheck={false}`
+ * removes the red-underline markers *and* the correction pass that rides on
+ * spell checking; `autocapitalize="off"` defeats the separate
+ * capitalize-words service, which isn't gated by either of the above; and
+ * `autocomplete="off"` keeps form autofill from popping a suggestion list
+ * over what's usually a popover.
+ *
+ * One shared constant, spread (`{...IDENTIFIER_INPUT_PROPS}`) at each site,
+ * exists so a future identifier input adopts the full set in one line
+ * instead of re-deriving it — three of today's four call sites had already
+ * drifted to a partial (`spellCheck`-only, or `spellCheck` + `autoComplete`)
+ * opt-out before this constant existed.
+ */
+export const IDENTIFIER_INPUT_PROPS = {
+  autoCorrect: "off",
+  autoCapitalize: "off",
+  spellCheck: false,
+  autoComplete: "off",
+} as const satisfies InputHTMLAttributes<HTMLInputElement>;


### PR DESCRIPTION
## What

Typing a project or branch name into the New Task panel's pickers was being mangled by macOS text services (`agetor` → `actor`, `feat/` → `Feat/`). The app ships in the system WKWebView, which applies "Correct spelling automatically" / "Capitalize words automatically" to any editable field that doesn't opt out, and the shared `SearchSelect` search box carried none of the opt-out attributes.

This adds one shared constant, `IDENTIFIER_INPUT_PROPS` (`src/mainview/lib/identifier-input.ts`):

```ts
{ autoCorrect: "off", autoCapitalize: "off", spellCheck: false, autoComplete: "off" }
```

and spreads it, as the **first** prop so explicit local props always win, on every input that must match existing text exactly — 36 sites in total.

## Rule

Written into the constant's doc comment so the next input doesn't re-derive it:

- **Identifier inputs** opt out: paths, branch/tag/ref names, naming patterns, hosts, harness slugs and binary paths, GitHub logins, label names, team slugs, numbers, hex colours.
- **Search / filter boxes** opt out: anything whose text is matched against content rather than composed (picker popovers, Kanban and Worktrees filter bars including their free-text boxes, the Extensions picker, the GitHub item search, the transcript search). A corrected query just finds nothing.
- **Composition fields keep autocorrect**: task Title and Prompt, GitHub titles / descriptions / release notes, prompt names. Password inputs never autocorrect.

## Sites

- `ui/search-select.tsx` and `ui/multi-search-select.tsx` search inputs — covers every Project / Branch picker (New Task panel and the issue-task dialog), Kanban filter dropdowns, and the Worktrees dialog automatically.
- `kanban/WorktreeOptions.tsx` branch-name input, `settings/BranchNamingDialog.tsx` pattern input.
- `kanban/ExtensionPicker.tsx` search box; `kanban/KanbanFilters.tsx` and `worktrees/WorktreesDialog.tsx` free-text filters; `kanban/RunPanel.tsx` transcript search.
- `settings/GitHubTokensSection.tsx` host input; `settings/SettingsDialog.tsx` harness Id / HOME / Bin fields.
- `kanban/GitHubDialog.tsx` — 24 inputs: labels, assignees, milestone, item search, head/base branch, reviewers, teams, label name + hex, tag name, ref, workflow-dispatch input name, `#number`, transfer owner/repo.

Three sites previously had a hand-written `spellCheck={false}` only; they now use the full set.

## Datalist carve-out

Inputs backed by a `<datalist>` (Settings host, GitHub Labels, GitHub Tag name) spread the constant and then set `autoComplete={undefined}`. Per the HTML spec `autocomplete` shouldn't gate datalist suggestions, but engines have differed and the WKWebView behaviour is unverified, so the override keeps those dropdowns exactly as they behaved before. The doc comment names the removal condition: confirm in the packaged app that the detected-hosts dropdown still appears with `autocomplete="off"`, then delete the three overrides.

## Tests

- `src/mainview/lib/identifier-input.test.ts` pins the constant to exactly the four attributes (deep-equal plus exact key list).
- `e2e/identifier-inputs.spec.ts` (6 tests) asserts the DOM attributes on the Project and Branch search boxes, the branch-name input, a Kanban dropdown search box, the Kanban free-text filter, the Extensions picker search, the Settings harness editor slug/bin fields, and the Settings host input (which must carry the three correction attributes and **no** `autocomplete`). It also pins the prose split with a negative check that the Title input keeps autocorrect.
- Chromium can't exercise macOS autocorrect, so attribute presence is the automatable check; behaviour itself is a manual pass in the packaged app.

Verification: `bun run typecheck` clean; `bun test` 4003 passed; Playwright 66/67 with the one failure a pre-existing close-animation race in `unread-indicator.spec.ts` that passes on retry.

## Manual checks before merging

1. In the packaged app, type into the Project and Branch pickers and confirm no correction or capitalization.
2. Settings → Git host tokens: confirm the detected-hosts dropdown still appears. If it does, the datalist overrides can go in a follow-up.

Plan and ledger: `docs/plans/remove-autocorrect-from-pickers.md`.